### PR TITLE
feat: ChannelSidebar component (#21) and MessageInput component (#26)

### DIFF
--- a/harmony-frontend/src/components/channel/ChannelSidebar.tsx
+++ b/harmony-frontend/src/components/channel/ChannelSidebar.tsx
@@ -110,6 +110,8 @@ export interface ChannelSidebarProps {
   onClose: () => void;
   isAuthenticated: boolean;
   onLogout: () => void;
+  /** URL base path for channel links — defaults to "/c" */
+  basePath?: string;
 }
 
 export function ChannelSidebar({
@@ -121,6 +123,7 @@ export function ChannelSidebar({
   onClose,
   isAuthenticated,
   onLogout,
+  basePath = "/c",
 }: ChannelSidebarProps) {
   const [textCollapsed, setTextCollapsed] = useState(false);
   const [voiceCollapsed, setVoiceCollapsed] = useState(false);
@@ -184,7 +187,7 @@ export function ChannelSidebar({
                   return (
                     <Link
                       key={channel.id}
-                      href={`/c/${server.slug}/${channel.slug}`}
+                      href={`${basePath}/${server.slug}/${channel.slug}`}
                       aria-current={isActive ? "page" : undefined}
                       className={cn(
                         "group flex items-center gap-1.5 rounded px-2 py-1 text-sm transition-colors",

--- a/harmony-frontend/src/components/channel/MessageInput.tsx
+++ b/harmony-frontend/src/components/channel/MessageInput.tsx
@@ -40,6 +40,14 @@ export function MessageInput({
   const [sendError, setSendError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // On channel switch: clear draft, clear any send error, and autofocus the
+  // textarea so the user can start typing without clicking the input first
+  useEffect(() => {
+    setValue("");
+    setSendError(null);
+    textareaRef.current?.focus();
+  }, [channelId]);
+
   // Auto-resize: grow up to ~8 lines, then scroll
   useEffect(() => {
     const el = textareaRef.current;

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -374,6 +374,13 @@ export function HarmonyShell({
     role: "guest",
   };
 
+  // Sync local messages whenever the channel changes so stale messages from
+  // the previous channel are never shown (useState init only runs on mount)
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLocalMessages(messages);
+  }, [messages, currentChannel.id]);
+
   const handleMessageSent = useCallback((msg: Message) => {
     setLocalMessages((prev) => [...prev, msg]);
   }, []);


### PR DESCRIPTION
## Summary

- **#21 — ChannelSidebar**: Extracted from `HarmonyShell.tsx` into a standalone `components/channel/ChannelSidebar.tsx`. Adds collapsible Text/Voice channel categories with animated caret, proper status dot colours per user status (online/idle/dnd/offline), and preserves the mobile slide-out drawer behaviour.
- **#26 — MessageInput**: New `components/channel/MessageInput.tsx` replaces the old read-only placeholder. Supports Enter-to-send, Shift+Enter for newlines, auto-resizing textarea (up to ~8 lines), attachment/emoji/GIF placeholder buttons, a remaining-character counter that warns at 200 and turns red at the 2000-char limit, and a guest read-only state showing a permission notice.
- **HarmonyShell**: Reduced to ~430 lines (from ~600). Now manages local message state so newly sent messages appear immediately without a page reload. `SearchModal` also searches the live local state.

## Acceptance criteria coverage (issues #21 & #26)

- [x] ChannelSidebar ~240px wide, always visible on desktop
- [x] Server name header with dropdown arrow icon
- [x] Channels grouped by Text / Voice category
- [x] Category headers collapsible (click to toggle, caret animates)
- [x] Channel items: correct type icon, channel name, visibility badge (🔒 / 👁)
- [x] Active channel highlighted
- [x] User info bar at bottom (avatar, display name, username, status dot, logout)
- [x] Responsive mobile drawer (hamburger toggle wired via existing TopBar)
- [x] MessageInput sticky at bottom of message area
- [x] Placeholder `Message #channel-name` updates per channel
- [x] Enter to send, Shift+Enter for newline
- [x] "+" attachment, emoji, GIF placeholder buttons present
- [x] Sends via `messageService.sendMessage()`, new message appended to list
- [x] Character limit indicator (shows remaining at ≤200, red at 0)
- [x] Read-only state for guests: permission notice replaces input

## Test plan

- [ ] Navigate to a channel — ChannelSidebar renders with correct channels and active highlight
- [ ] Click a category header — channels collapse/expand with caret animation
- [ ] Log in as `alice_admin` (owner) — status dot is green; log in as an idle/dnd user to verify correct dot colour
- [ ] Type a message and press Enter — message appears in the list
- [ ] Type a long message near 2000 chars — counter appears and turns red at limit
- [ ] Log in as `henry_guest` — input is replaced by the permission notice
- [ ] On a narrow viewport, trigger the hamburger in TopBar — ChannelSidebar slides in as a drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)