### PR TITLE
Use jq to sanitize variables in JSON. Add default tag to posts

### DIFF
--- a/.github/workflows/discord-forum-pr.yml
+++ b/.github/workflows/discord-forum-pr.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           jq -n \
             --arg tn "PR #$PR_NUM: $PR_TITLE" \
-            --arg ct "**New Pull Request opened by @$USER:**\n$PR_URL" \
+            --arg ct "**New Pull Request opened by @$USER:** $PR_URL" \
             --arg tag "1479275090901336146" \
             '{thread_name: $tn, content: $ct, applied_tags: [$tag]}' | \
           curl -s -X POST "$WEBHOOK_URL" \


### PR DESCRIPTION
Use jq instead of curl so that double quotes in PR titles don't break the JSON

Add a tag argument so that each new PR has the "Needs Review" tag by default