### PR TITLE
Automate Discord Forum Thread Creation and PR Comment Syncing

### DIFF
--- a/.github/workflows/discord-forum-pr.yml
+++ b/.github/workflows/discord-forum-pr.yml
@@ -4,23 +4,37 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  pull-requests: write # Required to update the PR body
+
 jobs:
   create-forum-post:
     runs-on: ubuntu-latest
     steps:
-      - name: Send Webhook to Discord Forum
+      - name: Send Webhook and Save Thread ID
         env:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_NUM: ${{ github.event.pull_request.number }}
           USER: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          jq -n \
+          # Append ?wait=true to receive the message object back from Discord
+          RESPONSE=$(jq -n \
             --arg tn "PR #$PR_NUM: $PR_TITLE" \
-            --arg ct "**New Pull Request opened by @$USER:** $PR_URL" \
+            --arg ct "**New Pull Request opened by @$USER:**\n$PR_URL" \
             --arg tag "1479275090901336146" \
             '{thread_name: $tn, content: $ct, applied_tags: [$tag]}' | \
-          curl -s -X POST "$WEBHOOK_URL" \
+          curl -s -X POST "$WEBHOOK_URL?wait=true" \
             -H "Content-Type: application/json" \
-            -d @-
+            -d @-)
+          
+          # Extract the channel_id (which acts as the thread ID in a forum)
+          THREAD_ID=$(echo "$RESPONSE" | jq -r .channel_id)
+          
+          # Append the Thread ID as a hidden HTML comment in the PR body
+          gh pr edit $PR_NUM --body "$PR_BODY
+          
+          **Discord Thread ID:** $THREAD_ID"

--- a/.github/workflows/discord-pr-comments.yml
+++ b/.github/workflows/discord-pr-comments.yml
@@ -1,0 +1,35 @@
+name: Sync PR Comments to Discord
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  sync-comment:
+    # GitHub treats PRs as issues; this ensures it only runs on PR comments
+    if: ${{ github.event.issue.pull_request }} 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Route Comment to Discord Thread
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+          PR_BODY: ${{ github.event.issue.body }}
+        run: |
+          # Extract the numeric thread ID matching the visible text [1]
+          THREAD_ID=$(echo "$PR_BODY" | grep -oP '\*\*Discord Thread ID:\*\* \K[0-9]+')
+          
+          # Abort cleanly if no thread ID was found
+          if [ -z "$THREAD_ID" ]; then
+            echo "No associated Discord thread found for this PR."
+            exit 0
+          fi
+
+          # Send the comment directly to the specific forum thread [2]
+          jq -n \
+            --arg ct "**@$COMMENT_USER commented:**\n$COMMENT_BODY" \
+            '{content: $ct}' | \
+          curl -s -X POST "$WEBHOOK_URL?thread_id=$THREAD_ID" \
+            -H "Content-Type: application/json" \
+            -d @-


### PR DESCRIPTION
**Motivation**
To centralize Pull Request discussions, this update automates the creation of Discord Forum posts for new Pull Requests and synchronizes any subsequent GitHub comments directly to the corresponding Discord thread.

**Changes Made**
* **Updated PR Opening Workflow (`.github/workflows/discord-forum-pr.yml`):** * Configured the webhook `cURL` request to append `?wait=true` to receive the message object back from the Discord API.
* Extracts the generated `channel_id` (thread ID) from the response using `jq`.
* Appends the extracted thread ID directly to the PR description body using the GitHub CLI (`gh pr edit`) as visible text (`**Discord Thread ID:** <ID>`).
* Added the `actions/checkout` step and assigned the `GH_TOKEN` environment variable to ensure the GitHub CLI can authenticate and execute within the correct repository context.


* **Created Comment Sync Workflow (`.github/workflows/discord-pr-comments.yml`):**
* Triggers on the `issue_comment` event, specifically filtering to ensure it only runs on Pull Request comments.
* Uses `grep` with a regular expression to parse the PR description body and extract the saved Discord Thread ID.
* Constructs a JSON payload safely using `jq` and routes the comment content directly to the existing Discord thread via the webhook's `?thread_id=` parameter.

**Discord Thread ID:** 1479287050225057892