### PR TITLE
fix: replace flaky setTimeout with deterministic promise in visibility event test (#147)

### DIFF
--- a/harmony-backend/tests/visibility.service.test.ts
+++ b/harmony-backend/tests/visibility.service.test.ts
@@ -12,7 +12,7 @@
 import { ChannelVisibility, ChannelType } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import { visibilityService, SetVisibilityInput } from '../src/services/visibility.service';
-import { eventBus, EventChannels } from '../src/events/eventBus';
+import { eventBus, EventChannels, VisibilityChangedPayload } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
 
 let serverId: string;
@@ -357,10 +357,23 @@ describe('visibilityService.setVisibility — VISIBILITY_CHANGED event', () => {
       data: { visibility: ChannelVisibility.PRIVATE, indexedAt: null },
     });
 
+    // Collect all received payloads. Expose a Promise that resolves as soon
+    // as the subscription callback delivers a payload for our target channel,
+    // eliminating the timing-dependent setTimeout wait.
     const receivedPayloads: unknown[] = [];
+    let resolveOnEvent!: (p: VisibilityChangedPayload) => void;
+    const eventReceived = new Promise<VisibilityChangedPayload>(
+      (resolve) => { resolveOnEvent = resolve; },
+    );
+
     const { unsubscribe, ready } = eventBus.subscribe(
       EventChannels.VISIBILITY_CHANGED,
-      (payload) => receivedPayloads.push(payload),
+      (payload) => {
+        receivedPayloads.push(payload);
+        if (payload.channelId === textChannelId) {
+          resolveOnEvent(payload);
+        }
+      },
     );
 
     await ready;
@@ -369,18 +382,14 @@ describe('visibilityService.setVisibility — VISIBILITY_CHANGED event', () => {
       makeInput(textChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
     );
 
-    // Give Redis Pub/Sub a moment to deliver
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    // Wait for the callback to fire rather than using a fixed timeout
+    const payload = await eventReceived;
 
     expect(receivedPayloads.length).toBeGreaterThanOrEqual(1);
-    const payload = (receivedPayloads as Record<string, unknown>[]).find(
-      (p) => p.channelId === textChannelId,
-    );
-    expect(payload).toBeDefined();
-    expect(payload!.channelId).toBe(textChannelId);
-    expect(payload!.oldVisibility).toBe(ChannelVisibility.PRIVATE);
-    expect(payload!.newVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
-    expect(payload!.actorId).toBe(userId);
+    expect(payload.channelId).toBe(textChannelId);
+    expect(payload.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+    expect(payload.newVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+    expect(payload.actorId).toBe(userId);
 
     unsubscribe();
   });

--- a/harmony-backend/tests/visibility.service.test.ts
+++ b/harmony-backend/tests/visibility.service.test.ts
@@ -384,20 +384,27 @@ describe('visibilityService.setVisibility — VISIBILITY_CHANGED event', () => {
 
     // Wait for the callback to fire rather than using a fixed timeout, but
     // guard against hanging indefinitely if the event is never delivered.
+    // Clear the timer after the race to avoid a dangling handle that keeps
+    // the Node.js event loop alive after the test finishes.
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () =>
+          reject(
+            new Error(
+              `Timed out waiting for VISIBILITY_CHANGED event for channel ${textChannelId}`,
+            ),
+          ),
+        2000,
+      );
+    });
+
     const payload = await Promise.race<VisibilityChangedPayload>([
       eventReceived,
-      new Promise<never>((_, reject) =>
-        setTimeout(
-          () =>
-            reject(
-              new Error(
-                `Timed out waiting for VISIBILITY_CHANGED event for channel ${textChannelId}`,
-              ),
-            ),
-          2000,
-        ),
-      ),
+      timeoutPromise,
     ]);
+
+    clearTimeout(timeoutId!);
 
     expect(receivedPayloads.length).toBeGreaterThanOrEqual(1);
     expect(payload.channelId).toBe(textChannelId);

--- a/harmony-backend/tests/visibility.service.test.ts
+++ b/harmony-backend/tests/visibility.service.test.ts
@@ -382,8 +382,22 @@ describe('visibilityService.setVisibility — VISIBILITY_CHANGED event', () => {
       makeInput(textChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
     );
 
-    // Wait for the callback to fire rather than using a fixed timeout
-    const payload = await eventReceived;
+    // Wait for the callback to fire rather than using a fixed timeout, but
+    // guard against hanging indefinitely if the event is never delivered.
+    const payload = await Promise.race<VisibilityChangedPayload>([
+      eventReceived,
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error(
+                `Timed out waiting for VISIBILITY_CHANGED event for channel ${textChannelId}`,
+              ),
+            ),
+          2000,
+        ),
+      ),
+    ]);
 
     expect(receivedPayloads.length).toBeGreaterThanOrEqual(1);
     expect(payload.channelId).toBe(textChannelId);


### PR DESCRIPTION
## Summary

- Replaces `setTimeout(resolve, 200)` in the `VISIBILITY_CHANGED` event emission test with a `Promise` that resolves directly from the subscription callback when a matching payload arrives.
- Imports `VisibilityChangedPayload` type from `eventBus` to keep the new promise fully typed — no casts needed.
- All other test logic is unchanged; the assertions are identical.

**Why this is better:** The old approach waited an arbitrary 200ms hoping Redis Pub/Sub would deliver within that window. Under CI load this could fail. The new approach waits exactly as long as delivery actually takes — neither more nor less.

Closes #147

## Test plan
- [ ] Run `npm test` in `harmony-backend` — all visibility service tests pass, including the event emission test
- [ ] Confirm no `setTimeout` remains in the visibility test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)