### PR TITLE
feat: real-time user status changes propagate to connected clients (#231)

### DIFF
--- a/harmony-backend/src/events/eventTypes.ts
+++ b/harmony-backend/src/events/eventTypes.ts
@@ -20,6 +20,7 @@ export const EventChannels = {
   CHANNEL_UPDATED: 'harmony:CHANNEL_UPDATED',
   CHANNEL_DELETED: 'harmony:CHANNEL_DELETED',
   SERVER_UPDATED: 'harmony:SERVER_UPDATED',
+  USER_STATUS_CHANGED: 'harmony:USER_STATUS_CHANGED',
 } as const;
 
 export type EventChannelName = (typeof EventChannels)[keyof typeof EventChannels];
@@ -122,6 +123,12 @@ export interface ServerUpdatedPayload {
   timestamp: string;
 }
 
+export interface UserStatusChangedPayload {
+  userId: string;
+  serverId: string;
+  status: string;
+}
+
 // Map each channel to its payload type for type-safe subscribe/publish
 export interface EventPayloadMap {
   [EventChannels.VISIBILITY_CHANGED]: VisibilityChangedPayload;
@@ -138,6 +145,7 @@ export interface EventPayloadMap {
   [EventChannels.CHANNEL_UPDATED]: ChannelUpdatedPayload;
   [EventChannels.CHANNEL_DELETED]: ChannelDeletedPayload;
   [EventChannels.SERVER_UPDATED]: ServerUpdatedPayload;
+  [EventChannels.USER_STATUS_CHANGED]: UserStatusChangedPayload;
 }
 
 export type EventHandler<C extends EventChannelName> = (payload: EventPayloadMap[C]) => void;

--- a/harmony-backend/src/events/eventTypes.ts
+++ b/harmony-backend/src/events/eventTypes.ts
@@ -126,7 +126,8 @@ export interface ServerUpdatedPayload {
 export interface UserStatusChangedPayload {
   userId: string;
   serverId: string;
-  status: string;
+  /** Prisma UserStatus enum value; normalized to lowercase before emitting over SSE. */
+  status: 'ONLINE' | 'IDLE' | 'DND' | 'OFFLINE';
 }
 
 // Map each channel to its payload type for type-safe subscribe/publish

--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -26,6 +26,7 @@ import type {
   ChannelUpdatedPayload,
   ChannelDeletedPayload,
   ServerUpdatedPayload,
+  UserStatusChangedPayload,
 } from '../events/eventTypes';
 
 export const eventsRouter = Router();
@@ -334,6 +335,18 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     },
   );
 
+  // ── Subscribe to member status change events ──────────────────────────────
+  // Status reflects presence (ONLINE/IDLE/OFFLINE) not identity, so it is emitted
+  // regardless of the user's publicProfile setting — consistent with the rationale
+  // documented in PR #202 for member join/leave events.
+  const { unsubscribe: unsubStatusChanged } = eventBus.subscribe(
+    EventChannels.USER_STATUS_CHANGED,
+    (payload: UserStatusChangedPayload) => {
+      if (payload.serverId !== serverId) return;
+      sendEvent(res, 'member:statusChanged', { id: payload.userId, status: payload.status });
+    },
+  );
+
   // ── Heartbeat ────────────────────────────────────────────────────────────
   const heartbeat = setInterval(() => {
     res.write(':\n\n');
@@ -345,5 +358,6 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     unsubChannelCreated();
     unsubChannelUpdated();
     unsubChannelDeleted();
+    unsubStatusChanged();
   });
 });

--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -343,7 +343,8 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     EventChannels.USER_STATUS_CHANGED,
     (payload: UserStatusChangedPayload) => {
       if (payload.serverId !== serverId) return;
-      sendEvent(res, 'member:statusChanged', { id: payload.userId, status: payload.status });
+      // Normalize Prisma enum ('IDLE') to the lowercase format the frontend expects ('idle').
+      sendEvent(res, 'member:statusChanged', { id: payload.userId, status: payload.status.toLowerCase() });
     },
   );
 

--- a/harmony-backend/src/services/user.service.ts
+++ b/harmony-backend/src/services/user.service.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import { Prisma, UserStatus } from '@prisma/client';
 import { prisma } from '../db/prisma';
 import { isSystemAdmin } from '../lib/admin.utils';
+import { eventBus, EventChannels } from '../events/eventBus';
 
 export interface UpdateUserInput {
   displayName?: string;
@@ -90,7 +91,7 @@ export const userService = {
 
   async updateUser(userId: string, patch: UpdateUserInput) {
     try {
-      return await prisma.user.update({
+      const updated = await prisma.user.update({
         where: { id: userId },
         select: SELF_PROFILE_SELECT,
         data: {
@@ -100,6 +101,26 @@ export const userService = {
           ...(patch.status !== undefined && { status: patch.status }),
         },
       });
+
+      // When status changes, publish one event per server the user belongs to so
+      // all connected members of those servers can update their member sidebar in real time.
+      // Status reflects presence only (not identity), so we publish for all servers
+      // regardless of the user's publicProfile setting.
+      if (patch.status !== undefined) {
+        const memberships = await prisma.serverMember.findMany({
+          where: { userId },
+          select: { serverId: true },
+        });
+        for (const { serverId } of memberships) {
+          void eventBus.publish(EventChannels.USER_STATUS_CHANGED, {
+            userId,
+            serverId,
+            status: patch.status,
+          });
+        }
+      }
+
+      return updated;
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });

--- a/harmony-backend/tests/events.router.status.test.ts
+++ b/harmony-backend/tests/events.router.status.test.ts
@@ -1,0 +1,309 @@
+/**
+ * events.router.status.test.ts — Issue #231
+ *
+ * Integration tests for member:statusChanged SSE events on
+ * GET /api/events/server/:serverId.
+ *
+ * eventBus, prisma, and authService are mocked — no running Redis/DB needed.
+ */
+
+import http from 'http';
+import { createApp } from '../src/app';
+import { eventBus } from '../src/events/eventBus';
+import { prisma } from '../src/db/prisma';
+import type { Express } from 'express';
+
+const VALID_TOKEN = 'valid-token';
+const VALID_SERVER_ID = '550e8400-e29b-41d4-a716-446655440002';
+const CHANGING_USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-ffffffffffff';
+
+// ─── Mock eventBus ─────────────────────────────────────────────────────────────
+
+jest.mock('../src/events/eventBus', () => ({
+  eventBus: {
+    subscribe: jest.fn(),
+    publish: jest.fn().mockResolvedValue(undefined),
+  },
+  EventChannels: {
+    MESSAGE_CREATED: 'harmony:MESSAGE_CREATED',
+    MESSAGE_EDITED: 'harmony:MESSAGE_EDITED',
+    MESSAGE_DELETED: 'harmony:MESSAGE_DELETED',
+    CHANNEL_CREATED: 'harmony:CHANNEL_CREATED',
+    CHANNEL_UPDATED: 'harmony:CHANNEL_UPDATED',
+    CHANNEL_DELETED: 'harmony:CHANNEL_DELETED',
+    MEMBER_JOINED: 'harmony:MEMBER_JOINED',
+    MEMBER_LEFT: 'harmony:MEMBER_LEFT',
+    USER_STATUS_CHANGED: 'harmony:USER_STATUS_CHANGED',
+  },
+}));
+
+// ─── Mock authService ──────────────────────────────────────────────────────────
+
+jest.mock('../src/services/auth.service', () => ({
+  authService: {
+    verifyAccessToken: jest.fn(() => ({ sub: 'test-user-id' })),
+  },
+}));
+
+// ─── Mock Prisma ───────────────────────────────────────────────────────────────
+
+jest.mock('../src/db/prisma', () => ({
+  prisma: {
+    message: { findUnique: jest.fn(), create: jest.fn(), update: jest.fn() },
+    channel: { findUnique: jest.fn() },
+    server: { findUnique: jest.fn() },
+    serverMember: { findFirst: jest.fn() },
+    user: { findUnique: jest.fn() },
+  },
+}));
+
+// ─── Mock cacheService ─────────────────────────────────────────────────────────
+
+jest.mock('../src/services/cache.service', () => ({
+  cacheService: {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    invalidate: jest.fn().mockResolvedValue(undefined),
+    invalidatePattern: jest.fn().mockResolvedValue(undefined),
+    getOrRevalidate: jest.fn(),
+  },
+  CacheTTL: { channelMessages: 60, channelVisibility: 60 },
+  CacheKeys: { channelMessages: jest.fn(), channelVisibility: jest.fn() },
+  sanitizeKeySegment: (s: string) => s,
+}));
+
+// ─── Mock rate-limit middleware ────────────────────────────────────────────────
+
+jest.mock('../src/middleware/rate-limit.middleware', () => ({
+  tokenBucketRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+  _clearBucketsForTesting: jest.fn(),
+}));
+
+// ─── SSE helper ───────────────────────────────────────────────────────────────
+
+function sseGet(
+  server: http.Server,
+  path: string,
+  timeoutMs = 400,
+): Promise<{ statusCode: number; headers: Record<string, string | string[] | undefined> }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
+    const port = addr.port;
+
+    const req = http.get({ hostname: 'localhost', port, path }, (res) => {
+      const headers = res.headers as Record<string, string | string[] | undefined>;
+      const statusCode = res.statusCode ?? 0;
+      res.on('data', () => {});
+      const timer = setTimeout(() => {
+        res.destroy();
+        resolve({ statusCode, headers });
+      }, timeoutMs);
+      res.on('close', () => {
+        clearTimeout(timer);
+        resolve({ statusCode, headers });
+      });
+    });
+
+    req.on('error', reject);
+    req.setTimeout(timeoutMs + 500, () => {
+      req.destroy();
+      reject(new Error('Request timed out'));
+    });
+  });
+}
+
+// ─── Test setup ───────────────────────────────────────────────────────────────
+
+const mockSubscribe = eventBus.subscribe as jest.Mock;
+
+let app: Express;
+let httpServer: http.Server;
+
+beforeAll((done) => {
+  mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
+  app = createApp();
+  httpServer = app.listen(0, done);
+});
+
+afterAll((done) => {
+  httpServer.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
+  (prisma.server.findUnique as jest.Mock).mockResolvedValue({ id: VALID_SERVER_ID });
+  (prisma.serverMember.findFirst as jest.Mock).mockResolvedValue({ userId: 'test-user-id' });
+});
+
+// ─── Status event subscription ────────────────────────────────────────────────
+
+describe('GET /api/events/server/:serverId — status event subscription', () => {
+  const sseUrl = (id: string) => `/api/events/server/${id}?token=${VALID_TOKEN}`;
+
+  it('subscribes to USER_STATUS_CHANGED event channel', async () => {
+    await sseGet(httpServer, sseUrl(VALID_SERVER_ID));
+
+    const subscribedChannels = (mockSubscribe.mock.calls as unknown[][]).map((c) => c[0]);
+    expect(subscribedChannels).toContain('harmony:USER_STATUS_CHANGED');
+  });
+
+  it('subscribes to channel events alongside the status event', async () => {
+    await sseGet(httpServer, sseUrl(VALID_SERVER_ID));
+
+    const subscribedChannels = (mockSubscribe.mock.calls as unknown[][]).map((c) => c[0]);
+    expect(subscribedChannels).toContain('harmony:CHANNEL_CREATED');
+    expect(subscribedChannels).toContain('harmony:CHANNEL_UPDATED');
+    expect(subscribedChannels).toContain('harmony:CHANNEL_DELETED');
+  });
+});
+
+// ─── member:statusChanged event delivery ──────────────────────────────────────
+
+describe('GET /api/events/server/:serverId — member:statusChanged event', () => {
+  it('fires the USER_STATUS_CHANGED handler and emits member:statusChanged', async () => {
+    let statusChangedHandler: ((payload: unknown) => void) | null = null;
+
+    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => void) => {
+      if (channel === 'harmony:USER_STATUS_CHANGED') {
+        statusChangedHandler = handler;
+      }
+      return { unsubscribe: jest.fn(), ready: Promise.resolve() };
+    });
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad address');
+    const port = (addr as { port: number }).port;
+
+    const chunks: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get(
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        (res) => {
+          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+
+          setTimeout(() => {
+            if (statusChangedHandler) {
+              statusChangedHandler({
+                userId: CHANGING_USER_ID,
+                serverId: VALID_SERVER_ID,
+                status: 'IDLE',
+              });
+            }
+
+            setTimeout(() => {
+              res.destroy();
+              resolve();
+            }, 50);
+          }, 50);
+
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+    });
+
+    const body = chunks.join('');
+    expect(body).toContain('event: member:statusChanged');
+    expect(body).toContain(CHANGING_USER_ID);
+    expect(body).toContain('"status":"IDLE"');
+  });
+
+  it('does not emit member:statusChanged for a different server', async () => {
+    let statusChangedHandler: ((payload: unknown) => void) | null = null;
+
+    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => void) => {
+      if (channel === 'harmony:USER_STATUS_CHANGED') {
+        statusChangedHandler = handler;
+      }
+      return { unsubscribe: jest.fn(), ready: Promise.resolve() };
+    });
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad address');
+    const port = (addr as { port: number }).port;
+
+    const chunks: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get(
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        (res) => {
+          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+
+          setTimeout(() => {
+            if (statusChangedHandler) {
+              // Fire with a different serverId — should be filtered out
+              statusChangedHandler({
+                userId: CHANGING_USER_ID,
+                serverId: 'different-server-id',
+                status: 'OFFLINE',
+              });
+            }
+
+            setTimeout(() => {
+              res.destroy();
+              resolve();
+            }, 50);
+          }, 50);
+
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+    });
+
+    const body = chunks.join('');
+    expect(body).not.toContain('event: member:statusChanged');
+  });
+
+  it('emits member:statusChanged regardless of publicProfile (status reflects presence not identity)', async () => {
+    // Status is presence-only data — it is always emitted regardless of publicProfile.
+    // This test verifies no extra DB lookup occurs (the payload has everything needed).
+    let statusChangedHandler: ((payload: unknown) => void) | null = null;
+
+    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => void) => {
+      if (channel === 'harmony:USER_STATUS_CHANGED') {
+        statusChangedHandler = handler;
+      }
+      return { unsubscribe: jest.fn(), ready: Promise.resolve() };
+    });
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad address');
+    const port = (addr as { port: number }).port;
+
+    const chunks: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get(
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        (res) => {
+          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+
+          setTimeout(() => {
+            if (statusChangedHandler) {
+              statusChangedHandler({
+                userId: CHANGING_USER_ID,
+                serverId: VALID_SERVER_ID,
+                status: 'ONLINE',
+              });
+            }
+
+            setTimeout(() => {
+              res.destroy();
+              resolve();
+            }, 50);
+          }, 50);
+
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+    });
+
+    const body = chunks.join('');
+    expect(body).toContain('event: member:statusChanged');
+    // Verify no DB lookup was needed (user.findUnique not called for status changes)
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/harmony-backend/tests/events.router.status.test.ts
+++ b/harmony-backend/tests/events.router.status.test.ts
@@ -207,7 +207,8 @@ describe('GET /api/events/server/:serverId — member:statusChanged event', () =
     const body = chunks.join('');
     expect(body).toContain('event: member:statusChanged');
     expect(body).toContain(CHANGING_USER_ID);
-    expect(body).toContain('"status":"IDLE"');
+    // SSE emits lowercase (Prisma enum 'IDLE' → frontend 'idle' via .toLowerCase())
+    expect(body).toContain('"status":"idle"');
   });
 
   it('does not emit member:statusChanged for a different server', async () => {

--- a/harmony-frontend/src/__tests__/useServerEvents.test.tsx
+++ b/harmony-frontend/src/__tests__/useServerEvents.test.tsx
@@ -1,0 +1,484 @@
+/**
+ * useServerEvents.test.tsx — Issue #185 / #186 / #231
+ *
+ * Tests the useServerEvents hook that subscribes to real-time SSE events for
+ * channel list updates, member list updates, and member status changes on a server.
+ *
+ * EventSource is mocked to avoid actual network connections.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useServerEvents } from '../hooks/useServerEvents';
+import { ChannelType, ChannelVisibility } from '../types/channel';
+import type { Channel } from '../types/channel';
+import type { User } from '../types/user';
+
+// ─── Mock api-client ──────────────────────────────────────────────────────────
+
+jest.mock('../lib/api-client', () => ({
+  getAccessToken: jest.fn(() => 'mock-token'),
+}));
+
+// ─── Mock EventSource ─────────────────────────────────────────────────────────
+
+type EventSourceHandler = (event: MessageEvent) => void;
+
+interface MockEventSourceInstance {
+  url: string;
+  addEventListener: jest.Mock;
+  removeEventListener: jest.Mock;
+  close: jest.Mock;
+  onerror: ((event: Event) => void) | null;
+  onopen: ((event: Event) => void) | null;
+  simulateEvent: (type: string, data: unknown) => void;
+  simulateOpen: () => void;
+  simulateError: () => void;
+}
+
+let mockEventSourceInstance: MockEventSourceInstance | null = null;
+
+const MockEventSource = jest.fn().mockImplementation((url: string) => {
+  const handlers = new Map<string, EventSourceHandler[]>();
+
+  const instance: MockEventSourceInstance = {
+    url,
+    addEventListener: jest.fn((type: string, handler: EventSourceHandler) => {
+      if (!handlers.has(type)) handlers.set(type, []);
+      handlers.get(type)!.push(handler);
+    }),
+    removeEventListener: jest.fn((type: string, handler: EventSourceHandler) => {
+      const list = handlers.get(type) ?? [];
+      handlers.set(
+        type,
+        list.filter(h => h !== handler),
+      );
+    }),
+    close: jest.fn(),
+    onerror: null,
+    onopen: null,
+
+    simulateEvent(type: string, data: unknown) {
+      const event = new MessageEvent(type, { data: JSON.stringify(data) });
+      (handlers.get(type) ?? []).forEach(h => h(event));
+    },
+
+    simulateOpen() {
+      if (this.onopen) this.onopen(new Event('open'));
+    },
+
+    simulateError() {
+      if (this.onerror) this.onerror(new Event('error'));
+    },
+  };
+
+  mockEventSourceInstance = instance;
+  return instance;
+});
+
+(MockEventSource as unknown as { CONNECTING: number; OPEN: number; CLOSED: number }).CONNECTING = 0;
+(MockEventSource as unknown as { CONNECTING: number; OPEN: number; CLOSED: number }).OPEN = 1;
+(MockEventSource as unknown as { CONNECTING: number; OPEN: number; CLOSED: number }).CLOSED = 2;
+
+Object.defineProperty(global, 'EventSource', {
+  writable: true,
+  value: MockEventSource,
+});
+
+// ─── Fixture data ─────────────────────────────────────────────────────────────
+
+const SERVER_ID = '550e8400-e29b-41d4-a716-446655440010';
+const API_URL = 'http://localhost:4000';
+
+const MOCK_CHANNEL: Channel = {
+  id: 'ch-001',
+  serverId: SERVER_ID,
+  name: 'general',
+  slug: 'general',
+  type: ChannelType.TEXT,
+  visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+  position: 0,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+const MOCK_USER: User = {
+  id: 'user-new',
+  username: 'newmember',
+  displayName: 'New Member',
+  status: 'online',
+  role: 'member',
+};
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockEventSourceInstance = null;
+  process.env = { ...originalEnv, NEXT_PUBLIC_API_URL: API_URL };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+// ─── Connection ───────────────────────────────────────────────────────────────
+
+describe('useServerEvents — connection', () => {
+  it('creates an EventSource with the correct server URL', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    expect(MockEventSource).toHaveBeenCalledWith(
+      `${API_URL}/api/events/server/${SERVER_ID}?token=mock-token`,
+    );
+  });
+
+  it('does NOT create EventSource when enabled=false', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        enabled: false,
+      }),
+    );
+
+    expect(MockEventSource).not.toHaveBeenCalled();
+  });
+
+  it('closes the EventSource on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    unmount();
+
+    expect(mockEventSourceInstance?.close).toHaveBeenCalled();
+  });
+
+  it('registers listeners for all six event types', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberJoined: jest.fn(),
+        onMemberLeft: jest.fn(),
+        onMemberStatusChanged: jest.fn(),
+      }),
+    );
+
+    const addedTypes = (
+      mockEventSourceInstance!.addEventListener.mock.calls as [string, unknown][]
+    ).map(([type]) => type);
+
+    expect(addedTypes).toContain('channel:created');
+    expect(addedTypes).toContain('channel:updated');
+    expect(addedTypes).toContain('channel:deleted');
+    expect(addedTypes).toContain('member:joined');
+    expect(addedTypes).toContain('member:left');
+    expect(addedTypes).toContain('member:statusChanged');
+  });
+});
+
+// ─── Channel event handling ───────────────────────────────────────────────────
+
+describe('useServerEvents — channel events', () => {
+  it('calls onChannelCreated with parsed channel on channel:created event', () => {
+    const onChannelCreated = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated,
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('channel:created', MOCK_CHANNEL);
+    });
+
+    expect(onChannelCreated).toHaveBeenCalledTimes(1);
+    expect(onChannelCreated).toHaveBeenCalledWith(MOCK_CHANNEL);
+  });
+
+  it('calls onChannelUpdated with parsed channel on channel:updated event', () => {
+    const onChannelUpdated = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated,
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('channel:updated', { ...MOCK_CHANNEL, name: 'renamed' });
+    });
+
+    expect(onChannelUpdated).toHaveBeenCalledTimes(1);
+    expect(onChannelUpdated).toHaveBeenCalledWith({ ...MOCK_CHANNEL, name: 'renamed' });
+  });
+
+  it('calls onChannelDeleted with channelId on channel:deleted event', () => {
+    const onChannelDeleted = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('channel:deleted', { channelId: 'ch-001' });
+    });
+
+    expect(onChannelDeleted).toHaveBeenCalledTimes(1);
+    expect(onChannelDeleted).toHaveBeenCalledWith('ch-001');
+  });
+});
+
+// ─── Member event handling ────────────────────────────────────────────────────
+
+describe('useServerEvents — member events', () => {
+  it('calls onMemberJoined with parsed User on member:joined event', () => {
+    const onMemberJoined = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberJoined,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('member:joined', MOCK_USER);
+    });
+
+    expect(onMemberJoined).toHaveBeenCalledTimes(1);
+    expect(onMemberJoined).toHaveBeenCalledWith(MOCK_USER);
+  });
+
+  it('calls onMemberLeft with userId on member:left event', () => {
+    const onMemberLeft = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberLeft,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('member:left', { userId: 'user-new' });
+    });
+
+    expect(onMemberLeft).toHaveBeenCalledTimes(1);
+    expect(onMemberLeft).toHaveBeenCalledWith('user-new');
+  });
+
+  it('does not throw when onMemberJoined is not provided', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        // onMemberJoined intentionally omitted
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        mockEventSourceInstance!.simulateEvent('member:joined', MOCK_USER);
+      });
+    }).not.toThrow();
+  });
+
+  it('does not throw when onMemberLeft is not provided', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        // onMemberLeft intentionally omitted
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        mockEventSourceInstance!.simulateEvent('member:left', { userId: 'user-new' });
+      });
+    }).not.toThrow();
+  });
+
+  it('removes member:joined and member:left listeners on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberJoined: jest.fn(),
+        onMemberLeft: jest.fn(),
+      }),
+    );
+
+    unmount();
+
+    const removedTypes = (
+      mockEventSourceInstance!.removeEventListener.mock.calls as [string, unknown][]
+    ).map(([type]) => type);
+
+    expect(removedTypes).toContain('member:joined');
+    expect(removedTypes).toContain('member:left');
+  });
+
+  it('does not call onMemberJoined on malformed JSON', () => {
+    const onMemberJoined = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberJoined,
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        const badEvent = new MessageEvent('member:joined', { data: 'not-json{{{' });
+        (mockEventSourceInstance!.addEventListener.mock.calls as [string, EventSourceHandler][])
+          .filter(([type]) => type === 'member:joined')
+          .forEach(([, handler]) => handler(badEvent));
+      });
+    }).not.toThrow();
+
+    expect(onMemberJoined).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Member status change handling ───────────────────────────────────────────
+
+describe('useServerEvents — member status change events', () => {
+  it('calls onMemberStatusChanged with id and status on member:statusChanged event', () => {
+    const onMemberStatusChanged = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberStatusChanged,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('member:statusChanged', {
+        id: 'user-new',
+        status: 'idle',
+      });
+    });
+
+    expect(onMemberStatusChanged).toHaveBeenCalledTimes(1);
+    expect(onMemberStatusChanged).toHaveBeenCalledWith({ id: 'user-new', status: 'idle' });
+  });
+
+  it('does not throw when onMemberStatusChanged is not provided', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        // onMemberStatusChanged intentionally omitted
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        mockEventSourceInstance!.simulateEvent('member:statusChanged', {
+          id: 'user-new',
+          status: 'offline',
+        });
+      });
+    }).not.toThrow();
+  });
+
+  it('removes member:statusChanged listener on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberStatusChanged: jest.fn(),
+      }),
+    );
+
+    unmount();
+
+    const removedTypes = (
+      mockEventSourceInstance!.removeEventListener.mock.calls as [string, unknown][]
+    ).map(([type]) => type);
+
+    expect(removedTypes).toContain('member:statusChanged');
+  });
+
+  it('does not call onMemberStatusChanged on malformed JSON', () => {
+    const onMemberStatusChanged = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberStatusChanged,
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        const badEvent = new MessageEvent('member:statusChanged', { data: 'not-json{{{' });
+        (mockEventSourceInstance!.addEventListener.mock.calls as [string, EventSourceHandler][])
+          .filter(([type]) => type === 'member:statusChanged')
+          .forEach(([, handler]) => handler(badEvent));
+      });
+    }).not.toThrow();
+
+    expect(onMemberStatusChanged).not.toHaveBeenCalled();
+  });
+});

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -117,6 +117,14 @@ export function HarmonyShell({
     setPrevChannelsProp(channels);
     setLocalChannels(channels);
   }
+  // Local members state so join/leave/status events update the sidebar without reload.
+  const [localMembers, setLocalMembers] = useState<User[]>(members);
+  // Reset when the members prop changes (server navigation or SSR revalidation).
+  const [prevMembersProp, setPrevMembersProp] = useState(members);
+  if (prevMembersProp !== members) {
+    setPrevMembersProp(members);
+    setLocalMembers(members);
+  }
   // Channel creation modal state.
   const [isCreateChannelOpen, setIsCreateChannelOpen] = useState(false);
   const [createChannelDefaultType, setCreateChannelDefaultType] = useState<ChannelType>(
@@ -227,11 +235,32 @@ export function HarmonyShell({
     [currentChannel.id, currentServer.slug, basePath, router],
   );
 
+  // ── Real-time member list updates ─────────────────────────────────────────
+
+  const handleMemberJoined = useCallback((user: User) => {
+    setLocalMembers(prev => {
+      // Dedup: ignore if the user is already in the list
+      if (prev.some(m => m.id === user.id)) return prev;
+      return [...prev, user];
+    });
+  }, []);
+
+  const handleMemberLeft = useCallback((userId: string) => {
+    setLocalMembers(prev => prev.filter(m => m.id !== userId));
+  }, []);
+
+  const handleMemberStatusChanged = useCallback(({ id, status }: { id: string; status: string }) => {
+    setLocalMembers(prev => prev.map(m => (m.id === id ? { ...m, status } : m)));
+  }, []);
+
   useServerEvents({
     serverId: currentServer.id,
     onChannelCreated: handleChannelCreated,
     onChannelUpdated: handleChannelUpdated,
     onChannelDeleted: handleChannelDeleted,
+    onMemberJoined: handleMemberJoined,
+    onMemberLeft: handleMemberLeft,
+    onMemberStatusChanged: handleMemberStatusChanged,
     enabled: isAuthenticated,
   });
 
@@ -328,12 +357,12 @@ export function HarmonyShell({
             {!isAuthLoading && !isAuthenticated && (
               <GuestPromoBanner
                 serverName={currentServer.name}
-                memberCount={currentServer.memberCount ?? members.length}
+                memberCount={currentServer.memberCount ?? localMembers.length}
               />
             )}
           </div>
           <MembersSidebar
-            members={members}
+            members={localMembers}
             isOpen={isMembersOpen}
             onClose={() => setIsMembersOpen(false)}
           />

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -21,7 +21,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useChannelEvents } from '@/hooks/useChannelEvents';
 import { useServerEvents } from '@/hooks/useServerEvents';
 import { useServerListSync } from '@/hooks/useServerListSync';
-import { ChannelType, ChannelVisibility } from '@/types';
+import { ChannelType, ChannelVisibility, UserStatus } from '@/types';
 import { useRouter } from 'next/navigation';
 import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
 import type { Server, Channel, Message, User } from '@/types';
@@ -249,7 +249,7 @@ export function HarmonyShell({
     setLocalMembers(prev => prev.filter(m => m.id !== userId));
   }, []);
 
-  const handleMemberStatusChanged = useCallback(({ id, status }: { id: string; status: string }) => {
+  const handleMemberStatusChanged = useCallback(({ id, status }: { id: string; status: UserStatus }) => {
     setLocalMembers(prev => prev.map(m => (m.id === id ? { ...m, status } : m)));
   }, []);
 

--- a/harmony-frontend/src/hooks/useServerEvents.ts
+++ b/harmony-frontend/src/hooks/useServerEvents.ts
@@ -1,7 +1,11 @@
 /**
- * useServerEvents — Issue #185
+ * useServerEvents — Issue #185 / #186 / #231
  *
- * Subscribes to real-time SSE events for a server's channel list.
+ * Subscribes to real-time SSE events for a server.
+ * Handles channel list updates (created/updated/deleted), member list
+ * updates (joined/left), and member status changes over the single
+ * /api/events/server/:serverId endpoint.
+ *
  * Uses the native EventSource API (no library needed).
  *
  * Usage:
@@ -10,6 +14,11 @@
  *     onChannelCreated: (ch) => setChannels(prev => [...prev, ch]),
  *     onChannelUpdated: (ch) => setChannels(prev => prev.map(c => c.id === ch.id ? ch : c)),
  *     onChannelDeleted: (id) => setChannels(prev => prev.filter(c => c.id !== id)),
+ *     onMemberJoined: (user) => setMembers(prev => [...prev, user]),
+ *     onMemberLeft: (userId) => setMembers(prev => prev.filter(m => m.id !== userId)),
+ *     onMemberStatusChanged: ({ id, status }) => setMembers(prev =>
+ *       prev.map(m => m.id === id ? { ...m, status } : m)
+ *     ),
  *   });
  */
 
@@ -17,6 +26,7 @@
 
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import type { Channel } from '@/types/channel';
+import type { User } from '@/types/user';
 import { getAccessToken } from '@/lib/api-client';
 
 export interface UseServerEventsOptions {
@@ -24,6 +34,12 @@ export interface UseServerEventsOptions {
   onChannelCreated: (channel: Channel) => void;
   onChannelUpdated: (channel: Channel) => void;
   onChannelDeleted: (channelId: string) => void;
+  /** Called when a member joins the server. Optional. */
+  onMemberJoined?: (user: User) => void;
+  /** Called with the userId when a member leaves or is kicked. Optional. */
+  onMemberLeft?: (userId: string) => void;
+  /** Called when a member's presence status changes (online/idle/offline). Optional. */
+  onMemberStatusChanged?: (data: { id: string; status: string }) => void;
   /** Set to false to disable the connection (e.g. for unauthenticated guests). Defaults to true. */
   enabled?: boolean;
 }
@@ -33,17 +49,26 @@ export function useServerEvents({
   onChannelCreated,
   onChannelUpdated,
   onChannelDeleted,
+  onMemberJoined,
+  onMemberLeft,
+  onMemberStatusChanged,
   enabled = true,
 }: UseServerEventsOptions): void {
   // Keep stable references to callbacks so the effect doesn't re-run on every render.
   const onCreatedRef = useRef(onChannelCreated);
   const onUpdatedRef = useRef(onChannelUpdated);
   const onDeletedRef = useRef(onChannelDeleted);
+  const onMemberJoinedRef = useRef(onMemberJoined);
+  const onMemberLeftRef = useRef(onMemberLeft);
+  const onMemberStatusChangedRef = useRef(onMemberStatusChanged);
 
   useLayoutEffect(() => {
     onCreatedRef.current = onChannelCreated;
     onUpdatedRef.current = onChannelUpdated;
     onDeletedRef.current = onChannelDeleted;
+    onMemberJoinedRef.current = onMemberJoined;
+    onMemberLeftRef.current = onMemberLeft;
+    onMemberStatusChangedRef.current = onMemberStatusChanged;
   });
 
   useEffect(() => {
@@ -83,9 +108,39 @@ export function useServerEvents({
       }
     };
 
+    const handleMemberJoined = (event: MessageEvent<string>) => {
+      try {
+        const user = JSON.parse(event.data) as User;
+        onMemberJoinedRef.current?.(user);
+      } catch {
+        // Ignore malformed payloads
+      }
+    };
+
+    const handleMemberLeft = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as { userId: string };
+        onMemberLeftRef.current?.(payload.userId);
+      } catch {
+        // Ignore malformed payloads
+      }
+    };
+
+    const handleMemberStatusChanged = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as { id: string; status: string };
+        onMemberStatusChangedRef.current?.(payload);
+      } catch {
+        // Ignore malformed payloads
+      }
+    };
+
     es.addEventListener('channel:created', handleCreated);
     es.addEventListener('channel:updated', handleUpdated);
     es.addEventListener('channel:deleted', handleDeleted);
+    es.addEventListener('member:joined', handleMemberJoined);
+    es.addEventListener('member:left', handleMemberLeft);
+    es.addEventListener('member:statusChanged', handleMemberStatusChanged);
 
     let everOpened = false;
 
@@ -103,6 +158,9 @@ export function useServerEvents({
       es.removeEventListener('channel:created', handleCreated);
       es.removeEventListener('channel:updated', handleUpdated);
       es.removeEventListener('channel:deleted', handleDeleted);
+      es.removeEventListener('member:joined', handleMemberJoined);
+      es.removeEventListener('member:left', handleMemberLeft);
+      es.removeEventListener('member:statusChanged', handleMemberStatusChanged);
       es.close();
     };
   }, [serverId, enabled]);

--- a/harmony-frontend/src/hooks/useServerEvents.ts
+++ b/harmony-frontend/src/hooks/useServerEvents.ts
@@ -27,7 +27,7 @@
 
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import type { Channel, ChannelVisibility } from '@/types/channel';
-import type { User } from '@/types/user';
+import type { User, UserStatus } from '@/types/user';
 import { getAccessToken } from '@/lib/api-client';
 
 export interface UseServerEventsOptions {
@@ -40,7 +40,7 @@ export interface UseServerEventsOptions {
   /** Called with the userId when a member leaves or is kicked. Optional. */
   onMemberLeft?: (userId: string) => void;
   /** Called when a member's presence status changes (online/idle/offline). Optional. */
-  onMemberStatusChanged?: (data: { id: string; status: string }) => void;
+  onMemberStatusChanged?: (data: { id: string; status: UserStatus }) => void;
   /**
    * Called when a channel's visibility changes. The updated channel object is
    * provided along with the previous visibility so callers can detect access
@@ -138,7 +138,7 @@ export function useServerEvents({
 
     const handleMemberStatusChanged = (event: MessageEvent<string>) => {
       try {
-        const payload = JSON.parse(event.data) as { id: string; status: string };
+        const payload = JSON.parse(event.data) as { id: string; status: UserStatus };
         onMemberStatusChangedRef.current?.(payload);
       } catch {
         // Ignore malformed payloads


### PR DESCRIPTION
## Summary

Closes #231

Implements real-time propagation of user status changes (ONLINE/IDLE/OFFLINE) to all connected server members via SSE.

### Changes

- **`eventTypes.ts`**: Added `USER_STATUS_CHANGED` channel constant and `UserStatusChangedPayload` interface `{ userId, serverId, status }`
- **`user.service.ts`**: After a status update, queries all servers the user belongs to and publishes one `USER_STATUS_CHANGED` event per server
- **`events.router.ts`**: Added `USER_STATUS_CHANGED` subscriber on the `/server/:serverId` SSE route; emits `member:statusChanged` with `{ id, status }` — no extra DB lookup needed since the payload is self-contained
- **`useServerEvents.ts`**: Extended with `onMemberJoined`, `onMemberLeft`, and `onMemberStatusChanged` callbacks (the first two were also missing from main since PR #202 hasn't merged yet)
- **`HarmonyShell.tsx`**: Added `localMembers` state with proper prop-reset tracking; wired all three member event handlers to `useServerEvents`
- **`events.router.status.test.ts`**: Backend integration tests for the new SSE handler
- **`useServerEvents.test.tsx`**: Frontend hook tests covering all event types including the new status change callback

### Notes

- Status is emitted regardless of `publicProfile` (presence reflects availability, not identity — consistent with the rationale documented in PR #202)
- The backend `events.router` tests were already failing on main before this PR due to an unrelated Prisma schema issue (`parentMessageId`/`replyCount` missing from schema in PR #220). My new test file has the same pre-existing failure; this PR does not introduce new test failures.
- Frontend tests: all 40 pass

## Test plan

- [ ] Status change published when user status updates via `userService.updateUser`
- [ ] `USER_STATUS_CHANGED` events published per server (one per server the user is a member of)
- [ ] SSE `member:statusChanged` event delivered to connected server members
- [ ] Members sidebar updates status in real time without reload
- [ ] Private-profile user status still propagated (no identity data exposed)
- [ ] Backend: `events.router.status.test.ts` — 3 tests covering subscription, delivery, server filtering, and no-DB-lookup assertion
- [ ] Frontend: `useServerEvents.test.tsx` — tests for connection, channel events, member events, and status change events

🤖 Generated with [Claude Code](https://claude.com/claude-code)