### PR TITLE
feat: make alice_admin loginable in mock seed

### DIFF
--- a/harmony-backend/src/dev/mockSeed.ts
+++ b/harmony-backend/src/dev/mockSeed.ts
@@ -75,6 +75,10 @@ const VALID_CHANNEL_TYPES = new Set<string>(Object.values(ChannelType));
 const VALID_CHANNEL_VISIBILITIES = new Set<string>(Object.values(ChannelVisibility));
 const MOCK_SEED_NAMESPACE = 'harmony:mock-seed';
 
+// user-001 (alice_admin) is the only loginable mock account — keep in sync with
+// the assertion in mock-seed.test.ts that looks up this user by username.
+const ALICE_ADMIN_HASH = '$2b$12$kypwUxiUZqWl6OO4n/jHxOY8pqzxJ9rcgOU7mUSLsTfDcKdArtwY.';
+
 export function legacyIdToUuid(legacyId: string): string {
   const hash = createHash('sha1').update(`${MOCK_SEED_NAMESPACE}:${legacyId}`).digest();
   const bytes = Buffer.from(hash.subarray(0, 16));
@@ -146,10 +150,8 @@ export function buildMockSeedData(raw: RawSnapshot = snapshot): BuiltMockSeedDat
       .map((channel) => channel.serverId),
   );
 
-  // alice_admin (user-001) gets a real password hash so the account is loginable.
+  // user-001 is alice_admin — the only loginable mock account (see ALICE_ADMIN_HASH above).
   // All other mock users keep '!' (invalid hash — login intentionally disabled).
-  const ALICE_ADMIN_HASH = '$2b$12$kypwUxiUZqWl6OO4n/jHxOY8pqzxJ9rcgOU7mUSLsTfDcKdArtwY.';
-
   const users = raw.users.map<Prisma.UserCreateManyInput>((user, index) => ({
     id: userIds.get(user.id)!,
     username: user.username,

--- a/harmony-backend/tests/mock-seed.test.ts
+++ b/harmony-backend/tests/mock-seed.test.ts
@@ -56,8 +56,9 @@ describe('buildMockSeedData', () => {
     expect(data.users.every((user) => user.email === `${user.username}@mock.harmony.test`)).toBe(
       true,
     );
-    // alice_admin (user-001) has a real bcrypt hash so the account is loginable in dev/demo.
-    // All other mock users keep '!' (login intentionally disabled).
+    // alice_admin is user-001 in mock-seed-data.json — the only loginable mock account.
+    // Identified by username here because mapped users don't carry the raw JSON id.
+    // Keep in sync with the ALICE_ADMIN_HASH constant in mockSeed.ts.
     const alice = data.users.find((u) => u.username === 'alice_admin');
     const others = data.users.filter((u) => u.username !== 'alice_admin');
     expect(alice?.passwordHash).toMatch(/^\$2[ab]\$\d+\$/);


### PR DESCRIPTION
## Summary

- Assigns a real bcrypt hash to `alice_admin` (`user-001`) so the Harmony HQ server owner account is usable in local dev and demo environments
- All other mock users retain `'!'` (intentionally unloggable — no change)
- Adds `passwordHash` to the user upsert `update` block so re-running `npm run db:seed:mock` correctly refreshes the hash on existing rows

**Credentials (dev/demo only):**
| Field | Value |
|---|---|
| Email | `alice_admin@mock.harmony.test` |
| Password | `HarmonyAdmin123!` |
| Role | `OWNER` of Harmony HQ |

## Test plan

- [ ] Run `npm run db:seed:mock` on a fresh DB — verify alice_admin can log in
- [ ] Run `npm run db:seed:mock` a second time (reconcile path) — verify login still works
- [ ] Verify other mock users (e.g. `bob_dev`) cannot log in (invalid credentials expected)
- [ ] Run existing backend test suite: `npm test`