### PR TITLE
fix: gate pin button behind MODERATOR+ role and show descriptive 403 error

### DIFF
--- a/harmony-frontend/src/__tests__/MessageItem.test.tsx
+++ b/harmony-frontend/src/__tests__/MessageItem.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MessageItem } from '@/components/message/MessageItem';
+import type { Message } from '@/types';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & { alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...props} />
+  ),
+}));
+
+jest.mock('@/lib/utils', () => ({
+  formatMessageTimestamp: () => 'Today at 12:00 PM',
+  formatTimeOnly: () => '12:00 PM',
+}));
+
+jest.mock('@/app/actions/pinMessage', () => ({
+  pinMessageAction: jest.fn(),
+  unpinMessageAction: jest.fn(),
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const baseMessage: Message = {
+  id: 'msg-1',
+  channelId: 'ch-1',
+  authorId: 'user-1',
+  author: {
+    id: 'user-1',
+    username: 'testuser',
+    displayName: 'Test User',
+  },
+  content: 'Hello world',
+  timestamp: '2024-01-01T12:00:00Z',
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('MessageItem — pin button', () => {
+  /**
+   * Test 1: Non-admin users must not see the "More actions" button that
+   * exposes Pin/Unpin. After fixing HarmonyShell to derive canPin from the
+   * member's server-scoped role (MODERATOR+) rather than isAuthenticated,
+   * non-admin users receive canPin={false} and the button must be absent.
+   */
+  it('does not render the pin button for a user without admin permission', () => {
+    render(<MessageItem message={baseMessage} canPin={false} serverId='server-1' />);
+
+    expect(screen.queryByRole('button', { name: /more actions/i })).not.toBeInTheDocument();
+  });
+
+  /**
+   * Test 2: When the backend rejects a pin request with HTTP 403, the UI must
+   * display a descriptive error popup so the user understands they lack
+   * the required permission.
+   */
+  it('shows a descriptive 403 error popup when the pin action is forbidden', async () => {
+    const { pinMessageAction } = jest.requireMock<typeof import('@/app/actions/pinMessage')>(
+      '@/app/actions/pinMessage',
+    );
+
+    // Simulate the server returning 403 Forbidden.
+    const forbiddenError = Object.assign(new Error('Forbidden'), { status: 403 });
+    (pinMessageAction as jest.Mock).mockRejectedValueOnce(forbiddenError);
+
+    render(<MessageItem message={baseMessage} canPin={true} serverId='server-1' />);
+
+    // Open the "More actions" dropdown.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+
+    // Click "Pin Message" inside the dropdown.
+    fireEvent.click(screen.getByRole('button', { name: /pin message/i }));
+
+    // The error popup must describe the permission failure — not just "Failed".
+    await waitFor(() => {
+      expect(screen.getByText(/you don't have permission to pin messages/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -182,11 +182,16 @@ export function HarmonyShell({
 
   const { notifyServerCreated, notifyServerJoined } = useServerListSync();
 
-  // Show the pin UI to all authenticated members — the backend enforces message:pin
-  // permission (MODERATOR+) and will reject unauthorized calls with 403.
-  // Client-side role filtering is unreliable here because localMembers carries the
-  // global platform role, not the server-scoped membership role.
-  const canPin = isAuthenticated;
+  // Show the pin UI only to members with MODERATOR+ server-scoped role.
+  // checkIsAdmin covers system admins and the server owner by userId.
+  // localMembers carries server-scoped roles, so memberRecord?.role is reliable.
+  const currentMemberRecord = localMembers.find(m => m.id === authUser?.id);
+  const canPin =
+    isAuthenticated &&
+    (checkIsAdmin(currentServer.ownerId) ||
+      currentMemberRecord?.role === 'owner' ||
+      currentMemberRecord?.role === 'admin' ||
+      currentMemberRecord?.role === 'moderator');
 
   const handleServerCreated = useCallback(
     (server: Server, defaultChannel: Channel) => {

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -42,7 +42,14 @@ function ReactionList({ reactions, messageId }: { reactions: Reaction[]; message
 
 function PinMenuIcon() {
   return (
-    <svg className='h-3.5 w-3.5 flex-shrink-0' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth={2} aria-hidden='true'>
+    <svg
+      className='h-3.5 w-3.5 flex-shrink-0'
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth={2}
+      aria-hidden='true'
+    >
       <path d='M12 17v5' />
       <path d='M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z' />
     </svg>
@@ -52,6 +59,10 @@ function PinMenuIcon() {
 // ─── Hover action bar ─────────────────────────────────────────────────────────
 
 type PinState = 'idle' | 'loading' | 'success' | 'error';
+
+const PIN_ERROR_MESSAGES: Record<number, string> = {
+  403: "You don't have permission to pin messages",
+};
 
 /**
  * Hover/focus-within action bar for a message.
@@ -73,6 +84,7 @@ function ActionBar({
   const [isMoreOpen, setIsMoreOpen] = useState(false);
   const [isPinned, setIsPinned] = useState(initialPinned ?? false);
   const [pinState, setPinState] = useState<PinState>('idle');
+  const [pinErrorMessage, setPinErrorMessage] = useState<string>('Failed');
   const moreRef = useRef<HTMLDivElement>(null);
 
   // Close dropdown on outside click
@@ -100,7 +112,9 @@ function ActionBar({
       setIsPinned(prev => !prev);
       setPinState('success');
       setTimeout(() => setPinState('idle'), 2000);
-    } catch {
+    } catch (err: unknown) {
+      const status = (err as { status?: number }).status;
+      setPinErrorMessage(PIN_ERROR_MESSAGES[status ?? 0] ?? 'Failed to pin message');
       setPinState('error');
       setTimeout(() => setPinState('idle'), 3000);
     }
@@ -112,9 +126,7 @@ function ActionBar({
       {pinState === 'success' && (
         <span className='px-2 text-xs text-green-400'>{isPinned ? '📌 Pinned' : 'Unpinned'}</span>
       )}
-      {pinState === 'error' && (
-        <span className='px-2 text-xs text-red-400'>Failed</span>
-      )}
+      {pinState === 'error' && <span className='px-2 text-xs text-red-400'>{pinErrorMessage}</span>}
 
       {/* Reply (stub) */}
       <button
@@ -123,7 +135,13 @@ function ActionBar({
         title='Reply'
         className='flex h-8 w-8 items-center justify-center text-gray-400 hover:text-white hover:bg-white/10 rounded-md transition-colors'
       >
-        <svg className='h-4 w-4' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true' focusable='false'>
+        <svg
+          className='h-4 w-4'
+          viewBox='0 0 24 24'
+          fill='currentColor'
+          aria-hidden='true'
+          focusable='false'
+        >
           <path d='M10 9V5l-7 7 7 7v-4.1c5 0 8.5 1.6 11 5.1-1-5-4-10-11-11z' />
         </svg>
       </button>
@@ -135,7 +153,13 @@ function ActionBar({
         title='Add Reaction'
         className='flex h-8 w-8 items-center justify-center text-gray-400 hover:text-white hover:bg-white/10 rounded-md transition-colors'
       >
-        <svg className='h-4 w-4' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true' focusable='false'>
+        <svg
+          className='h-4 w-4'
+          viewBox='0 0 24 24'
+          fill='currentColor'
+          aria-hidden='true'
+          focusable='false'
+        >
           <path d='M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm0 22C6.486 22 2 17.514 2 12S6.486 2 12 2s10 4.486 10 10-4.486 10-10 10zm-3.5-9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm7 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm1.476 2.37a.75.75 0 0 0-1.06-1.06 4.5 4.5 0 0 1-6.832 0 .75.75 0 0 0-1.061 1.06 6 6 0 0 0 8.953 0z' />
         </svg>
       </button>
@@ -151,7 +175,13 @@ function ActionBar({
             onClick={() => setIsMoreOpen(v => !v)}
             className='flex h-8 w-8 items-center justify-center text-gray-400 hover:text-white hover:bg-white/10 rounded-md transition-colors'
           >
-            <svg className='h-4 w-4' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true' focusable='false'>
+            <svg
+              className='h-4 w-4'
+              viewBox='0 0 24 24'
+              fill='currentColor'
+              aria-hidden='true'
+              focusable='false'
+            >
               <path d='M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z' />
             </svg>
           </button>


### PR DESCRIPTION
## Summary

- **`HarmonyShell.tsx`**: `canPin` was derived from `isAuthenticated`, showing the pin button to every logged-in user regardless of role. It now checks the user's server-scoped member record for `owner`, `admin`, or `moderator` — consistent with how other role checks already work in the file.
- **`MessageItem.tsx`**: The error handler now reads the thrown error's `status` field and maps known HTTP codes to human-readable messages. A 403 now shows `"You don't have permission to pin messages"` instead of the generic `"Failed"`.
- **`MessageItem.test.tsx`**: Two new Jest tests covering the fixed behavior — non-admins don't see the pin button, and a 403 rejection surfaces a descriptive error popup.

## Test plan

- [ ] Run `npm test` in `harmony-frontend/` — both `MessageItem` tests should pass
- [ ] Log in as a regular member (non-moderator) and verify the More actions button is absent on messages
- [ ] Log in as a moderator/admin and verify the More actions button and Pin/Unpin option are present
- [ ] (Optional) Force a 403 from the backend and confirm the error popup reads "You don't have permission to pin messages"