### PR TITLE
[codex] improve frontend MC/DC test coverage

### DIFF
--- a/harmony-frontend/src/__tests__/middleware.test.ts
+++ b/harmony-frontend/src/__tests__/middleware.test.ts
@@ -1,0 +1,134 @@
+jest.mock('next/server', () => {
+  const createResponse = (status: number, location?: string) => {
+    const headerMap = new Map<string, string>();
+
+    if (status === 200) {
+      headerMap.set('x-middleware-next', '1');
+    }
+
+    if (location) {
+      headerMap.set('location', location);
+    }
+
+    return {
+      status,
+      headers: {
+        get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
+      },
+      cookies: {
+        delete: (name: string) => {
+          headerMap.set('set-cookie', `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT`);
+        },
+      },
+    };
+  };
+
+  return {
+    NextResponse: {
+      next: () => createResponse(200),
+      redirect: (url: URL) => createResponse(307, url.toString()),
+    },
+  };
+});
+
+import { AUTH_COOKIE_NAME } from '../lib/auth-constants';
+import { config, middleware } from '../middleware';
+
+function buildRequest(pathname: string, cookieValue?: string) {
+  return {
+    nextUrl: { pathname },
+    url: `http://localhost${pathname}`,
+    cookies: {
+      get: jest.fn((name: string) => {
+        if (name !== AUTH_COOKIE_NAME || cookieValue === undefined) return undefined;
+        return { name, value: cookieValue };
+      }),
+    },
+  } as never;
+}
+
+function encodePayload(value: unknown) {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function createJwt(payload: unknown) {
+  return `header.${encodePayload(payload)}.signature`;
+}
+
+describe('middleware', () => {
+  it('exports the protected route matcher configuration', () => {
+    expect(config.matcher).toEqual(['/channels/:path*', '/settings/:path*']);
+  });
+
+  it('passes through unprotected routes', () => {
+    const response = middleware(buildRequest('/public'));
+
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+    expect(response.headers.get('location')).toBeNull();
+  });
+
+  it('redirects the exact channels route when no auth cookie is present', () => {
+    const response = middleware(buildRequest('/channels'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost/auth/login?returnUrl=%2Fchannels',
+    );
+  });
+
+  it('redirects the exact settings route when no auth cookie is present', () => {
+    const response = middleware(buildRequest('/settings'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost/auth/login?returnUrl=%2Fsettings',
+    );
+  });
+
+  it('allows protected channel routes with a plain base64url session cookie', () => {
+    const response = middleware(
+      buildRequest('/channels/general', encodePayload({ sub: 'user-1', username: 'alice' })),
+    );
+
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+  });
+
+  it('allows protected settings routes with a JWT-style session cookie', () => {
+    const response = middleware(buildRequest('/settings/profile', createJwt({ sub: 'user-1' })));
+
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+  });
+
+  it('redirects and clears cookies when the decoded payload is a non-object value', () => {
+    const response = middleware(buildRequest('/channels/general', encodePayload('bad-session')));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost/auth/login?returnUrl=%2Fchannels%2Fgeneral',
+    );
+    expect(response.headers.get('set-cookie')).toContain(`${AUTH_COOKIE_NAME}=;`);
+  });
+
+  it('redirects and clears cookies when the decoded payload is null', () => {
+    const response = middleware(buildRequest('/channels/general', encodePayload(null)));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('set-cookie')).toContain(`${AUTH_COOKIE_NAME}=;`);
+  });
+
+  it('redirects and clears cookies when the decoded payload is missing sub', () => {
+    const response = middleware(
+      buildRequest('/channels/general', encodePayload({ username: 'alice' })),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('set-cookie')).toContain(`${AUTH_COOKIE_NAME}=;`);
+  });
+
+  it('redirects and clears cookies when the payload cannot be decoded as JSON', () => {
+    const response = middleware(buildRequest('/channels/general', 'not-base64'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('set-cookie')).toContain(`${AUTH_COOKIE_NAME}=;`);
+  });
+});

--- a/harmony-frontend/src/__tests__/trpc-client.test.ts
+++ b/harmony-frontend/src/__tests__/trpc-client.test.ts
@@ -1,0 +1,217 @@
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+import { cookies } from 'next/headers';
+import { publicGet, TrpcHttpError, trpcMutate, trpcQuery } from '../lib/trpc-client';
+
+const mockedCookies = jest.mocked(cookies);
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+function createJsonResponse(body: unknown, status: number) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+function createTextResponse(body: string, status: number) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockRejectedValue(new Error('json() not expected')),
+    text: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe('trpc-client', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockFetch;
+  });
+
+  describe('publicGet', () => {
+    it('returns parsed JSON for successful public API responses', async () => {
+      mockFetch.mockResolvedValue(createJsonResponse({ id: 'server-1' }, 200));
+
+      await expect(publicGet<{ id: string }>('/servers/server-1')).resolves.toEqual({
+        id: 'server-1',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:4000/api/public/servers/server-1',
+        expect.objectContaining({
+          next: { revalidate: 60 },
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+
+    it('returns null for 404 public API responses', async () => {
+      mockFetch.mockResolvedValue(createTextResponse('', 404));
+
+      await expect(publicGet('/servers/missing')).resolves.toBeNull();
+    });
+
+    it('throws for non-404 public API failures', async () => {
+      mockFetch.mockResolvedValue(createTextResponse('', 500));
+
+      await expect(publicGet('/servers/failing')).rejects.toThrow('Public API error: 500');
+    });
+  });
+
+  describe('trpcQuery', () => {
+    it('serializes input and attaches the auth token when available', async () => {
+      mockedCookies.mockResolvedValue({
+        get: jest.fn(() => ({ name: 'auth_token', value: 'secret-token' })),
+      } as never);
+      mockFetch.mockResolvedValue(createJsonResponse({ result: { data: { ok: true } } }, 200));
+
+      await expect(
+        trpcQuery<{ ok: boolean }>('channel.getChannels', { serverId: 'server-1' }),
+      ).resolves.toEqual({ ok: true });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:4000/trpc/channel.getChannels?input=%7B%22serverId%22%3A%22server-1%22%7D',
+        expect.objectContaining({
+          cache: 'no-store',
+          headers: { Authorization: 'Bearer secret-token' },
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+
+    it('omits input and authorization when no auth token is available', async () => {
+      mockedCookies.mockResolvedValue({
+        get: jest.fn(() => undefined),
+      } as never);
+      mockFetch.mockResolvedValue(createJsonResponse({ result: { data: ['a', 'b'] } }, 200));
+
+      await expect(trpcQuery<string[]>('channel.list')).resolves.toEqual(['a', 'b']);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:4000/trpc/channel.list',
+        expect.objectContaining({
+          cache: 'no-store',
+          headers: {},
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+
+    it('continues without authorization when cookies() throws outside request context', async () => {
+      mockedCookies.mockRejectedValue(new Error('No request context'));
+      mockFetch.mockResolvedValue(createJsonResponse({ result: { data: { ok: true } } }, 200));
+
+      await expect(trpcQuery<{ ok: boolean }>('channel.health')).resolves.toEqual({ ok: true });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:4000/trpc/channel.health',
+        expect.objectContaining({ headers: {} }),
+      );
+    });
+
+    it('throws a typed HTTP error for non-ok tRPC responses', async () => {
+      mockedCookies.mockResolvedValue({
+        get: jest.fn(() => undefined),
+      } as never);
+      mockFetch.mockResolvedValue(createTextResponse('Forbidden', 403));
+
+      await expect(trpcQuery('channel.getChannels')).rejects.toEqual(
+        expect.objectContaining<Partial<TrpcHttpError>>({
+          name: 'TrpcHttpError',
+          procedure: 'channel.getChannels',
+          status: 403,
+        }),
+      );
+    });
+
+    it('throws when the tRPC query response is missing result.data', async () => {
+      mockedCookies.mockResolvedValue({
+        get: jest.fn(() => undefined),
+      } as never);
+      mockFetch.mockResolvedValue(createJsonResponse({ result: {} }, 200));
+
+      await expect(trpcQuery('channel.getChannels')).rejects.toThrow(
+        'tRPC query [channel.getChannels]: response missing result.data',
+      );
+    });
+  });
+
+  describe('trpcMutate', () => {
+    it('posts JSON input and attaches the auth token when available', async () => {
+      mockedCookies.mockResolvedValue({
+        get: jest.fn(() => ({ name: 'auth_token', value: 'secret-token' })),
+      } as never);
+      mockFetch.mockResolvedValue(
+        createJsonResponse({ result: { data: { id: 'channel-1' } } }, 200),
+      );
+
+      await expect(
+        trpcMutate<{ id: string }>('channel.createChannel', {
+          serverId: 'server-1',
+          name: 'general',
+        }),
+      ).resolves.toEqual({ id: 'channel-1' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:4000/trpc/channel.createChannel',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer secret-token',
+          },
+          body: JSON.stringify({ serverId: 'server-1', name: 'general' }),
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+
+    it('sends an empty JSON object when mutation input is undefined', async () => {
+      mockedCookies.mockResolvedValue({
+        get: jest.fn(() => undefined),
+      } as never);
+      mockFetch.mockResolvedValue(createJsonResponse({ result: { data: { ok: true } } }, 200));
+
+      await expect(trpcMutate<{ ok: boolean }>('channel.touch')).resolves.toEqual({ ok: true });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:4000/trpc/channel.touch',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        }),
+      );
+    });
+
+    it('throws a typed HTTP error for non-ok mutation responses', async () => {
+      mockedCookies.mockResolvedValue({
+        get: jest.fn(() => undefined),
+      } as never);
+      mockFetch.mockResolvedValue(createTextResponse('Bad Request', 400));
+
+      await expect(trpcMutate('channel.createChannel')).rejects.toEqual(
+        expect.objectContaining<Partial<TrpcHttpError>>({
+          name: 'TrpcHttpError',
+          procedure: 'channel.createChannel',
+          status: 400,
+        }),
+      );
+    });
+
+    it('throws when the mutation response is missing result.data', async () => {
+      mockedCookies.mockResolvedValue({
+        get: jest.fn(() => undefined),
+      } as never);
+      mockFetch.mockResolvedValue(createJsonResponse({ result: {} }, 200));
+
+      await expect(trpcMutate('channel.createChannel')).rejects.toThrow(
+        'tRPC mutation [channel.createChannel]: response missing result.data',
+      );
+    });
+  });
+});

--- a/harmony-frontend/src/__tests__/utils.test.ts
+++ b/harmony-frontend/src/__tests__/utils.test.ts
@@ -1,0 +1,180 @@
+import type { AxiosError } from 'axios';
+import {
+  cn,
+  formatDate,
+  formatMessageTimestamp,
+  formatRelativeTime,
+  formatTimeOnly,
+  getChannelUrl,
+  getUserErrorMessage,
+  truncate,
+} from '../lib/utils';
+
+describe('utils', () => {
+  describe('cn', () => {
+    it('merges conditional and conflicting Tailwind classes', () => {
+      expect(cn('px-2 py-1', false && 'hidden', 'px-4')).toBe('py-1 px-4');
+    });
+  });
+
+  describe('formatDate', () => {
+    it('formats string and Date inputs consistently', () => {
+      const date = new Date(2026, 2, 30, 12, 0, 0);
+
+      expect(formatDate(date)).toBe('March 30, 2026');
+      expect(formatDate(date.toISOString())).toBe('March 30, 2026');
+    });
+  });
+
+  describe('formatRelativeTime', () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date(2026, 2, 30, 12, 0, 0));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('returns just now for timestamps under one minute old', () => {
+      expect(formatRelativeTime(new Date(2026, 2, 30, 11, 59, 30))).toBe('just now');
+    });
+
+    it('returns minutes for timestamps under one hour old', () => {
+      expect(formatRelativeTime(new Date(2026, 2, 30, 11, 15, 0))).toBe('45m ago');
+    });
+
+    it('returns hours for timestamps under one day old', () => {
+      expect(formatRelativeTime(new Date(2026, 2, 30, 9, 0, 0))).toBe('3h ago');
+    });
+
+    it('returns days for timestamps under one week old', () => {
+      expect(formatRelativeTime(new Date(2026, 2, 27, 12, 0, 0))).toBe('3d ago');
+    });
+
+    it('falls back to a formatted date for older timestamps', () => {
+      expect(formatRelativeTime(new Date(2026, 2, 20, 12, 0, 0))).toBe('March 20, 2026');
+    });
+  });
+
+  describe('formatMessageTimestamp', () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date(2026, 2, 30, 12, 0, 0));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('returns an empty string for invalid dates', () => {
+      expect(formatMessageTimestamp('not-a-date')).toBe('');
+    });
+
+    it('formats same-day timestamps as Today', () => {
+      expect(formatMessageTimestamp(new Date(2026, 2, 30, 9, 5, 0))).toMatch(/^Today at /);
+    });
+
+    it('formats previous-day timestamps as Yesterday', () => {
+      expect(formatMessageTimestamp(new Date(2026, 2, 29, 9, 5, 0))).toMatch(/^Yesterday at /);
+    });
+
+    it('formats older timestamps as a date', () => {
+      expect(formatMessageTimestamp(new Date(2026, 2, 20, 9, 5, 0))).toBe('3/20/2026');
+    });
+  });
+
+  describe('formatTimeOnly', () => {
+    it('returns an empty string for invalid dates', () => {
+      expect(formatTimeOnly('not-a-date')).toBe('');
+    });
+
+    it('formats valid timestamps as time-only output', () => {
+      expect(formatTimeOnly(new Date(2026, 2, 30, 15, 42, 0))).toBe('3:42 PM');
+    });
+  });
+
+  describe('getUserErrorMessage', () => {
+    it('joins validation detail messages from Axios errors', () => {
+      const err = {
+        isAxiosError: true,
+        response: {
+          data: {
+            details: [{ message: 'Name is required' }, { message: 'Topic is too long' }],
+          },
+        },
+      } as AxiosError;
+
+      expect(getUserErrorMessage(err)).toBe('Name is required. Topic is too long');
+    });
+
+    it('returns string API errors when they are not generic validation failures', () => {
+      const err = {
+        isAxiosError: true,
+        response: { data: { error: 'Forbidden' } },
+      } as AxiosError;
+
+      expect(getUserErrorMessage(err)).toBe('Forbidden');
+    });
+
+    it('prefers nested API error messages for structured errors', () => {
+      const err = {
+        isAxiosError: true,
+        response: { data: { error: { message: 'Nested problem' } } },
+      } as AxiosError;
+
+      expect(getUserErrorMessage(err)).toBe('Nested problem');
+    });
+
+    it('falls back to response.message when error is the generic validation marker', () => {
+      const err = {
+        isAxiosError: true,
+        response: { data: { error: 'Validation failed', message: 'Email is invalid' } },
+      } as AxiosError;
+
+      expect(getUserErrorMessage(err)).toBe('Email is invalid');
+    });
+
+    it('returns the provided fallback for generic HTTP status errors', () => {
+      expect(
+        getUserErrorMessage(new Error('Request failed with status code 403'), 'Try again'),
+      ).toBe('Try again');
+    });
+
+    it('returns ordinary Error messages directly', () => {
+      expect(getUserErrorMessage(new Error('Channel not found'))).toBe('Channel not found');
+    });
+
+    it('returns the fallback for unknown error shapes', () => {
+      expect(getUserErrorMessage({ nope: true }, 'Fallback message')).toBe('Fallback message');
+    });
+  });
+
+  describe('truncate', () => {
+    it('returns the original text when it already fits', () => {
+      expect(truncate('hello', 5)).toBe('hello');
+    });
+
+    it('adds an ellipsis when the text exceeds the limit', () => {
+      expect(truncate('hello world', 5)).toBe('hello...');
+    });
+  });
+
+  describe('getChannelUrl', () => {
+    const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
+    afterEach(() => {
+      process.env.NEXT_PUBLIC_BASE_URL = originalBaseUrl;
+    });
+
+    it('uses the configured base URL when present', () => {
+      process.env.NEXT_PUBLIC_BASE_URL = 'https://harmony.example';
+
+      expect(getChannelUrl('server', 'general')).toBe('https://harmony.example/c/server/general');
+    });
+
+    it('falls back to localhost when no base URL is configured', () => {
+      delete process.env.NEXT_PUBLIC_BASE_URL;
+
+      expect(getChannelUrl('server', 'general')).toBe('http://localhost:3000/c/server/general');
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- added focused tests for `middleware.ts` route protection and cookie validation decisions
- added tests for `trpc-client.ts` covering auth token handling, input serialization, HTTP failure paths, and missing `result.data`
- added tests for `utils.ts` covering date formatting boundaries, fallback paths, and error-message selection precedence

## Why
The frontend test suite had weak branch coverage in decision-heavy utility code. These tests were added to improve confidence in the independent conditions that drive redirects, fallback behavior, and API error handling.

## Impact
- raises frontend coverage substantially, especially branch coverage
- gives better regression protection for route auth behavior and server-side tRPC client behavior
- improves confidence in utility fallback logic that feeds user-visible messages and timestamps

## Validation
- `npm test -- --coverage --coverageReporters=json-summary --runInBand`
  - frontend coverage moved from 73.10% lines / 45.71% branches to 85.22% lines / 72.03% branches
- `npx prettier --write src/__tests__/utils.test.ts src/__tests__/middleware.test.ts src/__tests__/trpc-client.test.ts`
- `npx tsc --noEmit`
  - still fails because of pre-existing errors in `src/__tests__/issue-242-join-server-fix.test.ts` at lines 218, 220, and 228