### PR TITLE
docs(tests): test specification for server.service.ts

### DIFF
--- a/docs/test-specs/server-service-spec.md
+++ b/docs/test-specs/server-service-spec.md
@@ -97,9 +97,11 @@ Program paths:
 
 - Server is created successfully; a default channel is created; the creator is added as owner; the new server is returned.
 - Name that produces an empty slug (e.g. all special characters) throws `TRPCError` with code `BAD_REQUEST` from `generateUniqueSlug`.
-- Slug collision is resolved automatically by appending a numeric suffix and retrying, up to 10 attempts; if all 10 slugs collide, throws `TRPCError` with code `CONFLICT`.
-- A transient Prisma `P2002` unique-violation on `server.create` triggers `withSlugRetry` to regenerate the slug and retry up to 3 times before throwing `CONFLICT`.
-- An unexpected non-`P2002` Prisma error from `server.create` is rethrown as-is.
+- Slug collision is resolved automatically by appending a numeric suffix and retrying; `generateUniqueSlug` probes 10 total candidates (`base`, `base-1` through `base-9`); if all 10 are already taken, throws `TRPCError` with code `CONFLICT`.
+- A transient Prisma `P2002` unique-violation on `server.create` triggers `withSlugRetry` to regenerate the slug and retry; `withSlugRetry` makes up to 3 total attempts (attempts 0, 1, 2) and retries only while `attempt < maxRetries - 1` (i.e. attempts 0 and 1); if a P2002 occurs on the final attempt (attempt 2), the raw Prisma error is rethrown directly — it is not mapped to `TRPCError`.
+- An unexpected non-`P2002` Prisma error from `server.create` is rethrown as-is on the first attempt, without any retry.
+- `channelService.createDefaultChannel` is called after the server is created; if it rejects, `createServer` rejects with the same error.
+- `serverMemberService.addOwner` is called after the default channel is created; if it rejects, `createServer` rejects with the same error.
 
 ### 3.7 `updateServer`
 
@@ -112,7 +114,8 @@ Program paths:
 - Actor is the owner: update succeeds without renaming.
 - Actor is the owner: update with a new name regenerates the slug and persists both changes.
 - Actor is not the owner but is a system admin: update succeeds.
-- Name change that exhausts all slug attempts throws `TRPCError` with code `CONFLICT`.
+- Name change where all 10 `generateUniqueSlug` candidates are already occupied throws `TRPCError` with code `CONFLICT`.
+- Name change where `withSlugRetry` exhausts all 3 attempts with consecutive P2002 violations rethrows the raw Prisma error on the final attempt (not mapped to `TRPCError`).
 - `SERVER_UPDATED` event is published after any successful update.
 - Return value is the updated server record.
 
@@ -226,9 +229,12 @@ Description: creates a server, seeds a default channel, and registers the creato
 | Create server with all optional fields provided                | Valid `name`, `description`, `iconUrl`, `isPublic = true`, `ownerId`                                  | Returns created server; `channelService.createDefaultChannel` called with new server id; `serverMemberService.addOwner` called with `ownerId` and server id    |
 | Create server with only required fields                        | Valid `name` and `ownerId`; no optional fields                                                        | Returns created server; default channel and owner membership are created                                                                                      |
 | Throw BAD_REQUEST when name produces empty slug                | `name` composed entirely of special characters (e.g. `"!!!"`)                                         | Throws `TRPCError` with code `BAD_REQUEST` and message `Cannot generate slug from name`                                                                       |
-| Throw CONFLICT when all slug attempts are taken                | Valid `name`; `prisma.server.count` mocked to always return `1` for the base slug and all 10 suffixes | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`                                                                        |
-| Retry on transient P2002 during server create                  | Valid `name`; `prisma.server.create` throws `P2002` on first attempt then succeeds on second         | Returns successfully created server; retried without further error                                                                                            |
-| Throw on non-P2002 Prisma error during server create           | Valid `name`; `prisma.server.create` throws a non-`P2002` Prisma error                               | Throws the original Prisma error unchanged                                                                                                                    |
+| Throw CONFLICT when all generateUniqueSlug candidates are taken | Valid `name`; `prisma.server.count` mocked to return non-zero for all 10 candidates (`base` through `base-9`) | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`                                                                 |
+| Retry on transient P2002 during server create (attempt 0)      | Valid `name`; `prisma.server.create` throws `P2002` on first attempt (attempt 0) then succeeds on second (attempt 1) | Returns successfully created server; `withSlugRetry` retried once without further error                                                         |
+| Rethrow raw P2002 when withSlugRetry exhausts all 3 attempts   | Valid `name`; `prisma.server.create` throws `P2002` on all 3 attempts (attempts 0, 1, 2)            | Throws the original `PrismaClientKnownRequestError` with code `P2002`; does NOT throw `TRPCError`                                                             |
+| Throw on non-P2002 Prisma error during server create           | Valid `name`; `prisma.server.create` throws a non-`P2002` Prisma error on attempt 0                  | Throws the original Prisma error unchanged; no retry is attempted                                                                                             |
+| Propagate createDefaultChannel failure                         | Server created successfully; `channelService.createDefaultChannel` mocked to reject with an error    | `createServer` rejects with the same error; the rejection is not swallowed                                                                                    |
+| Propagate addOwner failure                                     | Server and default channel created successfully; `serverMemberService.addOwner` mocked to reject     | `createServer` rejects with the same error; the rejection is not swallowed                                                                                    |
 
 ### 4.7 `updateServer`
 
@@ -243,7 +249,8 @@ Description: updates server metadata, handles name changes with slug regeneratio
 | Skip slug regeneration when name is unchanged                | Existing server; `actorId === server.ownerId`; `data.name === server.name`                     | Update is applied with the existing slug; `generateUniqueSlug` is not called; `SERVER_UPDATED` event is published                            |
 | Allow system admin to update a server they do not own        | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `true`         | Returns updated server; `SERVER_UPDATED` event is published                                                                                  |
 | Publish SERVER_UPDATED event after successful update         | Any successful update scenario                                                                  | `eventBus.publish` is called with `EventChannels.SERVER_UPDATED` and a payload containing `serverId`, `name`, `iconUrl`, `description`, and `timestamp` |
-| Throw CONFLICT when all slug attempts are taken on rename    | Valid `actorId`; name change; all slug candidates mocked as occupied                           | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`                                                       |
+| Throw CONFLICT when all generateUniqueSlug candidates are taken on rename | Valid `actorId`; name change; `prisma.server.count` returns non-zero for all 10 candidates (`base` through `base-9`) | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`              |
+| Rethrow raw P2002 when withSlugRetry exhausts all 3 attempts on rename   | Valid `actorId`; name change; `prisma.server.update` throws `P2002` on all 3 attempts         | Throws the original `PrismaClientKnownRequestError` with code `P2002`; does NOT throw `TRPCError`                                             |
 
 ### 4.8 `deleteServer`
 
@@ -295,7 +302,9 @@ Description: loads all members with user profile fields and sorts by role rank t
 - `updateServer` and `deleteServer` must independently check `isSystemAdmin`; a system admin who is not the owner must be permitted in both functions.
 - `SERVER_UPDATED` must be published after every successful update, including updates that do not change the name.
 - `createServer` must call `channelService.createDefaultChannel` and `serverMemberService.addOwner` in that order and with the correct server id, not the input id.
-- The `withSlugRetry` P2002 path only retries on a known `P2002` constraint error; any other Prisma error must pass through immediately without retry.
+- `withSlugRetry` retries only while `attempt < maxRetries - 1` (with `maxRetries = 3`, that means attempts 0 and 1 are retried; attempt 2 rethrows the raw P2002 directly). The `TRPCError(CONFLICT)` after the loop is unreachable code.
+- Non-`P2002` Prisma errors from `withSlugRetry` must pass through immediately on the first attempt without any retry.
+- `generateUniqueSlug` exhaustion (all 10 DB candidates occupied) maps to `TRPCError(CONFLICT)`; this is distinct from `withSlugRetry` P2002 exhaustion which rethrows the raw Prisma error.
 
 ## 6. Coverage Expectation
 
@@ -305,7 +314,8 @@ The cases above are intended to cover:
 - every explicit `TRPCError` branch in the service and its private helpers,
 - successful transaction paths with correct return values,
 - event publication side effects via `eventBus.publish`,
-- the slug-generation retry logic under collision and exhaustion scenarios,
+- the slug-generation retry logic under collision and exhaustion scenarios, distinguishing `generateUniqueSlug` CONFLICT from `withSlugRetry` raw-P2002 rethrow,
+- `createServer` post-insert failure paths (`createDefaultChannel` and `addOwner` rejections),
 - authorization guards for both owner and system-admin paths, and
 - representative unexpected database failure paths.
 

--- a/docs/test-specs/server-service-spec.md
+++ b/docs/test-specs/server-service-spec.md
@@ -1,0 +1,312 @@
+# Server Service Test Specification
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-backend/src/services/server.service.ts`.
+It covers all exported service functions and the exported utility:
+
+- `generateSlug` (exported utility)
+- `serverService.getPublicServers`
+- `serverService.getAllServers`
+- `serverService.getMemberServers`
+- `serverService.getServer`
+- `serverService.createServer`
+- `serverService.updateServer`
+- `serverService.deleteServer`
+- `serverService.incrementMemberCount`
+- `serverService.decrementMemberCount`
+- `serverService.getMembers`
+
+The internal helpers `generateUniqueSlug` and `withSlugRetry` are exercised indirectly through `createServer` and `updateServer`.
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Use a test database with isolated server, user, and membership fixtures per test.
+- Use distinct users for owner, admin, system-admin, and outsider scenarios.
+- Mock or spy on `eventBus.publish` so tests can verify event emission without requiring the full event system.
+- Mock `channelService.createDefaultChannel` and `serverMemberService.addOwner` when testing `createServer` in isolation; verify they are called with the correct arguments.
+- Mock `isSystemAdmin` to return `true` or `false` as needed per test scenario.
+- When unexpected Prisma failures are simulated, assert that the original error is surfaced unless the code explicitly maps it to a `TRPCError`.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `generateSlug`
+
+Purpose: convert a display name to a URL-safe lowercase slug by stripping non-alphanumeric characters, collapsing whitespace into hyphens, and removing leading/trailing hyphens.
+
+Program paths:
+
+- Name with mixed case, spaces, and safe characters is converted correctly.
+- Leading and trailing spaces are trimmed before processing.
+- Non-alphanumeric characters (excluding spaces and hyphens) are removed.
+- Consecutive whitespace characters are collapsed into a single hyphen.
+- Consecutive hyphens are collapsed into a single hyphen.
+- Leading and trailing hyphens are stripped from the result.
+- Name consisting entirely of special characters produces an empty string.
+- Empty string input produces an empty string.
+
+### 3.2 `getPublicServers`
+
+Purpose: return all servers marked as public, ordered by creation date descending, up to a configurable limit.
+
+Program paths:
+
+- Returns an ordered list of public servers with the default limit of 50.
+- Respects a caller-supplied limit smaller than 50.
+- Caps the effective limit at 100 even when a larger value is supplied.
+- Returns an empty array when no public servers exist.
+
+### 3.3 `getAllServers`
+
+Purpose: return all servers regardless of visibility (admin function), ordered by creation date descending.
+
+Program paths:
+
+- Returns all servers (public and private) with the default limit of 50.
+- Respects a caller-supplied limit smaller than 50.
+- Caps the effective limit at 100 even when a larger value is supplied.
+- Returns an empty array when no servers exist.
+
+### 3.4 `getMemberServers`
+
+Purpose: return the servers a given user belongs to, ordered by join date ascending.
+
+Program paths:
+
+- Returns servers in ascending `joinedAt` order for a user with memberships.
+- Returns an empty array for a user with no memberships.
+- Respects a caller-supplied limit.
+- Caps the effective limit at 100.
+
+### 3.5 `getServer`
+
+Purpose: look up a single server by its slug.
+
+Program paths:
+
+- Returns the matching server when a server with the given slug exists.
+- Returns `null` when no server matches the slug.
+
+### 3.6 `createServer`
+
+Purpose: create a new server, seed a default channel, and register the creator as `OWNER`.
+
+Program paths:
+
+- Server is created successfully; a default channel is created; the creator is added as owner; the new server is returned.
+- Name that produces an empty slug (e.g. all special characters) throws `TRPCError` with code `BAD_REQUEST` from `generateUniqueSlug`.
+- Slug collision is resolved automatically by appending a numeric suffix and retrying, up to 10 attempts; if all 10 slugs collide, throws `TRPCError` with code `CONFLICT`.
+- A transient Prisma `P2002` unique-violation on `server.create` triggers `withSlugRetry` to regenerate the slug and retry up to 3 times before throwing `CONFLICT`.
+- An unexpected non-`P2002` Prisma error from `server.create` is rethrown as-is.
+
+### 3.7 `updateServer`
+
+Purpose: update server metadata and optionally rename (with a new slug); enforces owner or system-admin authorization.
+
+Program paths:
+
+- Server does not exist.
+- Actor is not the owner and is not a system admin.
+- Actor is the owner: update succeeds without renaming.
+- Actor is the owner: update with a new name regenerates the slug and persists both changes.
+- Actor is not the owner but is a system admin: update succeeds.
+- Name change that exhausts all slug attempts throws `TRPCError` with code `CONFLICT`.
+- `SERVER_UPDATED` event is published after any successful update.
+- Return value is the updated server record.
+
+### 3.8 `deleteServer`
+
+Purpose: permanently delete a server; enforces owner or system-admin authorization.
+
+Program paths:
+
+- Server does not exist.
+- Actor is not the owner and is not a system admin.
+- Actor is the owner: server is deleted and returned.
+- Actor is not the owner but is a system admin: server is deleted and returned.
+
+### 3.9 `incrementMemberCount`
+
+Purpose: atomically increment a server's `memberCount` by one.
+
+Program paths:
+
+- Increments `memberCount` by 1 and returns the updated server record.
+
+### 3.10 `decrementMemberCount`
+
+Purpose: atomically decrement a server's `memberCount` by one, guarding against going below zero.
+
+Program paths:
+
+- Server does not exist.
+- Server exists but `memberCount` is already `0`.
+- Server exists and `memberCount > 0`: decrements and returns the updated server record.
+
+### 3.11 `getMembers`
+
+Purpose: return all members of a server with user profile data, sorted by role rank then join date.
+
+Program paths:
+
+- Returns members sorted by role hierarchy (`OWNER` first, `GUEST` last).
+- Within the same role, members are ordered by ascending `joinedAt`.
+- Returns an empty array when the server has no members.
+- Roles not present in the rank map are sorted after `GUEST` (rank `99`).
+
+## 4. Detailed Test Cases
+
+### 4.1 `generateSlug`
+
+Description: pure synchronous slug normalisation that can be tested without any database setup.
+
+| Test Purpose                                            | Inputs                              | Expected Output                                                  |
+| ------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------- |
+| Convert mixed-case name with spaces                     | `"Hello World"`                     | `"hello-world"`                                                  |
+| Trim leading and trailing whitespace                    | `"  My Server  "`                   | `"my-server"`                                                    |
+| Strip non-alphanumeric characters (except spaces/hyphens) | `"Café & Lounge!"`               | `"caf-lounge"` (non-ASCII/special chars removed)                 |
+| Collapse multiple spaces into one hyphen                | `"foo   bar"`                       | `"foo-bar"`                                                      |
+| Collapse consecutive hyphens into one                  | `"foo--bar"`                        | `"foo-bar"`                                                      |
+| Remove leading hyphen from result                      | `"-leading"`                        | `"leading"`                                                      |
+| Remove trailing hyphen from result                     | `"trailing-"`                       | `"trailing"`                                                     |
+| Return empty string when all characters are stripped   | `"!!!"`                             | `""`                                                             |
+| Return empty string for empty input                    | `""`                                | `""`                                                             |
+
+### 4.2 `getPublicServers`
+
+Description: retrieves public servers, most recently created first, within a configurable limit.
+
+| Test Purpose                                     | Inputs                                           | Expected Output                                                                              |
+| ------------------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Return public servers in descending creation order | Three seeded public servers; default `limit`   | Returns all three in newest-first order                                                      |
+| Exclude private servers                          | One public and one private server; default limit | Returns only the public server                                                               |
+| Respect caller-supplied limit                    | Five public servers; `limit = 2`                 | Returns exactly 2 servers                                                                    |
+| Cap effective limit at 100                       | `limit = 200`; prisma spy                        | `prisma.server.findMany` is called with `take: 100`                                          |
+| Return empty array when no public servers exist  | No servers seeded                                | Returns `[]`                                                                                 |
+
+### 4.3 `getAllServers`
+
+Description: retrieves all servers regardless of visibility (admin endpoint).
+
+| Test Purpose                           | Inputs                                              | Expected Output                                             |
+| -------------------------------------- | --------------------------------------------------- | ----------------------------------------------------------- |
+| Return both public and private servers | One public server and one private server seeded     | Returns both servers                                        |
+| Respect caller-supplied limit          | Five servers; `limit = 3`                           | Returns exactly 3 servers                                   |
+| Cap effective limit at 100             | `limit = 500`; prisma spy                           | `prisma.server.findMany` is called with `take: 100`         |
+| Return empty array when no servers exist | No servers seeded                                 | Returns `[]`                                                |
+
+### 4.4 `getMemberServers`
+
+Description: retrieves servers the user has joined, ordered by join date ascending.
+
+| Test Purpose                                 | Inputs                                                          | Expected Output                                                          |
+| -------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Return servers in ascending join order       | User with two memberships; older membership seeded second       | Returns the server joined first (lower `joinedAt`) at index 0            |
+| Return empty array for user with no memberships | Valid `userId` with no `serverMember` records               | Returns `[]`                                                             |
+| Respect caller-supplied limit               | User is a member of five servers; `limit = 2`                   | Returns exactly 2 servers                                                |
+| Cap effective limit at 100                  | `limit = 200`; prisma spy                                       | `prisma.serverMember.findMany` is called with `take: 100`                |
+
+### 4.5 `getServer`
+
+Description: looks up a single server by URL slug.
+
+| Test Purpose                    | Inputs                                     | Expected Output                              |
+| ------------------------------- | ------------------------------------------ | -------------------------------------------- |
+| Return server for known slug    | Valid slug of an existing server           | Returns the matching `Server` record         |
+| Return null for unknown slug    | A slug that does not match any server      | Returns `null`                               |
+
+### 4.6 `createServer`
+
+Description: creates a server, seeds a default channel, and registers the creator as owner.
+
+| Test Purpose                                                   | Inputs                                                                                                | Expected Output                                                                                                                                               |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Create server with all optional fields provided                | Valid `name`, `description`, `iconUrl`, `isPublic = true`, `ownerId`                                  | Returns created server; `channelService.createDefaultChannel` called with new server id; `serverMemberService.addOwner` called with `ownerId` and server id    |
+| Create server with only required fields                        | Valid `name` and `ownerId`; no optional fields                                                        | Returns created server; default channel and owner membership are created                                                                                      |
+| Throw BAD_REQUEST when name produces empty slug                | `name` composed entirely of special characters (e.g. `"!!!"`)                                         | Throws `TRPCError` with code `BAD_REQUEST` and message `Cannot generate slug from name`                                                                       |
+| Throw CONFLICT when all slug attempts are taken                | Valid `name`; `prisma.server.count` mocked to always return `1` for the base slug and all 10 suffixes | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`                                                                        |
+| Retry on transient P2002 during server create                  | Valid `name`; `prisma.server.create` throws `P2002` on first attempt then succeeds on second         | Returns successfully created server; retried without further error                                                                                            |
+| Throw on non-P2002 Prisma error during server create           | Valid `name`; `prisma.server.create` throws a non-`P2002` Prisma error                               | Throws the original Prisma error unchanged                                                                                                                    |
+
+### 4.7 `updateServer`
+
+Description: updates server metadata, handles name changes with slug regeneration, and enforces authorization.
+
+| Test Purpose                                                 | Inputs                                                                                          | Expected Output                                                                                                                              |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Throw NOT_FOUND when server does not exist                   | Unknown `id`; valid `actorId`; any `data`                                                       | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                                                                      |
+| Throw FORBIDDEN when actor is not owner and not system admin | Existing server; `actorId` different from `ownerId`; `isSystemAdmin` mocked to return `false`  | Throws `TRPCError` with code `FORBIDDEN` and message `Only the server owner can update`                                                      |
+| Allow owner to update without renaming                       | Existing server; `actorId === server.ownerId`; `data` without `name`                           | Returns updated server; slug is unchanged; `SERVER_UPDATED` event is published                                                               |
+| Allow owner to update with a new name                        | Existing server; `actorId === server.ownerId`; `data.name` is a new distinct value             | Returns updated server with new name and regenerated slug; `SERVER_UPDATED` event is published                                               |
+| Skip slug regeneration when name is unchanged                | Existing server; `actorId === server.ownerId`; `data.name === server.name`                     | Update is applied with the existing slug; `generateUniqueSlug` is not called; `SERVER_UPDATED` event is published                            |
+| Allow system admin to update a server they do not own        | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `true`         | Returns updated server; `SERVER_UPDATED` event is published                                                                                  |
+| Publish SERVER_UPDATED event after successful update         | Any successful update scenario                                                                  | `eventBus.publish` is called with `EventChannels.SERVER_UPDATED` and a payload containing `serverId`, `name`, `iconUrl`, `description`, and `timestamp` |
+| Throw CONFLICT when all slug attempts are taken on rename    | Valid `actorId`; name change; all slug candidates mocked as occupied                           | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`                                                       |
+
+### 4.8 `deleteServer`
+
+Description: permanently deletes a server record; enforces owner or system-admin authorization.
+
+| Test Purpose                                                   | Inputs                                                                                          | Expected Output                                                                              |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Throw NOT_FOUND when server does not exist                     | Unknown `id`; valid `actorId`                                                                   | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                      |
+| Throw FORBIDDEN when actor is not owner and not system admin   | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `false`        | Throws `TRPCError` with code `FORBIDDEN` and message `Only the server owner can delete`      |
+| Allow owner to delete their server                             | Existing server; `actorId === server.ownerId`                                                   | Deletes the server; returns the deleted server record                                        |
+| Allow system admin to delete a server they do not own          | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `true`         | Deletes the server; returns the deleted server record                                        |
+
+### 4.9 `incrementMemberCount`
+
+Description: atomically adds 1 to a server's `memberCount`.
+
+| Test Purpose                            | Inputs                                               | Expected Output                                                          |
+| --------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------ |
+| Increment memberCount by 1              | Existing server with `memberCount = 3`               | Returns server record with `memberCount = 4`                             |
+
+### 4.10 `decrementMemberCount`
+
+Description: atomically subtracts 1 from a server's `memberCount`, refusing to go below zero.
+
+| Test Purpose                                        | Inputs                                             | Expected Output                                                                                  |
+| --------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Decrement memberCount by 1                          | Existing server with `memberCount = 2`             | Returns server record with `memberCount = 1`                                                     |
+| Throw BAD_REQUEST when server does not exist        | Unknown `id`                                       | Throws `TRPCError` with code `BAD_REQUEST` and message `Member count is already zero`            |
+| Throw BAD_REQUEST when memberCount is already zero  | Existing server with `memberCount = 0`             | Throws `TRPCError` with code `BAD_REQUEST` and message `Member count is already zero`            |
+
+### 4.11 `getMembers`
+
+Description: loads all members with user profile fields and sorts by role rank then join date.
+
+| Test Purpose                                              | Inputs                                                                                                   | Expected Output                                                                                                                   |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Return members sorted by role hierarchy                   | Server with seeded owner, admin, moderator, member, and guest memberships                                | Returns array with `OWNER` at index 0, followed by `ADMIN`, `MODERATOR`, `MEMBER`, `GUEST` in that order                         |
+| Preserve ascending join order within the same role        | Server with two `MEMBER` rows where the newer member was inserted first in the array                     | Returns the older-join member before the newer-join member                                                                        |
+| Return empty array when server has no members             | Valid `serverId` with no `serverMember` records                                                           | Returns `[]`                                                                                                                      |
+| Include user profile fields on each member                | Server with one seeded member whose user has `username`, `displayName`, `avatarUrl`, and `status` set   | Each returned element contains `user.id`, `user.username`, `user.displayName`, `user.avatarUrl`, and `user.status`                |
+| Sort unknown roles after all known roles                  | Server with a member whose role string is not in the `ROLE_RANK` map (e.g. `"CUSTOM"`)                  | The unknown-role member appears after any `GUEST` members; does not throw                                                         |
+
+## 5. Edge Cases to Explicitly Validate
+
+- `generateSlug` is a pure function; assert it without any database calls.
+- `generateUniqueSlug` must throw `BAD_REQUEST` when the base slug is empty, not `CONFLICT`.
+- `decrementMemberCount` must reject both a missing server and a server at zero with the same `BAD_REQUEST` error; the `!server || server.memberCount <= 0` compound condition must be tested with both failing branches.
+- Name unchanged in `updateServer` must not trigger a slug query; use a spy on `prisma.server.count` to confirm it is not called.
+- `updateServer` and `deleteServer` must independently check `isSystemAdmin`; a system admin who is not the owner must be permitted in both functions.
+- `SERVER_UPDATED` must be published after every successful update, including updates that do not change the name.
+- `createServer` must call `channelService.createDefaultChannel` and `serverMemberService.addOwner` in that order and with the correct server id, not the input id.
+- The `withSlugRetry` P2002 path only retries on a known `P2002` constraint error; any other Prisma error must pass through immediately without retry.
+
+## 6. Coverage Expectation
+
+The cases above are intended to cover:
+
+- all public service methods and the exported `generateSlug` utility,
+- every explicit `TRPCError` branch in the service and its private helpers,
+- successful transaction paths with correct return values,
+- event publication side effects via `eventBus.publish`,
+- the slug-generation retry logic under collision and exhaustion scenarios,
+- authorization guards for both owner and system-admin paths, and
+- representative unexpected database failure paths.
+
+Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures outside the service's direct branching logic.

--- a/llm-logs/acabrera04-logs/acabrera04-tests/2026-03-31-review-this-pr-https-github-com-acabrera04-harmony-pull-275-019d4620.md
+++ b/llm-logs/acabrera04-logs/acabrera04-tests/2026-03-31-review-this-pr-https-github-com-acabrera04-harmony-pull-275-019d4620.md
@@ -1,0 +1,2807 @@
+# Codex Conversation Export
+
+## Metadata
+
+- Thread ID: 019d4620-3571-77f3-a621-f3d9eb0d1b58
+- Timestamp: 2026-03-31T23:00:09.202Z
+- CWD: /Users/allen/repos/Harmony
+- Source: vscode
+- Model Provider: openai
+- Model: gpt-5.4
+- Reasoning Effort: high
+- Rollout Path: /Users/allen/.codex/sessions/2026/03/31/rollout-2026-03-31T19-00-09-019d4620-3571-77f3-a621-f3d9eb0d1b58.jsonl
+
+## Transcript
+
+### Turn 1: Review this PR
+
+#### 👤 User Prompt
+
+- Time: 2026-03-31T23:00:11.371Z
+
+```text
+Review this PR https://github.com/acabrera04/Harmony/pull/275
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:00:21.602Z
+
+I’m reviewing PR `#275` against the repo instructions first, then I’ll inspect the diff and verify whether the changes introduce behavioral or test risks.
+
+#### Tool: update_plan
+
+- Plan:
+  - [in_progress] Read repo workflow and PR review instructions
+  - [pending] Inspect PR metadata and changed files
+  - [pending] Review changed code for bugs, regressions, and missing tests
+  - [pending] Summarize findings with file/line references
+
+Output:
+
+```text
+Plan updated
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:00:29.273Z
+
+I’m loading the repository-specific review rules and workflow constraints before looking at the patch so the review stays aligned with project policy.
+
+#### Tool: exec_command
+
+```sh
+rtk read WORKFLOW.md
+```
+
+Output:
+
+````text
+## Workflow Orchestration
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean 
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop 
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests - then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+This project uses a **hybrid approach**: `tasks/todo.md` for AI context, GitHub Issues as the canonical tracker on the Harmony Project Board (course requirement).
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items (local scratch pad for AI context)
+2. **Identify the Issue**: If the task maps to an existing GitHub Issue, note the issue number at the top of `tasks/todo.md`
+3. **Announce Start**: Post an opening comment to the issue — `gh issue comment <number> --body "..."` — describing what will be done
+4. **Track Progress**: Mark items complete in `tasks/todo.md` as you go; post a comment to the issue at meaningful milestones (e.g., after a major step or when blocked)
+5. **Explain Changes**: High-level summary at each step
+6. **Document Results**: Add a review section to `tasks/todo.md` and post a final summary comment to the issue when complete
+7. **Capture Lessons**: Update `tasks/lessons.md` after corrections. Post the new lessons learned as a comment to the issue.
+
+### Issue Comment Format
+Use this structure for issue comments to keep the audit trail readable:
+
+```
+**[AI Agent — <Step>]**
+
+<What was done or decided>
+
+<Any blockers, decisions, or next steps>
+```
+
+Example steps: `Starting`, `In Progress`, `Blocked`, `Complete`
+
+## Core Principles
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
+- **Lean Context Files**: Keep AGENTS.md and similar files to only non-obvious, non-discoverable essentials. Research shows context file bloat decreases task success rates and increases inference cost by 20%+ with 2–4 extra steps per task (Gloaguen et al., 2026).
+
+#### Taken from https://x.com/mdancho84/status/2023738764841894352
+
+Gloaguen, T., Mündler, N., Müller, M., Raychev, V., & Vechev, M. (2026, February 12). Evaluating AGENTS.MD: Are Repository-Level context Files helpful for coding agents? arXiv.org. https://arxiv.org/abs/2602.11988
+````
+
+#### Tool: exec_command
+
+```sh
+rtk read .github/PR_REVIEW.md
+```
+
+Output:
+
+```text
+# PR Review Guidelines
+
+When conducting PR Reviews, follow these guidelines:
+1. **Prioritize Logic over Style:** Ensure the code is efficient, DRY (Don't Repeat Yourself), and logically sound.
+2. **Security First:** Verify that the changes do not introduce vulnerabilities (e.g., lack of input validation, exposed secrets).
+3. **Architectural Alignment:** If applicable, ensure the changes adhere strictly to the patterns defined in `@../docs/unified-backend-architecture.md`.
+4. **Issue Completion:** If the PR is attached to an issue, verify that the code successfully satisfies every acceptance criteria of that issue.
+5. **No Nitpicking:** Do not leave comments regarding stylistic choices, formatting, or subjective naming conventions unless they violate core project readability. Focus only on critical logic, performance, or architectural flaws.
+6. **Avoid Repetition:** Do not repeat feedback that has already been stated in previous reviews on this PR.
+7. **Iterative Reviews:** If this is not your first review on the PR:
+    - First, check if the new commits have correctly addressed your previous review comments.
+    - If a previous concern has been addressed, explicitly resolve the associated comment.
+8. **Prevent CI Failures:** Analyze the code for obvious issues that would break the pipeline. Specifically check for syntax errors, missing imports/dependencies, unhandled exceptions, and logic that would clearly break existing tests.
+
+**Execution Instruction**: Before providing your code feedback, output a markdown checklist of the 8 guidelines above. Mark each one as [x] if it passes or [ ] if it fails, and briefly explain why. Then, provide your single bundled review. Use inline subcomments within that single review for specific lines of codes. Do not post multiple standalone comments.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read README.md
+```
+
+Output:
+
+```text
+# Harmony
+A search engine indexible chat application
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:00:37.442Z
+
+I’ve got the review rubric. Next I’m pulling the PR metadata, existing review discussion, and the exact file diff so I can avoid duplicate feedback and focus on substantive regressions.
+
+#### Tool: update_plan
+
+- Plan:
+  - [completed] Read repo workflow and PR review instructions
+  - [in_progress] Inspect PR metadata and changed files
+  - [pending] Review changed code for bugs, regressions, and missing tests
+  - [pending] Summarize findings with file/line references
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: mcp__codex_apps__github_get_pr_info
+
+```json
+{
+  "pr_number": 275,
+  "repository_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"url":"https://github.com/acabrera04/Harmony/pull/275","number":275,"state":"open","merged":false,"mergeable":true,"draft":false,"body":"## Summary\n\n- Adds `docs/test-specs/server-service-spec.md` — an English-language test specification for `harmony-backend/src/services/server.service.ts`\n- Covers all 11 exported functions (`generateSlug`, `getPublicServers`, `getAllServers`, `getMemberServers`, `getServer`, `createServer`, `updateServer`, `deleteServer`, `incrementMemberCount`, `decrementMemberCount`, `getMembers`) plus the private slug helpers via `createServer`/`updateServer`\n- Each function section lists program paths and a table of concrete test cases with inputs and expected outputs, including all `TRPCError` branches, slug-retry/collision logic, authorization guards (owner vs system admin), event publication side effects, and edge cases\n\n## Test plan\n\n- [ ] Review spec tables to confirm every `TRPCError` branch in the source file has a corresponding test case\n- [ ] Confirm `generateSlug` cases cover the full regex pipeline (lowercase, trim, strip, collapse spaces, collapse hyphens, strip edges)\n- [ ] Confirm `decrementMemberCount` covers both failing branches of the compound `!server || server.memberCount <= 0` guard\n- [ ] Confirm `createServer` cases cover slug exhaustion, P2002 retry, and non-P2002 passthrough\n- [ ] Confirm `updateServer` cases cover owner path, system-admin path, name-unchanged path, and name-changed path\n\nCloses #259\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)","title":"docs(tests): test specification for server.service.ts","base":"main","base_sha":"b19f1dcad49e33a6b888b7b4c781cbf230959ba8","head":"test/issue-259-server-service-spec","head_sha":"5ccdc08d8f0252be7458c27ce9308f7742e78f96","merge_commit_sha":"0e255df7c1ef12eb57728252aab85ede07661b15","user":{"login":"declanblanc","name":"declanblanc","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/49934576?v=4","id":49934576},"requested_reviewers":null,"diff":null,"comments":null,"created_at":"2026-03-31T22:54:31Z","updated_at":"2026-03-31T22:54:31Z","closed_at":null,"merged_at":null,"commits":1,"changed_files":1,"additions":312,"deletions":0,"display_url":"https://github.com/acabrera04/Harmony/pull/275","display_title":"docs(tests): test specification for server.service.ts"}
+```
+
+#### Tool: mcp__codex_apps__github_list_pr_changed_filenames
+
+```json
+{
+  "pr_number": 275,
+  "repo_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"filenames":["docs/test-specs/server-service-spec.md"]}
+```
+
+#### Tool: mcp__codex_apps__github_fetch_pr_comments
+
+```json
+{
+  "pr_number": 275,
+  "repo_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"comments":[],"url":"https://github.com/acabrera04/Harmony/pull/275","title":"acabrera04/Harmony PR #275 comments","display_url":"https://github.com/acabrera04/Harmony/pull/275","display_title":"acabrera04/Harmony PR #275 comments"}
+```
+
+#### Tool: mcp__codex_apps__github_fetch_pr_patch
+
+```json
+{
+  "pr_number": 275,
+  "repo_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"patches":[{"filename":"docs/test-specs/server-service-spec.md","patch":"@@ -0,0 +1,312 @@\n+# Server Service Test Specification\n+\n+## 1. Overview\n+\n+This document defines the English-language test specification for `harmony-backend/src/services/server.service.ts`.\n+It covers all exported service functions and the exported utility:\n+\n+- `generateSlug` (exported utility)\n+- `serverService.getPublicServers`\n+- `serverService.getAllServers`\n+- `serverService.getMemberServers`\n+- `serverService.getServer`\n+- `serverService.createServer`\n+- `serverService.updateServer`\n+- `serverService.deleteServer`\n+- `serverService.incrementMemberCount`\n+- `serverService.decrementMemberCount`\n+- `serverService.getMembers`\n+\n+The internal helpers `generateUniqueSlug` and `withSlugRetry` are exercised indirectly through `createServer` and `updateServer`.\n+\n+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.\n+\n+## 2. Shared Test Setup and Assumptions\n+\n+- Use a test database with isolated server, user, and membership fixtures per test.\n+- Use distinct users for owner, admin, system-admin, and outsider scenarios.\n+- Mock or spy on `eventBus.publish` so tests can verify event emission without requiring the full event system.\n+- Mock `channelService.createDefaultChannel` and `serverMemberService.addOwner` when testing `createServer` in isolation; verify they are called with the correct arguments.\n+- Mock `isSystemAdmin` to return `true` or `false` as needed per test scenario.\n+- When unexpected Prisma failures are simulated, assert that the original error is surfaced unless the code explicitly maps it to a `TRPCError`.\n+\n+## 3. Function Purposes and Program Paths\n+\n+### 3.1 `generateSlug`\n+\n+Purpose: convert a display name to a URL-safe lowercase slug by stripping non-alphanumeric characters, collapsing whitespace into hyphens, and removing leading/trailing hyphens.\n+\n+Program paths:\n+\n+- Name with mixed case, spaces, and safe characters is converted correctly.\n+- Leading and trailing spaces are trimmed before processing.\n+- Non-alphanumeric characters (excluding spaces and hyphens) are removed.\n+- Consecutive whitespace characters are collapsed into a single hyphen.\n+- Consecutive hyphens are collapsed into a single hyphen.\n+- Leading and trailing hyphens are stripped from the result.\n+- Name consisting entirely of special characters produces an empty string.\n+- Empty string input produces an empty string.\n+\n+### 3.2 `getPublicServers`\n+\n+Purpose: return all servers marked as public, ordered by creation date descending, up to a configurable limit.\n+\n+Program paths:\n+\n+- Returns an ordered list of public servers with the default limit of 50.\n+- Respects a caller-supplied limit smaller than 50.\n+- Caps the effective limit at 100 even when a larger value is supplied.\n+- Returns an empty array when no public servers exist.\n+\n+### 3.3 `getAllServers`\n+\n+Purpose: return all servers regardless of visibility (admin function), ordered by creation date descending.\n+\n+Program paths:\n+\n+- Returns all servers (public and private) with the default limit of 50.\n+- Respects a caller-supplied limit smaller than 50.\n+- Caps the effective limit at 100 even when a larger value is supplied.\n+- Returns an empty array when no servers exist.\n+\n+### 3.4 `getMemberServers`\n+\n+Purpose: return the servers a given user belongs to, ordered by join date ascending.\n+\n+Program paths:\n+\n+- Returns servers in ascending `joinedAt` order for a user with memberships.\n+- Returns an empty array for a user with no memberships.\n+- Respects a caller-supplied limit.\n+- Caps the effective limit at 100.\n+\n+### 3.5 `getServer`\n+\n+Purpose: look up a single server by its slug.\n+\n+Program paths:\n+\n+- Returns the matching server when a server with the given slug exists.\n+- Returns `null` when no server matches the slug.\n+\n+### 3.6 `createServer`\n+\n+Purpose: create a new server, seed a default channel, and register the creator as `OWNER`.\n+\n+Program paths:\n+\n+- Server is created successfully; a default channel is created; the creator is added as owner; the new server is returned.\n+- Name that produces an empty slug (e.g. all special characters) throws `TRPCError` with code `BAD_REQUEST` from `generateUniqueSlug`.\n+- Slug collision is resolved automatically by appending a numeric suffix and retrying, up to 10 attempts; if all 10 slugs collide, throws `TRPCError` with code `CONFLICT`.\n+- A transient Prisma `P2002` unique-violation on `server.create` triggers `withSlugRetry` to regenerate the slug and retry up to 3 times before throwing `CONFLICT`.\n+- An unexpected non-`P2002` Prisma error from `server.create` is rethrown as-is.\n+\n+### 3.7 `updateServer`\n+\n+Purpose: update server metadata and optionally rename (with a new slug); enforces owner or system-admin authorization.\n+\n+Program paths:\n+\n+- Server does not exist.\n+- Actor is not the owner and is not a system admin.\n+- Actor is the owner: update succeeds without renaming.\n+- Actor is the owner: update with a new name regenerates the slug and persists both changes.\n+- Actor is not the owner but is a system admin: update succeeds.\n+- Name change that exhausts all slug attempts throws `TRPCError` with code `CONFLICT`.\n+- `SERVER_UPDATED` event is published after any successful update.\n+- Return value is the updated server record.\n+\n+### 3.8 `deleteServer`\n+\n+Purpose: permanently delete a server; enforces owner or system-admin authorization.\n+\n+Program paths:\n+\n+- Server does not exist.\n+- Actor is not the owner and is not a system admin.\n+- Actor is the owner: server is deleted and returned.\n+- Actor is not the owner but is a system admin: server is deleted and returned.\n+\n+### 3.9 `incrementMemberCount`\n+\n+Purpose: atomically increment a server's `memberCount` by one.\n+\n+Program paths:\n+\n+- Increments `memberCount` by 1 and returns the updated server record.\n+\n+### 3.10 `decrementMemberCount`\n+\n+Purpose: atomically decrement a server's `memberCount` by one, guarding against going below zero.\n+\n+Program paths:\n+\n+- Server does not exist.\n+- Server exists but `memberCount` is already `0`.\n+- Server exists and `memberCount > 0`: decrements and returns the updated server record.\n+\n+### 3.11 `getMembers`\n+\n+Purpose: return all members of a server with user profile data, sorted by role rank then join date.\n+\n+Program paths:\n+\n+- Returns members sorted by role hierarchy (`OWNER` first, `GUEST` last).\n+- Within the same role, members are ordered by ascending `joinedAt`.\n+- Returns an empty array when the server has no members.\n+- Roles not present in the rank map are sorted after `GUEST` (rank `99`).\n+\n+## 4. Detailed Test Cases\n+\n+### 4.1 `generateSlug`\n+\n+Description: pure synchronous slug normalisation that can be tested without any database setup.\n+\n+| Test Purpose                                            | Inputs                              | Expected Output                                                  |\n+| ------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------- |\n+| Convert mixed-case name with spaces                     | `\"Hello World\"`                     | `\"hello-world\"`                                                  |\n+| Trim leading and trailing whitespace                    | `\"  My Server  \"`                   | `\"my-server\"`                                                    |\n+| Strip non-alphanumeric characters (except spaces/hyphens) | `\"Café & Lounge!\"`               | `\"caf-lounge\"` (non-ASCII/special chars removed)                 |\n+| Collapse multiple spaces into one hyphen                | `\"foo   bar\"`                       | `\"foo-bar\"`                                                      |\n+| Collapse consecutive hyphens into one                  | `\"foo--bar\"`                        | `\"foo-bar\"`                                                      |\n+| Remove leading hyphen from result                      | `\"-leading\"`                        | `\"leading\"`                                                      |\n+| Remove trailing hyphen from result                     | `\"trailing-\"`                       | `\"trailing\"`                                                     |\n+| Return empty string when all characters are stripped   | `\"!!!\"`                             | `\"\"`                                                             |\n+| Return empty string for empty input                    | `\"\"`                                | `\"\"`                                                             |\n+\n+### 4.2 `getPublicServers`\n+\n+Description: retrieves public servers, most recently created first, within a configurable limit.\n+\n+| Test Purpose                                     | Inputs                                           | Expected Output                                                                              |\n+| ------------------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------------------------------- |\n+| Return public servers in descending creation order | Three seeded public servers; default `limit`   | Returns all three in newest-first order                                                      |\n+| Exclude private servers                          | One public and one private server; default limit | Returns only the public server                                                               |\n+| Respect caller-supplied limit                    | Five public servers; `limit = 2`                 | Returns exactly 2 servers                                                                    |\n+| Cap effective limit at 100                       | `limit = 200`; prisma spy                        | `prisma.server.findMany` is called with `take: 100`                                          |\n+| Return empty array when no public servers exist  | No servers seeded                                | Returns `[]`                                                                                 |\n+\n+### 4.3 `getAllServers`\n+\n+Description: retrieves all servers regardless of visibility (admin endpoint).\n+\n+| Test Purpose                           | Inputs                                              | Expected Output                                             |\n+| -------------------------------------- | --------------------------------------------------- | ----------------------------------------------------------- |\n+| Return both public and private servers | One public server and one private server seeded     | Returns both servers                                        |\n+| Respect caller-supplied limit          | Five servers; `limit = 3`                           | Returns exactly 3 servers                                   |\n+| Cap effective limit at 100             | `limit = 500`; prisma spy                           | `prisma.server.findMany` is called with `take: 100`         |\n+| Return empty array when no servers exist | No servers seeded                                 | Returns `[]`                                                |\n+\n+### 4.4 `getMemberServers`\n+\n+Description: retrieves servers the user has joined, ordered by join date ascending.\n+\n+| Test Purpose                                 | Inputs                                                          | Expected Output                                                          |\n+| -------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------ |\n+| Return servers in ascending join order       | User with two memberships; older membership seeded second       | Returns the server joined first (lower `joinedAt`) at index 0            |\n+| Return empty array for user with no memberships | Valid `userId` with no `serverMember` records               | Returns `[]`                                                             |\n+| Respect caller-supplied limit               | User is a member of five servers; `limit = 2`                   | Returns exactly 2 servers                                                |\n+| Cap effective limit at 100                  | `limit = 200`; prisma spy                                       | `prisma.serverMember.findMany` is called with `take: 100`                |\n+\n+### 4.5 `getServer`\n+\n+Description: looks up a single server by URL slug.\n+\n+| Test Purpose                    | Inputs                                     | Expected Output                              |\n+| ------------------------------- | ------------------------------------------ | -------------------------------------------- |\n+| Return server for known slug    | Valid slug of an existing server           | Returns the matching `Server` record         |\n+| Return null for unknown slug    | A slug that does not match any server      | Returns `null`                               |\n+\n+### 4.6 `createServer`\n+\n+Description: creates a server, seeds a default channel, and registers the creator as owner.\n+\n+| Test Purpose                                                   | Inputs                                                                                                | Expected Output                                                                                                                                               |\n+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |\n+| Create server with all optional fields provided                | Valid `name`, `description`, `iconUrl`, `isPublic = true`, `ownerId`                                  | Returns created server; `channelService.createDefaultChannel` called with new server id; `serverMemberService.addOwner` called with `ownerId` and server id    |\n+| Create server with only required fields                        | Valid `name` and `ownerId`; no optional fields                                                        | Returns created server; default channel and owner membership are created                                                                                      |\n+| Throw BAD_REQUEST when name produces empty slug                | `name` composed entirely of special characters (e.g. `\"!!!\"`)                                         | Throws `TRPCError` with code `BAD_REQUEST` and message `Cannot generate slug from name`                                                                       |\n+| Throw CONFLICT when all slug attempts are taken                | Valid `name`; `prisma.server.count` mocked to always return `1` for the base slug and all 10 suffixes | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`                                                                        |\n+| Retry on transient P2002 during server create                  | Valid `name`; `prisma.server.create` throws `P2002` on first attempt then succeeds on second         | Returns successfully created server; retried without further error                                                                                            |\n+| Throw on non-P2002 Prisma error during server create           | Valid `name`; `prisma.server.create` throws a non-`P2002` Prisma error                               | Throws the original Prisma error unchanged                                                                                                                    |\n+\n+### 4.7 `updateServer`\n+\n+Description: updates server metadata, handles name changes with slug regeneration, and enforces authorization.\n+\n+| Test Purpose                                                 | Inputs                                                                                          | Expected Output                                                                                                                              |\n+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |\n+| Throw NOT_FOUND when server does not exist                   | Unknown `id`; valid `actorId`; any `data`                                                       | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                                                                      |\n+| Throw FORBIDDEN when actor is not owner and not system admin | Existing server; `actorId` different from `ownerId`; `isSystemAdmin` mocked to return `false`  | Throws `TRPCError` with code `FORBIDDEN` and message `Only the server owner can update`                                                      |\n+| Allow owner to update without renaming                       | Existing server; `actorId === server.ownerId`; `data` without `name`                           | Returns updated server; slug is unchanged; `SERVER_UPDATED` event is published                                                               |\n+| Allow owner to update with a new name                        | Existing server; `actorId === server.ownerId`; `data.name` is a new distinct value             | Returns updated server with new name and regenerated slug; `SERVER_UPDATED` event is published                                               |\n+| Skip slug regeneration when name is unchanged                | Existing server; `actorId === server.ownerId`; `data.name === server.name`                     | Update is applied with the existing slug; `generateUniqueSlug` is not called; `SERVER_UPDATED` event is published                            |\n+| Allow system admin to update a server they do not own        | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `true`         | Returns updated server; `SERVER_UPDATED` event is published                                                                                  |\n+| Publish SERVER_UPDATED event after successful update         | Any successful update scenario                                                                  | `eventBus.publish` is called with `EventChannels.SERVER_UPDATED` and a payload containing `serverId`, `name`, `iconUrl`, `description`, and `timestamp` |\n+| Throw CONFLICT when all slug attempts are taken on rename    | Valid `actorId`; name change; all slug candidates mocked as occupied                           | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`                                                       |\n+\n+### 4.8 `deleteServer`\n+\n+Description: permanently deletes a server record; enforces owner or system-admin authorization.\n+\n+| Test Purpose                                                   | Inputs                                                                                          | Expected Output                                                                              |\n+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |\n+| Throw NOT_FOUND when server does not exist                     | Unknown `id`; valid `actorId`                                                                   | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                      |\n+| Throw FORBIDDEN when actor is not owner and not system admin   | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `false`        | Throws `TRPCError` with code `FORBIDDEN` and message `Only the server owner can delete`      |\n+| Allow owner to delete their server                             | Existing server; `actorId === server.ownerId`                                                   | Deletes the server; returns the deleted server record                                        |\n+| Allow system admin to delete a server they do not own          | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `true`         | Deletes the server; returns the deleted server record                                        |\n+\n+### 4.9 `incrementMemberCount`\n+\n+Description: atomically adds 1 to a server's `memberCount`.\n+\n+| Test Purpose                            | Inputs                                               | Expected Output                                                          |\n+| --------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------ |\n+| Increment memberCount by 1              | Existing server with `memberCount = 3`               | Returns server record with `memberCount = 4`                             |\n+\n+### 4.10 `decrementMemberCount`\n+\n+Description: atomically subtracts 1 from a server's `memberCount`, refusing to go below zero.\n+\n+| Test Purpose                                        | Inputs                                             | Expected Output                                                                                  |\n+| --------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------ |\n+| Decrement memberCount by 1                          | Existing server with `memberCount = 2`             | Returns server record with `memberCount = 1`                                                     |\n+| Throw BAD_REQUEST when server does not exist        | Unknown `id`                                       | Throws `TRPCError` with code `BAD_REQUEST` and message `Member count is already zero`            |\n+| Throw BAD_REQUEST when memberCount is already zero  | Existing server with `memberCount = 0`             | Throws `TRPCError` with code `BAD_REQUEST` and message `Member count is already zero`            |\n+\n+### 4.11 `getMembers`\n+\n+Description: loads all members with user profile fields and sorts by role rank then join date.\n+\n+| Test Purpose                                              | Inputs                                                                                                   | Expected Output                                                                                                                   |\n+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |\n+| Return members sorted by role hierarchy                   | Server with seeded owner, admin, moderator, member, and guest memberships                                | Returns array with `OWNER` at index 0, followed by `ADMIN`, `MODERATOR`, `MEMBER`, `GUEST` in that order                         |\n+| Preserve ascending join order within the same role        | Server with two `MEMBER` rows where the newer member was inserted first in the array                     | Returns the older-join member before the newer-join member                                                                        |\n+| Return empty array when server has no members             | Valid `serverId` with no `serverMember` records                                                           | Returns `[]`                                                                                                                      |\n+| Include user profile fields on each member                | Server with one seeded member whose user has `username`, `displayName`, `avatarUrl`, and `status` set   | Each returned element contains `user.id`, `user.username`, `user.displayName`, `user.avatarUrl`, and `user.status`                |\n+| Sort unknown roles after all known roles                  | Server with a member whose role string is not in the `ROLE_RANK` map (e.g. `\"CUSTOM\"`)                  | The unknown-role member appears after any `GUEST` members; does not throw                                                         |\n+\n+## 5. Edge Cases to Explicitly Validate\n+\n+- `generateSlug` is a pure function; assert it without any database calls.\n+- `generateUniqueSlug` must throw `BAD_REQUEST` when the base slug is empty, not `CONFLICT`.\n+- `decrementMemberCount` must reject both a missing server and a server at zero with the same `BAD_REQUEST` error; the `!server || server.memberCount <= 0` compound condition must be tested with both failing branches.\n+- Name unchanged in `updateServer` must not trigger a slug query; use a spy on `prisma.server.count` to confirm it is not called.\n+- `updateServer` and `deleteServer` must independently check `isSystemAdmin`; a system admin who is not the owner must be permitted in both functions.\n+- `SERVER_UPDATED` must be published after every successful update, including updates that do not change the name.\n+- `createServer` must call `channelService.createDefaultChannel` and `serverMemberService.addOwner` in that order and with the correct server id, not the input id.\n+- The `withSlugRetry` P2002 path only retries on a known `P2002` constraint error; any other Prisma error must pass through immediately without retry.\n+\n+## 6. Coverage Expectation\n+\n+The cases above are intended to cover:\n+\n+- all public service methods and the exported `generateSlug` utility,\n+- every explicit `TRPCError` branch in the service and its private helpers,\n+- successful transaction paths with correct return values,\n+- event publication side effects via `eventBus.publish`,\n+- the slug-generation retry logic under collision and exhaustion scenarios,\n+- authorization guards for both owner and system-admin paths, and\n+- representative unexpected database failure paths.\n+\n+Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures outside the service's direct branching logic."}],"url":"https://github.com/acabrera04/Harmony/pull/275","title":"acabrera04/Harmony#275 (patch)","display_url":"https://github.com/acabrera04/Harmony/pull/275","display_title":"acabrera04/Harmony#275 (patch)"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:00:53.179Z
+
+The PR is docs-only, so the main review risk is whether the specification actually matches the service logic and issue scope. I’m diffing the spec against the current `server.service.ts` implementation now.
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/services/server.service.ts
+```
+
+Output:
+
+```text
+import { Server, Prisma } from '@prisma/client';
+import { TRPCError } from '@trpc/server';
+import { prisma } from '../db/prisma';
+import { channelService } from './channel.service';
+import { serverMemberService } from './serverMember.service';
+import { isSystemAdmin } from '../lib/admin.utils';
+import { eventBus, EventChannels } from '../events/eventBus';
+
+const ROLE_RANK: Record<string, number> = {
+  OWNER: 0,
+  ADMIN: 1,
+  MODERATOR: 2,
+  MEMBER: 3,
+  GUEST: 4,
+};
+
+export interface ServerMemberWithUser {
+  userId: string;
+  serverId: string;
+  role: string;
+  joinedAt: Date;
+  user: {
+    id: string;
+    username: string;
+    displayName: string;
+    avatarUrl: string | null;
+    status: string;
+  };
+}
+
+export function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/[\s]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+async function generateUniqueSlug(name: string): Promise<string> {
+  const base = generateSlug(name);
+  if (!base)
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot generate slug from name' });
+
+  const MAX_ATTEMPTS = 10;
+  let candidate = base;
+  for (let suffix = 1; suffix <= MAX_ATTEMPTS; suffix++) {
+    if ((await prisma.server.count({ where: { slug: candidate } })) === 0) return candidate;
+    candidate = `${base}-${suffix}`;
+  }
+  throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });
+}
+
+/**
+ * Generic slug-collision retry helper.
+ * Calls fn(slug) up to maxRetries times, regenerating the slug on a P2002 unique violation.
+ */
+async function withSlugRetry(
+  name: string,
+  initialSlug: string,
+  fn: (slug: string) => Promise<Server>,
+  maxRetries = 3,
+): Promise<Server> {
+  let slug = initialSlug;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    if (attempt > 0) slug = await generateUniqueSlug(name);
+    try {
+      return await fn(slug);
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2002' &&
+        attempt < maxRetries - 1
+      ) {
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });
+}
+
+export const serverService = {
+  async getPublicServers(limit = 50): Promise<Server[]> {
+    return prisma.server.findMany({
+      where: { isPublic: true },
+      orderBy: { createdAt: 'desc' },
+      take: Math.min(limit, 100),
+    });
+  },
+
+  /** Dev admin: returns all servers regardless of visibility. */
+  async getAllServers(limit = 50): Promise<Server[]> {
+    return prisma.server.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: Math.min(limit, 100),
+    });
+  },
+
+  /** Returns only the servers the given user is a member of. */
+  async getMemberServers(userId: string, limit = 50): Promise<Server[]> {
+    const memberships = await prisma.serverMember.findMany({
+      where: { userId },
+      include: { server: true },
+      orderBy: { joinedAt: 'asc' },
+      take: Math.min(limit, 100),
+    });
+    return memberships.map((m) => m.server);
+  },
+
+  async getServer(slug: string): Promise<Server | null> {
+    return prisma.server.findUnique({ where: { slug } });
+  },
+
+  async createServer(input: {
+    name: string;
+    description?: string;
+    iconUrl?: string;
+    isPublic?: boolean;
+    ownerId: string;
+  }): Promise<Server> {
+    const slug = await generateUniqueSlug(input.name);
+    const server = await withSlugRetry(input.name, slug, (s) =>
+      prisma.server.create({ data: { ...input, slug: s } }),
+    );
+    await channelService.createDefaultChannel(server.id);
+    await serverMemberService.addOwner(input.ownerId, server.id);
+    return server;
+  },
+
+  async updateServer(
+    id: string,
+    actorId: string,
+    data: { name?: string; description?: string; iconUrl?: string; isPublic?: boolean },
+  ): Promise<Server> {
+    const server = await prisma.server.findUnique({ where: { id } });
+    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
+    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))
+      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can update' });
+
+    let updated: Server;
+    if (data.name && data.name !== server.name) {
+      const slug = await generateUniqueSlug(data.name);
+      updated = await withSlugRetry(data.name, slug, (s) =>
+        prisma.server.update({ where: { id }, data: { ...data, slug: s } }),
+      );
+    } else {
+      updated = await prisma.server.update({ where: { id }, data });
+    }
+
+    void eventBus.publish(EventChannels.SERVER_UPDATED, {
+      serverId: id,
+      name: updated.name,
+      iconUrl: updated.iconUrl ?? null,
+      description: updated.description ?? null,
+      timestamp: new Date().toISOString(),
+    });
+
+    return updated;
+  },
+
+  async deleteServer(id: string, actorId: string): Promise<Server> {
+    const server = await prisma.server.findUnique({ where: { id } });
+    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
+    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))
+      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can delete' });
+    return prisma.server.delete({ where: { id } });
+  },
+
+  async incrementMemberCount(id: string): Promise<Server> {
+    return prisma.server.update({
+      where: { id },
+      data: { memberCount: { increment: 1 } },
+    });
+  },
+
+  async decrementMemberCount(id: string): Promise<Server> {
+    const server = await prisma.server.findUnique({ where: { id } });
+    if (!server || server.memberCount <= 0) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Member count is already zero' });
+    }
+    return prisma.server.update({
+      where: { id },
+      data: { memberCount: { decrement: 1 } },
+    });
+  },
+
+  async getMembers(serverId: string): Promise<ServerMemberWithUser[]> {
+    const members = await prisma.serverMember.findMany({
+      where: { serverId },
+      include: {
+        user: {
+          select: { id: true, username: true, displayName: true, avatarUrl: true, status: true },
+        },
+      },
+    });
+    return members
+      .map((m) => ({ ...m, role: m.role as string }))
+      .sort(
+        (a, b) =>
+          (ROLE_RANK[a.role] ?? 99) - (ROLE_RANK[b.role] ?? 99) ||
+          a.joinedAt.getTime() - b.joinedAt.getTime(),
+      );
+  },
+};
+```
+
+#### Tool: mcp__codex_apps__github_fetch_issue
+
+```json
+{
+  "issue_number": 259,
+  "repo": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"issue":{"url":"https://github.com/acabrera04/Harmony/issues/259","title":"Test Specification — server.service.ts","issue_number":259,"body":"## Description\nWrite an English-language test specification for `harmony-backend/src/services/server.service.ts` (10 functions).\n\n## Functions to Specify\n- `getPublicServers`\n- `getAllServers`\n- `getMemberServers`\n- `getServer`\n- `createServer`\n- `updateServer`\n- `deleteServer`\n- `incrementMemberCount`\n- `decrementMemberCount`\n- `getMembers`\n\n## Requirements\n- List every function, its purpose, and all program paths\n- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**\n- Cover happy paths, error paths (not found, duplicate slugs, unauthorized), and edge cases\n- Target 80%+ code coverage of all execution paths\n- Output: `docs/test-specs/server-service-spec.md`\n\n## Acceptance Criteria\n- [ ] All 10 functions listed with descriptions\n- [ ] Table covers happy paths for each function\n- [ ] Table covers error/exception paths\n- [ ] Edge cases identified and documented\n- [ ] At least one test per function\n\n**Sprint:** 3 (P5 Testing)\n**Due:** March 30, 2026","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"display_url":"https://github.com/acabrera04/Harmony/issues/259","display_title":"Test Specification — server.service.ts"},"url":"https://github.com/acabrera04/Harmony/issues/259","title":"Test Specification — server.service.ts","display_url":"https://github.com/acabrera04/Harmony/issues/259","display_title":"Test Specification — server.service.ts"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:01:02.350Z
+
+I’ve confirmed the source file and issue scope. Now I’m checking whether the spec’s claimed paths and expected outputs actually match the implementation, and whether it misses any branch the issue requires.
+
+#### Tool: exec_command
+
+```sh
+rtk ls docs/test-specs
+```
+
+Output:
+
+```text
+server-member-service-spec.md  18.6K
+
+📊 1 files, 0 dirs (1 .md)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "Server Service Test Specification|## 1\. Overview|Acceptance Criteria" docs -g "*.md"
+```
+
+Output:
+
+```text
+🔍 4 in 4F:
+
+📄 docs/.../channel-visibility-toggle/design-brief.md (1):
+    25: ## 1. Overview & Goals
+
+📄 docs/.../guest-public-channel-view/design-brief.md (1):
+    25: ## 1. Overview & Goals
+
+📄 docs/dev-spec-seo-meta-tag-generation.md (1):
+  3139: ## 14. Acceptance Criteria
+
+📄 docs/test-specs/server-member-service-spec.md (1):
+     3: ## 1. Overview
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read docs/test-specs/server-member-service-spec.md
+```
+
+Output:
+
+```text
+# Server Member Service Test Specification
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-backend/src/services/serverMember.service.ts`.
+It covers all six exported service functions:
+
+- `addOwner`
+- `joinServer`
+- `leaveServer`
+- `getServerMembers`
+- `changeRole`
+- `removeMember`
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Use a test database with isolated server, user, and membership fixtures per test.
+- Use distinct users for owner, admin, moderator, member, guest, and outsider scenarios.
+- Seed role hierarchy fixtures to match the implementation order: `OWNER`, `ADMIN`, `MODERATOR`, `MEMBER`, `GUEST`.
+- Mock or spy on `eventBus.publish` so tests can verify event emission without requiring the full event system.
+- When transaction failures or unexpected Prisma failures are simulated, assert that the original error is surfaced unless the code explicitly maps it to a `TRPCError`.
+- Validate both the direct return value and the side effects on `server.memberCount` where applicable.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `addOwner`
+
+Purpose: add the creator of a new server as an `OWNER` membership and increment the server member count.
+
+Program paths:
+
+- Owner membership is created successfully and `memberCount` is incremented.
+- Database or transaction failure bubbles to the caller.
+
+### 3.2 `joinServer`
+
+Purpose: allow a user to join a public server as a `MEMBER`.
+
+Program paths:
+
+- Target server does not exist.
+- Target server exists but is private.
+- Membership is created successfully, `memberCount` is incremented, and `MEMBER_JOINED` is published.
+- Unique membership constraint fails because the user is already a member.
+- Unexpected transaction or Prisma failure bubbles to the caller.
+
+### 3.3 `leaveServer`
+
+Purpose: remove the current user's membership, unless that user is the server owner.
+
+Program paths:
+
+- Membership does not exist.
+- Membership exists but role is `OWNER`.
+- Membership is deleted successfully, `memberCount` is decremented, and `MEMBER_LEFT` is published with reason `LEFT`.
+- Database or transaction failure bubbles to the caller.
+
+### 3.4 `getServerMembers`
+
+Purpose: return all members for a server, enriched with user profile data and ordered by role hierarchy.
+
+Program paths:
+
+- Target server does not exist.
+- Target server exists and has no members.
+- Target server exists and members are returned in role-priority order, with same-role members retaining ascending `joinedAt` order from the database query.
+
+### 3.5 `changeRole`
+
+Purpose: let an actor with sufficient privilege update another member's role, while preventing owner reassignment and privilege escalation.
+
+Program paths:
+
+- Requested role is `OWNER`.
+- Actor is not a member of the server.
+- Target user is not a member of the server.
+- Target user is the `OWNER`.
+- Actor tries to change a member with equal or higher privilege.
+- Actor tries to assign a role equal to or higher than the actor's own role.
+- Role update succeeds.
+
+### 3.6 `removeMember`
+
+Purpose: let an actor remove a lower-privileged member from the server while protecting the owner and enforcing hierarchy.
+
+Program paths:
+
+- Actor is not a member of the server.
+- Target user is not a member of the server.
+- Target user is the `OWNER`.
+- Actor tries to remove a member with equal or higher privilege.
+- Removal succeeds, `memberCount` is decremented, and `MEMBER_LEFT` is published with reason `KICKED`.
+- Database or transaction failure bubbles to the caller.
+
+## 4. Detailed Test Cases
+
+### 4.1 `addOwner`
+
+Description: creates the initial owner membership for a newly created server.
+
+| Test Purpose                                     | Inputs                                                                                                | Expected Output                                                                                               |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Create owner membership for a new server         | Valid `userId` and `serverId` for an existing server with `memberCount = 0`                           | Returns created `ServerMember` with role `OWNER`; persists membership; increments `server.memberCount` to `1` |
+| Bubble transaction failure during owner creation | Valid `userId` and `serverId`; mocked transaction failure on `serverMember.create` or `server.update` | Throws the underlying database error; no false success is returned                                            |
+
+### 4.2 `joinServer`
+
+Description: joins a public server with the default `MEMBER` role.
+
+| Test Purpose                                 | Inputs                                                                                                  | Expected Output                                                                                                                                                         |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Join a public server successfully            | Non-member `userId`; existing public `serverId`                                                         | Returns created `ServerMember` with role `MEMBER`; increments `memberCount`; publishes `MEMBER_JOINED` with `userId`, `serverId`, role `MEMBER`, and an ISO `timestamp` |
+| Reject join when server does not exist       | Any `userId`; unknown `serverId`                                                                        | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                                                                                                 |
+| Reject join when server is private           | Non-member `userId`; existing private `serverId`                                                        | Throws `TRPCError` with code `FORBIDDEN` and message `This server is private`                                                                                           |
+| Reject duplicate join for existing member    | `userId` already present in `serverMember`; existing public `serverId`; mocked Prisma `P2002` on create | Throws `TRPCError` with code `CONFLICT` and message `Already a member of this server`; does not double-increment `memberCount`; does not publish join event             |
+| Bubble unexpected Prisma failure during join | Valid public server; mocked non-`P2002` Prisma error or transaction error                               | Throws the original error so operational failures are not masked                                                                                                        |
+
+### 4.3 `leaveServer`
+
+Description: removes a non-owner member from a server.
+
+| Test Purpose                                | Inputs                                                                                                  | Expected Output                                                                                                                                        |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Leave server successfully as non-owner      | Existing membership for `userId` with role `MEMBER`, `MODERATOR`, `ADMIN`, or `GUEST`; valid `serverId` | Returns `void`; deletes membership; decrements `memberCount`; publishes `MEMBER_LEFT` with `userId`, `serverId`, reason `LEFT`, and an ISO `timestamp` |
+| Reject leave when membership does not exist | Non-member `userId`; valid `serverId`                                                                   | Throws `TRPCError` with code `NOT_FOUND` and message `Not a member of this server`                                                                     |
+| Reject leave when caller is owner           | Existing membership for `userId` with role `OWNER`; valid `serverId`                                    | Throws `TRPCError` with code `BAD_REQUEST` and message `Server owner cannot leave. Transfer ownership or delete the server.`                           |
+| Bubble transaction failure during leave     | Existing non-owner membership; mocked transaction failure on delete or server update                    | Throws the underlying database error; membership state is not reported as successful if the transaction fails                                          |
+
+### 4.4 `getServerMembers`
+
+Description: loads all members for a server with user profile fields and role-priority sorting.
+
+| Test Purpose                                       | Inputs                                                                                  | Expected Output                                                                                                                          |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Return sorted member list for an existing server   | Existing `serverId` with seeded owner/admin/member fixtures and valid joined timestamps | Returns an array of `ServerMemberWithUser`; members are ordered `OWNER` before `ADMIN` before `MODERATOR` before `MEMBER` before `GUEST` |
+| Preserve ascending join order within the same role | Existing `serverId` with multiple `MEMBER` rows having different `joinedAt` values      | Returns same-role members in ascending `joinedAt` order after sorting                                                                    |
+| Return empty list when server has no members       | Existing `serverId` with no related `serverMember` records                              | Returns `[]`                                                                                                                             |
+| Reject lookup when server does not exist           | Unknown `serverId`                                                                      | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                                                                  |
+
+### 4.5 `changeRole`
+
+Description: updates a target member's role when the actor outranks both the target's current role and the requested new role.
+
+| Test Purpose                                                                 | Inputs                                                                                                                                         | Expected Output                                                                                                      |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Change a lower-privileged member's role successfully                         | `actorId` with role `OWNER` or `ADMIN`; `targetUserId` with lower privilege; `newRole` lower than actor role and not `OWNER`; valid `serverId` | Returns updated `ServerMember`; persists the new role                                                                |
+| Reject assigning `OWNER` directly                                            | Valid memberships; `newRole = OWNER`                                                                                                           | Throws `TRPCError` with code `BAD_REQUEST` and message `Cannot assign OWNER role. Use ownership transfer.`           |
+| Reject change when actor is not a server member                              | Outsider `actorId`; valid target membership; valid `newRole`; valid `serverId`                                                                 | Throws `TRPCError` with code `FORBIDDEN` and message `You are not a member of this server`                           |
+| Reject change when target is not a server member                             | Valid actor membership; unknown `targetUserId`; valid `newRole`; valid `serverId`                                                              | Throws `TRPCError` with code `NOT_FOUND` and message `Target user is not a member of this server`                    |
+| Reject change when target is owner                                           | Valid actor membership below owner; target membership role `OWNER`; valid `newRole`                                                            | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot change the role of the server owner`                    |
+| Reject change when actor does not outrank target                             | `actorId` and `targetUserId` with equal roles, or actor lower than target                                                                      | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot change role of a member with equal or higher privilege` |
+| Reject change when actor tries to assign equal or higher role than their own | Valid actor membership; lower-ranked target; `newRole` equal to actor role or higher                                                           | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot assign a role equal to or higher than your own`         |
+| Reject self-role-change through hierarchy rule                               | `actorId === targetUserId`; any non-owner role; valid `newRole`                                                                                | Throws `TRPCError` with code `FORBIDDEN` because the actor does not outrank the target when both are the same member |
+
+### 4.6 `removeMember`
+
+Description: removes a lower-privileged target member from the server.
+
+| Test Purpose                                          | Inputs                                                                                        | Expected Output                                                                                                                                                                       |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Remove a lower-privileged member successfully         | `actorId` with higher role than `targetUserId`; valid `serverId`                              | Returns `void`; deletes target membership; decrements `memberCount`; publishes `MEMBER_LEFT` with `userId` set to `targetUserId`, `serverId`, reason `KICKED`, and an ISO `timestamp` |
+| Reject removal when actor is not a server member      | Outsider `actorId`; existing target membership; valid `serverId`                              | Throws `TRPCError` with code `FORBIDDEN` and message `You are not a member of this server`                                                                                            |
+| Reject removal when target is not a server member     | Valid actor membership; unknown `targetUserId`; valid `serverId`                              | Throws `TRPCError` with code `NOT_FOUND` and message `Target user is not a member of this server`                                                                                     |
+| Reject removal of owner                               | Valid actor membership; target membership role `OWNER`; valid `serverId`                      | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot remove the server owner`                                                                                                 |
+| Reject removal when actor does not outrank target     | Actor and target have equal roles, or actor has lower privilege than target                   | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot remove a member with equal or higher privilege`                                                                          |
+| Reject self-removal through moderator/admin kick path | `actorId === targetUserId` for a non-owner actor; valid `serverId`                            | Throws `TRPCError` with code `FORBIDDEN` because the actor does not outrank the target                                                                                                |
+| Bubble transaction failure during removal             | Valid actor and target memberships with mocked transaction failure on delete or server update | Throws the underlying database error; no success event should be asserted                                                                                                             |
+
+## 5. Edge Cases to Explicitly Validate
+
+- Duplicate membership attempts must map Prisma unique constraint `P2002` to a `CONFLICT` error in `joinServer`.
+- Owners cannot leave the server through `leaveServer`.
+- Owners cannot be targeted by `changeRole` or `removeMember`.
+- Role hierarchy rules must block equal-rank operations, not only lower-rank operations.
+- A caller cannot promote another member to the caller's own role or any higher role.
+- Self-targeted moderation actions (`changeRole` or `removeMember` where `actorId === targetUserId`) should be rejected by the same hierarchy guard.
+- Event publication should only happen after successful membership changes.
+- `getServerMembers` should still behave correctly when the member list is empty.
+
+## 6. Coverage Expectation
+
+The cases above are intended to cover:
+
+- all six exported functions,
+- every explicit `TRPCError` branch,
+- successful transaction paths,
+- event publication side effects,
+- role hierarchy edge cases, and
+- representative unexpected database failure paths.
+
+Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures outside the service's direct branching logic.
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:01:39.318Z
+
+I’ve narrowed the review to spec accuracy. I’m pulling line-numbered views next so the findings point to exact rows in the new document rather than vague sections.
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+?? "P4: Backend Development | CS 485 AI-Assisted Software Engineering (Sp26).html"
+?? "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf"
+?? load-test.js
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git remote -v
+```
+
+Output:
+
+```text
+origin	git@github.com:acabrera04/Harmony.git (fetch)
+origin	git@github.com:acabrera04/Harmony.git (push)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git show --stat --oneline 5ccdc08d8f0252be7458c27ce9308f7742e78f96
+```
+
+Output:
+
+```text
+5ccdc08 docs(tests): add test specification for server.service.ts
+ docs/test-specs/server-service-spec.md | 312 +++++++++++++++++++++++++++++++++
+ 1 file changed, 312 insertions(+)
+```
+
+#### Tool: exec_command
+
+```sh
+git show 5ccdc08d8f0252be7458c27ce9308f7742e78f96:docs/test-specs/server-service-spec.md | nl -ba | sed -n '80,220p'
+```
+
+Output:
+
+```text
+    80	- Respects a caller-supplied limit.
+    81	- Caps the effective limit at 100.
+    82	
+    83	### 3.5 `getServer`
+    84	
+    85	Purpose: look up a single server by its slug.
+    86	
+    87	Program paths:
+    88	
+    89	- Returns the matching server when a server with the given slug exists.
+    90	- Returns `null` when no server matches the slug.
+    91	
+    92	### 3.6 `createServer`
+    93	
+    94	Purpose: create a new server, seed a default channel, and register the creator as `OWNER`.
+    95	
+    96	Program paths:
+    97	
+    98	- Server is created successfully; a default channel is created; the creator is added as owner; the new server is returned.
+    99	- Name that produces an empty slug (e.g. all special characters) throws `TRPCError` with code `BAD_REQUEST` from `generateUniqueSlug`.
+   100	- Slug collision is resolved automatically by appending a numeric suffix and retrying, up to 10 attempts; if all 10 slugs collide, throws `TRPCError` with code `CONFLICT`.
+   101	- A transient Prisma `P2002` unique-violation on `server.create` triggers `withSlugRetry` to regenerate the slug and retry up to 3 times before throwing `CONFLICT`.
+   102	- An unexpected non-`P2002` Prisma error from `server.create` is rethrown as-is.
+   103	
+   104	### 3.7 `updateServer`
+   105	
+   106	Purpose: update server metadata and optionally rename (with a new slug); enforces owner or system-admin authorization.
+   107	
+   108	Program paths:
+   109	
+   110	- Server does not exist.
+   111	- Actor is not the owner and is not a system admin.
+   112	- Actor is the owner: update succeeds without renaming.
+   113	- Actor is the owner: update with a new name regenerates the slug and persists both changes.
+   114	- Actor is not the owner but is a system admin: update succeeds.
+   115	- Name change that exhausts all slug attempts throws `TRPCError` with code `CONFLICT`.
+   116	- `SERVER_UPDATED` event is published after any successful update.
+   117	- Return value is the updated server record.
+   118	
+   119	### 3.8 `deleteServer`
+   120	
+   121	Purpose: permanently delete a server; enforces owner or system-admin authorization.
+   122	
+   123	Program paths:
+   124	
+   125	- Server does not exist.
+   126	- Actor is not the owner and is not a system admin.
+   127	- Actor is the owner: server is deleted and returned.
+   128	- Actor is not the owner but is a system admin: server is deleted and returned.
+   129	
+   130	### 3.9 `incrementMemberCount`
+   131	
+   132	Purpose: atomically increment a server's `memberCount` by one.
+   133	
+   134	Program paths:
+   135	
+   136	- Increments `memberCount` by 1 and returns the updated server record.
+   137	
+   138	### 3.10 `decrementMemberCount`
+   139	
+   140	Purpose: atomically decrement a server's `memberCount` by one, guarding against going below zero.
+   141	
+   142	Program paths:
+   143	
+   144	- Server does not exist.
+   145	- Server exists but `memberCount` is already `0`.
+   146	- Server exists and `memberCount > 0`: decrements and returns the updated server record.
+   147	
+   148	### 3.11 `getMembers`
+   149	
+   150	Purpose: return all members of a server with user profile data, sorted by role rank then join date.
+   151	
+   152	Program paths:
+   153	
+   154	- Returns members sorted by role hierarchy (`OWNER` first, `GUEST` last).
+   155	- Within the same role, members are ordered by ascending `joinedAt`.
+   156	- Returns an empty array when the server has no members.
+   157	- Roles not present in the rank map are sorted after `GUEST` (rank `99`).
+   158	
+   159	## 4. Detailed Test Cases
+   160	
+   161	### 4.1 `generateSlug`
+   162	
+   163	Description: pure synchronous slug normalisation that can be tested without any database setup.
+   164	
+   165	| Test Purpose                                            | Inputs                              | Expected Output                                                  |
+   166	| ------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------- |
+   167	| Convert mixed-case name with spaces                     | `"Hello World"`                     | `"hello-world"`                                                  |
+   168	| Trim leading and trailing whitespace                    | `"  My Server  "`                   | `"my-server"`                                                    |
+   169	| Strip non-alphanumeric characters (except spaces/hyphens) | `"Café & Lounge!"`               | `"caf-lounge"` (non-ASCII/special chars removed)                 |
+   170	| Collapse multiple spaces into one hyphen                | `"foo   bar"`                       | `"foo-bar"`                                                      |
+   171	| Collapse consecutive hyphens into one                  | `"foo--bar"`                        | `"foo-bar"`                                                      |
+   172	| Remove leading hyphen from result                      | `"-leading"`                        | `"leading"`                                                      |
+   173	| Remove trailing hyphen from result                     | `"trailing-"`                       | `"trailing"`                                                     |
+   174	| Return empty string when all characters are stripped   | `"!!!"`                             | `""`                                                             |
+   175	| Return empty string for empty input                    | `""`                                | `""`                                                             |
+   176	
+   177	### 4.2 `getPublicServers`
+   178	
+   179	Description: retrieves public servers, most recently created first, within a configurable limit.
+   180	
+   181	| Test Purpose                                     | Inputs                                           | Expected Output                                                                              |
+   182	| ------------------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+   183	| Return public servers in descending creation order | Three seeded public servers; default `limit`   | Returns all three in newest-first order                                                      |
+   184	| Exclude private servers                          | One public and one private server; default limit | Returns only the public server                                                               |
+   185	| Respect caller-supplied limit                    | Five public servers; `limit = 2`                 | Returns exactly 2 servers                                                                    |
+   186	| Cap effective limit at 100                       | `limit = 200`; prisma spy                        | `prisma.server.findMany` is called with `take: 100`                                          |
+   187	| Return empty array when no public servers exist  | No servers seeded                                | Returns `[]`                                                                                 |
+   188	
+   189	### 4.3 `getAllServers`
+   190	
+   191	Description: retrieves all servers regardless of visibility (admin endpoint).
+   192	
+   193	| Test Purpose                           | Inputs                                              | Expected Output                                             |
+   194	| -------------------------------------- | --------------------------------------------------- | ----------------------------------------------------------- |
+   195	| Return both public and private servers | One public server and one private server seeded     | Returns both servers                                        |
+   196	| Respect caller-supplied limit          | Five servers; `limit = 3`                           | Returns exactly 3 servers                                   |
+   197	| Cap effective limit at 100             | `limit = 500`; prisma spy                           | `prisma.server.findMany` is called with `take: 100`         |
+   198	| Return empty array when no servers exist | No servers seeded                                 | Returns `[]`                                                |
+   199	
+   200	### 4.4 `getMemberServers`
+   201	
+   202	Description: retrieves servers the user has joined, ordered by join date ascending.
+   203	
+   204	| Test Purpose                                 | Inputs                                                          | Expected Output                                                          |
+   205	| -------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------ |
+   206	| Return servers in ascending join order       | User with two memberships; older membership seeded second       | Returns the server joined first (lower `joinedAt`) at index 0            |
+   207	| Return empty array for user with no memberships | Valid `userId` with no `serverMember` records               | Returns `[]`                                                             |
+   208	| Respect caller-supplied limit               | User is a member of five servers; `limit = 2`                   | Returns exactly 2 servers                                                |
+   209	| Cap effective limit at 100                  | `limit = 200`; prisma spy                                       | `prisma.serverMember.findMany` is called with `take: 100`                |
+   210	
+   211	### 4.5 `getServer`
+   212	
+   213	Description: looks up a single server by URL slug.
+   214	
+   215	| Test Purpose                    | Inputs                                     | Expected Output                              |
+   216	| ------------------------------- | ------------------------------------------ | -------------------------------------------- |
+   217	| Return server for known slug    | Valid slug of an existing server           | Returns the matching `Server` record         |
+   218	| Return null for unknown slug    | A slug that does not match any server      | Returns `null`                               |
+   219	
+   220	### 4.6 `createServer`
+```
+
+#### Tool: exec_command
+
+```sh
+nl -ba harmony-backend/src/services/server.service.ts | sed -n '1,220p'
+```
+
+Output:
+
+```text
+     1	import { Server, Prisma } from '@prisma/client';
+     2	import { TRPCError } from '@trpc/server';
+     3	import { prisma } from '../db/prisma';
+     4	import { channelService } from './channel.service';
+     5	import { serverMemberService } from './serverMember.service';
+     6	import { isSystemAdmin } from '../lib/admin.utils';
+     7	import { eventBus, EventChannels } from '../events/eventBus';
+     8	
+     9	// Role hierarchy for sorting: lower rank = higher privilege
+    10	const ROLE_RANK: Record<string, number> = {
+    11	  OWNER: 0,
+    12	  ADMIN: 1,
+    13	  MODERATOR: 2,
+    14	  MEMBER: 3,
+    15	  GUEST: 4,
+    16	};
+    17	
+    18	export interface ServerMemberWithUser {
+    19	  userId: string;
+    20	  serverId: string;
+    21	  role: string;
+    22	  joinedAt: Date;
+    23	  user: {
+    24	    id: string;
+    25	    username: string;
+    26	    displayName: string;
+    27	    avatarUrl: string | null;
+    28	    status: string;
+    29	  };
+    30	}
+    31	
+    32	export function generateSlug(name: string): string {
+    33	  return name
+    34	    .toLowerCase()
+    35	    .trim()
+    36	    .replace(/[^a-z0-9\s-]/g, '')
+    37	    .replace(/[\s]+/g, '-')
+    38	    .replace(/-+/g, '-')
+    39	    .replace(/^-|-$/g, '');
+    40	}
+    41	
+    42	async function generateUniqueSlug(name: string): Promise<string> {
+    43	  const base = generateSlug(name);
+    44	  if (!base)
+    45	    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot generate slug from name' });
+    46	
+    47	  const MAX_ATTEMPTS = 10;
+    48	  let candidate = base;
+    49	  for (let suffix = 1; suffix <= MAX_ATTEMPTS; suffix++) {
+    50	    if ((await prisma.server.count({ where: { slug: candidate } })) === 0) return candidate;
+    51	    candidate = `${base}-${suffix}`;
+    52	  }
+    53	  throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });
+    54	}
+    55	
+    56	/**
+    57	 * Generic slug-collision retry helper.
+    58	 * Calls fn(slug) up to maxRetries times, regenerating the slug on a P2002 unique violation.
+    59	 */
+    60	async function withSlugRetry(
+    61	  name: string,
+    62	  initialSlug: string,
+    63	  fn: (slug: string) => Promise<Server>,
+    64	  maxRetries = 3,
+    65	): Promise<Server> {
+    66	  let slug = initialSlug;
+    67	  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    68	    if (attempt > 0) slug = await generateUniqueSlug(name);
+    69	    try {
+    70	      return await fn(slug);
+    71	    } catch (err) {
+    72	      if (
+    73	        err instanceof Prisma.PrismaClientKnownRequestError &&
+    74	        err.code === 'P2002' &&
+    75	        attempt < maxRetries - 1
+    76	      ) {
+    77	        continue;
+    78	      }
+    79	      throw err;
+    80	    }
+    81	  }
+    82	  throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });
+    83	}
+    84	
+    85	export const serverService = {
+    86	  async getPublicServers(limit = 50): Promise<Server[]> {
+    87	    return prisma.server.findMany({
+    88	      where: { isPublic: true },
+    89	      orderBy: { createdAt: 'desc' },
+    90	      take: Math.min(limit, 100),
+    91	    });
+    92	  },
+    93	
+    94	  /** Dev admin: returns all servers regardless of visibility. */
+    95	  async getAllServers(limit = 50): Promise<Server[]> {
+    96	    return prisma.server.findMany({
+    97	      orderBy: { createdAt: 'desc' },
+    98	      take: Math.min(limit, 100),
+    99	    });
+   100	  },
+   101	
+   102	  /** Returns only the servers the given user is a member of. */
+   103	  async getMemberServers(userId: string, limit = 50): Promise<Server[]> {
+   104	    const memberships = await prisma.serverMember.findMany({
+   105	      where: { userId },
+   106	      include: { server: true },
+   107	      orderBy: { joinedAt: 'asc' },
+   108	      take: Math.min(limit, 100),
+   109	    });
+   110	    return memberships.map((m) => m.server);
+   111	  },
+   112	
+   113	  async getServer(slug: string): Promise<Server | null> {
+   114	    return prisma.server.findUnique({ where: { slug } });
+   115	  },
+   116	
+   117	  async createServer(input: {
+   118	    name: string;
+   119	    description?: string;
+   120	    iconUrl?: string;
+   121	    isPublic?: boolean;
+   122	    ownerId: string;
+   123	  }): Promise<Server> {
+   124	    const slug = await generateUniqueSlug(input.name);
+   125	    const server = await withSlugRetry(input.name, slug, (s) =>
+   126	      prisma.server.create({ data: { ...input, slug: s } }),
+   127	    );
+   128	    await channelService.createDefaultChannel(server.id);
+   129	    await serverMemberService.addOwner(input.ownerId, server.id);
+   130	    return server;
+   131	  },
+   132	
+   133	  async updateServer(
+   134	    id: string,
+   135	    actorId: string,
+   136	    data: { name?: string; description?: string; iconUrl?: string; isPublic?: boolean },
+   137	  ): Promise<Server> {
+   138	    const server = await prisma.server.findUnique({ where: { id } });
+   139	    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
+   140	    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))
+   141	      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can update' });
+   142	
+   143	    let updated: Server;
+   144	    if (data.name && data.name !== server.name) {
+   145	      const slug = await generateUniqueSlug(data.name);
+   146	      updated = await withSlugRetry(data.name, slug, (s) =>
+   147	        prisma.server.update({ where: { id }, data: { ...data, slug: s } }),
+   148	      );
+   149	    } else {
+   150	      updated = await prisma.server.update({ where: { id }, data });
+   151	    }
+   152	
+   153	    void eventBus.publish(EventChannels.SERVER_UPDATED, {
+   154	      serverId: id,
+   155	      name: updated.name,
+   156	      iconUrl: updated.iconUrl ?? null,
+   157	      description: updated.description ?? null,
+   158	      timestamp: new Date().toISOString(),
+   159	    });
+   160	
+   161	    return updated;
+   162	  },
+   163	
+   164	  async deleteServer(id: string, actorId: string): Promise<Server> {
+   165	    const server = await prisma.server.findUnique({ where: { id } });
+   166	    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
+   167	    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))
+   168	      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can delete' });
+   169	    return prisma.server.delete({ where: { id } });
+   170	  },
+   171	
+   172	  async incrementMemberCount(id: string): Promise<Server> {
+   173	    return prisma.server.update({
+   174	      where: { id },
+   175	      data: { memberCount: { increment: 1 } },
+   176	    });
+   177	  },
+   178	
+   179	  async decrementMemberCount(id: string): Promise<Server> {
+   180	    const server = await prisma.server.findUnique({ where: { id } });
+   181	    if (!server || server.memberCount <= 0) {
+   182	      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Member count is already zero' });
+   183	    }
+   184	    return prisma.server.update({
+   185	      where: { id },
+   186	      data: { memberCount: { decrement: 1 } },
+   187	    });
+   188	  },
+   189	
+   190	  async getMembers(serverId: string): Promise<ServerMemberWithUser[]> {
+   191	    const members = await prisma.serverMember.findMany({
+   192	      where: { serverId },
+   193	      include: {
+   194	        user: {
+   195	          select: { id: true, username: true, displayName: true, avatarUrl: true, status: true },
+   196	        },
+   197	      },
+   198	    });
+   199	    return members
+   200	      .map((m) => ({ ...m, role: m.role as string }))
+   201	      .sort(
+   202	        (a, b) =>
+   203	          (ROLE_RANK[a.role] ?? 99) - (ROLE_RANK[b.role] ?? 99) ||
+   204	          a.joinedAt.getTime() - b.joinedAt.getTime(),
+   205	      );
+   206	  },
+   207	};
+```
+
+#### Tool: exec_command
+
+```sh
+git show 5ccdc08d8f0252be7458c27ce9308f7742e78f96:docs/test-specs/server-service-spec.md | nl -ba | sed -n '220,320p'
+```
+
+Output:
+
+```text
+   220	### 4.6 `createServer`
+   221	
+   222	Description: creates a server, seeds a default channel, and registers the creator as owner.
+   223	
+   224	| Test Purpose                                                   | Inputs                                                                                                | Expected Output                                                                                                                                               |
+   225	| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   226	| Create server with all optional fields provided                | Valid `name`, `description`, `iconUrl`, `isPublic = true`, `ownerId`                                  | Returns created server; `channelService.createDefaultChannel` called with new server id; `serverMemberService.addOwner` called with `ownerId` and server id    |
+   227	| Create server with only required fields                        | Valid `name` and `ownerId`; no optional fields                                                        | Returns created server; default channel and owner membership are created                                                                                      |
+   228	| Throw BAD_REQUEST when name produces empty slug                | `name` composed entirely of special characters (e.g. `"!!!"`)                                         | Throws `TRPCError` with code `BAD_REQUEST` and message `Cannot generate slug from name`                                                                       |
+   229	| Throw CONFLICT when all slug attempts are taken                | Valid `name`; `prisma.server.count` mocked to always return `1` for the base slug and all 10 suffixes | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`                                                                        |
+   230	| Retry on transient P2002 during server create                  | Valid `name`; `prisma.server.create` throws `P2002` on first attempt then succeeds on second         | Returns successfully created server; retried without further error                                                                                            |
+   231	| Throw on non-P2002 Prisma error during server create           | Valid `name`; `prisma.server.create` throws a non-`P2002` Prisma error                               | Throws the original Prisma error unchanged                                                                                                                    |
+   232	
+   233	### 4.7 `updateServer`
+   234	
+   235	Description: updates server metadata, handles name changes with slug regeneration, and enforces authorization.
+   236	
+   237	| Test Purpose                                                 | Inputs                                                                                          | Expected Output                                                                                                                              |
+   238	| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+   239	| Throw NOT_FOUND when server does not exist                   | Unknown `id`; valid `actorId`; any `data`                                                       | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                                                                      |
+   240	| Throw FORBIDDEN when actor is not owner and not system admin | Existing server; `actorId` different from `ownerId`; `isSystemAdmin` mocked to return `false`  | Throws `TRPCError` with code `FORBIDDEN` and message `Only the server owner can update`                                                      |
+   241	| Allow owner to update without renaming                       | Existing server; `actorId === server.ownerId`; `data` without `name`                           | Returns updated server; slug is unchanged; `SERVER_UPDATED` event is published                                                               |
+   242	| Allow owner to update with a new name                        | Existing server; `actorId === server.ownerId`; `data.name` is a new distinct value             | Returns updated server with new name and regenerated slug; `SERVER_UPDATED` event is published                                               |
+   243	| Skip slug regeneration when name is unchanged                | Existing server; `actorId === server.ownerId`; `data.name === server.name`                     | Update is applied with the existing slug; `generateUniqueSlug` is not called; `SERVER_UPDATED` event is published                            |
+   244	| Allow system admin to update a server they do not own        | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `true`         | Returns updated server; `SERVER_UPDATED` event is published                                                                                  |
+   245	| Publish SERVER_UPDATED event after successful update         | Any successful update scenario                                                                  | `eventBus.publish` is called with `EventChannels.SERVER_UPDATED` and a payload containing `serverId`, `name`, `iconUrl`, `description`, and `timestamp` |
+   246	| Throw CONFLICT when all slug attempts are taken on rename    | Valid `actorId`; name change; all slug candidates mocked as occupied                           | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`                                                       |
+   247	
+   248	### 4.8 `deleteServer`
+   249	
+   250	Description: permanently deletes a server record; enforces owner or system-admin authorization.
+   251	
+   252	| Test Purpose                                                   | Inputs                                                                                          | Expected Output                                                                              |
+   253	| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+   254	| Throw NOT_FOUND when server does not exist                     | Unknown `id`; valid `actorId`                                                                   | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                      |
+   255	| Throw FORBIDDEN when actor is not owner and not system admin   | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `false`        | Throws `TRPCError` with code `FORBIDDEN` and message `Only the server owner can delete`      |
+   256	| Allow owner to delete their server                             | Existing server; `actorId === server.ownerId`                                                   | Deletes the server; returns the deleted server record                                        |
+   257	| Allow system admin to delete a server they do not own          | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `true`         | Deletes the server; returns the deleted server record                                        |
+   258	
+   259	### 4.9 `incrementMemberCount`
+   260	
+   261	Description: atomically adds 1 to a server's `memberCount`.
+   262	
+   263	| Test Purpose                            | Inputs                                               | Expected Output                                                          |
+   264	| --------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------ |
+   265	| Increment memberCount by 1              | Existing server with `memberCount = 3`               | Returns server record with `memberCount = 4`                             |
+   266	
+   267	### 4.10 `decrementMemberCount`
+   268	
+   269	Description: atomically subtracts 1 from a server's `memberCount`, refusing to go below zero.
+   270	
+   271	| Test Purpose                                        | Inputs                                             | Expected Output                                                                                  |
+   272	| --------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+   273	| Decrement memberCount by 1                          | Existing server with `memberCount = 2`             | Returns server record with `memberCount = 1`                                                     |
+   274	| Throw BAD_REQUEST when server does not exist        | Unknown `id`                                       | Throws `TRPCError` with code `BAD_REQUEST` and message `Member count is already zero`            |
+   275	| Throw BAD_REQUEST when memberCount is already zero  | Existing server with `memberCount = 0`             | Throws `TRPCError` with code `BAD_REQUEST` and message `Member count is already zero`            |
+   276	
+   277	### 4.11 `getMembers`
+   278	
+   279	Description: loads all members with user profile fields and sorts by role rank then join date.
+   280	
+   281	| Test Purpose                                              | Inputs                                                                                                   | Expected Output                                                                                                                   |
+   282	| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+   283	| Return members sorted by role hierarchy                   | Server with seeded owner, admin, moderator, member, and guest memberships                                | Returns array with `OWNER` at index 0, followed by `ADMIN`, `MODERATOR`, `MEMBER`, `GUEST` in that order                         |
+   284	| Preserve ascending join order within the same role        | Server with two `MEMBER` rows where the newer member was inserted first in the array                     | Returns the older-join member before the newer-join member                                                                        |
+   285	| Return empty array when server has no members             | Valid `serverId` with no `serverMember` records                                                           | Returns `[]`                                                                                                                      |
+   286	| Include user profile fields on each member                | Server with one seeded member whose user has `username`, `displayName`, `avatarUrl`, and `status` set   | Each returned element contains `user.id`, `user.username`, `user.displayName`, `user.avatarUrl`, and `user.status`                |
+   287	| Sort unknown roles after all known roles                  | Server with a member whose role string is not in the `ROLE_RANK` map (e.g. `"CUSTOM"`)                  | The unknown-role member appears after any `GUEST` members; does not throw                                                         |
+   288	
+   289	## 5. Edge Cases to Explicitly Validate
+   290	
+   291	- `generateSlug` is a pure function; assert it without any database calls.
+   292	- `generateUniqueSlug` must throw `BAD_REQUEST` when the base slug is empty, not `CONFLICT`.
+   293	- `decrementMemberCount` must reject both a missing server and a server at zero with the same `BAD_REQUEST` error; the `!server || server.memberCount <= 0` compound condition must be tested with both failing branches.
+   294	- Name unchanged in `updateServer` must not trigger a slug query; use a spy on `prisma.server.count` to confirm it is not called.
+   295	- `updateServer` and `deleteServer` must independently check `isSystemAdmin`; a system admin who is not the owner must be permitted in both functions.
+   296	- `SERVER_UPDATED` must be published after every successful update, including updates that do not change the name.
+   297	- `createServer` must call `channelService.createDefaultChannel` and `serverMemberService.addOwner` in that order and with the correct server id, not the input id.
+   298	- The `withSlugRetry` P2002 path only retries on a known `P2002` constraint error; any other Prisma error must pass through immediately without retry.
+   299	
+   300	## 6. Coverage Expectation
+   301	
+   302	The cases above are intended to cover:
+   303	
+   304	- all public service methods and the exported `generateSlug` utility,
+   305	- every explicit `TRPCError` branch in the service and its private helpers,
+   306	- successful transaction paths with correct return values,
+   307	- event publication side effects via `eventBus.publish`,
+   308	- the slug-generation retry logic under collision and exhaustion scenarios,
+   309	- authorization guards for both owner and system-admin paths, and
+   310	- representative unexpected database failure paths.
+   311	
+   312	Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures outside the service's direct branching logic.
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:03:28.031Z
+
+- [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.
+- [x] Security first: docs-only change; no new security surface or secret exposure.
+- [x] Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.
+- [ ] Issue completion: issue #259 asks for all program paths, and the current spec does not fully capture the real `createServer`/`withSlugRetry` paths.
+- [x] No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.
+- [x] Avoid repetition: there are no existing PR comments to duplicate.
+- [x] Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.
+- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.
+
+**Bundled review**
+
+I found 3 substantive issues.
+
+1. [server-service-spec.md:101](/Users/allen/repos/Harmony/docs/test-specs/server-service-spec.md#L101) documents the `withSlugRetry` exhaustion path incorrectly. In [server.service.ts:67](/Users/allen/repos/Harmony/harmony-backend/src/services/server.service.ts#L67), a third `P2002` does not become `TRPCError(CONFLICT)`; it is rethrown as the original Prisma error. That makes the spec inaccurate for both `createServer` and renamed `updateServer` flows.
+
+2. [server-service-spec.md:224](/Users/allen/repos/Harmony/docs/test-specs/server-service-spec.md#L224) omits two real `createServer` failure branches. After the insert succeeds, [server.service.ts:128](/Users/allen/repos/Harmony/harmony-backend/src/services/server.service.ts#L128) and [server.service.ts:129](/Users/allen/repos/Harmony/harmony-backend/src/services/server.service.ts#L129) can still reject via `createDefaultChannel` or `addOwner`, but the spec never covers those paths despite claiming full program-path coverage.
+
+3. [server-service-spec.md:229](/Users/allen/repos/Harmony/docs/test-specs/server-service-spec.md#L229) describes the slug exhaustion boundary incorrectly. In [server.service.ts:47](/Users/allen/repos/Harmony/harmony-backend/src/services/server.service.ts#L47), `generateUniqueSlug` checks 10 total candidates (`base` through `base-9`), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong off-by-one boundary.
+
+### Turn 2: why are you telling me, post it on the PR as a single review with
+
+#### 👤 User Prompt
+
+- Time: 2026-03-31T23:04:12.429Z
+
+```text
+why are you telling me, post it on the PR as a single review with inline comments
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:04:31.124Z
+
+I’ve got the review content already. I’m formatting it into one GitHub review with inline comments and then I’ll post it directly to PR `#275`.
+
+#### Tool: exec_command
+
+```sh
+rtk read /Users/allen/.codex/plugins/cache/openai-curated/github/f78e3ad49297672a905eb7afb6aa0cef34edc79e/skills/github/SKILL.md
+```
+
+Output:
+
+```text
+---
+name: github
+description: Triage and orient GitHub repository, pull request, and issue work through the connected GitHub app. Use when the user asks for general GitHub help, wants PR or issue summaries, or needs repository context before choosing a more specific GitHub workflow.
+---
+
+# GitHub
+
+## Overview
+
+Use this skill as the umbrella entrypoint for general GitHub work in this plugin. It should decide whether the task stays in repo and PR triage or should be handed off to a more specific review, CI, or publish workflow.
+
+This plugin is intentionally hybrid:
+
+- Prefer the GitHub app from this plugin for repository, issue, pull request, comment, label, reaction, and PR creation workflows.
+- Use local `git` and `gh` only when the connector does not cover the job well, especially for current-branch PR discovery, branch creation, commit and push, `gh auth status`, and GitHub Actions log inspection.
+- Keep connector state and local checkout context aligned. If the request is about the current branch, resolve the local repo and branch before acting.
+
+Once the intent is clear, route to the specialist skill immediately and do not keep broad GitHub triage in scope longer than needed.
+
+## Connector-First Responsibilities
+
+Handle these directly in this skill when the request does not need a narrower specialist workflow:
+
+- repository orientation once the repo, PR, issue, or local checkout is identified
+- recent PR or issue triage
+- PR metadata summaries
+- PR patch inspection
+- PR comments, labels, and reactions
+- issue lookup and summarization
+- PR creation after a branch is already pushed
+
+Prefer the GitHub app from this plugin for those flows because it provides structured PR, issue, and review-adjacent data without depending on a local checkout. If the repository is not already identifiable from the user request or local git context, ask for the repo instead of pretending there is a repo-search flow that may not exist.
+
+## Routing Rules
+
+1. Resolve the operating context first:
+   - If the user provides a repository, PR number, issue number, or URL, use that.
+   - If the request is about "this branch" or "the current PR", resolve local git context and use `gh` only as needed to discover the branch PR.
+   - If the repository is still ambiguous after local inspection, ask for the repo identifier.
+2. Classify the request before taking action:
+   - `repo or PR triage`: summarize PRs, issues, patches, comments, labels, reactions, or repository state
+   - `review follow-up`: unresolved review threads, requested changes, or inline review feedback
+   - `CI debugging`: failing checks, Actions logs, or CI root-cause analysis
+   - `publish changes`: create or switch branches, stage changes, commit, push, and open a draft PR
+3. Route to the specialist skill as soon as the category is clear:
+   - Review comments and requested changes: `../gh-address-comments/SKILL.md`
+   - Failing GitHub Actions checks: `../gh-fix-ci/SKILL.md`
+   - Commit, push, and open PR: `../yeet/SKILL.md`
+4. Keep the hybrid model consistent after routing:
+   - connector first for PR and issue data
+   - local `git` and `gh` only for the specific gaps the connector does not cover
+
+## Default Workflow
+
+1. Resolve repository and item scope.
+2. Gather structured PR or issue context through the GitHub app from this plugin.
+3. Decide whether the task stays in connector-backed triage or needs a specialist skill.
+4. Route immediately when the work becomes review follow-up, CI debugging, or publish workflow.
+5. End with a clear summary of what was inspected, what changed, and what remains.
+
+## Output Expectations
+
+- For triage requests, return a concise summary of the repository, PR, or issue state and the next likely action.
+- For mixed requests, tell the user which specialist path you are taking and why.
+- For connector-backed write actions, restate the exact PR, issue, label, or reaction target before applying the change.
+- Never imply that GitHub Actions logs are available through the connector alone. That remains a `gh` workflow.
+
+## Examples
+
+- "Use GitHub to summarize the open PRs in this repo and tell me what needs attention."
+- "Help with this PR."
+- "Review the latest comments on PR 482 and tell me what is actionable."
+- "Debug the failing checks on this branch."
+- "Commit these changes, push them, and open a draft PR."
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read /Users/allen/.codex/plugins/cache/openai-curated/github/f78e3ad49297672a905eb7afb6aa0cef34edc79e/skills/gh-address-comments/SKILL.md
+```
+
+Output:
+
+```text
+---
+name: gh-address-comments
+description: Address actionable GitHub pull request review feedback. Use when the user wants to inspect unresolved review threads, requested changes, or inline review comments on a PR, then implement selected fixes. Use the GitHub app for PR metadata and flat comment reads, and use the bundled GraphQL script via `gh` whenever thread-level state, resolution status, or inline review context matters.
+---
+
+# GitHub PR Comment Handler
+
+Use this skill when the user wants to work through requested changes on a GitHub pull request. Use the GitHub app from this plugin for PR metadata and patch context, but treat thread-aware review data as a `gh api graphql` problem because the connector comment surface is flat and does not preserve full review-thread state.
+
+Run all `gh` commands with elevated network access. If CLI auth is required, confirm `gh auth status` first and ask the user to authenticate with `gh auth login` if it fails.
+
+## Workflow
+
+1. Resolve the PR.
+   - If the user provides a repository and PR number or URL, use that directly.
+   - If the request is about the current branch PR, use local git context plus `gh auth status` and `gh pr view --json number,url` to resolve it.
+2. Inspect review context with thread-aware reads.
+   - Use the GitHub app from this plugin to fetch PR metadata and patch context when the repo and PR are known.
+   - Use the bundled `scripts/fetch_comments.py` workflow whenever the task depends on unresolved review threads, inline review locations, or resolution state. That script fetches `reviewThreads`, `isResolved`, `isOutdated`, and file and line anchors that the connector comment surface does not preserve.
+   - Use connector-only comment reads only for lightweight top-level PR comment summaries.
+3. Cluster actionable review threads.
+   - Group comments by file or behavior area.
+   - Separate actionable change requests from informational comments, approvals, already-resolved threads, and duplicates.
+4. Confirm scope before editing.
+   - Present numbered actionable threads with a one-line summary of the required change.
+   - If the user did not ask to fix everything, ask which threads to address.
+   - If the user asks to fix everything, interpret that as all unresolved actionable threads and call out anything ambiguous.
+5. Implement the selected fixes locally.
+   - Keep each code change traceable back to the thread or feedback cluster it addresses.
+   - If a comment calls for explanation rather than code, draft the response rather than forcing a code change.
+6. Summarize the result.
+   - List which threads were addressed, which were intentionally left open, and what tests or checks support the change.
+
+## Write Safety
+
+- Do not reply on GitHub, resolve review threads, or submit a review unless the user explicitly asks for that write action.
+- If review comments conflict with each other or would cause a behavioral regression, surface the tradeoff before making changes.
+- If a comment is ambiguous, ask for clarification or draft a proposed response instead of guessing.
+- Do not treat flat PR comments from the connector as a complete representation of review-thread state.
+- If `gh` hits auth or rate-limit issues mid-run, ask the user to re-authenticate and retry.
+
+## Fallback
+
+If neither the connector nor `gh` can resolve the PR cleanly, tell the user whether the blocker is missing repository scope, missing PR context, or CLI authentication, then ask for the missing repo or PR identifier or for a refreshed `gh` login.
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:04:50.998Z
+
+I’m using the GitHub review API directly because it supports one review body plus multiple inline comments in a single submission. First I’m verifying `gh` auth, then I’ll send the review on the PR head commit.
+
+#### Tool: exec_command
+
+```sh
+gh auth status
+```
+
+Output:
+
+```text
+github.com
+  ✓ Logged in to github.com account acabrera04 (keyring)
+  - Active account: true
+  - Git operations protocol: ssh
+  - Token: gho_************************************
+  - Token scopes: 'admin:public_key', 'gist', 'project', 'read:org', 'repo', 'workflow'
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr view 275 --repo acabrera04/Harmony --json headRefOid,reviewDecision,url,title
+```
+
+Output:
+
+```text
+{"headRefOid":"5ccdc08d8f0252be7458c27ce9308f7742e78f96","reviewDecision":"REVIEW_REQUIRED","title":"docs(tests): test specification for server.service.ts","url":"https://github.com/acabrera04/Harmony/pull/275"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:04:58.886Z
+
+The review text is set. I’m posting it as `REQUEST_CHANGES` with three inline comments anchored to the spec lines that are inaccurate or incomplete.
+
+#### Tool: exec_command
+
+```sh
+review_body=$(cat <<'EOF'
+- [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.
+- [x] Security first: docs-only change; no new security surface or secret exposure.
+- [x] Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.
+- [ ] Issue completion: issue #259 asks for all program paths, and the current spec does not fully capture the real `createServer`/`withSlugRetry` paths.
+- [x] No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.
+- [x] Avoid repetition: there are no existing PR comments to duplicate.
+- [x] Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.
+- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.
+
+**Bundled review**
+
+I found 3 substantive issues.
+
+1. `withSlugRetry` exhaustion is documented incorrectly. In `server.service.ts`, a third `P2002` does not become `TRPCError(CONFLICT)`; it is rethrown as the original Prisma error. That makes the spec inaccurate for both `createServer` and renamed `updateServer` flows.
+
+2. `createServer` is missing two real failure paths. After the insert succeeds, `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)` can still reject, but the spec never covers those paths despite claiming full program-path coverage.
+
+3. The slug exhaustion boundary is off by one. `generateUniqueSlug` checks 10 total candidates (`base` through `base-9`), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.
+EOF
+)
+
+jq -n \
+  --arg body "$review_body" \
+  --arg commit_id "5ccdc08d8f0252be7458c27ce9308f7742e78f96" \
+  '{event:"REQUEST_CHANGES", body:$body, commit_id:$commit_id, comments:[
+    {path:"docs/test-specs/server-service-spec.md", line:101, side:"RIGHT", body:"This says repeated `P2002` collisions in `withSlugRetry` eventually become `TRPCError(CONFLICT)`, but the implementation actually rethrows the third `P2002` directly because it only retries while `attempt < maxRetries - 1`. Tests written from this doc would assert the wrong contract for both `createServer` and rename-in-`updateServer`."},
+    {path:"docs/test-specs/server-service-spec.md", line:229, side:"RIGHT", body:"The slug-exhaustion boundary is off by one here. `generateUniqueSlug` only probes 10 total candidates: `base`, then `base-1` through `base-9`. `base-10` is never checked, so this test case does not match the current source."},
+    {path:"docs/test-specs/server-service-spec.md", line:230, side:"RIGHT", body:"`createServer` has two additional awaited branches after `prisma.server.create`: `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)`. If either rejects, the service rejects too, but this section never specifies those paths even though the document claims to cover all program paths and representative failure cases."}
+  ]}' \
+| gh api repos/acabrera04/Harmony/pulls/275/reviews --method POST --input -
+```
+
+Output:
+
+```text
+
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:05:18.511Z
+
+The first submission command was over-escaped by the shell wrapper. I’m correcting it and reissuing a clean API call now.
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 90178,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'review_body=$(cat <<'"'EOF'
+- [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real "'`createServer` failure paths.
+- [x] Security first: docs-only change; no new security surface or secret exposure.
+- [x] Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.
+- [ ] Issue completion: issue #259 asks for all program paths, and the current spec does not fully capture the real `createServer`/`withSlugRetry` paths.
+- [x] No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.
+- [x] Avoid repetition: there are no existing PR comments to duplicate.
+- [x] Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.
+- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.
+
+**Bundled review**
+
+I found 3 substantive issues.
+
+1. `withSlugRetry` exhaustion is documented incorrectly. In `server.service.ts`, a third `P2002` does not become `TRPCError(CONFLICT)`; it is rethrown as the original Prisma error. That makes the spec inaccurate for both `createServer` and renamed `updateServer` flows.
+
+2. `createServer` is missing two real failure paths. After the insert succeeds, `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)` can still reject, but the spec never covers those paths despite claiming full program-path coverage.
+
+3. The slug exhaustion boundary is off by one. `generateUniqueSlug` checks 10 total candidates (`base` through `base-9`), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.
+EOF
+)
+
+jq -n '"\\
+  --arg body \""'$review_body" '"\\
+  --arg commit_id \"5ccdc08d8f0252be7458c27ce9308f7742e78f96\" \\
+  '{event:\"REQUEST_CHANGES\", body:"'$body, commit_id:$commit_id, comments:[
+    {path:"docs/test-specs/server-service-spec.md", line:101, side:"RIGHT", body:"This says repeated `P2002` collisions in `withSlugRetry` eventually become `TRPCError(CONFLICT)`, but the implementation actually rethrows the third `P2002` directly because it only retries while `attempt < maxRetries - 1`. Tests written from this doc would assert the wrong contract for both `createServer` and rename-in-`updateServer`."},
+    {path:"docs/test-specs/server-service-spec.md", line:229, side:"RIGHT", body:"The slug-exhaustion boundary is off by one here. `generateUniqueSlug` only probes 10 total candidates: `base`, then `base-1` through `base-9`. `base-10` is never checked, so this test case does not match the current source."},
+    {path:"docs/test-specs/server-service-spec.md", line:230, side:"RIGHT", body:"`createServer` has two additional awaited branches after `prisma.server.create`: `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)`. If either rejects, the service rejects too, but this section never specifies those paths even though the document claims to cover all program paths and representative failure cases."}
+  ]}'"' \\
+| gh api repos/acabrera04/Harmony/pulls/275/reviews --method POST --input -"
+Chunk ID: a186c5
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 821
+Output:
+{"id":4040719486,"node_id":"PRR_kwDORIrGY87w2Hx-","user":{"login":"acabrera04","id":145043651,"node_id":"U_kgDOCKUwww","avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","gravatar_id":"","url":"https://api.github.com/users/acabrera04","html_url":"https://github.com/acabrera04","followers_url":"https://api.github.com/users/acabrera04/followers","following_url":"https://api.github.com/users/acabrera04/following{/other_user}","gists_url":"https://api.github.com/users/acabrera04/gists{/gist_id}","starred_url":"https://api.github.com/users/acabrera04/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/acabrera04/subscriptions","organizations_url":"https://api.github.com/users/acabrera04/orgs","repos_url":"https://api.github.com/users/acabrera04/repos","events_url":"https://api.github.com/users/acabrera04/events{/privacy}","received_events_url":"https://api.github.com/users/acabrera04/received_events","type":"User","user_view_type":"public","site_admin":false},"body":"- [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.\n- [x] Security first: docs-only change; no new security surface or secret exposure.\n- [x] Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.\n- [ ] Issue completion: issue #259 asks for all program paths, and the current spec does not fully capture the real `createServer`/`withSlugRetry` paths.\n- [x] No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.\n- [x] Avoid repetition: there are no existing PR comments to duplicate.\n- [x] Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.\n- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.\n\n**Bundled review**\n\nI found 3 substantive issues.\n\n1. `withSlugRetry` exhaustion is documented incorrectly. In `server.service.ts`, a third `P2002` does not become `TRPCError(CONFLICT)`; it is rethrown as the original Prisma error. That makes the spec inaccurate for both `createServer` and renamed `updateServer` flows.\n\n2. `createServer` is missing two real failure paths. After the insert succeeds, `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)` can still reject, but the spec never covers those paths despite claiming full program-path coverage.\n\n3. The slug exhaustion boundary is off by one. `generateUniqueSlug` checks 10 total candidates (`base` through `base-9`), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.","state":"CHANGES_REQUESTED","html_url":"https://github.com/acabrera04/Harmony/pull/275#pullrequestreview-4040719486","pull_request_url":"https://api.github.com/repos/acabrera04/Harmony/pulls/275","author_association":"OWNER","_links":{"html":{"href":"https://github.com/acabrera04/Harmony/pull/275#pullrequestreview-4040719486"},"pull_request":{"href":"https://api.github.com/repos/acabrera04/Harmony/pulls/275"}},"submitted_at":"2026-03-31T23:05:14Z","commit_id":"5ccdc08d8f0252be7458c27ce9308f7742e78f96"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:05:24.692Z
+
+The review posted successfully. I’m doing one quick verification pass to confirm the inline comments are attached to the expected lines, not just the top-level review body.
+
+#### Tool: mcp__codex_apps__github_fetch_pr_comments
+
+```json
+{
+  "pr_number": 275,
+  "repo_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"comments":[{"url":"https://github.com/acabrera04/Harmony/pull/275#discussion_r3018902248","body":"This says repeated `P2002` collisions in `withSlugRetry` eventually become `TRPCError(CONFLICT)`, but the implementation actually rethrows the third `P2002` directly because it only retries while `attempt < maxRetries - 1`. Tests written from this doc would assert the wrong contract for both `createServer` and rename-in-`updateServer`.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":3018902248,"pull_request_review_id":4040719486,"in_reply_to_id":null,"created_at":"2026-03-31T23:05:14Z","review":null,"side":"RIGHT","line":101,"start_line":null,"path":"docs/test-specs/server-service-spec.md","body_html":"<p dir=\"auto\">This says repeated <code class=\"notranslate\">P2002</code> collisions in <code class=\"notranslate\">withSlugRetry</code> eventually become <code class=\"notranslate\">TRPCError(CONFLICT)</code>, but the implementation actually rethrows the third <code class=\"notranslate\">P2002</code> directly because it only retries while <code class=\"notranslate\">attempt &lt; maxRetries - 1</code>. Tests written from this doc would assert the wrong contract for both <code class=\"notranslate\">createServer</code> and rename-in-<code class=\"notranslate\">updateServer</code>.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#discussion_r3018902251","body":"The slug-exhaustion boundary is off by one here. `generateUniqueSlug` only probes 10 total candidates: `base`, then `base-1` through `base-9`. `base-10` is never checked, so this test case does not match the current source.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":3018902251,"pull_request_review_id":4040719486,"in_reply_to_id":null,"created_at":"2026-03-31T23:05:14Z","review":null,"side":"RIGHT","line":229,"start_line":null,"path":"docs/test-specs/server-service-spec.md","body_html":"<p dir=\"auto\">The slug-exhaustion boundary is off by one here. <code class=\"notranslate\">generateUniqueSlug</code> only probes 10 total candidates: <code class=\"notranslate\">base</code>, then <code class=\"notranslate\">base-1</code> through <code class=\"notranslate\">base-9</code>. <code class=\"notranslate\">base-10</code> is never checked, so this test case does not match the current source.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#discussion_r3018902253","body":"`createServer` has two additional awaited branches after `prisma.server.create`: `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)`. If either rejects, the service rejects too, but this section never specifies those paths even though the document claims to cover all program paths and representative failure cases.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":3018902253,"pull_request_review_id":4040719486,"in_reply_to_id":null,"created_at":"2026-03-31T23:05:14Z","review":null,"side":"RIGHT","line":230,"start_line":null,"path":"docs/test-specs/server-service-spec.md","body_html":"<p dir=\"auto\"><code class=\"notranslate\">createServer</code> has two additional awaited branches after <code class=\"notranslate\">prisma.server.create</code>: <code class=\"notranslate\">channelService.createDefaultChannel(server.id)</code> and <code class=\"notranslate\">serverMemberService.addOwner(input.ownerId, server.id)</code>. If either rejects, the service rejects too, but this section never specifies those paths even though the document claims to cover all program paths and representative failure cases.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#pullrequestreview-4040719486","body":"- [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.\n- [x] Security first: docs-only change; no new security surface or secret exposure.\n- [x] Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.\n- [ ] Issue completion: issue #259 asks for all program paths, and the current spec does not fully capture the real `createServer`/`withSlugRetry` paths.\n- [x] No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.\n- [x] Avoid repetition: there are no existing PR comments to duplicate.\n- [x] Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.\n- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.\n\n**Bundled review**\n\nI found 3 substantive issues.\n\n1. `withSlugRetry` exhaustion is documented incorrectly. In `server.service.ts`, a third `P2002` does not become `TRPCError(CONFLICT)`; it is rethrown as the original Prisma error. That makes the spec inaccurate for both `createServer` and renamed `updateServer` flows.\n\n2. `createServer` is missing two real failure paths. After the insert succeeds, `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)` can still reject, but the spec never covers those paths despite claiming full program-path coverage.\n\n3. The slug exhaustion boundary is off by one. `generateUniqueSlug` checks 10 total candidates (`base` through `base-9`), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":4040719486,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:05:14Z","review":"CHANGES_REQUESTED","side":null,"line":null,"start_line":null,"path":null,"body_html":"<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Incomplete task\"> Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real <code class=\"notranslate\">createServer</code> failure paths.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Security first: docs-only change; no new security surface or secret exposure.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Incomplete task\"> Issue completion: issue <a class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"4166268741\" data-permission-text=\"Title is private\" data-url=\"https://github.com/acabrera04/Harmony/issues/259\" data-hovercard-type=\"issue\" data-hovercard-url=\"/acabrera04/Harmony/issues/259/hovercard\" href=\"https://github.com/acabrera04/Harmony/issues/259\">#259</a> asks for all program paths, and the current spec does not fully capture the real <code class=\"notranslate\">createServer</code>/<code class=\"notranslate\">withSlugRetry</code> paths.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Avoid repetition: there are no existing PR comments to duplicate.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.</li>\n</ul>\n<p dir=\"auto\"><strong>Bundled review</strong></p>\n<p dir=\"auto\">I found 3 substantive issues.</p>\n<ol dir=\"auto\">\n<li>\n<p dir=\"auto\"><code class=\"notranslate\">withSlugRetry</code> exhaustion is documented incorrectly. In <code class=\"notranslate\">server.service.ts</code>, a third <code class=\"notranslate\">P2002</code> does not become <code class=\"notranslate\">TRPCError(CONFLICT)</code>; it is rethrown as the original Prisma error. That makes the spec inaccurate for both <code class=\"notranslate\">createServer</code> and renamed <code class=\"notranslate\">updateServer</code> flows.</p>\n</li>\n<li>\n<p dir=\"auto\"><code class=\"notranslate\">createServer</code> is missing two real failure paths. After the insert succeeds, <code class=\"notranslate\">channelService.createDefaultChannel(server.id)</code> and <code class=\"notranslate\">serverMemberService.addOwner(input.ownerId, server.id)</code> can still reject, but the spec never covers those paths despite claiming full program-path coverage.</p>\n</li>\n<li>\n<p dir=\"auto\">The slug exhaustion boundary is off by one. <code class=\"notranslate\">generateUniqueSlug</code> checks 10 total candidates (<code class=\"notranslate\">base</code> through <code class=\"notranslate\">base-9</code>), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.</p>\n</li>\n</ol>"}],"url":"https://github.com/acabrera04/Harmony/pull/275","title":"acabrera04/Harmony PR #275 comments","display_url":"https://github.com/acabrera04/Harmony/pull/275","display_title":"acabrera04/Harmony PR #275 comments"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh api repos/acabrera04/Harmony/pulls/275/comments --jq '.[] | {path, line, body}'
+```
+
+Output:
+
+```text
+{"body":"This says repeated `P2002` collisions in `withSlugRetry` eventually become `TRPCError(CONFLICT)`, but the implementation actually rethrows the third `P2002` directly because it only retries while `attempt \u003c maxRetries - 1`. Tests written from this doc would assert the wrong contract for both `createServer` and rename-in-`updateServer`.","line":101,"path":"docs/test-specs/server-service-spec.md"}
+{"body":"The slug-exhaustion boundary is off by one here. `generateUniqueSlug` only probes 10 total candidates: `base`, then `base-1` through `base-9`. `base-10` is never checked, so this test case does not match the current source.","line":229,"path":"docs/test-specs/server-service-spec.md"}
+{"body":"`createServer` has two additional awaited branches after `prisma.server.create`: `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)`. If either rejects, the service rejects too, but this section never specifies those paths even though the document claims to cover all program paths and representative failure cases.","line":230,"path":"docs/test-specs/server-service-spec.md"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:05:29.313Z
+
+The review is posted on PR `#275` as a single `REQUEST_CHANGES` review with three inline comments attached to `docs/test-specs/server-service-spec.md` at lines 101, 229, and 230.
+
+Review URL: [pullrequestreview-4040719486](https://github.com/acabrera04/Harmony/pull/275#pullrequestreview-4040719486)
+
+### Turn 3: Declan pushed new changes, review
+
+#### 👤 User Prompt
+
+- Time: 2026-03-31T23:14:26.919Z
+
+```text
+Declan pushed new changes, review again
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:14:35.069Z
+
+I’m checking the new head commit on PR `#275`, verifying whether the previous review comments were addressed, and then I’ll submit an updated review on the PR.
+
+#### Tool: update_plan
+
+- Plan:
+  - [in_progress] Fetch latest PR state and new diff
+  - [pending] Compare new changes against previous review findings
+  - [pending] Review updated patch for remaining or new issues
+  - [pending] Submit updated GitHub review
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: mcp__codex_apps__github_get_pr_info
+
+```json
+{
+  "pr_number": 275,
+  "repository_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"url":"https://github.com/acabrera04/Harmony/pull/275","number":275,"state":"open","merged":false,"mergeable":true,"draft":false,"body":"## Summary\n\n- Adds `docs/test-specs/server-service-spec.md` — an English-language test specification for `harmony-backend/src/services/server.service.ts`\n- Covers all 11 exported functions (`generateSlug`, `getPublicServers`, `getAllServers`, `getMemberServers`, `getServer`, `createServer`, `updateServer`, `deleteServer`, `incrementMemberCount`, `decrementMemberCount`, `getMembers`) plus the private slug helpers via `createServer`/`updateServer`\n- Each function section lists program paths and a table of concrete test cases with inputs and expected outputs, including all `TRPCError` branches, slug-retry/collision logic, authorization guards (owner vs system admin), event publication side effects, and edge cases\n\n## Test plan\n\n- [ ] Review spec tables to confirm every `TRPCError` branch in the source file has a corresponding test case\n- [ ] Confirm `generateSlug` cases cover the full regex pipeline (lowercase, trim, strip, collapse spaces, collapse hyphens, strip edges)\n- [ ] Confirm `decrementMemberCount` covers both failing branches of the compound `!server || server.memberCount <= 0` guard\n- [ ] Confirm `createServer` cases cover slug exhaustion, P2002 retry, and non-P2002 passthrough\n- [ ] Confirm `updateServer` cases cover owner path, system-admin path, name-unchanged path, and name-changed path\n\nCloses #259\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)","title":"docs(tests): test specification for server.service.ts","base":"main","base_sha":"b19f1dcad49e33a6b888b7b4c781cbf230959ba8","head":"test/issue-259-server-service-spec","head_sha":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5","merge_commit_sha":"df5dcd1a8072644d1dd279d3b3e6af5cceb54762","user":{"login":"declanblanc","name":"declanblanc","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/49934576?v=4","id":49934576},"requested_reviewers":null,"diff":null,"comments":null,"created_at":"2026-03-31T22:54:31Z","updated_at":"2026-03-31T23:14:24Z","closed_at":null,"merged_at":null,"commits":2,"changed_files":1,"additions":322,"deletions":0,"display_url":"https://github.com/acabrera04/Harmony/pull/275","display_title":"docs(tests): test specification for server.service.ts"}
+```
+
+#### Tool: mcp__codex_apps__github_fetch_pr_comments
+
+```json
+{
+  "pr_number": 275,
+  "repo_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"comments":[{"url":"https://github.com/acabrera04/Harmony/pull/275#discussion_r3018902248","body":"This says repeated `P2002` collisions in `withSlugRetry` eventually become `TRPCError(CONFLICT)`, but the implementation actually rethrows the third `P2002` directly because it only retries while `attempt < maxRetries - 1`. Tests written from this doc would assert the wrong contract for both `createServer` and rename-in-`updateServer`.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":3018902248,"pull_request_review_id":4040719486,"in_reply_to_id":null,"created_at":"2026-03-31T23:05:14Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/server-service-spec.md","body_html":"<p dir=\"auto\">This says repeated <code class=\"notranslate\">P2002</code> collisions in <code class=\"notranslate\">withSlugRetry</code> eventually become <code class=\"notranslate\">TRPCError(CONFLICT)</code>, but the implementation actually rethrows the third <code class=\"notranslate\">P2002</code> directly because it only retries while <code class=\"notranslate\">attempt &lt; maxRetries - 1</code>. Tests written from this doc would assert the wrong contract for both <code class=\"notranslate\">createServer</code> and rename-in-<code class=\"notranslate\">updateServer</code>.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#discussion_r3018902251","body":"The slug-exhaustion boundary is off by one here. `generateUniqueSlug` only probes 10 total candidates: `base`, then `base-1` through `base-9`. `base-10` is never checked, so this test case does not match the current source.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":3018902251,"pull_request_review_id":4040719486,"in_reply_to_id":null,"created_at":"2026-03-31T23:05:14Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/server-service-spec.md","body_html":"<p dir=\"auto\">The slug-exhaustion boundary is off by one here. <code class=\"notranslate\">generateUniqueSlug</code> only probes 10 total candidates: <code class=\"notranslate\">base</code>, then <code class=\"notranslate\">base-1</code> through <code class=\"notranslate\">base-9</code>. <code class=\"notranslate\">base-10</code> is never checked, so this test case does not match the current source.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#discussion_r3018902253","body":"`createServer` has two additional awaited branches after `prisma.server.create`: `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)`. If either rejects, the service rejects too, but this section never specifies those paths even though the document claims to cover all program paths and representative failure cases.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":3018902253,"pull_request_review_id":4040719486,"in_reply_to_id":null,"created_at":"2026-03-31T23:05:14Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/server-service-spec.md","body_html":"<p dir=\"auto\"><code class=\"notranslate\">createServer</code> has two additional awaited branches after <code class=\"notranslate\">prisma.server.create</code>: <code class=\"notranslate\">channelService.createDefaultChannel(server.id)</code> and <code class=\"notranslate\">serverMemberService.addOwner(input.ownerId, server.id)</code>. If either rejects, the service rejects too, but this section never specifies those paths even though the document claims to cover all program paths and representative failure cases.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#pullrequestreview-4040719486","body":"- [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.\n- [x] Security first: docs-only change; no new security surface or secret exposure.\n- [x] Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.\n- [ ] Issue completion: issue #259 asks for all program paths, and the current spec does not fully capture the real `createServer`/`withSlugRetry` paths.\n- [x] No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.\n- [x] Avoid repetition: there are no existing PR comments to duplicate.\n- [x] Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.\n- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.\n\n**Bundled review**\n\nI found 3 substantive issues.\n\n1. `withSlugRetry` exhaustion is documented incorrectly. In `server.service.ts`, a third `P2002` does not become `TRPCError(CONFLICT)`; it is rethrown as the original Prisma error. That makes the spec inaccurate for both `createServer` and renamed `updateServer` flows.\n\n2. `createServer` is missing two real failure paths. After the insert succeeds, `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)` can still reject, but the spec never covers those paths despite claiming full program-path coverage.\n\n3. The slug exhaustion boundary is off by one. `generateUniqueSlug` checks 10 total candidates (`base` through `base-9`), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":4040719486,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:05:14Z","review":"CHANGES_REQUESTED","side":null,"line":null,"start_line":null,"path":null,"body_html":"<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Incomplete task\"> Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real <code class=\"notranslate\">createServer</code> failure paths.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Security first: docs-only change; no new security surface or secret exposure.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Incomplete task\"> Issue completion: issue <a class=\"issue-link js-issue-link\" data-error-text=\"Failed to load title\" data-id=\"4166268741\" data-permission-text=\"Title is private\" data-url=\"https://github.com/acabrera04/Harmony/issues/259\" data-hovercard-type=\"issue\" data-hovercard-url=\"/acabrera04/Harmony/issues/259/hovercard\" href=\"https://github.com/acabrera04/Harmony/issues/259\">#259</a> asks for all program paths, and the current spec does not fully capture the real <code class=\"notranslate\">createServer</code>/<code class=\"notranslate\">withSlugRetry</code> paths.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Avoid repetition: there are no existing PR comments to duplicate.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.</li>\n</ul>\n<p dir=\"auto\"><strong>Bundled review</strong></p>\n<p dir=\"auto\">I found 3 substantive issues.</p>\n<ol dir=\"auto\">\n<li>\n<p dir=\"auto\"><code class=\"notranslate\">withSlugRetry</code> exhaustion is documented incorrectly. In <code class=\"notranslate\">server.service.ts</code>, a third <code class=\"notranslate\">P2002</code> does not become <code class=\"notranslate\">TRPCError(CONFLICT)</code>; it is rethrown as the original Prisma error. That makes the spec inaccurate for both <code class=\"notranslate\">createServer</code> and renamed <code class=\"notranslate\">updateServer</code> flows.</p>\n</li>\n<li>\n<p dir=\"auto\"><code class=\"notranslate\">createServer</code> is missing two real failure paths. After the insert succeeds, <code class=\"notranslate\">channelService.createDefaultChannel(server.id)</code> and <code class=\"notranslate\">serverMemberService.addOwner(input.ownerId, server.id)</code> can still reject, but the spec never covers those paths despite claiming full program-path coverage.</p>\n</li>\n<li>\n<p dir=\"auto\">The slug exhaustion boundary is off by one. <code class=\"notranslate\">generateUniqueSlug</code> checks 10 total candidates (<code class=\"notranslate\">base</code> through <code class=\"notranslate\">base-9</code>), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.</p>\n</li>\n</ol>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#discussion_r3018919068","body":"Fixed. The spec now accurately documents that `withSlugRetry` with `maxRetries = 3` retries only while `attempt < maxRetries - 1` (attempts 0 and 1). On the final attempt (attempt 2) a P2002 is rethrown directly as the raw `PrismaClientKnownRequestError` — not mapped to `TRPCError`. The `TRPCError(CONFLICT)` after the loop is unreachable code. Sections 3.6, 3.7, 4.6, 4.7, and 5 have all been updated to reflect this, including a new test case specifically for the P2002 exhaustion path.","user":{"login":"declanblanc","name":"declanblanc","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/49934576?v=4","id":49934576},"id":3018919068,"pull_request_review_id":4040745852,"in_reply_to_id":3018902248,"created_at":"2026-03-31T23:11:44Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/server-service-spec.md","body_html":"<p dir=\"auto\">Fixed. The spec now accurately documents that <code class=\"notranslate\">withSlugRetry</code> with <code class=\"notranslate\">maxRetries = 3</code> retries only while <code class=\"notranslate\">attempt &lt; maxRetries - 1</code> (attempts 0 and 1). On the final attempt (attempt 2) a P2002 is rethrown directly as the raw <code class=\"notranslate\">PrismaClientKnownRequestError</code> — not mapped to <code class=\"notranslate\">TRPCError</code>. The <code class=\"notranslate\">TRPCError(CONFLICT)</code> after the loop is unreachable code. Sections 3.6, 3.7, 4.6, 4.7, and 5 have all been updated to reflect this, including a new test case specifically for the P2002 exhaustion path.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#pullrequestreview-4040745852","body":"","user":{"login":"declanblanc","name":"declanblanc","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/49934576?u=9c678b968e7ec28f7ab260a227783a7416590c4f&v=4","id":49934576},"id":4040745852,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:11:44Z","review":"COMMENTED","side":null,"line":null,"start_line":null,"path":null,"body_html":""},{"url":"https://github.com/acabrera04/Harmony/pull/275#discussion_r3018919189","body":"Fixed. The mock description now correctly says `base` through `base-9` — 10 total candidates probed by `generateUniqueSlug`. `base-10` is generated as the next candidate but the loop exits before checking it, so mocking all 10 occupations is sufficient to trigger the CONFLICT throw.","user":{"login":"declanblanc","name":"declanblanc","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/49934576?v=4","id":49934576},"id":3018919189,"pull_request_review_id":4040746018,"in_reply_to_id":3018902251,"created_at":"2026-03-31T23:11:46Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/server-service-spec.md","body_html":"<p dir=\"auto\">Fixed. The mock description now correctly says <code class=\"notranslate\">base</code> through <code class=\"notranslate\">base-9</code> — 10 total candidates probed by <code class=\"notranslate\">generateUniqueSlug</code>. <code class=\"notranslate\">base-10</code> is generated as the next candidate but the loop exits before checking it, so mocking all 10 occupations is sufficient to trigger the CONFLICT throw.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#pullrequestreview-4040746018","body":"","user":{"login":"declanblanc","name":"declanblanc","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/49934576?u=9c678b968e7ec28f7ab260a227783a7416590c4f&v=4","id":49934576},"id":4040746018,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:11:46Z","review":"COMMENTED","side":null,"line":null,"start_line":null,"path":null,"body_html":""},{"url":"https://github.com/acabrera04/Harmony/pull/275#discussion_r3018919294","body":"Fixed. Added both missing program paths to section 3.6 and two corresponding test cases to section 4.6: one for `channelService.createDefaultChannel` rejecting and one for `serverMemberService.addOwner` rejecting. Both cases assert that `createServer` propagates the rejection without swallowing it.","user":{"login":"declanblanc","name":"declanblanc","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/49934576?v=4","id":49934576},"id":3018919294,"pull_request_review_id":4040746162,"in_reply_to_id":3018902253,"created_at":"2026-03-31T23:11:48Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/server-service-spec.md","body_html":"<p dir=\"auto\">Fixed. Added both missing program paths to section 3.6 and two corresponding test cases to section 4.6: one for <code class=\"notranslate\">channelService.createDefaultChannel</code> rejecting and one for <code class=\"notranslate\">serverMemberService.addOwner</code> rejecting. Both cases assert that <code class=\"notranslate\">createServer</code> propagates the rejection without swallowing it.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#pullrequestreview-4040746162","body":"","user":{"login":"declanblanc","name":"declanblanc","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/49934576?u=9c678b968e7ec28f7ab260a227783a7416590c4f&v=4","id":49934576},"id":4040746162,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:11:48Z","review":"COMMENTED","side":null,"line":null,"start_line":null,"path":null,"body_html":""},{"url":"https://github.com/acabrera04/Harmony/pull/275#issuecomment-4166247360","body":"@copilot review","user":{"login":"declanblanc","name":"declanblanc","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/49934576?v=4","id":49934576},"id":4166247360,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:12:08Z","review":null,"side":null,"line":null,"start_line":null,"path":null,"body_html":"<p dir=\"auto\"><a class=\"user-mention notranslate\" data-hovercard-type=\"copilot\" data-hovercard-url=\"/copilot/hovercard?bot=copilot-swe-agent\" data-octo-click=\"hovercard-link-click\" data-octo-dimensions=\"link_type:self\" href=\"https://gh.io/copilot-coding-agent-docs\">@copilot</a> review</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/275#issuecomment-4166258339","body":"\n> - [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.\n> - [x] Security first: docs-only change; no new security surface ...\n\nAll three issues were addressed in commit 9ff0b67:\n\n1. **withSlugRetry exhaustion** — Sections 3.6, 3.7, 4.6, 4.7, and 5 now correctly state that a P2002 on the final attempt (attempt 2 of 3) rethrows the raw `PrismaClientKnownRequestError` directly. The `TRPCError(CONFLICT)` after the loop is documented as unreachable dead code.\n\n2. **createServer missing paths** — Section 3.6 now lists both post-insert failure paths (`channelService.createDefaultChannel` rejection and `serverMemberService.addOwner` rejection), and section 4.6 adds a concrete test case for each.\n\n3. **Slug exhaustion boundary** — Section 4.6 and 4.7 now correctly describe the mock as covering all 10 total candidates (`base` through `base-9`); `base-10` is generated but never probed, so mocking those 10 is sufficient to trigger the CONFLICT throw.\n\n\n> @copilot review\n\nReviewed. The spec is accurate against the current `server.service.ts` implementation:\n\n- `withSlugRetry` exhaustion behavior is correctly documented: P2002 on attempt 2 rethrows the raw `PrismaClientKnownRequestError`; the `TRPCError(CONFLICT)` after the loop is unreachable and noted as such.\n- `generateUniqueSlug` probes exactly 10 candidates (`base`, `base-1` through `base-9`); boundary correctly specified in sections 4.6 and 4.7.\n- `createServer` post-insert failure paths (`createDefaultChannel` and `addOwner` rejections) are documented in sections 3.6 and 4.6.\n- All authorization guards, event publication side-effects, and slug-retry/collision paths are covered with correct test-case assertions.\n\nNo further inaccuracies found.","user":{"login":"Copilot","name":"Copilot","email":null,"avatar_url":"https://avatars.githubusercontent.com/in/1143301?v=4","id":198982749},"id":4166258339,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:14:22Z","review":null,"side":null,"line":null,"start_line":null,"path":null,"body_html":"<blockquote>\n<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Incomplete task\"> Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real <code class=\"notranslate\">createServer</code> failure paths.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Security first: docs-only change; no new security surface ...</li>\n</ul>\n</blockquote>\n<p dir=\"auto\">All three issues were addressed in commit <a class=\"commit-link\" data-hovercard-type=\"commit\" data-hovercard-url=\"https://github.com/acabrera04/Harmony/commit/9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5/hovercard\" href=\"https://github.com/acabrera04/Harmony/commit/9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5\"><tt>9ff0b67</tt></a>:</p>\n<ol dir=\"auto\">\n<li>\n<p dir=\"auto\"><strong>withSlugRetry exhaustion</strong> — Sections 3.6, 3.7, 4.6, 4.7, and 5 now correctly state that a P2002 on the final attempt (attempt 2 of 3) rethrows the raw <code class=\"notranslate\">PrismaClientKnownRequestError</code> directly. The <code class=\"notranslate\">TRPCError(CONFLICT)</code> after the loop is documented as unreachable dead code.</p>\n</li>\n<li>\n<p dir=\"auto\"><strong>createServer missing paths</strong> — Section 3.6 now lists both post-insert failure paths (<code class=\"notranslate\">channelService.createDefaultChannel</code> rejection and <code class=\"notranslate\">serverMemberService.addOwner</code> rejection), and section 4.6 adds a concrete test case for each.</p>\n</li>\n<li>\n<p dir=\"auto\"><strong>Slug exhaustion boundary</strong> — Section 4.6 and 4.7 now correctly describe the mock as covering all 10 total candidates (<code class=\"notranslate\">base</code> through <code class=\"notranslate\">base-9</code>); <code class=\"notranslate\">base-10</code> is generated but never probed, so mocking those 10 is sufficient to trigger the CONFLICT throw.</p>\n</li>\n</ol>\n<blockquote>\n<p dir=\"auto\"><a class=\"user-mention notranslate\" data-hovercard-type=\"copilot\" data-hovercard-url=\"/copilot/hovercard?bot=copilot-swe-agent\" data-octo-click=\"hovercard-link-click\" data-octo-dimensions=\"link_type:self\" href=\"https://gh.io/copilot-coding-agent-docs\">@copilot</a> review</p>\n</blockquote>\n<p dir=\"auto\">Reviewed. The spec is accurate against the current <code class=\"notranslate\">server.service.ts</code> implementation:</p>\n<ul dir=\"auto\">\n<li><code class=\"notranslate\">withSlugRetry</code> exhaustion behavior is correctly documented: P2002 on attempt 2 rethrows the raw <code class=\"notranslate\">PrismaClientKnownRequestError</code>; the <code class=\"notranslate\">TRPCError(CONFLICT)</code> after the loop is unreachable and noted as such.</li>\n<li><code class=\"notranslate\">generateUniqueSlug</code> probes exactly 10 candidates (<code class=\"notranslate\">base</code>, <code class=\"notranslate\">base-1</code> through <code class=\"notranslate\">base-9</code>); boundary correctly specified in sections 4.6 and 4.7.</li>\n<li><code class=\"notranslate\">createServer</code> post-insert failure paths (<code class=\"notranslate\">createDefaultChannel</code> and <code class=\"notranslate\">addOwner</code> rejections) are documented in sections 3.6 and 4.6.</li>\n<li>All authorization guards, event publication side-effects, and slug-retry/collision paths are covered with correct test-case assertions.</li>\n</ul>\n<p dir=\"auto\">No further inaccuracies found.</p>"}],"url":"https://github.com/acabrera04/Harmony/pull/275","title":"acabrera04/Harmony PR #275 comments","display_url":"https://github.com/acabrera04/Harmony/pull/275","display_title":"acabrera04/Harmony PR #275 comments"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr view 275 --repo acabrera04/Harmony --json headRefOid,commits,reviews,reviewDecision,url,title
+```
+
+Output:
+
+```text
+{"commits":[{"authoredDate":"2026-03-31T22:54:17Z","authors":[{"email":"declanblanc+github@gmail.com","id":"MDQ6VXNlcjQ5OTM0NTc2","login":"declanblanc","name":"tinkpad"},{"email":"noreply@anthropic.com","id":"MDQ6VXNlcjgxODQ3","login":"claude","name":"Claude Sonnet 4.6"}],"committedDate":"2026-03-31T22:54:17Z","messageBody":"English-language test spec covering all 11 exported functions and both\nprivate slug helpers (exercised via createServer/updateServer). Defines\nhappy paths, every TRPCError branch, slug-retry logic, authorization\nguards, event publication side effects, and edge cases required to reach\n≥80% path coverage.\n\nCloses #259\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>","messageHeadline":"docs(tests): add test specification for server.service.ts","oid":"5ccdc08d8f0252be7458c27ce9308f7742e78f96"},{"authoredDate":"2026-03-31T23:11:34Z","authors":[{"email":"declanblanc+github@gmail.com","id":"MDQ6VXNlcjQ5OTM0NTc2","login":"declanblanc","name":"tinkpad"},{"email":"noreply@anthropic.com","id":"MDQ6VXNlcjgxODQ3","login":"claude","name":"Claude Sonnet 4.6"}],"committedDate":"2026-03-31T23:11:34Z","messageBody":"…sing createServer paths\n\nThree accuracy issues flagged in code review:\n\n1. withSlugRetry with maxRetries=3 retries on P2002 only while attempt <\n   maxRetries-1 (attempts 0 and 1). On the final attempt (attempt 2), the\n   raw PrismaClientKnownRequestError is rethrown directly — not mapped to\n   TRPCError(CONFLICT). The trailing TRPCError after the loop is unreachable.\n   Updated section 3.6, 3.7, 4.6, 4.7, and 5 to reflect this.\n\n2. generateUniqueSlug probes 10 total candidates (base, base-1 … base-9).\n   base-10 is generated but never checked. Fixed the mock description in\n   section 4.6 and 4.7 to say \"base through base-9\" rather than\n   \"base slug and all 10 suffixes\".\n\n3. createServer has two additional awaited calls after prisma.server.create:\n   channelService.createDefaultChannel and serverMemberService.addOwner.\n   If either rejects, createServer rejects too. Added both as program paths\n   in section 3.6 and as test cases in section 4.6.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>","messageHeadline":"fix(test-spec): correct withSlugRetry exhaustion behavior and add mis…","oid":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5"}],"headRefOid":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5","reviewDecision":"CHANGES_REQUESTED","reviews":[{"id":"PRR_kwDORIrGY87w2Hx-","author":{"login":"acabrera04"},"authorAssociation":"OWNER","body":"- [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.\n- [x] Security first: docs-only change; no new security surface or secret exposure.\n- [x] Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.\n- [ ] Issue completion: issue #259 asks for all program paths, and the current spec does not fully capture the real `createServer`/`withSlugRetry` paths.\n- [x] No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.\n- [x] Avoid repetition: there are no existing PR comments to duplicate.\n- [x] Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.\n- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.\n\n**Bundled review**\n\nI found 3 substantive issues.\n\n1. `withSlugRetry` exhaustion is documented incorrectly. In `server.service.ts`, a third `P2002` does not become `TRPCError(CONFLICT)`; it is rethrown as the original Prisma error. That makes the spec inaccurate for both `createServer` and renamed `updateServer` flows.\n\n2. `createServer` is missing two real failure paths. After the insert succeeds, `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)` can still reject, but the spec never covers those paths despite claiming full program-path coverage.\n\n3. The slug exhaustion boundary is off by one. `generateUniqueSlug` checks 10 total candidates (`base` through `base-9`), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.","submittedAt":"2026-03-31T23:05:14Z","includesCreatedEdit":false,"reactionGroups":[],"state":"CHANGES_REQUESTED","commit":{"oid":"5ccdc08d8f0252be7458c27ce9308f7742e78f96"}},{"id":"PRR_kwDORIrGY87w2ON8","author":{"login":"declanblanc"},"authorAssociation":"COLLABORATOR","body":"","submittedAt":"2026-03-31T23:11:44Z","includesCreatedEdit":false,"reactionGroups":[],"state":"COMMENTED","commit":{"oid":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5"}},{"id":"PRR_kwDORIrGY87w2OQi","author":{"login":"declanblanc"},"authorAssociation":"COLLABORATOR","body":"","submittedAt":"2026-03-31T23:11:46Z","includesCreatedEdit":false,"reactionGroups":[],"state":"COMMENTED","commit":{"oid":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5"}},{"id":"PRR_kwDORIrGY87w2OSy","author":{"login":"declanblanc"},"authorAssociation":"COLLABORATOR","body":"","submittedAt":"2026-03-31T23:11:48Z","includesCreatedEdit":false,"reactionGroups":[],"state":"COMMENTED","commit":{"oid":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5"}}],"title":"docs(tests): test specification for server.service.ts","url":"https://github.com/acabrera04/Harmony/pull/275"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr diff 275 --repo acabrera04/Harmony --name-only
+```
+
+Output:
+
+```text
+docs/test-specs/server-service-spec.md
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:14:47.200Z
+
+The PR now has a second commit that explicitly targets the three prior findings. I’m reading the current version of the spec and the incremental diff to verify the fixes and check for any new inaccuracies before I submit the follow-up review.
+
+#### Tool: update_plan
+
+- Plan:
+  - [completed] Fetch latest PR state and new diff
+  - [in_progress] Compare new changes against previous review findings
+  - [pending] Review updated patch for remaining or new issues
+  - [pending] Submit updated GitHub review
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr diff 275 --repo acabrera04/Harmony
+```
+
+Output:
+
+```text
+diff --git a/docs/test-specs/server-service-spec.md b/docs/test-specs/server-service-spec.md
+new file mode 100644
+index 0000000..af9ee8a
+--- /dev/null
++++ b/docs/test-specs/server-service-spec.md
+@@ -0,0 +1,322 @@
++# Server Service Test Specification
++
++## 1. Overview
++
++This document defines the English-language test specification for `harmony-backend/src/services/server.service.ts`.
++It covers all exported service functions and the exported utility:
++
++- `generateSlug` (exported utility)
++- `serverService.getPublicServers`
++- `serverService.getAllServers`
++- `serverService.getMemberServers`
++- `serverService.getServer`
++- `serverService.createServer`
++- `serverService.updateServer`
++- `serverService.deleteServer`
++- `serverService.incrementMemberCount`
++- `serverService.decrementMemberCount`
++- `serverService.getMembers`
++
++The internal helpers `generateUniqueSlug` and `withSlugRetry` are exercised indirectly through `createServer` and `updateServer`.
++
++The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
++
++## 2. Shared Test Setup and Assumptions
++
++- Use a test database with isolated server, user, and membership fixtures per test.
++- Use distinct users for owner, admin, system-admin, and outsider scenarios.
++- Mock or spy on `eventBus.publish` so tests can verify event emission without requiring the full event system.
++- Mock `channelService.createDefaultChannel` and `serverMemberService.addOwner` when testing `createServer` in isolation; verify they are called with the correct arguments.
++- Mock `isSystemAdmin` to return `true` or `false` as needed per test scenario.
++- When unexpected Prisma failures are simulated, assert that the original error is surfaced unless the code explicitly maps it to a `TRPCError`.
++
++## 3. Function Purposes and Program Paths
++
++### 3.1 `generateSlug`
++
++Purpose: convert a display name to a URL-safe lowercase slug by stripping non-alphanumeric characters, collapsing whitespace into hyphens, and removing leading/trailing hyphens.
++
++Program paths:
++
++- Name with mixed case, spaces, and safe characters is converted correctly.
++- Leading and trailing spaces are trimmed before processing.
++- Non-alphanumeric characters (excluding spaces and hyphens) are removed.
++- Consecutive whitespace characters are collapsed into a single hyphen.
++- Consecutive hyphens are collapsed into a single hyphen.
++- Leading and trailing hyphens are stripped from the result.
++- Name consisting entirely of special characters produces an empty string.
++- Empty string input produces an empty string.
++
++### 3.2 `getPublicServers`
++
++Purpose: return all servers marked as public, ordered by creation date descending, up to a configurable limit.
++
++Program paths:
++
++- Returns an ordered list of public servers with the default limit of 50.
++- Respects a caller-supplied limit smaller than 50.
++- Caps the effective limit at 100 even when a larger value is supplied.
++- Returns an empty array when no public servers exist.
++
++### 3.3 `getAllServers`
++
++Purpose: return all servers regardless of visibility (admin function), ordered by creation date descending.
++
++Program paths:
++
++- Returns all servers (public and private) with the default limit of 50.
++- Respects a caller-supplied limit smaller than 50.
++- Caps the effective limit at 100 even when a larger value is supplied.
++- Returns an empty array when no servers exist.
++
++### 3.4 `getMemberServers`
++
++Purpose: return the servers a given user belongs to, ordered by join date ascending.
++
++Program paths:
++
++- Returns servers in ascending `joinedAt` order for a user with memberships.
++- Returns an empty array for a user with no memberships.
++- Respects a caller-supplied limit.
++- Caps the effective limit at 100.
++
++### 3.5 `getServer`
++
++Purpose: look up a single server by its slug.
++
++Program paths:
++
++- Returns the matching server when a server with the given slug exists.
++- Returns `null` when no server matches the slug.
++
++### 3.6 `createServer`
++
++Purpose: create a new server, seed a default channel, and register the creator as `OWNER`.
++
++Program paths:
++
++- Server is created successfully; a default channel is created; the creator is added as owner; the new server is returned.
++- Name that produces an empty slug (e.g. all special characters) throws `TRPCError` with code `BAD_REQUEST` from `generateUniqueSlug`.
++- Slug collision is resolved automatically by appending a numeric suffix and retrying; `generateUniqueSlug` probes 10 total candidates (`base`, `base-1` through `base-9`); if all 10 are already taken, throws `TRPCError` with code `CONFLICT`.
++- A transient Prisma `P2002` unique-violation on `server.create` triggers `withSlugRetry` to regenerate the slug and retry; `withSlugRetry` makes up to 3 total attempts (attempts 0, 1, 2) and retries only while `attempt < maxRetries - 1` (i.e. attempts 0 and 1); if a P2002 occurs on the final attempt (attempt 2), the raw Prisma error is rethrown directly — it is not mapped to `TRPCError`.
++- An unexpected non-`P2002` Prisma error from `server.create` is rethrown as-is on the first attempt, without any retry.
++- `channelService.createDefaultChannel` is called after the server is created; if it rejects, `createServer` rejects with the same error.
++- `serverMemberService.addOwner` is called after the default channel is created; if it rejects, `createServer` rejects with the same error.
++
++### 3.7 `updateServer`
++
++Purpose: update server metadata and optionally rename (with a new slug); enforces owner or system-admin authorization.
++
++Program paths:
++
++- Server does not exist.
++- Actor is not the owner and is not a system admin.
++- Actor is the owner: update succeeds without renaming.
++- Actor is the owner: update with a new name regenerates the slug and persists both changes.
++- Actor is not the owner but is a system admin: update succeeds.
++- Name change where all 10 `generateUniqueSlug` candidates are already occupied throws `TRPCError` with code `CONFLICT`.
++- Name change where `withSlugRetry` exhausts all 3 attempts with consecutive P2002 violations rethrows the raw Prisma error on the final attempt (not mapped to `TRPCError`).
++- `SERVER_UPDATED` event is published after any successful update.
++- Return value is the updated server record.
++
++### 3.8 `deleteServer`
++
++Purpose: permanently delete a server; enforces owner or system-admin authorization.
++
++Program paths:
++
++- Server does not exist.
++- Actor is not the owner and is not a system admin.
++- Actor is the owner: server is deleted and returned.
++- Actor is not the owner but is a system admin: server is deleted and returned.
++
++### 3.9 `incrementMemberCount`
++
++Purpose: atomically increment a server's `memberCount` by one.
++
++Program paths:
++
++- Increments `memberCount` by 1 and returns the updated server record.
++
++### 3.10 `decrementMemberCount`
++
++Purpose: atomically decrement a server's `memberCount` by one, guarding against going below zero.
++
++Program paths:
++
++- Server does not exist.
++- Server exists but `memberCount` is already `0`.
++- Server exists and `memberCount > 0`: decrements and returns the updated server record.
++
++### 3.11 `getMembers`
++
++Purpose: return all members of a server with user profile data, sorted by role rank then join date.
++
++Program paths:
++
++- Returns members sorted by role hierarchy (`OWNER` first, `GUEST` last).
++- Within the same role, members are ordered by ascending `joinedAt`.
++- Returns an empty array when the server has no members.
++- Roles not present in the rank map are sorted after `GUEST` (rank `99`).
++
++## 4. Detailed Test Cases
++
++### 4.1 `generateSlug`
++
++Description: pure synchronous slug normalisation that can be tested without any database setup.
++
++| Test Purpose                                            | Inputs                              | Expected Output                                                  |
++| ------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------- |
++| Convert mixed-case name with spaces                     | `"Hello World"`                     | `"hello-world"`                                                  |
++| Trim leading and trailing whitespace                    | `"  My Server  "`                   | `"my-server"`                                                    |
++| Strip non-alphanumeric characters (except spaces/hyphens) | `"Café & Lounge!"`               | `"caf-lounge"` (non-ASCII/special chars removed)                 |
++| Collapse multiple spaces into one hyphen                | `"foo   bar"`                       | `"foo-bar"`                                                      |
++| Collapse consecutive hyphens into one                  | `"foo--bar"`                        | `"foo-bar"`                                                      |
++| Remove leading hyphen from result                      | `"-leading"`                        | `"leading"`                                                      |
++| Remove trailing hyphen from result                     | `"trailing-"`                       | `"trailing"`                                                     |
++| Return empty string when all characters are stripped   | `"!!!"`                             | `""`                                                             |
++| Return empty string for empty input                    | `""`                                | `""`                                                             |
++
++### 4.2 `getPublicServers`
++
++Description: retrieves public servers, most recently created first, within a configurable limit.
++
++| Test Purpose                                     | Inputs                                           | Expected Output                                                                              |
++| ------------------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------------------------------- |
++| Return public servers in descending creation order | Three seeded public servers; default `limit`   | Returns all three in newest-first order                                                      |
++| Exclude private servers                          | One public and one private server; default limit | Returns only the public server                                                               |
++| Respect caller-supplied limit                    | Five public servers; `limit = 2`                 | Returns exactly 2 servers                                                                    |
++| Cap effective limit at 100                       | `limit = 200`; prisma spy                        | `prisma.server.findMany` is called with `take: 100`                                          |
++| Return empty array when no public servers exist  | No servers seeded                                | Returns `[]`                                                                                 |
++
++### 4.3 `getAllServers`
++
++Description: retrieves all servers regardless of visibility (admin endpoint).
++
++| Test Purpose                           | Inputs                                              | Expected Output                                             |
++| -------------------------------------- | --------------------------------------------------- | ----------------------------------------------------------- |
++| Return both public and private servers | One public server and one private server seeded     | Returns both servers                                        |
++| Respect caller-supplied limit          | Five servers; `limit = 3`                           | Returns exactly 3 servers                                   |
++| Cap effective limit at 100             | `limit = 500`; prisma spy                           | `prisma.server.findMany` is called with `take: 100`         |
++| Return empty array when no servers exist | No servers seeded                                 | Returns `[]`                                                |
++
++### 4.4 `getMemberServers`
++
++Description: retrieves servers the user has joined, ordered by join date ascending.
++
++| Test Purpose                                 | Inputs                                                          | Expected Output                                                          |
++| -------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------ |
++| Return servers in ascending join order       | User with two memberships; older membership seeded second       | Returns the server joined first (lower `joinedAt`) at index 0            |
++| Return empty array for user with no memberships | Valid `userId` with no `serverMember` records               | Returns `[]`                                                             |
++| Respect caller-supplied limit               | User is a member of five servers; `limit = 2`                   | Returns exactly 2 servers                                                |
++| Cap effective limit at 100                  | `limit = 200`; prisma spy                                       | `prisma.serverMember.findMany` is called with `take: 100`                |
++
++### 4.5 `getServer`
++
++Description: looks up a single server by URL slug.
++
++| Test Purpose                    | Inputs                                     | Expected Output                              |
++| ------------------------------- | ------------------------------------------ | -------------------------------------------- |
++| Return server for known slug    | Valid slug of an existing server           | Returns the matching `Server` record         |
++| Return null for unknown slug    | A slug that does not match any server      | Returns `null`                               |
++
++### 4.6 `createServer`
++
++Description: creates a server, seeds a default channel, and registers the creator as owner.
++
++| Test Purpose                                                   | Inputs                                                                                                | Expected Output                                                                                                                                               |
++| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
++| Create server with all optional fields provided                | Valid `name`, `description`, `iconUrl`, `isPublic = true`, `ownerId`                                  | Returns created server; `channelService.createDefaultChannel` called with new server id; `serverMemberService.addOwner` called with `ownerId` and server id    |
++| Create server with only required fields                        | Valid `name` and `ownerId`; no optional fields                                                        | Returns created server; default channel and owner membership are created                                                                                      |
++| Throw BAD_REQUEST when name produces empty slug                | `name` composed entirely of special characters (e.g. `"!!!"`)                                         | Throws `TRPCError` with code `BAD_REQUEST` and message `Cannot generate slug from name`                                                                       |
++| Throw CONFLICT when all generateUniqueSlug candidates are taken | Valid `name`; `prisma.server.count` mocked to return non-zero for all 10 candidates (`base` through `base-9`) | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`                                                                 |
++| Retry on transient P2002 during server create (attempt 0)      | Valid `name`; `prisma.server.create` throws `P2002` on first attempt (attempt 0) then succeeds on second (attempt 1) | Returns successfully created server; `withSlugRetry` retried once without further error                                                         |
++| Rethrow raw P2002 when withSlugRetry exhausts all 3 attempts   | Valid `name`; `prisma.server.create` throws `P2002` on all 3 attempts (attempts 0, 1, 2)            | Throws the original `PrismaClientKnownRequestError` with code `P2002`; does NOT throw `TRPCError`                                                             |
++| Throw on non-P2002 Prisma error during server create           | Valid `name`; `prisma.server.create` throws a non-`P2002` Prisma error on attempt 0                  | Throws the original Prisma error unchanged; no retry is attempted                                                                                             |
++| Propagate createDefaultChannel failure                         | Server created successfully; `channelService.createDefaultChannel` mocked to reject with an error    | `createServer` rejects with the same error; the rejection is not swallowed                                                                                    |
++| Propagate addOwner failure                                     | Server and default channel created successfully; `serverMemberService.addOwner` mocked to reject     | `createServer` rejects with the same error; the rejection is not swallowed                                                                                    |
++
++### 4.7 `updateServer`
++
++Description: updates server metadata, handles name changes with slug regeneration, and enforces authorization.
++
++| Test Purpose                                                 | Inputs                                                                                          | Expected Output                                                                                                                              |
++| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
++| Throw NOT_FOUND when server does not exist                   | Unknown `id`; valid `actorId`; any `data`                                                       | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                                                                      |
++| Throw FORBIDDEN when actor is not owner and not system admin | Existing server; `actorId` different from `ownerId`; `isSystemAdmin` mocked to return `false`  | Throws `TRPCError` with code `FORBIDDEN` and message `Only the server owner can update`                                                      |
++| Allow owner to update without renaming                       | Existing server; `actorId === server.ownerId`; `data` without `name`                           | Returns updated server; slug is unchanged; `SERVER_UPDATED` event is published                                                               |
++| Allow owner to update with a new name                        | Existing server; `actorId === server.ownerId`; `data.name` is a new distinct value             | Returns updated server with new name and regenerated slug; `SERVER_UPDATED` event is published                                               |
++| Skip slug regeneration when name is unchanged                | Existing server; `actorId === server.ownerId`; `data.name === server.name`                     | Update is applied with the existing slug; `generateUniqueSlug` is not called; `SERVER_UPDATED` event is published                            |
++| Allow system admin to update a server they do not own        | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `true`         | Returns updated server; `SERVER_UPDATED` event is published                                                                                  |
++| Publish SERVER_UPDATED event after successful update         | Any successful update scenario                                                                  | `eventBus.publish` is called with `EventChannels.SERVER_UPDATED` and a payload containing `serverId`, `name`, `iconUrl`, `description`, and `timestamp` |
++| Throw CONFLICT when all generateUniqueSlug candidates are taken on rename | Valid `actorId`; name change; `prisma.server.count` returns non-zero for all 10 candidates (`base` through `base-9`) | Throws `TRPCError` with code `CONFLICT` and message `Unable to generate a unique slug`              |
++| Rethrow raw P2002 when withSlugRetry exhausts all 3 attempts on rename   | Valid `actorId`; name change; `prisma.server.update` throws `P2002` on all 3 attempts         | Throws the original `PrismaClientKnownRequestError` with code `P2002`; does NOT throw `TRPCError`                                             |
++
++### 4.8 `deleteServer`
++
++Description: permanently deletes a server record; enforces owner or system-admin authorization.
++
++| Test Purpose                                                   | Inputs                                                                                          | Expected Output                                                                              |
++| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
++| Throw NOT_FOUND when server does not exist                     | Unknown `id`; valid `actorId`                                                                   | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                      |
++| Throw FORBIDDEN when actor is not owner and not system admin   | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `false`        | Throws `TRPCError` with code `FORBIDDEN` and message `Only the server owner can delete`      |
++| Allow owner to delete their server                             | Existing server; `actorId === server.ownerId`                                                   | Deletes the server; returns the deleted server record                                        |
++| Allow system admin to delete a server they do not own          | Existing server; `actorId !== server.ownerId`; `isSystemAdmin` mocked to return `true`         | Deletes the server; returns the deleted server record                                        |
++
++### 4.9 `incrementMemberCount`
++
++Description: atomically adds 1 to a server's `memberCount`.
++
++| Test Purpose                            | Inputs                                               | Expected Output                                                          |
++| --------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------ |
++| Increment memberCount by 1              | Existing server with `memberCount = 3`               | Returns server record with `memberCount = 4`                             |
++
++### 4.10 `decrementMemberCount`
++
++Description: atomically subtracts 1 from a server's `memberCount`, refusing to go below zero.
++
++| Test Purpose                                        | Inputs                                             | Expected Output                                                                                  |
++| --------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
++| Decrement memberCount by 1                          | Existing server with `memberCount = 2`             | Returns server record with `memberCount = 1`                                                     |
++| Throw BAD_REQUEST when server does not exist        | Unknown `id`                                       | Throws `TRPCError` with code `BAD_REQUEST` and message `Member count is already zero`            |
++| Throw BAD_REQUEST when memberCount is already zero  | Existing server with `memberCount = 0`             | Throws `TRPCError` with code `BAD_REQUEST` and message `Member count is already zero`            |
++
++### 4.11 `getMembers`
++
++Description: loads all members with user profile fields and sorts by role rank then join date.
++
++| Test Purpose                                              | Inputs                                                                                                   | Expected Output                                                                                                                   |
++| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
++| Return members sorted by role hierarchy                   | Server with seeded owner, admin, moderator, member, and guest memberships                                | Returns array with `OWNER` at index 0, followed by `ADMIN`, `MODERATOR`, `MEMBER`, `GUEST` in that order                         |
++| Preserve ascending join order within the same role        | Server with two `MEMBER` rows where the newer member was inserted first in the array                     | Returns the older-join member before the newer-join member                                                                        |
++| Return empty array when server has no members             | Valid `serverId` with no `serverMember` records                                                           | Returns `[]`                                                                                                                      |
++| Include user profile fields on each member                | Server with one seeded member whose user has `username`, `displayName`, `avatarUrl`, and `status` set   | Each returned element contains `user.id`, `user.username`, `user.displayName`, `user.avatarUrl`, and `user.status`                |
++| Sort unknown roles after all known roles                  | Server with a member whose role string is not in the `ROLE_RANK` map (e.g. `"CUSTOM"`)                  | The unknown-role member appears after any `GUEST` members; does not throw                                                         |
++
++## 5. Edge Cases to Explicitly Validate
++
++- `generateSlug` is a pure function; assert it without any database calls.
++- `generateUniqueSlug` must throw `BAD_REQUEST` when the base slug is empty, not `CONFLICT`.
++- `decrementMemberCount` must reject both a missing server and a server at zero with the same `BAD_REQUEST` error; the `!server || server.memberCount <= 0` compound condition must be tested with both failing branches.
++- Name unchanged in `updateServer` must not trigger a slug query; use a spy on `prisma.server.count` to confirm it is not called.
++- `updateServer` and `deleteServer` must independently check `isSystemAdmin`; a system admin who is not the owner must be permitted in both functions.
++- `SERVER_UPDATED` must be published after every successful update, including updates that do not change the name.
++- `createServer` must call `channelService.createDefaultChannel` and `serverMemberService.addOwner` in that order and with the correct server id, not the input id.
++- `withSlugRetry` retries only while `attempt < maxRetries - 1` (with `maxRetries = 3`, that means attempts 0 and 1 are retried; attempt 2 rethrows the raw P2002 directly). The `TRPCError(CONFLICT)` after the loop is unreachable code.
++- Non-`P2002` Prisma errors from `withSlugRetry` must pass through immediately on the first attempt without any retry.
++- `generateUniqueSlug` exhaustion (all 10 DB candidates occupied) maps to `TRPCError(CONFLICT)`; this is distinct from `withSlugRetry` P2002 exhaustion which rethrows the raw Prisma error.
++
++## 6. Coverage Expectation
++
++The cases above are intended to cover:
++
++- all public service methods and the exported `generateSlug` utility,
++- every explicit `TRPCError` branch in the service and its private helpers,
++- successful transaction paths with correct return values,
++- event publication side effects via `eventBus.publish`,
++- the slug-generation retry logic under collision and exhaustion scenarios, distinguishing `generateUniqueSlug` CONFLICT from `withSlugRetry` raw-P2002 rethrow,
++- `createServer` post-insert failure paths (`createDefaultChannel` and `addOwner` rejections),
++- authorization guards for both owner and system-admin paths, and
++- representative unexpected database failure paths.
++
++Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures outside the service's direct branching logic.
+```
+
+#### Tool: exec_command
+
+```sh
+gh api repos/acabrera04/Harmony/contents/docs/test-specs/server-service-spec.md?ref=9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5 --jq '.content' | tr -d '\n' | base64 --decode | nl -ba | sed -n '90,320p'
+```
+
+Output:
+
+```text
+zsh:1: no matches found: repos/acabrera04/Harmony/contents/docs/test-specs/server-service-spec.md?ref=9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5
+```
+
+#### Tool: exec_command
+
+```sh
+nl -ba harmony-backend/src/services/server.service.ts | sed -n '32,210p'
+```
+
+Output:
+
+```text
+    32	export function generateSlug(name: string): string {
+    33	  return name
+    34	    .toLowerCase()
+    35	    .trim()
+    36	    .replace(/[^a-z0-9\s-]/g, '')
+    37	    .replace(/[\s]+/g, '-')
+    38	    .replace(/-+/g, '-')
+    39	    .replace(/^-|-$/g, '');
+    40	}
+    41	
+    42	async function generateUniqueSlug(name: string): Promise<string> {
+    43	  const base = generateSlug(name);
+    44	  if (!base)
+    45	    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot generate slug from name' });
+    46	
+    47	  const MAX_ATTEMPTS = 10;
+    48	  let candidate = base;
+    49	  for (let suffix = 1; suffix <= MAX_ATTEMPTS; suffix++) {
+    50	    if ((await prisma.server.count({ where: { slug: candidate } })) === 0) return candidate;
+    51	    candidate = `${base}-${suffix}`;
+    52	  }
+    53	  throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });
+    54	}
+    55	
+    56	/**
+    57	 * Generic slug-collision retry helper.
+    58	 * Calls fn(slug) up to maxRetries times, regenerating the slug on a P2002 unique violation.
+    59	 */
+    60	async function withSlugRetry(
+    61	  name: string,
+    62	  initialSlug: string,
+    63	  fn: (slug: string) => Promise<Server>,
+    64	  maxRetries = 3,
+    65	): Promise<Server> {
+    66	  let slug = initialSlug;
+    67	  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    68	    if (attempt > 0) slug = await generateUniqueSlug(name);
+    69	    try {
+    70	      return await fn(slug);
+    71	    } catch (err) {
+    72	      if (
+    73	        err instanceof Prisma.PrismaClientKnownRequestError &&
+    74	        err.code === 'P2002' &&
+    75	        attempt < maxRetries - 1
+    76	      ) {
+    77	        continue;
+    78	      }
+    79	      throw err;
+    80	    }
+    81	  }
+    82	  throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });
+    83	}
+    84	
+    85	export const serverService = {
+    86	  async getPublicServers(limit = 50): Promise<Server[]> {
+    87	    return prisma.server.findMany({
+    88	      where: { isPublic: true },
+    89	      orderBy: { createdAt: 'desc' },
+    90	      take: Math.min(limit, 100),
+    91	    });
+    92	  },
+    93	
+    94	  /** Dev admin: returns all servers regardless of visibility. */
+    95	  async getAllServers(limit = 50): Promise<Server[]> {
+    96	    return prisma.server.findMany({
+    97	      orderBy: { createdAt: 'desc' },
+    98	      take: Math.min(limit, 100),
+    99	    });
+   100	  },
+   101	
+   102	  /** Returns only the servers the given user is a member of. */
+   103	  async getMemberServers(userId: string, limit = 50): Promise<Server[]> {
+   104	    const memberships = await prisma.serverMember.findMany({
+   105	      where: { userId },
+   106	      include: { server: true },
+   107	      orderBy: { joinedAt: 'asc' },
+   108	      take: Math.min(limit, 100),
+   109	    });
+   110	    return memberships.map((m) => m.server);
+   111	  },
+   112	
+   113	  async getServer(slug: string): Promise<Server | null> {
+   114	    return prisma.server.findUnique({ where: { slug } });
+   115	  },
+   116	
+   117	  async createServer(input: {
+   118	    name: string;
+   119	    description?: string;
+   120	    iconUrl?: string;
+   121	    isPublic?: boolean;
+   122	    ownerId: string;
+   123	  }): Promise<Server> {
+   124	    const slug = await generateUniqueSlug(input.name);
+   125	    const server = await withSlugRetry(input.name, slug, (s) =>
+   126	      prisma.server.create({ data: { ...input, slug: s } }),
+   127	    );
+   128	    await channelService.createDefaultChannel(server.id);
+   129	    await serverMemberService.addOwner(input.ownerId, server.id);
+   130	    return server;
+   131	  },
+   132	
+   133	  async updateServer(
+   134	    id: string,
+   135	    actorId: string,
+   136	    data: { name?: string; description?: string; iconUrl?: string; isPublic?: boolean },
+   137	  ): Promise<Server> {
+   138	    const server = await prisma.server.findUnique({ where: { id } });
+   139	    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
+   140	    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))
+   141	      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can update' });
+   142	
+   143	    let updated: Server;
+   144	    if (data.name && data.name !== server.name) {
+   145	      const slug = await generateUniqueSlug(data.name);
+   146	      updated = await withSlugRetry(data.name, slug, (s) =>
+   147	        prisma.server.update({ where: { id }, data: { ...data, slug: s } }),
+   148	      );
+   149	    } else {
+   150	      updated = await prisma.server.update({ where: { id }, data });
+   151	    }
+   152	
+   153	    void eventBus.publish(EventChannels.SERVER_UPDATED, {
+   154	      serverId: id,
+   155	      name: updated.name,
+   156	      iconUrl: updated.iconUrl ?? null,
+   157	      description: updated.description ?? null,
+   158	      timestamp: new Date().toISOString(),
+   159	    });
+   160	
+   161	    return updated;
+   162	  },
+   163	
+   164	  async deleteServer(id: string, actorId: string): Promise<Server> {
+   165	    const server = await prisma.server.findUnique({ where: { id } });
+   166	    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
+   167	    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))
+   168	      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can delete' });
+   169	    return prisma.server.delete({ where: { id } });
+   170	  },
+   171	
+   172	  async incrementMemberCount(id: string): Promise<Server> {
+   173	    return prisma.server.update({
+   174	      where: { id },
+   175	      data: { memberCount: { increment: 1 } },
+   176	    });
+   177	  },
+   178	
+   179	  async decrementMemberCount(id: string): Promise<Server> {
+   180	    const server = await prisma.server.findUnique({ where: { id } });
+   181	    if (!server || server.memberCount <= 0) {
+   182	      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Member count is already zero' });
+   183	    }
+   184	    return prisma.server.update({
+   185	      where: { id },
+   186	      data: { memberCount: { decrement: 1 } },
+   187	    });
+   188	  },
+   189	
+   190	  async getMembers(serverId: string): Promise<ServerMemberWithUser[]> {
+   191	    const members = await prisma.serverMember.findMany({
+   192	      where: { serverId },
+   193	      include: {
+   194	        user: {
+   195	          select: { id: true, username: true, displayName: true, avatarUrl: true, status: true },
+   196	        },
+   197	      },
+   198	    });
+   199	    return members
+   200	      .map((m) => ({ ...m, role: m.role as string }))
+   201	      .sort(
+   202	        (a, b) =>
+   203	          (ROLE_RANK[a.role] ?? 99) - (ROLE_RANK[b.role] ?? 99) ||
+   204	          a.joinedAt.getTime() - b.joinedAt.getTime(),
+   205	      );
+   206	  },
+   207	};
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:15:06.005Z
+
+The updated spec now appears aligned with the service implementation. I’m fetching the review-thread IDs so I can resolve the three addressed threads and then replace the earlier `CHANGES_REQUESTED` state with an approval.
+
+#### Tool: update_plan
+
+- Plan:
+  - [completed] Fetch latest PR state and new diff
+  - [completed] Compare new changes against previous review findings
+  - [completed] Review updated patch for remaining or new issues
+  - [in_progress] Submit updated GitHub review
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: exec_command
+
+```sh
+gh api graphql -f query='query { repository(owner:"acabrera04", name:"Harmony") { pullRequest(number: 275) { reviewThreads(first: 20) { nodes { id isResolved comments(first: 10) { nodes { id body path line author { login } } } } } } } }'
+```
+
+Output:
+
+```text
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"PRRT_kwDORIrGY854F6yl","isResolved":true,"comments":{"nodes":[{"id":"PRRC_kwDORIrGY86z8Mro","body":"This says repeated `P2002` collisions in `withSlugRetry` eventually become `TRPCError(CONFLICT)`, but the implementation actually rethrows the third `P2002` directly because it only retries while `attempt < maxRetries - 1`. Tests written from this doc would assert the wrong contract for both `createServer` and rename-in-`updateServer`.","path":"docs/test-specs/server-service-spec.md","line":null,"author":{"login":"acabrera04"}},{"id":"PRRC_kwDORIrGY86z8Qyc","body":"Fixed. The spec now accurately documents that `withSlugRetry` with `maxRetries = 3` retries only while `attempt < maxRetries - 1` (attempts 0 and 1). On the final attempt (attempt 2) a P2002 is rethrown directly as the raw `PrismaClientKnownRequestError` — not mapped to `TRPCError`. The `TRPCError(CONFLICT)` after the loop is unreachable code. Sections 3.6, 3.7, 4.6, 4.7, and 5 have all been updated to reflect this, including a new test case specifically for the P2002 exhaustion path.","path":"docs/test-specs/server-service-spec.md","line":null,"author":{"login":"declanblanc"}}]}},{"id":"PRRT_kwDORIrGY854F6yo","isResolved":true,"comments":{"nodes":[{"id":"PRRC_kwDORIrGY86z8Mrr","body":"The slug-exhaustion boundary is off by one here. `generateUniqueSlug` only probes 10 total candidates: `base`, then `base-1` through `base-9`. `base-10` is never checked, so this test case does not match the current source.","path":"docs/test-specs/server-service-spec.md","line":null,"author":{"login":"acabrera04"}},{"id":"PRRC_kwDORIrGY86z8Q0V","body":"Fixed. The mock description now correctly says `base` through `base-9` — 10 total candidates probed by `generateUniqueSlug`. `base-10` is generated as the next candidate but the loop exits before checking it, so mocking all 10 occupations is sufficient to trigger the CONFLICT throw.","path":"docs/test-specs/server-service-spec.md","line":null,"author":{"login":"declanblanc"}}]}},{"id":"PRRT_kwDORIrGY854F6yq","isResolved":true,"comments":{"nodes":[{"id":"PRRC_kwDORIrGY86z8Mrt","body":"`createServer` has two additional awaited branches after `prisma.server.create`: `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)`. If either rejects, the service rejects too, but this section never specifies those paths even though the document claims to cover all program paths and representative failure cases.","path":"docs/test-specs/server-service-spec.md","line":null,"author":{"login":"acabrera04"}},{"id":"PRRC_kwDORIrGY86z8Q1-","body":"Fixed. Added both missing program paths to section 3.6 and two corresponding test cases to section 4.6: one for `channelService.createDefaultChannel` rejecting and one for `serverMemberService.addOwner` rejecting. Both cases assert that `createServer` propagates the rejection without swallowing it.","path":"docs/test-specs/server-service-spec.md","line":null,"author":{"login":"declanblanc"}}]}}]}}}}}
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr view 275 --repo acabrera04/Harmony --comments
+```
+
+Output:
+
+```text
+author:	acabrera04
+association:	owner
+edited:	false
+status:	changes requested
+--
+- [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.
+- [x] Security first: docs-only change; no new security surface or secret exposure.
+- [x] Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.
+- [ ] Issue completion: issue #259 asks for all program paths, and the current spec does not fully capture the real `createServer`/`withSlugRetry` paths.
+- [x] No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.
+- [x] Avoid repetition: there are no existing PR comments to duplicate.
+- [x] Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.
+- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.
+
+**Bundled review**
+
+I found 3 substantive issues.
+
+1. `withSlugRetry` exhaustion is documented incorrectly. In `server.service.ts`, a third `P2002` does not become `TRPCError(CONFLICT)`; it is rethrown as the original Prisma error. That makes the spec inaccurate for both `createServer` and renamed `updateServer` flows.
+
+2. `createServer` is missing two real failure paths. After the insert succeeds, `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)` can still reject, but the spec never covers those paths despite claiming full program-path coverage.
+
+3. The slug exhaustion boundary is off by one. `generateUniqueSlug` checks 10 total candidates (`base` through `base-9`), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.
+--
+author:	declanblanc
+association:	collaborator
+edited:	false
+status:	none
+--
+@copilot review
+--
+author:	copilot-swe-agent
+association:	contributor
+edited:	true
+status:	none
+--
+
+> - [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.
+> - [x] Security first: docs-only change; no new security surface ...
+
+All three issues were addressed in commit 9ff0b67:
+
+1. **withSlugRetry exhaustion** — Sections 3.6, 3.7, 4.6, 4.7, and 5 now correctly state that a P2002 on the final attempt (attempt 2 of 3) rethrows the raw `PrismaClientKnownRequestError` directly. The `TRPCError(CONFLICT)` after the loop is documented as unreachable dead code.
+
+2. **createServer missing paths** — Section 3.6 now lists both post-insert failure paths (`channelService.createDefaultChannel` rejection and `serverMemberService.addOwner` rejection), and section 4.6 adds a concrete test case for each.
+
+3. **Slug exhaustion boundary** — Section 4.6 and 4.7 now correctly describe the mock as covering all 10 total candidates (`base` through `base-9`); `base-10` is generated but never probed, so mocking those 10 is sufficient to trigger the CONFLICT throw.
+
+
+> @copilot review
+
+Reviewed. The spec is accurate against the current `server.service.ts` implementation:
+
+- `withSlugRetry` exhaustion behavior is correctly documented: P2002 on attempt 2 rethrows the raw `PrismaClientKnownRequestError`; the `TRPCError(CONFLICT)` after the loop is unreachable and noted as such.
+- `generateUniqueSlug` probes exactly 10 candidates (`base`, `base-1` through `base-9`); boundary correctly specified in sections 4.6 and 4.7.
+- `createServer` post-insert failure paths (`createDefaultChannel` and `addOwner` rejections) are documented in sections 3.6 and 4.6.
+- All authorization guards, event publication side-effects, and slug-retry/collision paths are covered with correct test-case assertions.
+
+No further inaccuracies found.
+--
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:15:24.328Z
+
+The prior threads are already resolved, and the updated doc matches the current `server.service.ts` behavior. I’m posting an approval review that explicitly marks the re-review checklist as passing.
+
+#### Tool: exec_command
+
+```sh
+review_body=$(cat <<'EOF'
+- [x] Logic over style: the previously incorrect retry/exhaustion descriptions are fixed, and the spec now matches the service logic.
+- [x] Security first: docs-only change; no new security surface or secret exposure.
+- [x] Architectural alignment: the document remains aligned with the existing backend service behavior.
+- [x] Issue completion: issue #259 acceptance criteria are satisfied; the spec now covers the requested functions, happy paths, error paths, and edge cases.
+- [x] No nitpicking: no style-only concerns; this re-review focused on behavioral accuracy and coverage.
+- [x] Avoid repetition: the prior three findings were addressed, and I am not repeating resolved feedback.
+- [x] Iterative reviews: the new commit resolves the previously raised concerns.
+- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.
+
+**Bundled review**
+
+The follow-up commit addresses the prior review correctly. The `withSlugRetry` final-attempt behavior is now documented accurately, the `generateUniqueSlug` exhaustion boundary matches the implementation, and `createServer` now includes the missing post-insert failure paths. I did not find any new inaccuracies in the updated spec.
+EOF
+)
+
+gh pr review 275 --repo acabrera04/Harmony --approve --body "$review_body"
+```
+
+Output:
+
+```text
+
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:15:37.391Z
+
+The approval is posted. I’m confirming GitHub now reflects the updated review state on the current head commit.
+
+#### Tool: exec_command
+
+```sh
+gh pr view 275 --repo acabrera04/Harmony --json reviewDecision,reviews,url
+```
+
+Output:
+
+```text
+{"reviewDecision":"APPROVED","reviews":[{"id":"PRR_kwDORIrGY87w2Hx-","author":{"login":"acabrera04"},"authorAssociation":"OWNER","body":"- [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.\n- [x] Security first: docs-only change; no new security surface or secret exposure.\n- [x] Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.\n- [ ] Issue completion: issue #259 asks for all program paths, and the current spec does not fully capture the real `createServer`/`withSlugRetry` paths.\n- [x] No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.\n- [x] Avoid repetition: there are no existing PR comments to duplicate.\n- [x] Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.\n- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.\n\n**Bundled review**\n\nI found 3 substantive issues.\n\n1. `withSlugRetry` exhaustion is documented incorrectly. In `server.service.ts`, a third `P2002` does not become `TRPCError(CONFLICT)`; it is rethrown as the original Prisma error. That makes the spec inaccurate for both `createServer` and renamed `updateServer` flows.\n\n2. `createServer` is missing two real failure paths. After the insert succeeds, `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)` can still reject, but the spec never covers those paths despite claiming full program-path coverage.\n\n3. The slug exhaustion boundary is off by one. `generateUniqueSlug` checks 10 total candidates (`base` through `base-9`), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.","submittedAt":"2026-03-31T23:05:14Z","includesCreatedEdit":false,"reactionGroups":[],"state":"CHANGES_REQUESTED","commit":{"oid":"5ccdc08d8f0252be7458c27ce9308f7742e78f96"}},{"id":"PRR_kwDORIrGY87w2ON8","author":{"login":"declanblanc"},"authorAssociation":"COLLABORATOR","body":"","submittedAt":"2026-03-31T23:11:44Z","includesCreatedEdit":false,"reactionGroups":[],"state":"COMMENTED","commit":{"oid":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5"}},{"id":"PRR_kwDORIrGY87w2OQi","author":{"login":"declanblanc"},"authorAssociation":"COLLABORATOR","body":"","submittedAt":"2026-03-31T23:11:46Z","includesCreatedEdit":false,"reactionGroups":[],"state":"COMMENTED","commit":{"oid":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5"}},{"id":"PRR_kwDORIrGY87w2OSy","author":{"login":"declanblanc"},"authorAssociation":"COLLABORATOR","body":"","submittedAt":"2026-03-31T23:11:48Z","includesCreatedEdit":false,"reactionGroups":[],"state":"COMMENTED","commit":{"oid":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5"}},{"id":"PRR_kwDORIrGY87w2R_k","author":{"login":"acabrera04"},"authorAssociation":"OWNER","body":"- [x] Logic over style: the previously incorrect retry/exhaustion descriptions are fixed, and the spec now matches the service logic.\n- [x] Security first: docs-only change; no new security surface or secret exposure.\n- [x] Architectural alignment: the document remains aligned with the existing backend service behavior.\n- [x] Issue completion: issue #259 acceptance criteria are satisfied; the spec now covers the requested functions, happy paths, error paths, and edge cases.\n- [x] No nitpicking: no style-only concerns; this re-review focused on behavioral accuracy and coverage.\n- [x] Avoid repetition: the prior three findings were addressed, and I am not repeating resolved feedback.\n- [x] Iterative reviews: the new commit resolves the previously raised concerns.\n- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.\n\n**Bundled review**\n\nThe follow-up commit addresses the prior review correctly. The `withSlugRetry` final-attempt behavior is now documented accurately, the `generateUniqueSlug` exhaustion boundary matches the implementation, and `createServer` now includes the missing post-insert failure paths. I did not find any new inaccuracies in the updated spec.","submittedAt":"2026-03-31T23:15:31Z","includesCreatedEdit":false,"reactionGroups":[],"state":"APPROVED","commit":{"oid":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5"}}],"url":"https://github.com/acabrera04/Harmony/pull/275"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr view 275 --repo acabrera04/Harmony --comments
+```
+
+Output:
+
+```text
+author:	acabrera04
+association:	owner
+edited:	false
+status:	changes requested
+--
+- [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.
+- [x] Security first: docs-only change; no new security surface or secret exposure.
+- [x] Architectural alignment: nothing here conflicts with the backend architecture; this is a test-spec document.
+- [ ] Issue completion: issue #259 asks for all program paths, and the current spec does not fully capture the real `createServer`/`withSlugRetry` paths.
+- [x] No nitpicking: findings are about incorrect behavior and missing coverage, not formatting or naming.
+- [x] Avoid repetition: there are no existing PR comments to duplicate.
+- [x] Iterative reviews: this appears to be the first review on the PR, so there were no prior concerns to re-check.
+- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.
+
+**Bundled review**
+
+I found 3 substantive issues.
+
+1. `withSlugRetry` exhaustion is documented incorrectly. In `server.service.ts`, a third `P2002` does not become `TRPCError(CONFLICT)`; it is rethrown as the original Prisma error. That makes the spec inaccurate for both `createServer` and renamed `updateServer` flows.
+
+2. `createServer` is missing two real failure paths. After the insert succeeds, `channelService.createDefaultChannel(server.id)` and `serverMemberService.addOwner(input.ownerId, server.id)` can still reject, but the spec never covers those paths despite claiming full program-path coverage.
+
+3. The slug exhaustion boundary is off by one. `generateUniqueSlug` checks 10 total candidates (`base` through `base-9`), not the base plus 10 suffixes. A test authored from the current wording would encode the wrong boundary.
+--
+author:	declanblanc
+association:	collaborator
+edited:	false
+status:	none
+--
+@copilot review
+--
+author:	copilot-swe-agent
+association:	contributor
+edited:	true
+status:	none
+--
+
+> - [ ] Logic over style: the spec has behavioral inaccuracies around slug retry/exhaustion and misses real `createServer` failure paths.
+> - [x] Security first: docs-only change; no new security surface ...
+
+All three issues were addressed in commit 9ff0b67:
+
+1. **withSlugRetry exhaustion** — Sections 3.6, 3.7, 4.6, 4.7, and 5 now correctly state that a P2002 on the final attempt (attempt 2 of 3) rethrows the raw `PrismaClientKnownRequestError` directly. The `TRPCError(CONFLICT)` after the loop is documented as unreachable dead code.
+
+2. **createServer missing paths** — Section 3.6 now lists both post-insert failure paths (`channelService.createDefaultChannel` rejection and `serverMemberService.addOwner` rejection), and section 4.6 adds a concrete test case for each.
+
+3. **Slug exhaustion boundary** — Section 4.6 and 4.7 now correctly describe the mock as covering all 10 total candidates (`base` through `base-9`); `base-10` is generated but never probed, so mocking those 10 is sufficient to trigger the CONFLICT throw.
+
+
+> @copilot review
+
+Reviewed. The spec is accurate against the current `server.service.ts` implementation:
+
+- `withSlugRetry` exhaustion behavior is correctly documented: P2002 on attempt 2 rethrows the raw `PrismaClientKnownRequestError`; the `TRPCError(CONFLICT)` after the loop is unreachable and noted as such.
+- `generateUniqueSlug` probes exactly 10 candidates (`base`, `base-1` through `base-9`); boundary correctly specified in sections 4.6 and 4.7.
+- `createServer` post-insert failure paths (`createDefaultChannel` and `addOwner` rejections) are documented in sections 3.6 and 4.6.
+- All authorization guards, event publication side-effects, and slug-retry/collision paths are covered with correct test-case assertions.
+
+No further inaccuracies found.
+--
+author:	acabrera04
+association:	owner
+edited:	false
+status:	approved
+--
+- [x] Logic over style: the previously incorrect retry/exhaustion descriptions are fixed, and the spec now matches the service logic.
+- [x] Security first: docs-only change; no new security surface or secret exposure.
+- [x] Architectural alignment: the document remains aligned with the existing backend service behavior.
+- [x] Issue completion: issue #259 acceptance criteria are satisfied; the spec now covers the requested functions, happy paths, error paths, and edge cases.
+- [x] No nitpicking: no style-only concerns; this re-review focused on behavioral accuracy and coverage.
+- [x] Avoid repetition: the prior three findings were addressed, and I am not repeating resolved feedback.
+- [x] Iterative reviews: the new commit resolves the previously raised concerns.
+- [x] Prevent CI failures: the patch is Markdown-only and does not introduce an obvious build or syntax failure.
+
+**Bundled review**
+
+The follow-up commit addresses the prior review correctly. The `withSlugRetry` final-attempt behavior is now documented accurately, the `generateUniqueSlug` exhaustion boundary matches the implementation, and `createServer` now includes the missing post-insert failure paths. I did not find any new inaccuracies in the updated spec.
+--
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:15:41.516Z
+
+I re-reviewed PR `#275` on the new head commit `9ff0b67` and posted an approval. The previous three findings are fixed, the old threads are resolved, and GitHub now shows the PR as `APPROVED`.
+
+Review state: [PR #275](https://github.com/acabrera04/Harmony/pull/275)
+
+### Turn 4: [$codex-conversation-exporter](/Users/allen/repos/codex-logs-export/skil
+
+#### 👤 User Prompt
+
+- Time: 2026-03-31T23:25:55.100Z
+
+```text
+[$codex-conversation-exporter](/Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md) get the logs from this chat 019d4620-3571-77f3-a621-f3d9eb0d1b58 and export it to llm-logs/acabrera04-logs/acabrera04-tests/ and push it onto the same branch as PR #275
+```
+
+_No assistant or tool activity recorded after this prompt._
+
+### Turn 5: <skill> <name>codex-conversation-exporter</name>
+
+#### 👤 User Prompt
+
+- Time: 2026-03-31T23:25:55.100Z
+
+````text
+<skill>
+<name>codex-conversation-exporter</name>
+<path>/Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md</path>
+---
+name: codex-conversation-exporter
+description: Export Codex session logs to Markdown using the local codex-export CLI instead of reconstructing transcripts with model tokens.
+---
+
+# Codex Conversation Exporter
+
+Use this skill when the user asks to export Codex logs, save a Codex conversation, convert a session to Markdown, or archive a transcript locally.
+
+## Rules
+
+- Prefer the local `codex-export` CLI over reconstructing a transcript in-model.
+- If the user has not identified a session, run `codex-export list` first and show the relevant candidates.
+- Default to messages plus tool activity.
+- Include hidden system/developer prompts only when the user explicitly asks for them.
+- Write to a user-visible path unless the user asks for stdout or another destination.
+- Report the output path back to the user after a file export.
+
+## Command patterns
+
+List recent sessions:
+
+```bash
+codex-export list
+codex-export list --limit 10
+codex-export list --since 2026-03-30
+```
+
+Export by thread id:
+
+```bash
+codex-export export <thread-id>
+codex-export export <thread-id> --out ~/Desktop
+codex-export export <thread-id> --messages-only
+codex-export export <thread-id> --all
+codex-export export <thread-id> --include-hidden-prompts
+codex-export export <thread-id> --stdout
+```
+
+Export by rollout path:
+
+```bash
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl --out ~/Desktop
+```
+
+## Flag guide
+
+- `--out <file-or-dir>` writes to a specific file or directory.
+- `--stdout` prints the Markdown instead of writing a file.
+- `--messages-only` omits tool calls and tool outputs.
+- `--all` includes low-level tool metadata and raw wrappers that are hidden by default.
+- `--include-hidden-prompts` includes developer/system prompt layers.
+- `--since <date>` filters `list` results.
+- `--limit <n>` caps `list` results.
+
+## Agent behavior
+
+When the user says "export this conversation" without a thread id:
+
+1. Run `codex-export list`.
+2. Identify the most likely current session from title, cwd, and recency.
+3. Export it with the default mode unless the user requested a different output.
+4. Return the exact file path written.
+
+`codex-log-export` remains available as a compatibility alias.
+
+</skill>
+````
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:26:06.414Z
+
+I’m using the `codex-conversation-exporter` workflow. First I’ll verify the current branch/repo state, confirm the PR branch name, and export thread `019d4620-3571-77f3-a621-f3d9eb0d1b58` into the requested `llm-logs/acabrera04-logs/acabrera04-tests/` path before committing and pushing only that file.
+
+#### Tool: update_plan
+
+- Plan:
+  - [in_progress] Load exporter skill and inspect git/PR branch state
+  - [pending] Export the requested Codex thread to the target directory
+  - [pending] Stage and commit only the exported log on the PR branch
+  - [pending] Push the branch and report the exported path
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read /Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md
+```
+
+Output:
+
+````text
+---
+name: codex-conversation-exporter
+description: Export Codex session logs to Markdown using the local codex-export CLI instead of reconstructing transcripts with model tokens.
+---
+
+# Codex Conversation Exporter
+
+Use this skill when the user asks to export Codex logs, save a Codex conversation, convert a session to Markdown, or archive a transcript locally.
+
+## Rules
+
+- Prefer the local `codex-export` CLI over reconstructing a transcript in-model.
+- If the user has not identified a session, run `codex-export list` first and show the relevant candidates.
+- Default to messages plus tool activity.
+- Include hidden system/developer prompts only when the user explicitly asks for them.
+- Write to a user-visible path unless the user asks for stdout or another destination.
+- Report the output path back to the user after a file export.
+
+## Command patterns
+
+List recent sessions:
+
+```bash
+codex-export list
+codex-export list --limit 10
+codex-export list --since 2026-03-30
+```
+
+Export by thread id:
+
+```bash
+codex-export export <thread-id>
+codex-export export <thread-id> --out ~/Desktop
+codex-export export <thread-id> --messages-only
+codex-export export <thread-id> --all
+codex-export export <thread-id> --include-hidden-prompts
+codex-export export <thread-id> --stdout
+```
+
+Export by rollout path:
+
+```bash
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl --out ~/Desktop
+```
+
+## Flag guide
+
+- `--out <file-or-dir>` writes to a specific file or directory.
+- `--stdout` prints the Markdown instead of writing a file.
+- `--messages-only` omits tool calls and tool outputs.
+- `--all` includes low-level tool metadata and raw wrappers that are hidden by default.
+- `--include-hidden-prompts` includes developer/system prompt layers.
+- `--since <date>` filters `list` results.
+- `--limit <n>` caps `list` results.
+
+## Agent behavior
+
+When the user says "export this conversation" without a thread id:
+
+1. Run `codex-export list`.
+2. Identify the most likely current session from title, cwd, and recency.
+3. Export it with the default mode unless the user requested a different output.
+4. Return the exact file path written.
+
+`codex-log-export` remains available as a compatibility alias.
+````
+
+#### Tool: exec_command
+
+```sh
+git branch --show-current
+```
+
+Output:
+
+```text
+main
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+?? "P4: Backend Development | CS 485 AI-Assisted Software Engineering (Sp26).html"
+?? "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf"
+?? load-test.js
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr view 275 --repo acabrera04/Harmony --json headRefName,headRefOid,url
+```
+
+Output:
+
+```text
+{"headRefName":"test/issue-259-server-service-spec","headRefOid":"9ff0b67fa0b35066617c1e3cef20eadfa9dd0df5","url":"https://github.com/acabrera04/Harmony/pull/275"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:26:18.764Z
+
+The repo is currently on `main`, while PR `#275` is on `test/issue-259-server-service-spec`. I’m switching to that branch next, then I’ll run `codex-export export` straight into the requested log directory.
+
+#### Tool: exec_command
+
+```sh
+git rev-parse --verify test/issue-259-server-service-spec
+```
+
+Output:
+
+```text
+fatal: Needed a single revision
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls llm-logs/acabrera04-logs/acabrera04-tests
+```
+
+Output:
+
+```text
+2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md  197.0K
+2026-03-30-do-issue-268-for-me-with-making-a-test-spec-019d410b.md  218.6K
+
+📊 2 files, 0 dirs (2 .md)
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:26:21.683Z
+
+The PR branch isn’t checked out locally yet. I’m fetching `test/issue-259-server-service-spec` from `origin`, switching onto it, and then exporting the conversation into the existing `llm-logs/acabrera04-logs/acabrera04-tests/` directory.
+
+#### Tool: exec_command
+
+```sh
+git fetch origin test/issue-259-server-service-spec:test/issue-259-server-service-spec && git checkout test/issue-259-server-service-spec
+```
+
+Output:
+
+```text
+From github.com:acabrera04/Harmony
+ * [new branch]      test/issue-259-server-service-spec -> test/issue-259-server-service-spec
+Switched to branch 'test/issue-259-server-service-spec'
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:26:26.759Z
+
+I’m on the PR branch now. Next step is the actual export with the default transcript mode, which includes messages and tool activity but not hidden system/developer prompts.
+
+#### Tool: exec_command
+
+```sh
+codex-export export 019d4620-3571-77f3-a621-f3d9eb0d1b58 --out /Users/allen/repos/Harmony/llm-logs/acabrera04-logs/acabrera04-tests/
+```


### PR DESCRIPTION
## Summary

- Adds `docs/test-specs/server-service-spec.md` — an English-language test specification for `harmony-backend/src/services/server.service.ts`
- Covers all 11 exported functions (`generateSlug`, `getPublicServers`, `getAllServers`, `getMemberServers`, `getServer`, `createServer`, `updateServer`, `deleteServer`, `incrementMemberCount`, `decrementMemberCount`, `getMembers`) plus the private slug helpers via `createServer`/`updateServer`
- Each function section lists program paths and a table of concrete test cases with inputs and expected outputs, including all `TRPCError` branches, slug-retry/collision logic, authorization guards (owner vs system admin), event publication side effects, and edge cases

## Test plan

- [ ] Review spec tables to confirm every `TRPCError` branch in the source file has a corresponding test case
- [ ] Confirm `generateSlug` cases cover the full regex pipeline (lowercase, trim, strip, collapse spaces, collapse hyphens, strip edges)
- [ ] Confirm `decrementMemberCount` covers both failing branches of the compound `!server || server.memberCount <= 0` guard
- [ ] Confirm `createServer` cases cover slug exhaustion, P2002 retry, and non-P2002 passthrough
- [ ] Confirm `updateServer` cases cover owner path, system-admin path, name-unchanged path, and name-changed path

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)