### PR TITLE
docs: frontend channel service test specification (#261)

### DIFF
--- a/docs/test-specs/frontend-channel-service-spec.md
+++ b/docs/test-specs/frontend-channel-service-spec.md
@@ -44,7 +44,9 @@ Purpose: return a single channel by server slug and channel slug, or `null` if n
 Program paths:
 
 - `publicGet` for the server resolves with `null`; function returns `null` immediately.
+- `publicGet` for the server rejects; the rejection propagates uncaught to the caller (this call sits outside both `try` blocks).
 - Server resolves; public channel list resolves and contains a matching slug; channel is returned with `visibility` hardcoded to `PUBLIC_INDEXABLE`.
+- Server resolves; public channel list resolves with `null`; falls through to tRPC fallback.
 - Server resolves; public channel list resolves but contains no matching slug; falls through to tRPC fallback.
 - Server resolves; public channel list `publicGet` call throws; falls through to tRPC fallback.
 - tRPC fallback resolves with channel data; channel is returned.
@@ -123,8 +125,10 @@ Description: fetches a single channel by slug pair, attempting the public REST e
 | Test Purpose | Inputs | Expected Output |
 | --- | --- | --- |
 | Return null when server lookup fails | `serverSlug = "my-server"`; `publicGet` for server resolves with `null` | Returns `null`; no further network calls are made |
+| Propagate rejection when server lookup rejects | `serverSlug = "my-server"`; `publicGet` for server rejects with a network error | Promise rejects with the same error; rejection is not caught |
 | Return channel from public endpoint on slug match | Server resolves; public channel list contains a record with matching `channelSlug` | Returns `Channel` with `visibility = PUBLIC_INDEXABLE`; `serverId` filled from server lookup |
 | Supplement missing public fields with defaults | Public channel record omits `position` and `createdAt` | Returned channel has `position = 0` and `createdAt` equal to epoch ISO string |
+| Fall through to tRPC when public channel list returns null | Server resolves; `publicGet` for channels resolves with `null`; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; does not log an error |
 | Fall through to tRPC when slug not in public list | Server resolves; public channel list has no matching slug; tRPC resolves with channel data | Returns the tRPC-adapted `Channel` |
 | Fall through to tRPC when public endpoint throws | Server resolves; public channels `publicGet` throws; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; thrown error is swallowed silently |
 | Return null when tRPC resolves with falsy value | Server resolves; public endpoint miss; tRPC resolves with `null` | Returns `null` |
@@ -160,8 +164,8 @@ Description: creates a new channel and returns the backend-confirmed record.
 
 | Test Purpose | Inputs | Expected Output |
 | --- | --- | --- |
-| Create channel with all fields | Full `Channel` object minus `id`, `createdAt`, `updatedAt`; `trpcMutate` resolves with full record | Returns adapted `Channel`; mutation called with all provided fields |
-| Create channel with optional fields absent | `topic` and `description` omitted; `trpcMutate` resolves | Returns adapted `Channel`; `topic` passed as `undefined` in mutation args |
+| Create channel with all fields | Full `Channel` object minus `id`, `createdAt`, `updatedAt`; `trpcMutate` resolves with full record | Returns adapted `Channel`; mutation called with `serverId`, `name`, `slug`, `type`, `visibility`, `topic`, and `position`; `description` is not forwarded |
+| Create channel with optional fields absent | `topic` omitted; `description` is accepted in the input type but not forwarded to the mutation; `trpcMutate` resolves | Returns adapted `Channel`; `topic` passed as `undefined` in mutation args; `description` not present in mutation payload |
 | Create channel with each visibility value | `visibility = PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, or `PRIVATE`; `trpcMutate` resolves | Returns adapted `Channel` with the correct `visibility` field |
 | Propagate rejection to caller | Valid input; `trpcMutate` rejects | Promise rejects with the underlying error |
 
@@ -177,9 +181,10 @@ Description: fetches a paginated audit log, adapting each entry and validating f
 | Forward offset option | `options = { offset: 5 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, offset: 5 }` |
 | Forward startDate option | `options = { startDate: "2026-01-01T00:00:00.000Z" }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, startDate: "2026-01-01T00:00:00.000Z" }` |
 | Omit options when none provided | `options` not passed; `trpcQuery` resolves | `trpcQuery` called with only `serverId` and `channelId` |
+| Fall back to epoch string for non-string timestamp | Entry has `timestamp = 42` (a number); `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
 | Fall back to epoch string for invalid timestamp | Entry has `timestamp = "not-a-date"`; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
 | Fall back to epoch string for missing timestamp | Entry has no `timestamp` field; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
-| Emit warn for missing required string fields | Entry missing `id`, `channelId`, `actorId`, or `action`; `trpcQuery` resolves | Each missing field emits a `console.warn`; function still returns an entry |
+| Warn only on missing/non-string core fields | Entry has missing or non-string `id`, `channelId`, `actorId`, or `action`; `trpcQuery` resolves | Each problematic core field emits a `console.warn`; function still returns an entry; no warnings expected for `oldValue`, `newValue`, `ipAddress`, or `userAgent` |
 | Propagate rejection to caller | Valid args; `trpcQuery` rejects | Promise rejects with the underlying error |
 
 ### 4.7 `deleteChannel`
@@ -198,8 +203,8 @@ Description: deletes a channel and signals success via a boolean return value.
 - The public REST hit in `getChannel` always overrides the raw `visibility` field with `PUBLIC_INDEXABLE`; the test must confirm this even when the raw record contains a different value.
 - Missing `position` and `createdAt` from public channel records are filled with defaults (`0` and epoch ISO); tests should assert these exact defaults.
 - `updateChannel` must only forward `name` and `topic` when those keys are explicitly present in `patch`; the absence of a key must not result in the key being sent as `undefined` to the mutation.
-- `toFrontendChannel` and `toAuditLogEntry` emit `console.warn` for every missing required field; each warning path should be exercised at least once.
-- `toAuditLogEntry` falls back to an epoch ISO timestamp for any non-string or unparseable `timestamp` value; both non-string and invalid-string cases must be tested.
+- `toFrontendChannel` emits `console.warn` when any of its guarded fields (`id`, `serverId`, `slug`, `createdAt`) are missing or non-string; tests should cover at least one warning for each. `toAuditLogEntry` emits `console.warn` when any of its guarded fields (`id`, `channelId`, `actorId`, `action`) are missing or non-string; tests should likewise exercise each warning condition at least once. No warnings are emitted for `oldValue`, `newValue`, `ipAddress`, or `userAgent`.
+- `toAuditLogEntry` falls back to an epoch ISO timestamp for any non-string or unparseable `timestamp` value; all three cases (non-string, invalid-string, missing) must be tested, and corresponding `console.warn` calls should be asserted.
 - All three `ChannelVisibility` values (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) must appear in at least one test for `updateVisibility` and `createChannel`.
 
 ## 6. Mock Strategy
@@ -232,6 +237,6 @@ The cases above are intended to cover:
 - public-REST-to-tRPC fallback logic in `getChannel`,
 - all three `ChannelVisibility` enum values,
 - field-level validation warnings in `toFrontendChannel` and `toAuditLogEntry`, and
-- optional field defaults (missing `position`, `createdAt`, `topic`, `description`).
+- optional field defaults (missing `position`, `createdAt`, `topic`).
 
 Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures (e.g., React `cache` internals) outside the service's direct branching logic.

--- a/docs/test-specs/frontend-channel-service-spec.md
+++ b/docs/test-specs/frontend-channel-service-spec.md
@@ -1,0 +1,237 @@
+# Channel Service Test Specification (Frontend)
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-frontend/src/services/channelService.ts`.
+It covers all seven exported service functions:
+
+- `getChannels`
+- `getChannel`
+- `updateVisibility`
+- `updateChannel`
+- `createChannel`
+- `getAuditLog`
+- `deleteChannel`
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Mock `trpcQuery` and `trpcMutate` from `@/lib/trpc-client` using Jest module mocking.
+- Mock `publicGet` from `@/lib/trpc-client` for tests that exercise the public REST path.
+- Reset all mocks between tests to ensure isolation.
+- Use `console.warn` spies to assert that `toFrontendChannel` and `toAuditLogEntry` emit validation warnings for malformed API responses.
+- The `getChannel` export is wrapped in React's `cache()`. Tests should call the function directly and mock the underlying transport layer rather than the cache wrapper.
+- All resolved mock payloads must conform to the `Record<string, unknown>` shapes expected by the adapter functions; omit or corrupt individual fields to exercise validation warnings.
+- `ChannelVisibility` enum values under test: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `getChannels`
+
+Purpose: fetch all channels for a server (including PRIVATE channels) via the authenticated tRPC `channel.getChannels` endpoint.
+
+Program paths:
+
+- `trpcQuery` resolves with a non-empty array; each raw record is adapted and returned.
+- `trpcQuery` resolves with `null` or `undefined`; the function returns `[]`.
+- `trpcQuery` rejects; the error propagates to the caller uncaught.
+
+### 3.2 `getChannel`
+
+Purpose: return a single channel by server slug and channel slug, or `null` if not found. Tries the public REST endpoint first to support unauthenticated guest views, then falls back to authenticated tRPC.
+
+Program paths:
+
+- `publicGet` for the server resolves with `null`; function returns `null` immediately.
+- Server resolves; public channel list resolves and contains a matching slug; channel is returned with `visibility` hardcoded to `PUBLIC_INDEXABLE`.
+- Server resolves; public channel list resolves but contains no matching slug; falls through to tRPC fallback.
+- Server resolves; public channel list `publicGet` call throws; falls through to tRPC fallback.
+- tRPC fallback resolves with channel data; channel is returned.
+- tRPC fallback resolves with `null`/falsy; function returns `null`.
+- tRPC fallback rejects; function catches the error, logs it, and returns `null`.
+
+### 3.3 `updateVisibility`
+
+Purpose: update a channel's visibility via the authenticated tRPC `channel.setVisibility` mutation. Returns `void`.
+
+Program paths:
+
+- `trpcMutate` resolves; function returns `void`.
+- `trpcMutate` rejects; error propagates to the caller.
+
+### 3.4 `updateChannel`
+
+Purpose: update a channel's `name` and/or `topic` metadata via tRPC. Only defined patch keys are forwarded.
+
+Program paths:
+
+- Patch includes both `name` and `topic`; both are forwarded and the adapted result is returned.
+- Patch includes only `name` (no `topic`); only `name` is forwarded.
+- Patch includes only `topic` (no `name`); only `topic` is forwarded.
+- Patch is empty (`{}`); neither key is forwarded; adapted result is still returned.
+- `trpcMutate` rejects; error propagates to the caller.
+
+### 3.5 `createChannel`
+
+Purpose: create a new channel via tRPC `channel.createChannel` and return the adapted `Channel`.
+
+Program paths:
+
+- All required fields are provided; `trpcMutate` resolves; adapted channel is returned.
+- `trpcMutate` rejects; error propagates to the caller.
+
+### 3.6 `getAuditLog`
+
+Purpose: fetch a paginated visibility audit log for a channel via tRPC `channel.getAuditLog`.
+
+Program paths:
+
+- `trpcQuery` resolves with a populated `entries` array and `total`; each entry is adapted and returned.
+- `trpcQuery` resolves with an empty `entries` array; returns `{ entries: [], total: 0 }`.
+- Options are partially provided (`limit` only, `offset` only, or `startDate` only); present keys are forwarded.
+- Options are omitted entirely; query is called with only `serverId` and `channelId`.
+- An entry has an invalid or missing `timestamp`; `toAuditLogEntry` falls back to epoch ISO string and emits a `console.warn`.
+- `trpcQuery` rejects; error propagates to the caller.
+
+### 3.7 `deleteChannel`
+
+Purpose: delete a channel via tRPC and return `true` on success.
+
+Program paths:
+
+- `trpcMutate` resolves; function returns `true`.
+- `trpcMutate` rejects; error propagates to the caller.
+
+## 4. Detailed Test Cases
+
+### 4.1 `getChannels`
+
+Description: fetches the full channel list for a server, adapting each record from the raw backend shape.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return adapted channels for a server | `serverId = "s1"`; `trpcQuery` resolves with two valid raw channel records | Returns an array of two `Channel` objects with all fields correctly mapped |
+| Return empty array when API returns null | `serverId = "s1"`; `trpcQuery` resolves with `null` | Returns `[]` |
+| Return empty array when API returns undefined | `serverId = "s1"`; `trpcQuery` resolves with `undefined` | Returns `[]` |
+| Propagate rejection to caller | `serverId = "s1"`; `trpcQuery` rejects with a network error | The promise rejects with the same error; caller receives it without masking |
+
+### 4.2 `getChannel`
+
+Description: fetches a single channel by slug pair, attempting the public REST endpoint before falling back to authenticated tRPC.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return null when server lookup fails | `serverSlug = "my-server"`; `publicGet` for server resolves with `null` | Returns `null`; no further network calls are made |
+| Return channel from public endpoint on slug match | Server resolves; public channel list contains a record with matching `channelSlug` | Returns `Channel` with `visibility = PUBLIC_INDEXABLE`; `serverId` filled from server lookup |
+| Supplement missing public fields with defaults | Public channel record omits `position` and `createdAt` | Returned channel has `position = 0` and `createdAt` equal to epoch ISO string |
+| Fall through to tRPC when slug not in public list | Server resolves; public channel list has no matching slug; tRPC resolves with channel data | Returns the tRPC-adapted `Channel` |
+| Fall through to tRPC when public endpoint throws | Server resolves; public channels `publicGet` throws; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; thrown error is swallowed silently |
+| Return null when tRPC resolves with falsy value | Server resolves; public endpoint miss; tRPC resolves with `null` | Returns `null` |
+| Return null when tRPC rejects | Server resolves; public endpoint miss; tRPC rejects | Returns `null`; logs error via `console.error` |
+| Correctly set visibility to PUBLIC_INDEXABLE for public hit | Server resolves; public list match with any `visibility` value in raw record | Returned channel always has `visibility = PUBLIC_INDEXABLE` regardless of raw field |
+
+### 4.3 `updateVisibility`
+
+Description: sends a visibility mutation to the backend with no return value.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Successfully set visibility to PUBLIC_INDEXABLE | `channelId = "c1"`, `visibility = PUBLIC_INDEXABLE`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with `{ serverId, channelId, visibility }` |
+| Successfully set visibility to PUBLIC_NO_INDEX | `channelId = "c1"`, `visibility = PUBLIC_NO_INDEX`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |
+| Successfully set visibility to PRIVATE | `channelId = "c1"`, `visibility = PRIVATE`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |
+| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 403 error | Promise rejects with the same error |
+
+### 4.4 `updateChannel`
+
+Description: sends partial channel metadata updates, forwarding only the keys that are explicitly set.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Update both name and topic | `patch = { name: "general", topic: "chat" }`; `trpcMutate` resolves with a full channel record | Returns adapted `Channel`; mutation called with `name` and `topic` |
+| Update name only | `patch = { name: "general" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `topic` key |
+| Update topic only | `patch = { topic: "new topic" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `name` key |
+| Empty patch sends no extra keys | `patch = {}`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called with only `serverId` and `channelId` |
+| Propagate rejection to caller | Valid patch; `trpcMutate` rejects | Promise rejects with the underlying error |
+
+### 4.5 `createChannel`
+
+Description: creates a new channel and returns the backend-confirmed record.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Create channel with all fields | Full `Channel` object minus `id`, `createdAt`, `updatedAt`; `trpcMutate` resolves with full record | Returns adapted `Channel`; mutation called with all provided fields |
+| Create channel with optional fields absent | `topic` and `description` omitted; `trpcMutate` resolves | Returns adapted `Channel`; `topic` passed as `undefined` in mutation args |
+| Create channel with each visibility value | `visibility = PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, or `PRIVATE`; `trpcMutate` resolves | Returns adapted `Channel` with the correct `visibility` field |
+| Propagate rejection to caller | Valid input; `trpcMutate` rejects | Promise rejects with the underlying error |
+
+### 4.6 `getAuditLog`
+
+Description: fetches a paginated audit log, adapting each entry and validating field types.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return entries and total from API | `serverId`, `channelId`; `trpcQuery` resolves with two valid entries and `total = 2` | Returns `{ entries: [AuditLogEntry, AuditLogEntry], total: 2 }` |
+| Return empty list | `serverId`, `channelId`; `trpcQuery` resolves with `{ entries: [], total: 0 }` | Returns `{ entries: [], total: 0 }` |
+| Forward limit option | `options = { limit: 10 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, limit: 10 }` |
+| Forward offset option | `options = { offset: 5 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, offset: 5 }` |
+| Forward startDate option | `options = { startDate: "2026-01-01T00:00:00.000Z" }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, startDate: "2026-01-01T00:00:00.000Z" }` |
+| Omit options when none provided | `options` not passed; `trpcQuery` resolves | `trpcQuery` called with only `serverId` and `channelId` |
+| Fall back to epoch string for invalid timestamp | Entry has `timestamp = "not-a-date"`; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
+| Fall back to epoch string for missing timestamp | Entry has no `timestamp` field; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
+| Emit warn for missing required string fields | Entry missing `id`, `channelId`, `actorId`, or `action`; `trpcQuery` resolves | Each missing field emits a `console.warn`; function still returns an entry |
+| Propagate rejection to caller | Valid args; `trpcQuery` rejects | Promise rejects with the underlying error |
+
+### 4.7 `deleteChannel`
+
+Description: deletes a channel and signals success via a boolean return value.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return true on successful deletion | `channelId = "c1"`, `serverId = "s1"`; `trpcMutate` resolves | Returns `true`; `trpcMutate` called with `{ serverId, channelId }` |
+| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 404 error | Promise rejects with the underlying error; `true` is never returned |
+
+## 5. Edge Cases to Explicitly Validate
+
+- `getChannels` must not suppress transport errors; callers that use the channel count for position computation depend on the error surfacing to avoid data corruption.
+- `getChannel` uses `cache()` wrapping; test the inner async function directly by mocking at the transport layer.
+- The public REST hit in `getChannel` always overrides the raw `visibility` field with `PUBLIC_INDEXABLE`; the test must confirm this even when the raw record contains a different value.
+- Missing `position` and `createdAt` from public channel records are filled with defaults (`0` and epoch ISO); tests should assert these exact defaults.
+- `updateChannel` must only forward `name` and `topic` when those keys are explicitly present in `patch`; the absence of a key must not result in the key being sent as `undefined` to the mutation.
+- `toFrontendChannel` and `toAuditLogEntry` emit `console.warn` for every missing required field; each warning path should be exercised at least once.
+- `toAuditLogEntry` falls back to an epoch ISO timestamp for any non-string or unparseable `timestamp` value; both non-string and invalid-string cases must be tested.
+- All three `ChannelVisibility` values (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) must appear in at least one test for `updateVisibility` and `createChannel`.
+
+## 6. Mock Strategy
+
+All external dependencies are mocked at the module level with `jest.mock`:
+
+```
+jest.mock('@/lib/trpc-client', () => ({
+  trpcQuery:  jest.fn(),
+  trpcMutate: jest.fn(),
+  publicGet:  jest.fn(),
+}));
+```
+
+Reset all mocks in `beforeEach` with `jest.resetAllMocks()` to prevent cross-test contamination.
+
+- **`trpcQuery`** — resolve with well-formed raw objects to test happy paths; reject with an `Error` to test propagation; resolve with `null`/`undefined` to test null-guard branches.
+- **`trpcMutate`** — resolve to test `updateVisibility`, `updateChannel`, `createChannel`, and `deleteChannel` happy paths; reject to test error propagation in each.
+- **`publicGet`** — resolve with a server object (containing at minimum `{ id: "s1" }`) to simulate a successful server lookup; resolve with `null` to test the early-return path; resolve with a channels payload or throw to test the public channel list branches.
+- **`console.warn` / `console.error`** — use `jest.spyOn(console, 'warn')` and `jest.spyOn(console, 'error')` in tests that exercise validation warnings; restore spies in `afterEach`.
+
+## 7. Coverage Expectation
+
+The cases above are intended to cover:
+
+- all seven exported functions,
+- every explicit null-guard and early-return branch,
+- successful transport call paths and their return value adaption,
+- all transport rejection paths and their propagation behavior,
+- public-REST-to-tRPC fallback logic in `getChannel`,
+- all three `ChannelVisibility` enum values,
+- field-level validation warnings in `toFrontendChannel` and `toAuditLogEntry`, and
+- optional field defaults (missing `position`, `createdAt`, `topic`, `description`).
+
+Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures (e.g., React `cache` internals) outside the service's direct branching logic.

--- a/llm-logs/acabrera04-logs/acabrera04-tests/2026-03-31-review-this-pr-https-github-com-acabrera04-harmony-pull-276-019d4628.md
+++ b/llm-logs/acabrera04-logs/acabrera04-tests/2026-03-31-review-this-pr-https-github-com-acabrera04-harmony-pull-276-019d4628.md
@@ -1,0 +1,2259 @@
+# Codex Conversation Export
+
+## Metadata
+
+- Thread ID: 019d4628-b19f-7992-bfef-a6a018df474e
+- Timestamp: 2026-03-31T23:09:25.282Z
+- CWD: /Users/allen/repos/Harmony
+- Source: vscode
+- Model Provider: openai
+- Model: gpt-5.4
+- Reasoning Effort: high
+- Rollout Path: /Users/allen/.codex/sessions/2026/03/31/rollout-2026-03-31T19-09-25-019d4628-b19f-7992-bfef-a6a018df474e.jsonl
+
+## Transcript
+
+### Turn 1: Review this PR
+
+#### 👤 User Prompt
+
+- Time: 2026-03-31T23:09:36.305Z
+
+```text
+Review this PR https://github.com/acabrera04/Harmony/pull/276
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:09:46.624Z
+
+Reviewing PR `#276`. I’m loading the repo’s required review guidance first, then I’ll inspect the PR diff and changed files against the current codebase.
+
+#### Tool: exec_command
+
+```sh
+rtk read WORKFLOW.md
+```
+
+Output:
+
+````text
+## Workflow Orchestration
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean 
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop 
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests - then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+This project uses a **hybrid approach**: `tasks/todo.md` for AI context, GitHub Issues as the canonical tracker on the Harmony Project Board (course requirement).
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items (local scratch pad for AI context)
+2. **Identify the Issue**: If the task maps to an existing GitHub Issue, note the issue number at the top of `tasks/todo.md`
+3. **Announce Start**: Post an opening comment to the issue — `gh issue comment <number> --body "..."` — describing what will be done
+4. **Track Progress**: Mark items complete in `tasks/todo.md` as you go; post a comment to the issue at meaningful milestones (e.g., after a major step or when blocked)
+5. **Explain Changes**: High-level summary at each step
+6. **Document Results**: Add a review section to `tasks/todo.md` and post a final summary comment to the issue when complete
+7. **Capture Lessons**: Update `tasks/lessons.md` after corrections. Post the new lessons learned as a comment to the issue.
+
+### Issue Comment Format
+Use this structure for issue comments to keep the audit trail readable:
+
+```
+**[AI Agent — <Step>]**
+
+<What was done or decided>
+
+<Any blockers, decisions, or next steps>
+```
+
+Example steps: `Starting`, `In Progress`, `Blocked`, `Complete`
+
+## Core Principles
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
+- **Lean Context Files**: Keep AGENTS.md and similar files to only non-obvious, non-discoverable essentials. Research shows context file bloat decreases task success rates and increases inference cost by 20%+ with 2–4 extra steps per task (Gloaguen et al., 2026).
+
+#### Taken from https://x.com/mdancho84/status/2023738764841894352
+
+Gloaguen, T., Mündler, N., Müller, M., Raychev, V., & Vechev, M. (2026, February 12). Evaluating AGENTS.MD: Are Repository-Level context Files helpful for coding agents? arXiv.org. https://arxiv.org/abs/2602.11988
+````
+
+#### Tool: exec_command
+
+```sh
+rtk read .github/PR_REVIEW.md
+```
+
+Output:
+
+```text
+# PR Review Guidelines
+
+When conducting PR Reviews, follow these guidelines:
+1. **Prioritize Logic over Style:** Ensure the code is efficient, DRY (Don't Repeat Yourself), and logically sound.
+2. **Security First:** Verify that the changes do not introduce vulnerabilities (e.g., lack of input validation, exposed secrets).
+3. **Architectural Alignment:** If applicable, ensure the changes adhere strictly to the patterns defined in `@../docs/unified-backend-architecture.md`.
+4. **Issue Completion:** If the PR is attached to an issue, verify that the code successfully satisfies every acceptance criteria of that issue.
+5. **No Nitpicking:** Do not leave comments regarding stylistic choices, formatting, or subjective naming conventions unless they violate core project readability. Focus only on critical logic, performance, or architectural flaws.
+6. **Avoid Repetition:** Do not repeat feedback that has already been stated in previous reviews on this PR.
+7. **Iterative Reviews:** If this is not your first review on the PR:
+    - First, check if the new commits have correctly addressed your previous review comments.
+    - If a previous concern has been addressed, explicitly resolve the associated comment.
+8. **Prevent CI Failures:** Analyze the code for obvious issues that would break the pipeline. Specifically check for syntax errors, missing imports/dependencies, unhandled exceptions, and logic that would clearly break existing tests.
+
+**Execution Instruction**: Before providing your code feedback, output a markdown checklist of the 8 guidelines above. Mark each one as [x] if it passes or [ ] if it fails, and briefly explain why. Then, provide your single bundled review. Use inline subcomments within that single review for specific lines of codes. Do not post multiple standalone comments.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short --branch
+```
+
+Output:
+
+```text
+## main...origin/main
+?? "P4: Backend Development | CS 485 AI-Assisted Software Engineering (Sp26).html"
+?? "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf"
+?? load-test.js
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git remote -v
+```
+
+Output:
+
+```text
+origin	git@github.com:acabrera04/Harmony.git (fetch)
+origin	git@github.com:acabrera04/Harmony.git (push)
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:09:54.614Z
+
+I’ve loaded the repo’s mandatory review rules. Next I’m pulling the PR metadata, prior review comments, and exact patch so I can check for regressions and avoid repeating existing feedback.
+
+#### Tool: mcp__codex_apps__github_get_pr_info
+
+```json
+{
+  "pr_number": 276,
+  "repository_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"url":"https://github.com/acabrera04/Harmony/pull/276","number":276,"state":"open","merged":false,"mergeable":true,"draft":false,"body":"## Summary\n\n- Adds `docs/test-specs/frontend-channel-service-spec.md` for `harmony-frontend/src/services/channelService.ts`\n- Covers all 7 exported functions: `getChannels`, `getChannel`, `updateVisibility`, `updateChannel`, `createChannel`, `getAuditLog`, `deleteChannel`\n- Includes mock strategy for `trpcQuery`, `trpcMutate`, and `publicGet`\n- Documents all three `ChannelVisibility` enum edge cases (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`)\n- Covers public REST → tRPC fallback paths in `getChannel`, validation warning branches in adapters, and optional field defaults\n\n## Test plan\n\n- [ ] All 7 functions listed with purpose and program paths\n- [ ] Happy path covered for each function\n- [ ] Error/rejection propagation covered for each function\n- [ ] Visibility enum edge cases documented and tested in `updateVisibility` and `createChannel`\n- [ ] Public REST hit vs. fallback vs. server-not-found paths covered for `getChannel`\n- [ ] `toAuditLogEntry` timestamp fallback and missing-field warnings covered\n- [ ] Mock strategy documented with reset pattern\n\nCloses #261\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)","title":"docs: frontend channel service test specification (#261)","base":"main","base_sha":"b19f1dcad49e33a6b888b7b4c781cbf230959ba8","head":"codex/issue-261-frontend-channel-service-spec","head_sha":"7c62ee1c7d36581414fae5834cb0b7af5d18b88e","merge_commit_sha":"0864b10ccf0c208c40cff14655583be3901e77fb","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"requested_reviewers":null,"diff":null,"comments":null,"created_at":"2026-03-31T23:06:23Z","updated_at":"2026-03-31T23:06:25Z","closed_at":null,"merged_at":null,"commits":1,"changed_files":1,"additions":237,"deletions":0,"display_url":"https://github.com/acabrera04/Harmony/pull/276","display_title":"docs: frontend channel service test specification (#261)"}
+```
+
+#### Tool: mcp__codex_apps__github_fetch_pr_comments
+
+```json
+{
+  "pr_number": 276,
+  "repo_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"comments":[],"url":"https://github.com/acabrera04/Harmony/pull/276","title":"acabrera04/Harmony PR #276 comments","display_url":"https://github.com/acabrera04/Harmony/pull/276","display_title":"acabrera04/Harmony PR #276 comments"}
+```
+
+#### Tool: mcp__codex_apps__github_list_pr_changed_filenames
+
+```json
+{
+  "pr_number": 276,
+  "repo_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"filenames":["docs/test-specs/frontend-channel-service-spec.md"]}
+```
+
+#### Tool: mcp__codex_apps__github_fetch_pr_patch
+
+```json
+{
+  "pr_number": 276,
+  "repo_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+````text
+{"patches":[{"filename":"docs/test-specs/frontend-channel-service-spec.md","patch":"@@ -0,0 +1,237 @@\n+# Channel Service Test Specification (Frontend)\n+\n+## 1. Overview\n+\n+This document defines the English-language test specification for `harmony-frontend/src/services/channelService.ts`.\n+It covers all seven exported service functions:\n+\n+- `getChannels`\n+- `getChannel`\n+- `updateVisibility`\n+- `updateChannel`\n+- `createChannel`\n+- `getAuditLog`\n+- `deleteChannel`\n+\n+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.\n+\n+## 2. Shared Test Setup and Assumptions\n+\n+- Mock `trpcQuery` and `trpcMutate` from `@/lib/trpc-client` using Jest module mocking.\n+- Mock `publicGet` from `@/lib/trpc-client` for tests that exercise the public REST path.\n+- Reset all mocks between tests to ensure isolation.\n+- Use `console.warn` spies to assert that `toFrontendChannel` and `toAuditLogEntry` emit validation warnings for malformed API responses.\n+- The `getChannel` export is wrapped in React's `cache()`. Tests should call the function directly and mock the underlying transport layer rather than the cache wrapper.\n+- All resolved mock payloads must conform to the `Record<string, unknown>` shapes expected by the adapter functions; omit or corrupt individual fields to exercise validation warnings.\n+- `ChannelVisibility` enum values under test: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.\n+\n+## 3. Function Purposes and Program Paths\n+\n+### 3.1 `getChannels`\n+\n+Purpose: fetch all channels for a server (including PRIVATE channels) via the authenticated tRPC `channel.getChannels` endpoint.\n+\n+Program paths:\n+\n+- `trpcQuery` resolves with a non-empty array; each raw record is adapted and returned.\n+- `trpcQuery` resolves with `null` or `undefined`; the function returns `[]`.\n+- `trpcQuery` rejects; the error propagates to the caller uncaught.\n+\n+### 3.2 `getChannel`\n+\n+Purpose: return a single channel by server slug and channel slug, or `null` if not found. Tries the public REST endpoint first to support unauthenticated guest views, then falls back to authenticated tRPC.\n+\n+Program paths:\n+\n+- `publicGet` for the server resolves with `null`; function returns `null` immediately.\n+- Server resolves; public channel list resolves and contains a matching slug; channel is returned with `visibility` hardcoded to `PUBLIC_INDEXABLE`.\n+- Server resolves; public channel list resolves but contains no matching slug; falls through to tRPC fallback.\n+- Server resolves; public channel list `publicGet` call throws; falls through to tRPC fallback.\n+- tRPC fallback resolves with channel data; channel is returned.\n+- tRPC fallback resolves with `null`/falsy; function returns `null`.\n+- tRPC fallback rejects; function catches the error, logs it, and returns `null`.\n+\n+### 3.3 `updateVisibility`\n+\n+Purpose: update a channel's visibility via the authenticated tRPC `channel.setVisibility` mutation. Returns `void`.\n+\n+Program paths:\n+\n+- `trpcMutate` resolves; function returns `void`.\n+- `trpcMutate` rejects; error propagates to the caller.\n+\n+### 3.4 `updateChannel`\n+\n+Purpose: update a channel's `name` and/or `topic` metadata via tRPC. Only defined patch keys are forwarded.\n+\n+Program paths:\n+\n+- Patch includes both `name` and `topic`; both are forwarded and the adapted result is returned.\n+- Patch includes only `name` (no `topic`); only `name` is forwarded.\n+- Patch includes only `topic` (no `name`); only `topic` is forwarded.\n+- Patch is empty (`{}`); neither key is forwarded; adapted result is still returned.\n+- `trpcMutate` rejects; error propagates to the caller.\n+\n+### 3.5 `createChannel`\n+\n+Purpose: create a new channel via tRPC `channel.createChannel` and return the adapted `Channel`.\n+\n+Program paths:\n+\n+- All required fields are provided; `trpcMutate` resolves; adapted channel is returned.\n+- `trpcMutate` rejects; error propagates to the caller.\n+\n+### 3.6 `getAuditLog`\n+\n+Purpose: fetch a paginated visibility audit log for a channel via tRPC `channel.getAuditLog`.\n+\n+Program paths:\n+\n+- `trpcQuery` resolves with a populated `entries` array and `total`; each entry is adapted and returned.\n+- `trpcQuery` resolves with an empty `entries` array; returns `{ entries: [], total: 0 }`.\n+- Options are partially provided (`limit` only, `offset` only, or `startDate` only); present keys are forwarded.\n+- Options are omitted entirely; query is called with only `serverId` and `channelId`.\n+- An entry has an invalid or missing `timestamp`; `toAuditLogEntry` falls back to epoch ISO string and emits a `console.warn`.\n+- `trpcQuery` rejects; error propagates to the caller.\n+\n+### 3.7 `deleteChannel`\n+\n+Purpose: delete a channel via tRPC and return `true` on success.\n+\n+Program paths:\n+\n+- `trpcMutate` resolves; function returns `true`.\n+- `trpcMutate` rejects; error propagates to the caller.\n+\n+## 4. Detailed Test Cases\n+\n+### 4.1 `getChannels`\n+\n+Description: fetches the full channel list for a server, adapting each record from the raw backend shape.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Return adapted channels for a server | `serverId = \"s1\"`; `trpcQuery` resolves with two valid raw channel records | Returns an array of two `Channel` objects with all fields correctly mapped |\n+| Return empty array when API returns null | `serverId = \"s1\"`; `trpcQuery` resolves with `null` | Returns `[]` |\n+| Return empty array when API returns undefined | `serverId = \"s1\"`; `trpcQuery` resolves with `undefined` | Returns `[]` |\n+| Propagate rejection to caller | `serverId = \"s1\"`; `trpcQuery` rejects with a network error | The promise rejects with the same error; caller receives it without masking |\n+\n+### 4.2 `getChannel`\n+\n+Description: fetches a single channel by slug pair, attempting the public REST endpoint before falling back to authenticated tRPC.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Return null when server lookup fails | `serverSlug = \"my-server\"`; `publicGet` for server resolves with `null` | Returns `null`; no further network calls are made |\n+| Return channel from public endpoint on slug match | Server resolves; public channel list contains a record with matching `channelSlug` | Returns `Channel` with `visibility = PUBLIC_INDEXABLE`; `serverId` filled from server lookup |\n+| Supplement missing public fields with defaults | Public channel record omits `position` and `createdAt` | Returned channel has `position = 0` and `createdAt` equal to epoch ISO string |\n+| Fall through to tRPC when slug not in public list | Server resolves; public channel list has no matching slug; tRPC resolves with channel data | Returns the tRPC-adapted `Channel` |\n+| Fall through to tRPC when public endpoint throws | Server resolves; public channels `publicGet` throws; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; thrown error is swallowed silently |\n+| Return null when tRPC resolves with falsy value | Server resolves; public endpoint miss; tRPC resolves with `null` | Returns `null` |\n+| Return null when tRPC rejects | Server resolves; public endpoint miss; tRPC rejects | Returns `null`; logs error via `console.error` |\n+| Correctly set visibility to PUBLIC_INDEXABLE for public hit | Server resolves; public list match with any `visibility` value in raw record | Returned channel always has `visibility = PUBLIC_INDEXABLE` regardless of raw field |\n+\n+### 4.3 `updateVisibility`\n+\n+Description: sends a visibility mutation to the backend with no return value.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Successfully set visibility to PUBLIC_INDEXABLE | `channelId = \"c1\"`, `visibility = PUBLIC_INDEXABLE`, `serverId = \"s1\"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with `{ serverId, channelId, visibility }` |\n+| Successfully set visibility to PUBLIC_NO_INDEX | `channelId = \"c1\"`, `visibility = PUBLIC_NO_INDEX`, `serverId = \"s1\"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |\n+| Successfully set visibility to PRIVATE | `channelId = \"c1\"`, `visibility = PRIVATE`, `serverId = \"s1\"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |\n+| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 403 error | Promise rejects with the same error |\n+\n+### 4.4 `updateChannel`\n+\n+Description: sends partial channel metadata updates, forwarding only the keys that are explicitly set.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Update both name and topic | `patch = { name: \"general\", topic: \"chat\" }`; `trpcMutate` resolves with a full channel record | Returns adapted `Channel`; mutation called with `name` and `topic` |\n+| Update name only | `patch = { name: \"general\" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `topic` key |\n+| Update topic only | `patch = { topic: \"new topic\" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `name` key |\n+| Empty patch sends no extra keys | `patch = {}`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called with only `serverId` and `channelId` |\n+| Propagate rejection to caller | Valid patch; `trpcMutate` rejects | Promise rejects with the underlying error |\n+\n+### 4.5 `createChannel`\n+\n+Description: creates a new channel and returns the backend-confirmed record.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Create channel with all fields | Full `Channel` object minus `id`, `createdAt`, `updatedAt`; `trpcMutate` resolves with full record | Returns adapted `Channel`; mutation called with all provided fields |\n+| Create channel with optional fields absent | `topic` and `description` omitted; `trpcMutate` resolves | Returns adapted `Channel`; `topic` passed as `undefined` in mutation args |\n+| Create channel with each visibility value | `visibility = PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, or `PRIVATE`; `trpcMutate` resolves | Returns adapted `Channel` with the correct `visibility` field |\n+| Propagate rejection to caller | Valid input; `trpcMutate` rejects | Promise rejects with the underlying error |\n+\n+### 4.6 `getAuditLog`\n+\n+Description: fetches a paginated audit log, adapting each entry and validating field types.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Return entries and total from API | `serverId`, `channelId`; `trpcQuery` resolves with two valid entries and `total = 2` | Returns `{ entries: [AuditLogEntry, AuditLogEntry], total: 2 }` |\n+| Return empty list | `serverId`, `channelId`; `trpcQuery` resolves with `{ entries: [], total: 0 }` | Returns `{ entries: [], total: 0 }` |\n+| Forward limit option | `options = { limit: 10 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, limit: 10 }` |\n+| Forward offset option | `options = { offset: 5 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, offset: 5 }` |\n+| Forward startDate option | `options = { startDate: \"2026-01-01T00:00:00.000Z\" }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, startDate: \"2026-01-01T00:00:00.000Z\" }` |\n+| Omit options when none provided | `options` not passed; `trpcQuery` resolves | `trpcQuery` called with only `serverId` and `channelId` |\n+| Fall back to epoch string for invalid timestamp | Entry has `timestamp = \"not-a-date\"`; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |\n+| Fall back to epoch string for missing timestamp | Entry has no `timestamp` field; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |\n+| Emit warn for missing required string fields | Entry missing `id`, `channelId`, `actorId`, or `action`; `trpcQuery` resolves | Each missing field emits a `console.warn`; function still returns an entry |\n+| Propagate rejection to caller | Valid args; `trpcQuery` rejects | Promise rejects with the underlying error |\n+\n+### 4.7 `deleteChannel`\n+\n+Description: deletes a channel and signals success via a boolean return value.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Return true on successful deletion | `channelId = \"c1\"`, `serverId = \"s1\"`; `trpcMutate` resolves | Returns `true`; `trpcMutate` called with `{ serverId, channelId }` |\n+| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 404 error | Promise rejects with the underlying error; `true` is never returned |\n+\n+## 5. Edge Cases to Explicitly Validate\n+\n+- `getChannels` must not suppress transport errors; callers that use the channel count for position computation depend on the error surfacing to avoid data corruption.\n+- `getChannel` uses `cache()` wrapping; test the inner async function directly by mocking at the transport layer.\n+- The public REST hit in `getChannel` always overrides the raw `visibility` field with `PUBLIC_INDEXABLE`; the test must confirm this even when the raw record contains a different value.\n+- Missing `position` and `createdAt` from public channel records are filled with defaults (`0` and epoch ISO); tests should assert these exact defaults.\n+- `updateChannel` must only forward `name` and `topic` when those keys are explicitly present in `patch`; the absence of a key must not result in the key being sent as `undefined` to the mutation.\n+- `toFrontendChannel` and `toAuditLogEntry` emit `console.warn` for every missing required field; each warning path should be exercised at least once.\n+- `toAuditLogEntry` falls back to an epoch ISO timestamp for any non-string or unparseable `timestamp` value; both non-string and invalid-string cases must be tested.\n+- All three `ChannelVisibility` values (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) must appear in at least one test for `updateVisibility` and `createChannel`.\n+\n+## 6. Mock Strategy\n+\n+All external dependencies are mocked at the module level with `jest.mock`:\n+\n+```\n+jest.mock('@/lib/trpc-client', () => ({\n+  trpcQuery:  jest.fn(),\n+  trpcMutate: jest.fn(),\n+  publicGet:  jest.fn(),\n+}));\n+```\n+\n+Reset all mocks in `beforeEach` with `jest.resetAllMocks()` to prevent cross-test contamination.\n+\n+- **`trpcQuery`** — resolve with well-formed raw objects to test happy paths; reject with an `Error` to test propagation; resolve with `null`/`undefined` to test null-guard branches.\n+- **`trpcMutate`** — resolve to test `updateVisibility`, `updateChannel`, `createChannel`, and `deleteChannel` happy paths; reject to test error propagation in each.\n+- **`publicGet`** — resolve with a server object (containing at minimum `{ id: \"s1\" }`) to simulate a successful server lookup; resolve with `null` to test the early-return path; resolve with a channels payload or throw to test the public channel list branches.\n+- **`console.warn` / `console.error`** — use `jest.spyOn(console, 'warn')` and `jest.spyOn(console, 'error')` in tests that exercise validation warnings; restore spies in `afterEach`.\n+\n+## 7. Coverage Expectation\n+\n+The cases above are intended to cover:\n+\n+- all seven exported functions,\n+- every explicit null-guard and early-return branch,\n+- successful transport call paths and their return value adaption,\n+- all transport rejection paths and their propagation behavior,\n+- public-REST-to-tRPC fallback logic in `getChannel`,\n+- all three `ChannelVisibility` enum values,\n+- field-level validation warnings in `toFrontendChannel` and `toAuditLogEntry`, and\n+- optional field defaults (missing `position`, `createdAt`, `topic`, `description`).\n+\n+Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures (e.g., React `cache` internals) outside the service's direct branching logic."}],"url":"https://github.com/acabrera04/Harmony/pull/276","title":"acabrera04/Harmony#276 (patch)","display_url":"https://github.com/acabrera04/Harmony/pull/276","display_title":"acabrera04/Harmony#276 (patch)"}
+````
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:10:12.496Z
+
+The PR is docs-only and closes `#261`, so I’m checking the linked issue and the actual `channelService.ts` behavior now. I also want one nearby spec as a formatting/control sample so I can tell whether this document matches repo conventions or just sounds plausible.
+
+#### Tool: mcp__codex_apps__github_fetch_issue
+
+```json
+{
+  "issue_number": 261,
+  "repo": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"issue":{"url":"https://github.com/acabrera04/Harmony/issues/261","title":"Test Specification — channelService.ts (frontend)","issue_number":261,"body":"## Description\nWrite an English-language test specification for `harmony-frontend/src/services/channelService.ts` (8 functions).\n\n## Functions to Specify\n- `getChannels`\n- `getChannel`\n- `updateVisibility`\n- `updateChannel`\n- `createChannel`\n- `getAuditLog`\n- `deleteChannel`\n\n## Requirements\n- List every function, its purpose, and all program paths\n- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**\n- Cover happy paths, API error handling, visibility enum edge cases\n- Describe mock strategy for `apiClient` / `ApiClient`\n- Target 80%+ code coverage of all execution paths\n- Output: `docs/test-specs/frontend-channel-service-spec.md`\n\n## Acceptance Criteria\n- [ ] All functions listed with descriptions\n- [ ] Table covers happy paths for each function\n- [ ] Table covers API error handling paths\n- [ ] Visibility enum edge cases documented\n- [ ] Mock strategy documented\n- [ ] At least one test per function\n\n**Sprint:** 3 (P5 Testing)\n**Due:** March 30, 2026","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"display_url":"https://github.com/acabrera04/Harmony/issues/261","display_title":"Test Specification — channelService.ts (frontend)"},"url":"https://github.com/acabrera04/Harmony/issues/261","title":"Test Specification — channelService.ts (frontend)","display_url":"https://github.com/acabrera04/Harmony/issues/261","display_title":"Test Specification — channelService.ts (frontend)"}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/services/channelService.ts
+```
+
+Output:
+
+```text
+/**
+ * Channel Service (M2 — real API implementation)
+ * Replaces mock in-memory store with backend API calls.
+ * References: dev-spec-channel-visibility-toggle.md
+ */
+
+import { cache } from 'react';
+import { ChannelVisibility, type Channel } from '@/types';
+import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+
+/** Maps the backend Prisma Channel shape to the frontend Channel type. */
+function toFrontendChannel(raw: Record<string, unknown>): Channel {
+  if (typeof raw.id !== 'string') console.warn('[toFrontendChannel] missing or non-string "id"');
+  if (typeof raw.serverId !== 'string')
+    console.warn('[toFrontendChannel] missing or non-string "serverId"');
+  if (typeof raw.slug !== 'string')
+    console.warn('[toFrontendChannel] missing or non-string "slug"');
+  if (typeof raw.createdAt !== 'string')
+    console.warn('[toFrontendChannel] missing or non-string "createdAt"');
+  return {
+    id: raw.id as string,
+    serverId: raw.serverId as string,
+    name: raw.name as string,
+    slug: raw.slug as string,
+    type: raw.type as Channel['type'],
+    visibility: raw.visibility as ChannelVisibility,
+    topic: (raw.topic as string | undefined) ?? undefined,
+    position: (raw.position as number) ?? 0,
+    description: raw.description as string | undefined,
+    createdAt: raw.createdAt as string,
+    updatedAt: raw.updatedAt as string | undefined,
+  };
+}
+
+/**
+ * Returns all channels for a given server.
+ * Uses tRPC authed endpoint for full channel list (including PRIVATE channels).
+ * Errors propagate to the caller — callers that use the channel count (e.g.
+ * createChannelAction position computation) must not silently receive [] on a
+ * transient failure, which would corrupt channel ordering.
+ */
+export async function getChannels(serverId: string): Promise<Channel[]> {
+  const data = await trpcQuery<Record<string, unknown>[]>('channel.getChannels', { serverId });
+  return (data ?? []).map(toFrontendChannel);
+}
+
+/**
+ * Returns a single channel by server slug + channel slug, or null if not found.
+ *
+export const getChannel = cache(
+  async (serverSlug: string, channelSlug: string): Promise<Channel | null> => {
+    const serverData = await publicGet<Record<string, unknown>>(
+      `/servers/${encodeURIComponent(serverSlug)}`,
+    );
+    if (!serverData) return null;
+    const serverId = serverData.id as string;
+
+    try {
+      const publicData = await publicGet<{ channels: Record<string, unknown>[] }>(
+        `/servers/${encodeURIComponent(serverSlug)}/channels`,
+      );
+      if (publicData) {
+        const match = publicData.channels.find(c => (c.slug as string) === channelSlug);
+        if (match) {
+          return toFrontendChannel({
+            ...match,
+            serverId,
+            visibility: 'PUBLIC_INDEXABLE',
+            position: (match.position as number | undefined) ?? 0,
+            createdAt: (match.createdAt as string | undefined) ?? new Date(0).toISOString(),
+          });
+        }
+      }
+    } catch {
+    }
+
+    try {
+      const data = await trpcQuery<Record<string, unknown>>('channel.getChannel', {
+        serverId,
+        serverSlug,
+        channelSlug,
+      });
+      if (!data) return null;
+      return toFrontendChannel(data);
+    } catch (error) {
+      console.error(
+        `[channelService.getChannel] API call failed for "${serverSlug}/${channelSlug}":`,
+        error,
+      );
+      return null;
+    }
+  },
+);
+
+/**
+ * Updates the visibility of a channel via tRPC.
+ * Returns the visibility change result (not a full Channel object).
+ */
+export async function updateVisibility(
+  channelId: string,
+  visibility: ChannelVisibility,
+  serverId: string,
+): Promise<void> {
+  await trpcMutate('channel.setVisibility', {
+    serverId,
+    channelId,
+    visibility,
+  });
+}
+
+/**
+ * Updates editable metadata (name, topic) of a channel via tRPC.
+ * Note: `description` is not forwarded — the backend only supports `name`, `topic`, and `position`.
+ */
+export async function updateChannel(
+  channelId: string,
+  serverId: string,
+  patch: Partial<Pick<Channel, 'name' | 'topic'>>,
+): Promise<Channel> {
+  const data = await trpcMutate<Record<string, unknown>>('channel.updateChannel', {
+    serverId,
+    channelId,
+    ...(patch.name !== undefined && { name: patch.name }),
+    ...(patch.topic !== undefined && { topic: patch.topic }),
+  });
+  return toFrontendChannel(data);
+}
+
+/**
+ * Creates a new channel via tRPC.
+ */
+export async function createChannel(
+  channel: Omit<Channel, 'id' | 'createdAt' | 'updatedAt'>,
+): Promise<Channel> {
+  const data = await trpcMutate<Record<string, unknown>>('channel.createChannel', {
+    serverId: channel.serverId,
+    name: channel.name,
+    slug: channel.slug,
+    type: channel.type,
+    visibility: channel.visibility,
+    topic: channel.topic,
+    position: channel.position,
+  });
+  return toFrontendChannel(data);
+}
+
+export interface AuditLogEntry {
+  id: string;
+  channelId: string;
+  actorId: string;
+  action: string;
+  oldValue: Record<string, unknown>;
+  newValue: Record<string, unknown>;
+  timestamp: string;
+  ipAddress: string;
+  userAgent: string;
+}
+
+export interface AuditLogPage {
+  entries: AuditLogEntry[];
+  total: number;
+}
+
+/** Validates an audit log entry from the API, guarding against schema changes. */
+function toAuditLogEntry(raw: Record<string, unknown>): AuditLogEntry {
+  if (typeof raw.id !== 'string') console.warn('[toAuditLogEntry] missing or non-string "id"');
+  if (typeof raw.channelId !== 'string')
+    console.warn('[toAuditLogEntry] missing or non-string "channelId"');
+  if (typeof raw.actorId !== 'string')
+    console.warn('[toAuditLogEntry] missing or non-string "actorId"');
+  if (typeof raw.action !== 'string')
+    console.warn('[toAuditLogEntry] missing or non-string "action"');
+  const ts = raw.timestamp;
+  const validTimestamp =
+    typeof ts === 'string' && !isNaN(new Date(ts).getTime())
+      ? ts
+      : (() => {
+          console.warn('[toAuditLogEntry] missing or invalid "timestamp":', ts);
+          return new Date(0).toISOString();
+        })();
+  return {
+    id: raw.id as string,
+    channelId: raw.channelId as string,
+    actorId: raw.actorId as string,
+    action: raw.action as string,
+    oldValue: raw.oldValue as Record<string, unknown>,
+    newValue: raw.newValue as Record<string, unknown>,
+    timestamp: validTimestamp,
+    ipAddress: raw.ipAddress as string,
+    userAgent: raw.userAgent as string,
+  };
+}
+
+/**
+ * Fetches paginated visibility audit log for a channel via tRPC.
+ */
+export async function getAuditLog(
+  serverId: string,
+  channelId: string,
+  options: { limit?: number; offset?: number; startDate?: string } = {},
+): Promise<AuditLogPage> {
+  const data = await trpcQuery<{ entries: Record<string, unknown>[]; total: number }>(
+    'channel.getAuditLog',
+    { serverId, channelId, ...options },
+  );
+  return { entries: data.entries.map(toAuditLogEntry), total: data.total };
+}
+
+/**
+ * Deletes a channel by ID via tRPC. Returns true if deleted.
+ */
+export async function deleteChannel(channelId: string, serverId: string): Promise<boolean> {
+  await trpcMutate('channel.deleteChannel', { serverId, channelId });
+  return true;
+}
+
+export { ChannelVisibility };
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls docs/test-specs
+```
+
+Output:
+
+```text
+server-member-service-spec.md  18.6K
+
+📊 1 files, 0 dirs (1 .md)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "Channel Service Test Specification|Test Specification" docs/test-specs -g "*.md"
+```
+
+Output:
+
+```text
+🔍 1 in 1F:
+
+📄 docs/test-specs/server-member-service-spec.md (1):
+     1: # Server Member Service Test Specification
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read docs/test-specs/server-member-service-spec.md
+```
+
+Output:
+
+```text
+# Server Member Service Test Specification
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-backend/src/services/serverMember.service.ts`.
+It covers all six exported service functions:
+
+- `addOwner`
+- `joinServer`
+- `leaveServer`
+- `getServerMembers`
+- `changeRole`
+- `removeMember`
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Use a test database with isolated server, user, and membership fixtures per test.
+- Use distinct users for owner, admin, moderator, member, guest, and outsider scenarios.
+- Seed role hierarchy fixtures to match the implementation order: `OWNER`, `ADMIN`, `MODERATOR`, `MEMBER`, `GUEST`.
+- Mock or spy on `eventBus.publish` so tests can verify event emission without requiring the full event system.
+- When transaction failures or unexpected Prisma failures are simulated, assert that the original error is surfaced unless the code explicitly maps it to a `TRPCError`.
+- Validate both the direct return value and the side effects on `server.memberCount` where applicable.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `addOwner`
+
+Purpose: add the creator of a new server as an `OWNER` membership and increment the server member count.
+
+Program paths:
+
+- Owner membership is created successfully and `memberCount` is incremented.
+- Database or transaction failure bubbles to the caller.
+
+### 3.2 `joinServer`
+
+Purpose: allow a user to join a public server as a `MEMBER`.
+
+Program paths:
+
+- Target server does not exist.
+- Target server exists but is private.
+- Membership is created successfully, `memberCount` is incremented, and `MEMBER_JOINED` is published.
+- Unique membership constraint fails because the user is already a member.
+- Unexpected transaction or Prisma failure bubbles to the caller.
+
+### 3.3 `leaveServer`
+
+Purpose: remove the current user's membership, unless that user is the server owner.
+
+Program paths:
+
+- Membership does not exist.
+- Membership exists but role is `OWNER`.
+- Membership is deleted successfully, `memberCount` is decremented, and `MEMBER_LEFT` is published with reason `LEFT`.
+- Database or transaction failure bubbles to the caller.
+
+### 3.4 `getServerMembers`
+
+Purpose: return all members for a server, enriched with user profile data and ordered by role hierarchy.
+
+Program paths:
+
+- Target server does not exist.
+- Target server exists and has no members.
+- Target server exists and members are returned in role-priority order, with same-role members retaining ascending `joinedAt` order from the database query.
+
+### 3.5 `changeRole`
+
+Purpose: let an actor with sufficient privilege update another member's role, while preventing owner reassignment and privilege escalation.
+
+Program paths:
+
+- Requested role is `OWNER`.
+- Actor is not a member of the server.
+- Target user is not a member of the server.
+- Target user is the `OWNER`.
+- Actor tries to change a member with equal or higher privilege.
+- Actor tries to assign a role equal to or higher than the actor's own role.
+- Role update succeeds.
+
+### 3.6 `removeMember`
+
+Purpose: let an actor remove a lower-privileged member from the server while protecting the owner and enforcing hierarchy.
+
+Program paths:
+
+- Actor is not a member of the server.
+- Target user is not a member of the server.
+- Target user is the `OWNER`.
+- Actor tries to remove a member with equal or higher privilege.
+- Removal succeeds, `memberCount` is decremented, and `MEMBER_LEFT` is published with reason `KICKED`.
+- Database or transaction failure bubbles to the caller.
+
+## 4. Detailed Test Cases
+
+### 4.1 `addOwner`
+
+Description: creates the initial owner membership for a newly created server.
+
+| Test Purpose                                     | Inputs                                                                                                | Expected Output                                                                                               |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Create owner membership for a new server         | Valid `userId` and `serverId` for an existing server with `memberCount = 0`                           | Returns created `ServerMember` with role `OWNER`; persists membership; increments `server.memberCount` to `1` |
+| Bubble transaction failure during owner creation | Valid `userId` and `serverId`; mocked transaction failure on `serverMember.create` or `server.update` | Throws the underlying database error; no false success is returned                                            |
+
+### 4.2 `joinServer`
+
+Description: joins a public server with the default `MEMBER` role.
+
+| Test Purpose                                 | Inputs                                                                                                  | Expected Output                                                                                                                                                         |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Join a public server successfully            | Non-member `userId`; existing public `serverId`                                                         | Returns created `ServerMember` with role `MEMBER`; increments `memberCount`; publishes `MEMBER_JOINED` with `userId`, `serverId`, role `MEMBER`, and an ISO `timestamp` |
+| Reject join when server does not exist       | Any `userId`; unknown `serverId`                                                                        | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                                                                                                 |
+| Reject join when server is private           | Non-member `userId`; existing private `serverId`                                                        | Throws `TRPCError` with code `FORBIDDEN` and message `This server is private`                                                                                           |
+| Reject duplicate join for existing member    | `userId` already present in `serverMember`; existing public `serverId`; mocked Prisma `P2002` on create | Throws `TRPCError` with code `CONFLICT` and message `Already a member of this server`; does not double-increment `memberCount`; does not publish join event             |
+| Bubble unexpected Prisma failure during join | Valid public server; mocked non-`P2002` Prisma error or transaction error                               | Throws the original error so operational failures are not masked                                                                                                        |
+
+### 4.3 `leaveServer`
+
+Description: removes a non-owner member from a server.
+
+| Test Purpose                                | Inputs                                                                                                  | Expected Output                                                                                                                                        |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Leave server successfully as non-owner      | Existing membership for `userId` with role `MEMBER`, `MODERATOR`, `ADMIN`, or `GUEST`; valid `serverId` | Returns `void`; deletes membership; decrements `memberCount`; publishes `MEMBER_LEFT` with `userId`, `serverId`, reason `LEFT`, and an ISO `timestamp` |
+| Reject leave when membership does not exist | Non-member `userId`; valid `serverId`                                                                   | Throws `TRPCError` with code `NOT_FOUND` and message `Not a member of this server`                                                                     |
+| Reject leave when caller is owner           | Existing membership for `userId` with role `OWNER`; valid `serverId`                                    | Throws `TRPCError` with code `BAD_REQUEST` and message `Server owner cannot leave. Transfer ownership or delete the server.`                           |
+| Bubble transaction failure during leave     | Existing non-owner membership; mocked transaction failure on delete or server update                    | Throws the underlying database error; membership state is not reported as successful if the transaction fails                                          |
+
+### 4.4 `getServerMembers`
+
+Description: loads all members for a server with user profile fields and role-priority sorting.
+
+| Test Purpose                                       | Inputs                                                                                  | Expected Output                                                                                                                          |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Return sorted member list for an existing server   | Existing `serverId` with seeded owner/admin/member fixtures and valid joined timestamps | Returns an array of `ServerMemberWithUser`; members are ordered `OWNER` before `ADMIN` before `MODERATOR` before `MEMBER` before `GUEST` |
+| Preserve ascending join order within the same role | Existing `serverId` with multiple `MEMBER` rows having different `joinedAt` values      | Returns same-role members in ascending `joinedAt` order after sorting                                                                    |
+| Return empty list when server has no members       | Existing `serverId` with no related `serverMember` records                              | Returns `[]`                                                                                                                             |
+| Reject lookup when server does not exist           | Unknown `serverId`                                                                      | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                                                                  |
+
+### 4.5 `changeRole`
+
+Description: updates a target member's role when the actor outranks both the target's current role and the requested new role.
+
+| Test Purpose                                                                 | Inputs                                                                                                                                         | Expected Output                                                                                                      |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Change a lower-privileged member's role successfully                         | `actorId` with role `OWNER` or `ADMIN`; `targetUserId` with lower privilege; `newRole` lower than actor role and not `OWNER`; valid `serverId` | Returns updated `ServerMember`; persists the new role                                                                |
+| Reject assigning `OWNER` directly                                            | Valid memberships; `newRole = OWNER`                                                                                                           | Throws `TRPCError` with code `BAD_REQUEST` and message `Cannot assign OWNER role. Use ownership transfer.`           |
+| Reject change when actor is not a server member                              | Outsider `actorId`; valid target membership; valid `newRole`; valid `serverId`                                                                 | Throws `TRPCError` with code `FORBIDDEN` and message `You are not a member of this server`                           |
+| Reject change when target is not a server member                             | Valid actor membership; unknown `targetUserId`; valid `newRole`; valid `serverId`                                                              | Throws `TRPCError` with code `NOT_FOUND` and message `Target user is not a member of this server`                    |
+| Reject change when target is owner                                           | Valid actor membership below owner; target membership role `OWNER`; valid `newRole`                                                            | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot change the role of the server owner`                    |
+| Reject change when actor does not outrank target                             | `actorId` and `targetUserId` with equal roles, or actor lower than target                                                                      | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot change role of a member with equal or higher privilege` |
+| Reject change when actor tries to assign equal or higher role than their own | Valid actor membership; lower-ranked target; `newRole` equal to actor role or higher                                                           | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot assign a role equal to or higher than your own`         |
+| Reject self-role-change through hierarchy rule                               | `actorId === targetUserId`; any non-owner role; valid `newRole`                                                                                | Throws `TRPCError` with code `FORBIDDEN` because the actor does not outrank the target when both are the same member |
+
+### 4.6 `removeMember`
+
+Description: removes a lower-privileged target member from the server.
+
+| Test Purpose                                          | Inputs                                                                                        | Expected Output                                                                                                                                                                       |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Remove a lower-privileged member successfully         | `actorId` with higher role than `targetUserId`; valid `serverId`                              | Returns `void`; deletes target membership; decrements `memberCount`; publishes `MEMBER_LEFT` with `userId` set to `targetUserId`, `serverId`, reason `KICKED`, and an ISO `timestamp` |
+| Reject removal when actor is not a server member      | Outsider `actorId`; existing target membership; valid `serverId`                              | Throws `TRPCError` with code `FORBIDDEN` and message `You are not a member of this server`                                                                                            |
+| Reject removal when target is not a server member     | Valid actor membership; unknown `targetUserId`; valid `serverId`                              | Throws `TRPCError` with code `NOT_FOUND` and message `Target user is not a member of this server`                                                                                     |
+| Reject removal of owner                               | Valid actor membership; target membership role `OWNER`; valid `serverId`                      | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot remove the server owner`                                                                                                 |
+| Reject removal when actor does not outrank target     | Actor and target have equal roles, or actor has lower privilege than target                   | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot remove a member with equal or higher privilege`                                                                          |
+| Reject self-removal through moderator/admin kick path | `actorId === targetUserId` for a non-owner actor; valid `serverId`                            | Throws `TRPCError` with code `FORBIDDEN` because the actor does not outrank the target                                                                                                |
+| Bubble transaction failure during removal             | Valid actor and target memberships with mocked transaction failure on delete or server update | Throws the underlying database error; no success event should be asserted                                                                                                             |
+
+## 5. Edge Cases to Explicitly Validate
+
+- Duplicate membership attempts must map Prisma unique constraint `P2002` to a `CONFLICT` error in `joinServer`.
+- Owners cannot leave the server through `leaveServer`.
+- Owners cannot be targeted by `changeRole` or `removeMember`.
+- Role hierarchy rules must block equal-rank operations, not only lower-rank operations.
+- A caller cannot promote another member to the caller's own role or any higher role.
+- Self-targeted moderation actions (`changeRole` or `removeMember` where `actorId === targetUserId`) should be rejected by the same hierarchy guard.
+- Event publication should only happen after successful membership changes.
+- `getServerMembers` should still behave correctly when the member list is empty.
+
+## 6. Coverage Expectation
+
+The cases above are intended to cover:
+
+- all six exported functions,
+- every explicit `TRPCError` branch,
+- successful transaction paths,
+- event publication side effects,
+- role hierarchy edge cases, and
+- representative unexpected database failure paths.
+
+Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures outside the service's direct branching logic.
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:10:48.964Z
+
+I’ve identified a few mismatches between the spec and the real service behavior. I’m confirming them against the PR branch file with line numbers and the `Channel` type so the review comments are tight and defensible.
+
+#### Tool: exec_command
+
+```sh
+rtk git fetch origin pull/276/head
+```
+
+Output:
+
+```text
+ok fetched (1 new refs)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "export (enum|type|interface) Channel|interface Channel|type Channel" harmony-frontend/src -g "*.ts*"
+```
+
+Output:
+
+```text
+🔍 12 in 9F:
+
+📄 harmony-frontend/src/app/actions/createChannel.ts (1):
+    16: import { ChannelType, ChannelVisibility, type Channel } from '@/types';
+
+📄 harmony-frontend/.../channel/ChannelPageContent.tsx (1):
+     9: interface ChannelPageContentProps {
+
+📄 harmony-frontend/.../channel/ChannelSidebar.tsx (1):
+   146: export interface ChannelSidebarProps {
+
+📄 harmony-frontend/.../channel/CreateChannelModal.tsx (1):
+    12: import { ChannelType, ChannelVisibility, type Channel } from '@/types';
+
+📄 harmony-frontend/.../server/ServerSidebar.tsx (1):
+     9: interface Channel {
+
+📄 harmony-frontend/.../settings/ChannelSettingsPage.tsx (1):
+   535: export interface ChannelSettingsPageProps {
+
+📄 harmony-frontend/src/lib/constants.ts (1):
+    54: export enum ChannelVisibility {
+
+📄 harmony-frontend/src/services/channelService.ts (1):
+     8: import { ChannelVisibility, type Channel } from '@/types';
+
+📄 harmony-frontend/src/types/channel.ts (4):
+     6: export enum ChannelType {
+    12: export interface Channel {
+    26: export enum ChannelVisibility {
+    32: export interface ChannelDTO {
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/types/channel.ts
+```
+
+Output:
+
+```text
+/**
+ * Type Definitions: Channel
+ * Based on dev spec data schemas
+ */
+
+export enum ChannelType {
+  TEXT = 'TEXT',
+  VOICE = 'VOICE',
+  ANNOUNCEMENT = 'ANNOUNCEMENT',
+}
+
+export interface Channel {
+  id: string;
+  serverId: string;
+  name: string;
+  slug: string;
+  type: ChannelType;
+  visibility: ChannelVisibility;
+  topic?: string;
+  position: number;
+  description?: string;
+  createdAt: Date | string;
+  updatedAt?: Date | string;
+}
+
+export enum ChannelVisibility {
+  PUBLIC_INDEXABLE = 'PUBLIC_INDEXABLE',
+  PUBLIC_NO_INDEX = 'PUBLIC_NO_INDEX',
+  PRIVATE = 'PRIVATE',
+}
+
+export interface ChannelDTO {
+  id: string;
+  serverId: string;
+  name: string;
+  slug: string;
+  description?: string;
+  visibility: ChannelVisibility;
+  memberCount?: number;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git show FETCH_HEAD:docs/test-specs/frontend-channel-service-spec.md | nl -ba
+```
+
+Output:
+
+````text
+     1	# Channel Service Test Specification (Frontend)
+     2	
+     3	## 1. Overview
+     4	
+     5	This document defines the English-language test specification for `harmony-frontend/src/services/channelService.ts`.
+     6	It covers all seven exported service functions:
+     7	
+     8	- `getChannels`
+     9	- `getChannel`
+    10	- `updateVisibility`
+    11	- `updateChannel`
+    12	- `createChannel`
+    13	- `getAuditLog`
+    14	- `deleteChannel`
+    15	
+    16	The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+    17	
+    18	## 2. Shared Test Setup and Assumptions
+    19	
+    20	- Mock `trpcQuery` and `trpcMutate` from `@/lib/trpc-client` using Jest module mocking.
+    21	- Mock `publicGet` from `@/lib/trpc-client` for tests that exercise the public REST path.
+    22	- Reset all mocks between tests to ensure isolation.
+    23	- Use `console.warn` spies to assert that `toFrontendChannel` and `toAuditLogEntry` emit validation warnings for malformed API responses.
+    24	- The `getChannel` export is wrapped in React's `cache()`. Tests should call the function directly and mock the underlying transport layer rather than the cache wrapper.
+    25	- All resolved mock payloads must conform to the `Record<string, unknown>` shapes expected by the adapter functions; omit or corrupt individual fields to exercise validation warnings.
+    26	- `ChannelVisibility` enum values under test: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.
+    27	
+    28	## 3. Function Purposes and Program Paths
+    29	
+    30	### 3.1 `getChannels`
+    31	
+    32	Purpose: fetch all channels for a server (including PRIVATE channels) via the authenticated tRPC `channel.getChannels` endpoint.
+    33	
+    34	Program paths:
+    35	
+    36	- `trpcQuery` resolves with a non-empty array; each raw record is adapted and returned.
+    37	- `trpcQuery` resolves with `null` or `undefined`; the function returns `[]`.
+    38	- `trpcQuery` rejects; the error propagates to the caller uncaught.
+    39	
+    40	### 3.2 `getChannel`
+    41	
+    42	Purpose: return a single channel by server slug and channel slug, or `null` if not found. Tries the public REST endpoint first to support unauthenticated guest views, then falls back to authenticated tRPC.
+    43	
+    44	Program paths:
+    45	
+    46	- `publicGet` for the server resolves with `null`; function returns `null` immediately.
+    47	- Server resolves; public channel list resolves and contains a matching slug; channel is returned with `visibility` hardcoded to `PUBLIC_INDEXABLE`.
+    48	- Server resolves; public channel list resolves but contains no matching slug; falls through to tRPC fallback.
+    49	- Server resolves; public channel list `publicGet` call throws; falls through to tRPC fallback.
+    50	- tRPC fallback resolves with channel data; channel is returned.
+    51	- tRPC fallback resolves with `null`/falsy; function returns `null`.
+    52	- tRPC fallback rejects; function catches the error, logs it, and returns `null`.
+    53	
+    54	### 3.3 `updateVisibility`
+    55	
+    56	Purpose: update a channel's visibility via the authenticated tRPC `channel.setVisibility` mutation. Returns `void`.
+    57	
+    58	Program paths:
+    59	
+    60	- `trpcMutate` resolves; function returns `void`.
+    61	- `trpcMutate` rejects; error propagates to the caller.
+    62	
+    63	### 3.4 `updateChannel`
+    64	
+    65	Purpose: update a channel's `name` and/or `topic` metadata via tRPC. Only defined patch keys are forwarded.
+    66	
+    67	Program paths:
+    68	
+    69	- Patch includes both `name` and `topic`; both are forwarded and the adapted result is returned.
+    70	- Patch includes only `name` (no `topic`); only `name` is forwarded.
+    71	- Patch includes only `topic` (no `name`); only `topic` is forwarded.
+    72	- Patch is empty (`{}`); neither key is forwarded; adapted result is still returned.
+    73	- `trpcMutate` rejects; error propagates to the caller.
+    74	
+    75	### 3.5 `createChannel`
+    76	
+    77	Purpose: create a new channel via tRPC `channel.createChannel` and return the adapted `Channel`.
+    78	
+    79	Program paths:
+    80	
+    81	- All required fields are provided; `trpcMutate` resolves; adapted channel is returned.
+    82	- `trpcMutate` rejects; error propagates to the caller.
+    83	
+    84	### 3.6 `getAuditLog`
+    85	
+    86	Purpose: fetch a paginated visibility audit log for a channel via tRPC `channel.getAuditLog`.
+    87	
+    88	Program paths:
+    89	
+    90	- `trpcQuery` resolves with a populated `entries` array and `total`; each entry is adapted and returned.
+    91	- `trpcQuery` resolves with an empty `entries` array; returns `{ entries: [], total: 0 }`.
+    92	- Options are partially provided (`limit` only, `offset` only, or `startDate` only); present keys are forwarded.
+    93	- Options are omitted entirely; query is called with only `serverId` and `channelId`.
+    94	- An entry has an invalid or missing `timestamp`; `toAuditLogEntry` falls back to epoch ISO string and emits a `console.warn`.
+    95	- `trpcQuery` rejects; error propagates to the caller.
+    96	
+    97	### 3.7 `deleteChannel`
+    98	
+    99	Purpose: delete a channel via tRPC and return `true` on success.
+   100	
+   101	Program paths:
+   102	
+   103	- `trpcMutate` resolves; function returns `true`.
+   104	- `trpcMutate` rejects; error propagates to the caller.
+   105	
+   106	## 4. Detailed Test Cases
+   107	
+   108	### 4.1 `getChannels`
+   109	
+   110	Description: fetches the full channel list for a server, adapting each record from the raw backend shape.
+   111	
+   112	| Test Purpose | Inputs | Expected Output |
+   113	| --- | --- | --- |
+   114	| Return adapted channels for a server | `serverId = "s1"`; `trpcQuery` resolves with two valid raw channel records | Returns an array of two `Channel` objects with all fields correctly mapped |
+   115	| Return empty array when API returns null | `serverId = "s1"`; `trpcQuery` resolves with `null` | Returns `[]` |
+   116	| Return empty array when API returns undefined | `serverId = "s1"`; `trpcQuery` resolves with `undefined` | Returns `[]` |
+   117	| Propagate rejection to caller | `serverId = "s1"`; `trpcQuery` rejects with a network error | The promise rejects with the same error; caller receives it without masking |
+   118	
+   119	### 4.2 `getChannel`
+   120	
+   121	Description: fetches a single channel by slug pair, attempting the public REST endpoint before falling back to authenticated tRPC.
+   122	
+   123	| Test Purpose | Inputs | Expected Output |
+   124	| --- | --- | --- |
+   125	| Return null when server lookup fails | `serverSlug = "my-server"`; `publicGet` for server resolves with `null` | Returns `null`; no further network calls are made |
+   126	| Return channel from public endpoint on slug match | Server resolves; public channel list contains a record with matching `channelSlug` | Returns `Channel` with `visibility = PUBLIC_INDEXABLE`; `serverId` filled from server lookup |
+   127	| Supplement missing public fields with defaults | Public channel record omits `position` and `createdAt` | Returned channel has `position = 0` and `createdAt` equal to epoch ISO string |
+   128	| Fall through to tRPC when slug not in public list | Server resolves; public channel list has no matching slug; tRPC resolves with channel data | Returns the tRPC-adapted `Channel` |
+   129	| Fall through to tRPC when public endpoint throws | Server resolves; public channels `publicGet` throws; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; thrown error is swallowed silently |
+   130	| Return null when tRPC resolves with falsy value | Server resolves; public endpoint miss; tRPC resolves with `null` | Returns `null` |
+   131	| Return null when tRPC rejects | Server resolves; public endpoint miss; tRPC rejects | Returns `null`; logs error via `console.error` |
+   132	| Correctly set visibility to PUBLIC_INDEXABLE for public hit | Server resolves; public list match with any `visibility` value in raw record | Returned channel always has `visibility = PUBLIC_INDEXABLE` regardless of raw field |
+   133	
+   134	### 4.3 `updateVisibility`
+   135	
+   136	Description: sends a visibility mutation to the backend with no return value.
+   137	
+   138	| Test Purpose | Inputs | Expected Output |
+   139	| --- | --- | --- |
+   140	| Successfully set visibility to PUBLIC_INDEXABLE | `channelId = "c1"`, `visibility = PUBLIC_INDEXABLE`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with `{ serverId, channelId, visibility }` |
+   141	| Successfully set visibility to PUBLIC_NO_INDEX | `channelId = "c1"`, `visibility = PUBLIC_NO_INDEX`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |
+   142	| Successfully set visibility to PRIVATE | `channelId = "c1"`, `visibility = PRIVATE`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |
+   143	| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 403 error | Promise rejects with the same error |
+   144	
+   145	### 4.4 `updateChannel`
+   146	
+   147	Description: sends partial channel metadata updates, forwarding only the keys that are explicitly set.
+   148	
+   149	| Test Purpose | Inputs | Expected Output |
+   150	| --- | --- | --- |
+   151	| Update both name and topic | `patch = { name: "general", topic: "chat" }`; `trpcMutate` resolves with a full channel record | Returns adapted `Channel`; mutation called with `name` and `topic` |
+   152	| Update name only | `patch = { name: "general" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `topic` key |
+   153	| Update topic only | `patch = { topic: "new topic" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `name` key |
+   154	| Empty patch sends no extra keys | `patch = {}`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called with only `serverId` and `channelId` |
+   155	| Propagate rejection to caller | Valid patch; `trpcMutate` rejects | Promise rejects with the underlying error |
+   156	
+   157	### 4.5 `createChannel`
+   158	
+   159	Description: creates a new channel and returns the backend-confirmed record.
+   160	
+   161	| Test Purpose | Inputs | Expected Output |
+   162	| --- | --- | --- |
+   163	| Create channel with all fields | Full `Channel` object minus `id`, `createdAt`, `updatedAt`; `trpcMutate` resolves with full record | Returns adapted `Channel`; mutation called with all provided fields |
+   164	| Create channel with optional fields absent | `topic` and `description` omitted; `trpcMutate` resolves | Returns adapted `Channel`; `topic` passed as `undefined` in mutation args |
+   165	| Create channel with each visibility value | `visibility = PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, or `PRIVATE`; `trpcMutate` resolves | Returns adapted `Channel` with the correct `visibility` field |
+   166	| Propagate rejection to caller | Valid input; `trpcMutate` rejects | Promise rejects with the underlying error |
+   167	
+   168	### 4.6 `getAuditLog`
+   169	
+   170	Description: fetches a paginated audit log, adapting each entry and validating field types.
+   171	
+   172	| Test Purpose | Inputs | Expected Output |
+   173	| --- | --- | --- |
+   174	| Return entries and total from API | `serverId`, `channelId`; `trpcQuery` resolves with two valid entries and `total = 2` | Returns `{ entries: [AuditLogEntry, AuditLogEntry], total: 2 }` |
+   175	| Return empty list | `serverId`, `channelId`; `trpcQuery` resolves with `{ entries: [], total: 0 }` | Returns `{ entries: [], total: 0 }` |
+   176	| Forward limit option | `options = { limit: 10 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, limit: 10 }` |
+   177	| Forward offset option | `options = { offset: 5 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, offset: 5 }` |
+   178	| Forward startDate option | `options = { startDate: "2026-01-01T00:00:00.000Z" }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, startDate: "2026-01-01T00:00:00.000Z" }` |
+   179	| Omit options when none provided | `options` not passed; `trpcQuery` resolves | `trpcQuery` called with only `serverId` and `channelId` |
+   180	| Fall back to epoch string for invalid timestamp | Entry has `timestamp = "not-a-date"`; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
+   181	| Fall back to epoch string for missing timestamp | Entry has no `timestamp` field; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
+   182	| Emit warn for missing required string fields | Entry missing `id`, `channelId`, `actorId`, or `action`; `trpcQuery` resolves | Each missing field emits a `console.warn`; function still returns an entry |
+   183	| Propagate rejection to caller | Valid args; `trpcQuery` rejects | Promise rejects with the underlying error |
+   184	
+   185	### 4.7 `deleteChannel`
+   186	
+   187	Description: deletes a channel and signals success via a boolean return value.
+   188	
+   189	| Test Purpose | Inputs | Expected Output |
+   190	| --- | --- | --- |
+   191	| Return true on successful deletion | `channelId = "c1"`, `serverId = "s1"`; `trpcMutate` resolves | Returns `true`; `trpcMutate` called with `{ serverId, channelId }` |
+   192	| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 404 error | Promise rejects with the underlying error; `true` is never returned |
+   193	
+   194	## 5. Edge Cases to Explicitly Validate
+   195	
+   196	- `getChannels` must not suppress transport errors; callers that use the channel count for position computation depend on the error surfacing to avoid data corruption.
+   197	- `getChannel` uses `cache()` wrapping; test the inner async function directly by mocking at the transport layer.
+   198	- The public REST hit in `getChannel` always overrides the raw `visibility` field with `PUBLIC_INDEXABLE`; the test must confirm this even when the raw record contains a different value.
+   199	- Missing `position` and `createdAt` from public channel records are filled with defaults (`0` and epoch ISO); tests should assert these exact defaults.
+   200	- `updateChannel` must only forward `name` and `topic` when those keys are explicitly present in `patch`; the absence of a key must not result in the key being sent as `undefined` to the mutation.
+   201	- `toFrontendChannel` and `toAuditLogEntry` emit `console.warn` for every missing required field; each warning path should be exercised at least once.
+   202	- `toAuditLogEntry` falls back to an epoch ISO timestamp for any non-string or unparseable `timestamp` value; both non-string and invalid-string cases must be tested.
+   203	- All three `ChannelVisibility` values (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) must appear in at least one test for `updateVisibility` and `createChannel`.
+   204	
+   205	## 6. Mock Strategy
+   206	
+   207	All external dependencies are mocked at the module level with `jest.mock`:
+   208	
+   209	```
+   210	jest.mock('@/lib/trpc-client', () => ({
+   211	  trpcQuery:  jest.fn(),
+   212	  trpcMutate: jest.fn(),
+   213	  publicGet:  jest.fn(),
+   214	}));
+   215	```
+   216	
+   217	Reset all mocks in `beforeEach` with `jest.resetAllMocks()` to prevent cross-test contamination.
+   218	
+   219	- **`trpcQuery`** — resolve with well-formed raw objects to test happy paths; reject with an `Error` to test propagation; resolve with `null`/`undefined` to test null-guard branches.
+   220	- **`trpcMutate`** — resolve to test `updateVisibility`, `updateChannel`, `createChannel`, and `deleteChannel` happy paths; reject to test error propagation in each.
+   221	- **`publicGet`** — resolve with a server object (containing at minimum `{ id: "s1" }`) to simulate a successful server lookup; resolve with `null` to test the early-return path; resolve with a channels payload or throw to test the public channel list branches.
+   222	- **`console.warn` / `console.error`** — use `jest.spyOn(console, 'warn')` and `jest.spyOn(console, 'error')` in tests that exercise validation warnings; restore spies in `afterEach`.
+   223	
+   224	## 7. Coverage Expectation
+   225	
+   226	The cases above are intended to cover:
+   227	
+   228	- all seven exported functions,
+   229	- every explicit null-guard and early-return branch,
+   230	- successful transport call paths and their return value adaption,
+   231	- all transport rejection paths and their propagation behavior,
+   232	- public-REST-to-tRPC fallback logic in `getChannel`,
+   233	- all three `ChannelVisibility` enum values,
+   234	- field-level validation warnings in `toFrontendChannel` and `toAuditLogEntry`, and
+   235	- optional field defaults (missing `position`, `createdAt`, `topic`, `description`).
+   236	
+   237	Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures (e.g., React `cache` internals) outside the service's direct branching logic.
+````
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/services/channelService.ts | nl -ba
+```
+
+Output:
+
+```text
+     1	/**
+     2	 * Channel Service (M2 — real API implementation)
+     3	 * Replaces mock in-memory store with backend API calls.
+     4	 * References: dev-spec-channel-visibility-toggle.md
+     5	 */
+     6	
+     7	import { cache } from 'react';
+     8	import { ChannelVisibility, type Channel } from '@/types';
+     9	import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+    10	
+    11	/** Maps the backend Prisma Channel shape to the frontend Channel type. */
+    12	function toFrontendChannel(raw: Record<string, unknown>): Channel {
+    13	  if (typeof raw.id !== 'string') console.warn('[toFrontendChannel] missing or non-string "id"');
+    14	  if (typeof raw.serverId !== 'string')
+    15	    console.warn('[toFrontendChannel] missing or non-string "serverId"');
+    16	  if (typeof raw.slug !== 'string')
+    17	    console.warn('[toFrontendChannel] missing or non-string "slug"');
+    18	  if (typeof raw.createdAt !== 'string')
+    19	    console.warn('[toFrontendChannel] missing or non-string "createdAt"');
+    20	  return {
+    21	    id: raw.id as string,
+    22	    serverId: raw.serverId as string,
+    23	    name: raw.name as string,
+    24	    slug: raw.slug as string,
+    25	    type: raw.type as Channel['type'],
+    26	    visibility: raw.visibility as ChannelVisibility,
+    27	    topic: (raw.topic as string | undefined) ?? undefined,
+    28	    position: (raw.position as number) ?? 0,
+    29	    description: raw.description as string | undefined,
+    30	    createdAt: raw.createdAt as string,
+    31	    updatedAt: raw.updatedAt as string | undefined,
+    32	  };
+    33	}
+    34	
+    35	/**
+    36	 * Returns all channels for a given server.
+    37	 * Uses tRPC authed endpoint for full channel list (including PRIVATE channels).
+    38	 * Errors propagate to the caller — callers that use the channel count (e.g.
+    39	 * createChannelAction position computation) must not silently receive [] on a
+    40	 * transient failure, which would corrupt channel ordering.
+    41	 */
+    42	export async function getChannels(serverId: string): Promise<Channel[]> {
+    43	  const data = await trpcQuery<Record<string, unknown>[]>('channel.getChannels', { serverId });
+    44	  return (data ?? []).map(toFrontendChannel);
+    45	}
+    46	
+    47	/**
+    48	 * Returns a single channel by server slug + channel slug, or null if not found.
+    49	 *
+    50	export const getChannel = cache(
+    51	  async (serverSlug: string, channelSlug: string): Promise<Channel | null> => {
+    52	    const serverData = await publicGet<Record<string, unknown>>(
+    53	      `/servers/${encodeURIComponent(serverSlug)}`,
+    54	    );
+    55	    if (!serverData) return null;
+    56	    const serverId = serverData.id as string;
+    57	
+    58	    try {
+    59	      const publicData = await publicGet<{ channels: Record<string, unknown>[] }>(
+    60	        `/servers/${encodeURIComponent(serverSlug)}/channels`,
+    61	      );
+    62	      if (publicData) {
+    63	        const match = publicData.channels.find(c => (c.slug as string) === channelSlug);
+    64	        if (match) {
+    65	          return toFrontendChannel({
+    66	            ...match,
+    67	            serverId,
+    68	            visibility: 'PUBLIC_INDEXABLE',
+    69	            position: (match.position as number | undefined) ?? 0,
+    70	            createdAt: (match.createdAt as string | undefined) ?? new Date(0).toISOString(),
+    71	          });
+    72	        }
+    73	      }
+    74	    } catch {
+    75	    }
+    76	
+    77	    try {
+    78	      const data = await trpcQuery<Record<string, unknown>>('channel.getChannel', {
+    79	        serverId,
+    80	        serverSlug,
+    81	        channelSlug,
+    82	      });
+    83	      if (!data) return null;
+    84	      return toFrontendChannel(data);
+    85	    } catch (error) {
+    86	      console.error(
+    87	        `[channelService.getChannel] API call failed for "${serverSlug}/${channelSlug}":`,
+    88	        error,
+    89	      );
+    90	      return null;
+    91	    }
+    92	  },
+    93	);
+    94	
+    95	/**
+    96	 * Updates the visibility of a channel via tRPC.
+    97	 * Returns the visibility change result (not a full Channel object).
+    98	 */
+    99	export async function updateVisibility(
+   100	  channelId: string,
+   101	  visibility: ChannelVisibility,
+   102	  serverId: string,
+   103	): Promise<void> {
+   104	  await trpcMutate('channel.setVisibility', {
+   105	    serverId,
+   106	    channelId,
+   107	    visibility,
+   108	  });
+   109	}
+   110	
+   111	/**
+   112	 * Updates editable metadata (name, topic) of a channel via tRPC.
+   113	 * Note: `description` is not forwarded — the backend only supports `name`, `topic`, and `position`.
+   114	 */
+   115	export async function updateChannel(
+   116	  channelId: string,
+   117	  serverId: string,
+   118	  patch: Partial<Pick<Channel, 'name' | 'topic'>>,
+   119	): Promise<Channel> {
+   120	  const data = await trpcMutate<Record<string, unknown>>('channel.updateChannel', {
+   121	    serverId,
+   122	    channelId,
+   123	    ...(patch.name !== undefined && { name: patch.name }),
+   124	    ...(patch.topic !== undefined && { topic: patch.topic }),
+   125	  });
+   126	  return toFrontendChannel(data);
+   127	}
+   128	
+   129	/**
+   130	 * Creates a new channel via tRPC.
+   131	 */
+   132	export async function createChannel(
+   133	  channel: Omit<Channel, 'id' | 'createdAt' | 'updatedAt'>,
+   134	): Promise<Channel> {
+   135	  const data = await trpcMutate<Record<string, unknown>>('channel.createChannel', {
+   136	    serverId: channel.serverId,
+   137	    name: channel.name,
+   138	    slug: channel.slug,
+   139	    type: channel.type,
+   140	    visibility: channel.visibility,
+   141	    topic: channel.topic,
+   142	    position: channel.position,
+   143	  });
+   144	  return toFrontendChannel(data);
+   145	}
+   146	
+   147	export interface AuditLogEntry {
+   148	  id: string;
+   149	  channelId: string;
+   150	  actorId: string;
+   151	  action: string;
+   152	  oldValue: Record<string, unknown>;
+   153	  newValue: Record<string, unknown>;
+   154	  timestamp: string;
+   155	  ipAddress: string;
+   156	  userAgent: string;
+   157	}
+   158	
+   159	export interface AuditLogPage {
+   160	  entries: AuditLogEntry[];
+   161	  total: number;
+   162	}
+   163	
+   164	/** Validates an audit log entry from the API, guarding against schema changes. */
+   165	function toAuditLogEntry(raw: Record<string, unknown>): AuditLogEntry {
+   166	  if (typeof raw.id !== 'string') console.warn('[toAuditLogEntry] missing or non-string "id"');
+   167	  if (typeof raw.channelId !== 'string')
+   168	    console.warn('[toAuditLogEntry] missing or non-string "channelId"');
+   169	  if (typeof raw.actorId !== 'string')
+   170	    console.warn('[toAuditLogEntry] missing or non-string "actorId"');
+   171	  if (typeof raw.action !== 'string')
+   172	    console.warn('[toAuditLogEntry] missing or non-string "action"');
+   173	  const ts = raw.timestamp;
+   174	  const validTimestamp =
+   175	    typeof ts === 'string' && !isNaN(new Date(ts).getTime())
+   176	      ? ts
+   177	      : (() => {
+   178	          console.warn('[toAuditLogEntry] missing or invalid "timestamp":', ts);
+   179	          return new Date(0).toISOString();
+   180	        })();
+   181	  return {
+   182	    id: raw.id as string,
+   183	    channelId: raw.channelId as string,
+   184	    actorId: raw.actorId as string,
+   185	    action: raw.action as string,
+   186	    oldValue: raw.oldValue as Record<string, unknown>,
+   187	    newValue: raw.newValue as Record<string, unknown>,
+   188	    timestamp: validTimestamp,
+   189	    ipAddress: raw.ipAddress as string,
+   190	    userAgent: raw.userAgent as string,
+   191	  };
+   192	}
+   193	
+   194	/**
+   195	 * Fetches paginated visibility audit log for a channel via tRPC.
+   196	 */
+   197	export async function getAuditLog(
+   198	  serverId: string,
+   199	  channelId: string,
+   200	  options: { limit?: number; offset?: number; startDate?: string } = {},
+   201	): Promise<AuditLogPage> {
+   202	  const data = await trpcQuery<{ entries: Record<string, unknown>[]; total: number }>(
+   203	    'channel.getAuditLog',
+   204	    { serverId, channelId, ...options },
+   205	  );
+   206	  return { entries: data.entries.map(toAuditLogEntry), total: data.total };
+   207	}
+   208	
+   209	/**
+   210	 * Deletes a channel by ID via tRPC. Returns true if deleted.
+   211	 */
+   212	export async function deleteChannel(channelId: string, serverId: string): Promise<boolean> {
+   213	  await trpcMutate('channel.deleteChannel', { serverId, channelId });
+   214	  return true;
+   215	}
+   216	
+   217	export { ChannelVisibility };
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:12:04.694Z
+
+- [ ] Prioritize Logic over Style: the spec misses a real `getChannel` error path and one `createChannel` expectation conflicts with the service code.
+- [x] Security First: docs-only change; no new auth, input-validation, or secret-handling surface.
+- [x] Architectural Alignment: no backend architecture divergence is introduced by this documentation-only PR.
+- [ ] Issue Completion: `#261` asks for API error handling and all program paths; the current spec still leaves at least one reachable branch undocumented.
+- [x] No Nitpicking: findings are about behavioral/spec accuracy, not wording or formatting.
+- [x] Avoid Repetition: there are no existing review comments on this PR to duplicate.
+- [x] Iterative Reviews: first pass on this PR from me, so there was nothing prior to re-check or resolve.
+- [x] Prevent CI Failures: no immediate pipeline breakage in product code; the risk here is incorrect downstream test implementation, not current CI.
+
+Bundled review:
+
+1. [P1] In [docs/test-specs/frontend-channel-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/frontend-channel-service-spec.md#L163), the `createChannel` happy-path case says the mutation should be called with “all provided fields”. That is not what the service does: [`channelService.ts`](/Users/allen/repos/Harmony/harmony-frontend/src/services/channelService.ts#L135) forwards `serverId`, `name`, `slug`, `type`, `visibility`, `topic`, and `position`, but not `description`. Because `description` is part of the input type, this spec will drive a wrong test expectation.
+
+2. [P2] In [docs/test-specs/frontend-channel-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/frontend-channel-service-spec.md#L46), `getChannel` is described as covering all program paths, but it omits the initial server lookup rejection case. The first `publicGet('/servers/:slug')` call in [`channelService.ts`](/Users/allen/repos/Harmony/harmony-frontend/src/services/channelService.ts#L52) is outside both `try` blocks, so if that request rejects the promise propagates instead of returning `null`. That should be listed in section 3.2 and reflected in the test table to satisfy the issue’s API-error-handling requirement.
+
+3. [P2] In [docs/test-specs/frontend-channel-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/frontend-channel-service-spec.md#L180), the audit-log table covers invalid-string and missing timestamps, but not non-string timestamps. [`toAuditLogEntry()`](/Users/allen/repos/Harmony/harmony-frontend/src/services/channelService.ts#L173) uses the same fallback branch for any non-string value, and section 5 already says both non-string and invalid-string cases must be tested. Add that row so the detailed cases match the documented edge-case coverage.
+
+### Turn 2: # Review findings: ## Finding 1
+
+#### 👤 User Prompt
+
+- Time: 2026-03-31T23:14:18.781Z
+
+```text
+# Review findings:
+
+## Finding 1 (docs/test-specs/frontend-channel-service-spec.md:180-182) [added]
+[P2] Detailed cases omit the non-string timestamp branch
+
+The spec later says both non-string and invalid-string `timestamp` values must be tested, which matches `toAuditLogEntry()` falling back for any non-string or unparseable value. But the detailed table only includes invalid-string and missing-timestamp rows. Add an explicit non-string case here so the tabular test plan actually covers the documented branch set.
+
+## Finding 2 (docs/test-specs/frontend-channel-service-spec.md:46-52) [added]
+[P2] Missing `getChannel` server-lookup failure path
+
+The spec says it covers all program paths and API error handling, but `getChannel` still has an uncaught failure mode before either fallback branch runs: the initial `publicGet('/servers/:slug')` call can reject and that rejection bubbles to the caller because it sits outside both `try` blocks in `channelService.ts`. This section only covers the `null` result, the public-channel-list throw, and the tRPC throw, so a real transport error path is left undocumented and untested.
+
+## Finding 3 (docs/test-specs/frontend-channel-service-spec.md:163-164) [added]
+[P1] `createChannel` expectation contradicts the implementation
+
+This row says the happy-path test should assert that `trpcMutate` is called with all provided fields, but `createChannel()` does not forward every field from `Omit<Channel, ...>` today. In particular, `description` is part of the input type yet is not sent in the mutation payload in `channelService.ts`. A test written from this spec will fail immediately or push the service toward behavior it does not currently implement.
+
+## My request for Codex:
+post it on the PR as a single review with in line comments
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:14:33.951Z
+
+I have the three findings and the PR’s head commit. I’m posting a single `REQUEST_CHANGES` review with the required checklist in the body and three inline comments anchored to the spec file.
+
+#### Tool: mcp__codex_apps__github_add_review_to_pr
+
+```json
+{
+  "action": "REQUEST_CHANGES",
+  "commit_id": "7c62ee1c7d36581414fae5834cb0b7af5d18b88e",
+  "pr_number": 276,
+  "repo_full_name": "acabrera04/Harmony",
+  "review": "- [ ] Prioritize Logic over Style: the spec misses a real `getChannel` error path and one `createChannel` expectation conflicts with the service code.\n- [x] Security First: docs-only change; no new auth, input-validation, or secret-handling surface.\n- [x] Architectural Alignment: no backend architecture divergence is introduced by this documentation-only PR.\n- [ ] Issue Completion: `#261` asks for API error handling and all program paths; the current spec still leaves at least one reachable branch undocumented.\n- [x] No Nitpicking: findings are about behavioral/spec accuracy, not wording or formatting.\n- [x] Avoid Repetition: there are no existing review comments on this PR to duplicate.\n- [x] Iterative Reviews: first pass on this PR from me, so there was nothing prior to re-check or resolve.\n- [x] Prevent CI Failures: no immediate pipeline breakage in product code; the risk here is incorrect downstream test implementation, not current CI.\n\n1. In the `createChannel` table, the happy-path expectation says the mutation should be called with all provided fields. That does not match `channelService.ts`, which does not forward `description`. A test written from this spec will fail immediately or push the implementation toward behavior it does not currently have.\n\n2. In `getChannel`, the spec says it covers all program paths and API error handling, but it omits the initial server lookup rejection case. The first `publicGet('/servers/:slug')` call sits outside both `try` blocks in `channelService.ts`, so a rejection there bubbles to the caller instead of returning `null`.\n\n3. In the audit-log table, the detailed cases cover invalid-string and missing timestamps but not non-string timestamps. `toAuditLogEntry()` uses the same fallback branch for any non-string value, and section 5 already says both non-string and invalid-string cases must be tested, so the table should include that explicit row.",
+  "file_comments": [
+    "docs/test-specs/frontend-channel-service-spec.md:163: This row says the happy-path test should assert that `trpcMutate` is called with all provided fields, but `createChannel()` does not forward every field from `Omit<Channel, ...>` today. In particular, `description` is part of the input type yet is not sent in the mutation payload in `channelService.ts`. A test written from this spec will fail immediately or push the service toward behavior it does not currently implement.",
+    "docs/test-specs/frontend-channel-service-spec.md:46: The spec says it covers all program paths and API error handling, but `getChannel` still has an uncaught failure mode before either fallback branch runs: the initial `publicGet('/servers/:slug')` call can reject and that rejection bubbles to the caller because it sits outside both `try` blocks in `channelService.ts`. This section only covers the `null` result, the public-channel-list throw, and the tRPC throw, so a real transport error path is left undocumented and untested.",
+    "docs/test-specs/frontend-channel-service-spec.md:180: The spec later says both non-string and invalid-string `timestamp` values must be tested, which matches `toAuditLogEntry()` falling back for any non-string or unparseable value. But the detailed table only includes invalid-string and missing-timestamp rows. Add an explicit non-string case here so the tabular test plan actually covers the documented branch set."
+  ]
+}
+```
+
+Output:
+
+```text
+[{"type":"text","text":"Error code: INVALID_ARGUMENTError: Parameters failed connector schema validation: file_comments[0] [type]: Expected type ['object'], got str (does not match constraints configured by your ChatGPT workspace admin. If the issue persists, instruct the user to contact their workspace admin.); file_comments[1] [type]: Expected type ['object'], got str (does not match constraints configured by your ChatGPT workspace admin. If the issue persists, instruct the user to contact their workspace admin.); file_comments[2] [type]: Expected type ['object'], got str (does not match constraints configured by your ChatGPT workspace admin. If the issue persists, instruct the user to contact their workspace admin.)"}]
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:14:51.766Z
+
+The review API rejected my first attempt because inline comments need structured objects, not strings. I’m retrying with explicit file, line, and body fields.
+
+#### Tool: mcp__codex_apps__github_add_review_to_pr
+
+```json
+{
+  "action": "REQUEST_CHANGES",
+  "commit_id": "7c62ee1c7d36581414fae5834cb0b7af5d18b88e",
+  "pr_number": 276,
+  "repo_full_name": "acabrera04/Harmony",
+  "review": "- [ ] Prioritize Logic over Style: the spec misses a real `getChannel` error path and one `createChannel` expectation conflicts with the service code.\n- [x] Security First: docs-only change; no new auth, input-validation, or secret-handling surface.\n- [x] Architectural Alignment: no backend architecture divergence is introduced by this documentation-only PR.\n- [ ] Issue Completion: `#261` asks for API error handling and all program paths; the current spec still leaves at least one reachable branch undocumented.\n- [x] No Nitpicking: findings are about behavioral/spec accuracy, not wording or formatting.\n- [x] Avoid Repetition: there are no existing review comments on this PR to duplicate.\n- [x] Iterative Reviews: first pass on this PR from me, so there was nothing prior to re-check or resolve.\n- [x] Prevent CI Failures: no immediate pipeline breakage in product code; the risk here is incorrect downstream test implementation, not current CI.\n\n1. In the `createChannel` table, the happy-path expectation says the mutation should be called with all provided fields. That does not match `channelService.ts`, which does not forward `description`. A test written from this spec will fail immediately or push the implementation toward behavior it does not currently have.\n\n2. In `getChannel`, the spec says it covers all program paths and API error handling, but it omits the initial server lookup rejection case. The first `publicGet('/servers/:slug')` call sits outside both `try` blocks in `channelService.ts`, so a rejection there bubbles to the caller instead of returning `null`.\n\n3. In the audit-log table, the detailed cases cover invalid-string and missing timestamps but not non-string timestamps. `toAuditLogEntry()` uses the same fallback branch for any non-string value, and section 5 already says both non-string and invalid-string cases must be tested, so the table should include that explicit row.",
+  "file_comments": [
+    {
+      "path": "docs/test-specs/frontend-channel-service-spec.md",
+      "line": 163,
+      "body": "This row says the happy-path test should assert that `trpcMutate` is called with all provided fields, but `createChannel()` does not forward every field from `Omit<Channel, ...>` today. In particular, `description` is part of the input type yet is not sent in the mutation payload in `channelService.ts`. A test written from this spec will fail immediately or push the service toward behavior it does not currently implement."
+    },
+    {
+      "path": "docs/test-specs/frontend-channel-service-spec.md",
+      "line": 46,
+      "body": "The spec says it covers all program paths and API error handling, but `getChannel` still has an uncaught failure mode before either fallback branch runs: the initial `publicGet('/servers/:slug')` call can reject and that rejection bubbles to the caller because it sits outside both `try` blocks in `channelService.ts`. This section only covers the `null` result, the public-channel-list throw, and the tRPC throw, so a real transport error path is left undocumented and untested."
+    },
+    {
+      "path": "docs/test-specs/frontend-channel-service-spec.md",
+      "line": 180,
+      "body": "The spec later says both non-string and invalid-string `timestamp` values must be tested, which matches `toAuditLogEntry()` falling back for any non-string or unparseable value. But the detailed table only includes invalid-string and missing-timestamp rows. Add an explicit non-string case here so the tabular test plan actually covers the documented branch set."
+    }
+  ]
+}
+```
+
+Output:
+
+```text
+{"success":true,"review_id":4040759622}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:15:09.406Z
+
+Posted a single `REQUEST_CHANGES` review on PR `#276` with the checklist in the review body and three inline comments on the spec file.
+
+### Turn 3: # Review findings: ## Finding 1
+
+#### 👤 User Prompt
+
+- Time: 2026-03-31T23:36:05.756Z
+
+```text
+# Review findings:
+
+## Finding 1 (docs/test-specs/frontend-channel-service-spec.md:180-182) [added]
+[P2] Detailed cases omit the non-string timestamp branch
+
+The spec later says both non-string and invalid-string `timestamp` values must be tested, which matches `toAuditLogEntry()` falling back for any non-string or unparseable value. But the detailed table only includes invalid-string and missing-timestamp rows. Add an explicit non-string case here so the tabular test plan actually covers the documented branch set.
+
+## My request for Codex:
+Avanish pushed new changes, review again
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:36:14.531Z
+
+Re-reviewing PR `#276` against the latest head. I’m checking the updated patch, prior review state, and the spec’s current content against `channelService.ts` to see which concerns were fixed and whether anything new appeared.
+
+#### Tool: mcp__codex_apps__github_get_pr_info
+
+```json
+{
+  "pr_number": 276,
+  "repository_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+```text
+{"url":"https://github.com/acabrera04/Harmony/pull/276","number":276,"state":"open","merged":false,"mergeable":true,"draft":false,"body":"## Summary\n\n- Adds `docs/test-specs/frontend-channel-service-spec.md` for `harmony-frontend/src/services/channelService.ts`\n- Covers all 7 exported functions: `getChannels`, `getChannel`, `updateVisibility`, `updateChannel`, `createChannel`, `getAuditLog`, `deleteChannel`\n- Includes mock strategy for `trpcQuery`, `trpcMutate`, and `publicGet`\n- Documents all three `ChannelVisibility` enum edge cases (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`)\n- Covers public REST → tRPC fallback paths in `getChannel`, validation warning branches in adapters, and optional field defaults\n\n## Test plan\n\n- [ ] All 7 functions listed with purpose and program paths\n- [ ] Happy path covered for each function\n- [ ] Error/rejection propagation covered for each function\n- [ ] Visibility enum edge cases documented and tested in `updateVisibility` and `createChannel`\n- [ ] Public REST hit vs. fallback vs. server-not-found paths covered for `getChannel`\n- [ ] `toAuditLogEntry` timestamp fallback and missing-field warnings covered\n- [ ] Mock strategy documented with reset pattern\n\nCloses #261\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)","title":"docs: frontend channel service test specification (#261)","base":"main","base_sha":"b19f1dcad49e33a6b888b7b4c781cbf230959ba8","head":"codex/issue-261-frontend-channel-service-spec","head_sha":"2b172b6dc898fbc1bcc35bd714a5bbd077e05de6","merge_commit_sha":"f40bbfb9d240ccd5a147be87e78a5914462f59d2","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"requested_reviewers":null,"diff":null,"comments":null,"created_at":"2026-03-31T23:06:23Z","updated_at":"2026-03-31T23:36:08Z","closed_at":null,"merged_at":null,"commits":2,"changed_files":1,"additions":242,"deletions":0,"display_url":"https://github.com/acabrera04/Harmony/pull/276","display_title":"docs: frontend channel service test specification (#261)"}
+```
+
+#### Tool: mcp__codex_apps__github_fetch_pr_comments
+
+```json
+{
+  "pr_number": 276,
+  "repo_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+````text
+{"comments":[{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018915879","body":"The detailed test case tables use a leading double pipe (`|| ...`), which renders as an extra empty column in Markdown. Use a single leading `|` (as in other specs in this repo) so the tables render correctly.","user":{"login":"Copilot","name":"Copilot","email":null,"avatar_url":"https://avatars.githubusercontent.com/in/946600?v=4","id":175728472},"id":3018915879,"pull_request_review_id":4040741597,"in_reply_to_id":null,"created_at":"2026-03-31T23:10:27Z","review":null,"side":"RIGHT","line":119,"start_line":114,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">The detailed test case tables use a leading double pipe (<code class=\"notranslate\">|| ...</code>), which renders as an extra empty column in Markdown. Use a single leading <code class=\"notranslate\">|</code> (as in other specs in this repo) so the tables render correctly.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018915889","body":"The spec states that `toFrontendChannel` / `toAuditLogEntry` emit `console.warn` for *every* missing required field, but the current implementation only warns for specific fields (e.g., `toFrontendChannel`: id/serverId/slug/createdAt; `toAuditLogEntry`: id/channelId/actorId/action + timestamp validity). Please align the wording and the suggested warning-assertion tests with the actual warning conditions.\n```suggestion\n- `toFrontendChannel` emits `console.warn` when any of the core identity fields (`id`, `serverId`, `slug`, `createdAt`) are missing from the raw record; tests should cover at least one warning for each of these fields. `toAuditLogEntry` emits `console.warn` when any of its core identity fields (`id`, `channelId`, `actorId`, `action`) are missing, or when the `timestamp` fails validation; tests should likewise exercise each of these warning conditions at least once.\n- `toAuditLogEntry` falls back to an epoch ISO timestamp for any non-string or unparseable `timestamp` value; both non-string and invalid-string cases must be tested, and corresponding `console.warn` calls should be asserted.\n```","user":{"login":"Copilot","name":"Copilot","email":null,"avatar_url":"https://avatars.githubusercontent.com/in/946600?v=4","id":175728472},"id":3018915889,"pull_request_review_id":4040741597,"in_reply_to_id":null,"created_at":"2026-03-31T23:10:27Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">The spec states that <code class=\"notranslate\">toFrontendChannel</code> / <code class=\"notranslate\">toAuditLogEntry</code> emit <code class=\"notranslate\">console.warn</code> for <em>every</em> missing required field, but the current implementation only warns for specific fields (e.g., <code class=\"notranslate\">toFrontendChannel</code>: id/serverId/slug/createdAt; <code class=\"notranslate\">toAuditLogEntry</code>: id/channelId/actorId/action + timestamp validity). Please align the wording and the suggested warning-assertion tests with the actual warning conditions.</p>\n  <div class=\"my-2 border rounded-2 js-suggested-changes-blob diff-view js-check-hidden-unicode\" id=\"\">\n    <div class=\"f6 p-2 lh-condensed border-bottom d-flex\">\n      <div class=\"flex-auto flex-items-center color-fg-muted\">\n        Suggested change\n      </div>\n    </div>\n    <div itemprop=\"text\" class=\"blob-wrapper data file rounded-0\" style=\"margin: 0; border: none; overflow-y: visible; overflow-x: auto;\">\n      <table class=\"d-table tab-size mb-0 width-full\" data-paste-markdown-skip=\"\">\n          <tbody><tr class=\"border-0\">\n            <td class=\"blob-num blob-num-deletion text-right border-0 px-2 py-1 lh-default blob-num-hidden\" data-line-number=\"·\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-deletion js-blob-code-deletion blob-code-marker-deletion\"><span class=\"pl-v\">-</span> <span class=\"pl-s\">`</span><span class=\"pl-c1\">toFrontendChannel</span><span class=\"pl-s\">`</span> <span class=\"x x-first\">and </span><span class=\"pl-s x x-last\">`</span><span class=\"pl-c1\">toAuditLogEntry</span><span class=\"pl-s\">`</span> <span class=\"x x-first x-last\">emit</span> <span class=\"pl-s\">`</span><span class=\"pl-c1\">console.warn</span><span class=\"pl-s\">`</span> <span class=\"x x-first x-last\">for every </span>missing<span class=\"x x-first x-last\"> required field; each warning path </span>should <span class=\"x x-first x-last\">be exercised</span> at least once.</td>\n          </tr>\n          <tr class=\"border-0\">\n            <td class=\"blob-num blob-num-deletion text-right border-0 px-2 py-1 lh-default blob-num-hidden\" data-line-number=\"·\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-deletion js-blob-code-deletion blob-code-marker-deletion\"><span class=\"pl-v\">-</span> <span class=\"pl-s\">`</span><span class=\"pl-c1\">toAuditLogEntry</span><span class=\"pl-s\">`</span> falls back to an epoch ISO timestamp for any non-string or unparseable <span class=\"pl-s\">`</span><span class=\"pl-c1\">timestamp</span><span class=\"pl-s\">`</span> value; both non-string and invalid-string cases must be tested.</td>\n          </tr>\n          <tr class=\"border-0\">\n            <td class=\"blob-num blob-num-addition text-right border-0 px-2 py-1 lh-default blob-num-hidden\" data-line-number=\"·\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-addition js-blob-code-addition blob-code-marker-addition\"><span class=\"pl-v\">-</span> <span class=\"pl-s\">`</span><span class=\"pl-c1\">toFrontendChannel</span><span class=\"pl-s\">`</span> <span class=\"x x-first\">emits </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">console.warn</span><span class=\"pl-s x\">`</span><span class=\"x\"> when any of the core identity fields (</span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">id</span><span class=\"pl-s x\">`</span><span class=\"x\">, </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">serverId</span><span class=\"pl-s x\">`</span><span class=\"x\">, </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">slug</span><span class=\"pl-s x\">`</span><span class=\"x\">, </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">createdAt</span><span class=\"pl-s x\">`</span><span class=\"x\">) are missing from the raw record; tests should cover at least one warning for each of these fields. </span><span class=\"pl-s x x-last\">`</span><span class=\"pl-c1\">toAuditLogEntry</span><span class=\"pl-s\">`</span> <span class=\"x x-first x-last\">emits</span> <span class=\"pl-s\">`</span><span class=\"pl-c1\">console.warn</span><span class=\"pl-s\">`</span> <span class=\"x x-first\">when any of its core identity fields (</span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">id</span><span class=\"pl-s x\">`</span><span class=\"x\">, </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">channelId</span><span class=\"pl-s x\">`</span><span class=\"x\">, </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">actorId</span><span class=\"pl-s x\">`</span><span class=\"x\">, </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">action</span><span class=\"pl-s x\">`</span><span class=\"x x-last\">) are </span>missing<span class=\"x x-first\">, or when the </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">timestamp</span><span class=\"pl-s x\">`</span><span class=\"x x-last\"> fails validation; tests </span>should <span class=\"x x-first x-last\">likewise exercise each of these warning conditions</span> at least once.</td>\n          </tr>\n          <tr class=\"border-0\">\n            <td class=\"blob-num blob-num-addition text-right border-0 px-2 py-1 lh-default blob-num-hidden\" data-line-number=\"·\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-addition js-blob-code-addition blob-code-marker-addition\"><span class=\"pl-v\">-</span> <span class=\"pl-s\">`</span><span class=\"pl-c1\">toAuditLogEntry</span><span class=\"pl-s\">`</span> falls back to an epoch ISO timestamp for any non-string or unparseable <span class=\"pl-s\">`</span><span class=\"pl-c1\">timestamp</span><span class=\"pl-s\">`</span> value; both non-string and invalid-string cases must be tested<span class=\"x x-first\">, and corresponding </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">console.warn</span><span class=\"pl-s x\">`</span><span class=\"x x-last\"> calls should be asserted</span>.</td>\n          </tr>\n      </tbody></table>\n    </div>\n    <div class=\"js-apply-changes\"></div>\n  </div>\n"},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018915905","body":"The `getAuditLog` test case about warning on missing required fields is broader than the implementation: `toAuditLogEntry` only warns for `id`, `channelId`, `actorId`, and `action` when they are missing or non-strings (it does not warn for `oldValue`, `newValue`, `ipAddress`, or `userAgent`). Update the test case expectations to match what the adapter actually warns on.\n```suggestion\n| Warn only on missing/non-string core fields | Entry has missing or non-string `id`, `channelId`, `actorId`, or `action`; `trpcQuery` resolves | Each problematic core field emits a `console.warn`; function still returns an entry; no warnings expected for `oldValue`, `newValue`, `ipAddress`, or `userAgent` |\n```","user":{"login":"Copilot","name":"Copilot","email":null,"avatar_url":"https://avatars.githubusercontent.com/in/946600?v=4","id":175728472},"id":3018915905,"pull_request_review_id":4040741597,"in_reply_to_id":null,"created_at":"2026-03-31T23:10:28Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">The <code class=\"notranslate\">getAuditLog</code> test case about warning on missing required fields is broader than the implementation: <code class=\"notranslate\">toAuditLogEntry</code> only warns for <code class=\"notranslate\">id</code>, <code class=\"notranslate\">channelId</code>, <code class=\"notranslate\">actorId</code>, and <code class=\"notranslate\">action</code> when they are missing or non-strings (it does not warn for <code class=\"notranslate\">oldValue</code>, <code class=\"notranslate\">newValue</code>, <code class=\"notranslate\">ipAddress</code>, or <code class=\"notranslate\">userAgent</code>). Update the test case expectations to match what the adapter actually warns on.</p>\n  <div class=\"my-2 border rounded-2 js-suggested-changes-blob diff-view js-check-hidden-unicode\" id=\"\">\n    <div class=\"f6 p-2 lh-condensed border-bottom d-flex\">\n      <div class=\"flex-auto flex-items-center color-fg-muted\">\n        Suggested change\n      </div>\n    </div>\n    <div itemprop=\"text\" class=\"blob-wrapper data file rounded-0\" style=\"margin: 0; border: none; overflow-y: visible; overflow-x: auto;\">\n      <table class=\"d-table tab-size mb-0 width-full\" data-paste-markdown-skip=\"\">\n          <tbody><tr class=\"border-0\">\n            <td class=\"blob-num blob-num-deletion text-right border-0 px-2 py-1 lh-default blob-num-hidden\" data-line-number=\"·\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-deletion js-blob-code-deletion blob-code-marker-deletion\"><span class=\"pl-ml\">|</span> <span class=\"x x-first x-last\">Emit warn for</span> missing<span class=\"x x-first x-last\"> required </span>string fields <span class=\"pl-ml\">|</span> Entry missing <span class=\"pl-s\">`</span><span class=\"pl-c1\">id</span><span class=\"pl-s\">`</span>, <span class=\"pl-s\">`</span><span class=\"pl-c1\">channelId</span><span class=\"pl-s\">`</span>, <span class=\"pl-s\">`</span><span class=\"pl-c1\">actorId</span><span class=\"pl-s\">`</span>, or <span class=\"pl-s\">`</span><span class=\"pl-c1\">action</span><span class=\"pl-s\">`</span>; <span class=\"pl-s\">`</span><span class=\"pl-c1\">trpcQuery</span><span class=\"pl-s\">`</span> resolves <span class=\"pl-ml\">|</span> Each <span class=\"x x-first x-last\">missing </span>field emits a <span class=\"pl-s\">`</span><span class=\"pl-c1\">console.warn</span><span class=\"pl-s\">`</span>; function still returns an entry <span class=\"pl-ml\">|</span></td>\n          </tr>\n          <tr class=\"border-0\">\n            <td class=\"blob-num blob-num-addition text-right border-0 px-2 py-1 lh-default blob-num-hidden\" data-line-number=\"·\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-addition js-blob-code-addition blob-code-marker-addition\"><span class=\"pl-ml\">|</span> <span class=\"x x-first x-last\">Warn only on</span> missing<span class=\"x x-first x-last\">/non-</span>string <span class=\"x x-first x-last\">core </span>fields <span class=\"pl-ml\">|</span> Entry <span class=\"x x-first x-last\">has </span>missing <span class=\"x x-first x-last\">or non-string </span><span class=\"pl-s\">`</span><span class=\"pl-c1\">id</span><span class=\"pl-s\">`</span>, <span class=\"pl-s\">`</span><span class=\"pl-c1\">channelId</span><span class=\"pl-s\">`</span>, <span class=\"pl-s\">`</span><span class=\"pl-c1\">actorId</span><span class=\"pl-s\">`</span>, or <span class=\"pl-s\">`</span><span class=\"pl-c1\">action</span><span class=\"pl-s\">`</span>; <span class=\"pl-s\">`</span><span class=\"pl-c1\">trpcQuery</span><span class=\"pl-s\">`</span> resolves <span class=\"pl-ml\">|</span> Each <span class=\"x x-first x-last\">problematic core </span>field emits a <span class=\"pl-s\">`</span><span class=\"pl-c1\">console.warn</span><span class=\"pl-s\">`</span>; function still returns an entry<span class=\"x x-first\">; no warnings expected for </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">oldValue</span><span class=\"pl-s x\">`</span><span class=\"x\">, </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">newValue</span><span class=\"pl-s x\">`</span><span class=\"x\">, </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">ipAddress</span><span class=\"pl-s x\">`</span><span class=\"x\">, or </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">userAgent</span><span class=\"pl-s x x-last\">`</span> <span class=\"pl-ml\">|</span></td>\n          </tr>\n      </tbody></table>\n    </div>\n    <div class=\"js-apply-changes\"></div>\n  </div>\n"},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018915923","body":"`createChannel` currently does not forward `description` to the `channel.createChannel` mutation (backend input also has no `description`). The spec’s test case about omitting `description` (and the “optional field defaults … description” references) should be updated/removed or reframed as “description is ignored / not supported”.\n```suggestion\n| Create channel with optional fields absent | `topic` omitted (and `description` either omitted or, if provided, is ignored / not supported by the mutation); `trpcMutate` resolves | Returns adapted `Channel`; `topic` passed as `undefined` in mutation args; `description` not forwarded / ignored |\n```","user":{"login":"Copilot","name":"Copilot","email":null,"avatar_url":"https://avatars.githubusercontent.com/in/946600?v=4","id":175728472},"id":3018915923,"pull_request_review_id":4040741597,"in_reply_to_id":null,"created_at":"2026-03-31T23:10:28Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\"><code class=\"notranslate\">createChannel</code> currently does not forward <code class=\"notranslate\">description</code> to the <code class=\"notranslate\">channel.createChannel</code> mutation (backend input also has no <code class=\"notranslate\">description</code>). The spec’s test case about omitting <code class=\"notranslate\">description</code> (and the “optional field defaults … description” references) should be updated/removed or reframed as “description is ignored / not supported”.</p>\n  <div class=\"my-2 border rounded-2 js-suggested-changes-blob diff-view js-check-hidden-unicode\" id=\"\">\n    <div class=\"f6 p-2 lh-condensed border-bottom d-flex\">\n      <div class=\"flex-auto flex-items-center color-fg-muted\">\n        Suggested change\n      </div>\n    </div>\n    <div itemprop=\"text\" class=\"blob-wrapper data file rounded-0\" style=\"margin: 0; border: none; overflow-y: visible; overflow-x: auto;\">\n      <table class=\"d-table tab-size mb-0 width-full\" data-paste-markdown-skip=\"\">\n          <tbody><tr class=\"border-0\">\n            <td class=\"blob-num blob-num-deletion text-right border-0 px-2 py-1 lh-default blob-num-hidden\" data-line-number=\"·\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-deletion js-blob-code-deletion blob-code-marker-deletion\"><span class=\"pl-ml\">|</span> Create channel with optional fields absent <span class=\"pl-ml\">|</span> <span class=\"pl-s\">`</span><span class=\"pl-c1\">topic</span><span class=\"pl-s\">`</span> and <span class=\"pl-s\">`</span><span class=\"pl-c1\">description</span><span class=\"pl-s\">`</span> omitted; <span class=\"pl-s\">`</span><span class=\"pl-c1\">trpcMutate</span><span class=\"pl-s\">`</span> resolves <span class=\"pl-ml\">|</span> Returns adapted <span class=\"pl-s\">`</span><span class=\"pl-c1\">Channel</span><span class=\"pl-s\">`</span>; <span class=\"pl-s\">`</span><span class=\"pl-c1\">topic</span><span class=\"pl-s\">`</span> passed as <span class=\"pl-s\">`</span><span class=\"pl-c1\">undefined</span><span class=\"pl-s\">`</span> in mutation args <span class=\"pl-ml\">|</span></td>\n          </tr>\n          <tr class=\"border-0\">\n            <td class=\"blob-num blob-num-addition text-right border-0 px-2 py-1 lh-default blob-num-hidden\" data-line-number=\"·\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-addition js-blob-code-addition blob-code-marker-addition\"><span class=\"pl-ml\">|</span> Create channel with optional fields absent <span class=\"pl-ml\">|</span> <span class=\"pl-s\">`</span><span class=\"pl-c1\">topic</span><span class=\"pl-s\">`</span> <span class=\"x x-first x-last\">omitted (</span>and <span class=\"pl-s\">`</span><span class=\"pl-c1\">description</span><span class=\"pl-s\">`</span> <span class=\"x x-first x-last\">either </span>omitted<span class=\"x x-first x-last\"> or, if provided, is ignored / not supported by the mutation)</span>; <span class=\"pl-s\">`</span><span class=\"pl-c1\">trpcMutate</span><span class=\"pl-s\">`</span> resolves <span class=\"pl-ml\">|</span> Returns adapted <span class=\"pl-s\">`</span><span class=\"pl-c1\">Channel</span><span class=\"pl-s\">`</span>; <span class=\"pl-s\">`</span><span class=\"pl-c1\">topic</span><span class=\"pl-s\">`</span> passed as <span class=\"pl-s\">`</span><span class=\"pl-c1\">undefined</span><span class=\"pl-s\">`</span> in mutation args<span class=\"x x-first\">; </span><span class=\"pl-s x\">`</span><span class=\"pl-c1 x\">description</span><span class=\"pl-s x\">`</span><span class=\"x x-last\"> not forwarded / ignored</span> <span class=\"pl-ml\">|</span></td>\n          </tr>\n      </tbody></table>\n    </div>\n    <div class=\"js-apply-changes\"></div>\n  </div>\n"},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018915940","body":"For `getChannel`, there is a distinct branch where the public channels endpoint returns `null` (e.g., 404) and the code falls through to the tRPC fallback without entering the `if (publicData)` block. Consider adding an explicit test case for `publicGet('/servers/:slug/channels')` resolving to `null` to cover that branch separately from “no matching slug in list”.\n```suggestion\n| Fall through to tRPC when slug not in public list | Server resolves; public channel list has no matching slug; tRPC resolves with channel data | Returns the tRPC-adapted `Channel` |\n| Fall through to tRPC when public endpoint returns null | Server resolves; public channels `publicGet` resolves with `null`; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; does not log an error |\n```","user":{"login":"Copilot","name":"Copilot","email":null,"avatar_url":"https://avatars.githubusercontent.com/in/946600?v=4","id":175728472},"id":3018915940,"pull_request_review_id":4040741597,"in_reply_to_id":null,"created_at":"2026-03-31T23:10:28Z","review":null,"side":"RIGHT","line":132,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">For <code class=\"notranslate\">getChannel</code>, there is a distinct branch where the public channels endpoint returns <code class=\"notranslate\">null</code> (e.g., 404) and the code falls through to the tRPC fallback without entering the <code class=\"notranslate\">if (publicData)</code> block. Consider adding an explicit test case for <code class=\"notranslate\">publicGet('/servers/:slug/channels')</code> resolving to <code class=\"notranslate\">null</code> to cover that branch separately from “no matching slug in list”.</p>\n  <div class=\"my-2 border rounded-2 js-suggested-changes-blob diff-view js-check-hidden-unicode\" id=\"\">\n    <div class=\"f6 p-2 lh-condensed border-bottom d-flex\">\n      <div class=\"flex-auto flex-items-center color-fg-muted\">\n        Suggested change\n      </div>\n    </div>\n    <div itemprop=\"text\" class=\"blob-wrapper data file rounded-0\" style=\"margin: 0; border: none; overflow-y: visible; overflow-x: auto;\">\n      <table class=\"d-table tab-size mb-0 width-full\" data-paste-markdown-skip=\"\">\n          <tbody><tr class=\"border-0\">\n            <td class=\"blob-num blob-num-deletion text-right border-0 px-2 py-1 lh-default\" data-line-number=\"132\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-deletion js-blob-code-deletion blob-code-marker-deletion\"><span class=\"pl-ml\">|</span> Fall through to tRPC when slug not in public list <span class=\"pl-ml\">|</span> Server resolves; public channel list has no matching slug; tRPC resolves with channel data <span class=\"pl-ml\">|</span> Returns the tRPC-adapted <span class=\"pl-s\">`</span><span class=\"pl-c1\">Channel</span><span class=\"pl-s\">`</span> <span class=\"pl-ml\">|</span></td>\n          </tr>\n          <tr class=\"border-0\">\n            <td class=\"blob-num blob-num-addition text-right border-0 px-2 py-1 lh-default\" data-line-number=\"132\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-addition js-blob-code-addition blob-code-marker-addition\"><span class=\"pl-ml\">|</span> Fall through to tRPC when slug not in public list <span class=\"pl-ml\">|</span> Server resolves; public channel list has no matching slug; tRPC resolves with channel data <span class=\"pl-ml\">|</span> Returns the tRPC-adapted <span class=\"pl-s\">`</span><span class=\"pl-c1\">Channel</span><span class=\"pl-s\">`</span> <span class=\"pl-ml\">|</span></td>\n          </tr>\n          <tr class=\"border-0\">\n            <td class=\"blob-num blob-num-addition text-right border-0 px-2 py-1 lh-default\" data-line-number=\"133\"></td>\n            <td class=\"border-0 px-2 py-1 blob-code-inner blob-code-addition js-blob-code-addition blob-code-marker-addition\"><span class=\"pl-ml\">|</span> Fall through to tRPC when public endpoint returns null <span class=\"pl-ml\">|</span> Server resolves; public channels <span class=\"pl-s\">`</span><span class=\"pl-c1\">publicGet</span><span class=\"pl-s\">`</span> resolves with <span class=\"pl-s\">`</span><span class=\"pl-c1\">null</span><span class=\"pl-s\">`</span>; tRPC resolves with channel data <span class=\"pl-ml\">|</span> Returns the tRPC-adapted <span class=\"pl-s\">`</span><span class=\"pl-c1\">Channel</span><span class=\"pl-s\">`</span>; does not log an error <span class=\"pl-ml\">|</span></td>\n          </tr>\n      </tbody></table>\n    </div>\n    <div class=\"js-apply-changes\"></div>\n  </div>\n"},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018915955","body":"The mock reset guidance suggests `jest.resetAllMocks()`, but existing frontend tests in this repo use `jest.clearAllMocks()` in `beforeEach`. Unless you specifically need to reset mock implementations, consider switching to `clearAllMocks()` to match local convention (or explain why a full reset is required here).","user":{"login":"Copilot","name":"Copilot","email":null,"avatar_url":"https://avatars.githubusercontent.com/in/946600?v=4","id":175728472},"id":3018915955,"pull_request_review_id":4040741597,"in_reply_to_id":null,"created_at":"2026-03-31T23:10:28Z","review":null,"side":"RIGHT","line":227,"start_line":222,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">The mock reset guidance suggests <code class=\"notranslate\">jest.resetAllMocks()</code>, but existing frontend tests in this repo use <code class=\"notranslate\">jest.clearAllMocks()</code> in <code class=\"notranslate\">beforeEach</code>. Unless you specifically need to reset mock implementations, consider switching to <code class=\"notranslate\">clearAllMocks()</code> to match local convention (or explain why a full reset is required here).</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#pullrequestreview-4040741597","body":"## Pull request overview\n\nAdds a frontend test specification document for `harmony-frontend/src/services/channelService.ts` to guide Jest coverage of the service’s transport paths, public-REST fallback behavior, and adapter validation warnings.\n\n**Changes:**\n- Introduces an English-language test spec covering the 7 exported `channelService` functions and their major program paths.\n- Documents a Jest module-mocking strategy for `trpcQuery`, `trpcMutate`, and `publicGet`, plus console warning/error assertions.\n- Enumerates visibility edge cases and adapter warning/default behaviors to target 80%+ path coverage.\n\n\n\n\n\n---\n\n💡 <a href=\"/acabrera04/Harmony/new/main?filename=.github/instructions/*.instructions.md\" class=\"Link--inTextBlock\" target=\"_blank\" rel=\"noopener noreferrer\">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href=\"https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot\" class=\"Link--inTextBlock\" target=\"_blank\" rel=\"noopener noreferrer\">Learn how to get started</a>.","user":{"login":"copilot-pull-request-reviewer[bot]","name":"copilot-pull-request-reviewer[bot]","email":null,"avatar_url":"https://avatars.githubusercontent.com/in/946600?v=4","id":175728472},"id":4040741597,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:10:28Z","review":"COMMENTED","side":null,"line":null,"start_line":null,"path":null,"body_html":"<h2 dir=\"auto\">Pull request overview</h2>\n<p dir=\"auto\">Adds a frontend test specification document for <code class=\"notranslate\">harmony-frontend/src/services/channelService.ts</code> to guide Jest coverage of the service’s transport paths, public-REST fallback behavior, and adapter validation warnings.</p>\n<p dir=\"auto\"><strong>Changes:</strong></p>\n<ul dir=\"auto\">\n<li>Introduces an English-language test spec covering the 7 exported <code class=\"notranslate\">channelService</code> functions and their major program paths.</li>\n<li>Documents a Jest module-mocking strategy for <code class=\"notranslate\">trpcQuery</code>, <code class=\"notranslate\">trpcMutate</code>, and <code class=\"notranslate\">publicGet</code>, plus console warning/error assertions.</li>\n<li>Enumerates visibility edge cases and adapter warning/default behaviors to target 80%+ path coverage.</li>\n</ul>\n<hr>\n<p dir=\"auto\">💡 <a href=\"/acabrera04/Harmony/new/main?filename=.github/instructions/*.instructions.md\">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href=\"https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot\">Learn how to get started</a>.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018928286","body":"This row says the happy-path test should assert that `trpcMutate` is called with all provided fields, but `createChannel()` does not forward every field from `Omit<Channel, ...>` today. In particular, `description` is part of the input type yet is not sent in the mutation payload in `channelService.ts`. A test written from this spec will fail immediately or push the service toward behavior it does not currently implement.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":3018928286,"pull_request_review_id":4040759622,"in_reply_to_id":null,"created_at":"2026-03-31T23:15:07Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">This row says the happy-path test should assert that <code class=\"notranslate\">trpcMutate</code> is called with all provided fields, but <code class=\"notranslate\">createChannel()</code> does not forward every field from <code class=\"notranslate\">Omit&lt;Channel, ...&gt;</code> today. In particular, <code class=\"notranslate\">description</code> is part of the input type yet is not sent in the mutation payload in <code class=\"notranslate\">channelService.ts</code>. A test written from this spec will fail immediately or push the service toward behavior it does not currently implement.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018928288","body":"The spec says it covers all program paths and API error handling, but `getChannel` still has an uncaught failure mode before either fallback branch runs: the initial `publicGet('/servers/:slug')` call can reject and that rejection bubbles to the caller because it sits outside both `try` blocks in `channelService.ts`. This section only covers the `null` result, the public-channel-list throw, and the tRPC throw, so a real transport error path is left undocumented and untested.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":3018928288,"pull_request_review_id":4040759622,"in_reply_to_id":null,"created_at":"2026-03-31T23:15:07Z","review":null,"side":"RIGHT","line":46,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">The spec says it covers all program paths and API error handling, but <code class=\"notranslate\">getChannel</code> still has an uncaught failure mode before either fallback branch runs: the initial <code class=\"notranslate\">publicGet('/servers/:slug')</code> call can reject and that rejection bubbles to the caller because it sits outside both <code class=\"notranslate\">try</code> blocks in <code class=\"notranslate\">channelService.ts</code>. This section only covers the <code class=\"notranslate\">null</code> result, the public-channel-list throw, and the tRPC throw, so a real transport error path is left undocumented and untested.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018928290","body":"The spec later says both non-string and invalid-string `timestamp` values must be tested, which matches `toAuditLogEntry()` falling back for any non-string or unparseable value. But the detailed table only includes invalid-string and missing-timestamp rows. Add an explicit non-string case here so the tabular test plan actually covers the documented branch set.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":3018928290,"pull_request_review_id":4040759622,"in_reply_to_id":null,"created_at":"2026-03-31T23:15:07Z","review":null,"side":"RIGHT","line":185,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">The spec later says both non-string and invalid-string <code class=\"notranslate\">timestamp</code> values must be tested, which matches <code class=\"notranslate\">toAuditLogEntry()</code> falling back for any non-string or unparseable value. But the detailed table only includes invalid-string and missing-timestamp rows. Add an explicit non-string case here so the tabular test plan actually covers the documented branch set.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#pullrequestreview-4040759622","body":"- [ ] Prioritize Logic over Style: the spec misses a real `getChannel` error path and one `createChannel` expectation conflicts with the service code.\n- [x] Security First: docs-only change; no new auth, input-validation, or secret-handling surface.\n- [x] Architectural Alignment: no backend architecture divergence is introduced by this documentation-only PR.\n- [ ] Issue Completion: `#261` asks for API error handling and all program paths; the current spec still leaves at least one reachable branch undocumented.\n- [x] No Nitpicking: findings are about behavioral/spec accuracy, not wording or formatting.\n- [x] Avoid Repetition: there are no existing review comments on this PR to duplicate.\n- [x] Iterative Reviews: first pass on this PR from me, so there was nothing prior to re-check or resolve.\n- [x] Prevent CI Failures: no immediate pipeline breakage in product code; the risk here is incorrect downstream test implementation, not current CI.\n\n1. In the `createChannel` table, the happy-path expectation says the mutation should be called with all provided fields. That does not match `channelService.ts`, which does not forward `description`. A test written from this spec will fail immediately or push the implementation toward behavior it does not currently have.\n\n2. In `getChannel`, the spec says it covers all program paths and API error handling, but it omits the initial server lookup rejection case. The first `publicGet('/servers/:slug')` call sits outside both `try` blocks in `channelService.ts`, so a rejection there bubbles to the caller instead of returning `null`.\n\n3. In the audit-log table, the detailed cases cover invalid-string and missing timestamps but not non-string timestamps. `toAuditLogEntry()` uses the same fallback branch for any non-string value, and section 5 already says both non-string and invalid-string cases must be tested, so the table should include that explicit row.","user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"id":4040759622,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:15:07Z","review":"CHANGES_REQUESTED","side":null,"line":null,"start_line":null,"path":null,"body_html":"<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Incomplete task\"> Prioritize Logic over Style: the spec misses a real <code class=\"notranslate\">getChannel</code> error path and one <code class=\"notranslate\">createChannel</code> expectation conflicts with the service code.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Security First: docs-only change; no new auth, input-validation, or secret-handling surface.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Architectural Alignment: no backend architecture divergence is introduced by this documentation-only PR.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Incomplete task\"> Issue Completion: <code class=\"notranslate\">#261</code> asks for API error handling and all program paths; the current spec still leaves at least one reachable branch undocumented.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> No Nitpicking: findings are about behavioral/spec accuracy, not wording or formatting.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Avoid Repetition: there are no existing review comments on this PR to duplicate.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Iterative Reviews: first pass on this PR from me, so there was nothing prior to re-check or resolve.</li>\n<li class=\"task-list-item\"><input type=\"checkbox\" id=\"\" disabled=\"\" class=\"task-list-item-checkbox\" aria-label=\"Completed task\" checked=\"\"> Prevent CI Failures: no immediate pipeline breakage in product code; the risk here is incorrect downstream test implementation, not current CI.</li>\n</ul>\n<ol dir=\"auto\">\n<li>\n<p dir=\"auto\">In the <code class=\"notranslate\">createChannel</code> table, the happy-path expectation says the mutation should be called with all provided fields. That does not match <code class=\"notranslate\">channelService.ts</code>, which does not forward <code class=\"notranslate\">description</code>. A test written from this spec will fail immediately or push the implementation toward behavior it does not currently have.</p>\n</li>\n<li>\n<p dir=\"auto\">In <code class=\"notranslate\">getChannel</code>, the spec says it covers all program paths and API error handling, but it omits the initial server lookup rejection case. The first <code class=\"notranslate\">publicGet('/servers/:slug')</code> call sits outside both <code class=\"notranslate\">try</code> blocks in <code class=\"notranslate\">channelService.ts</code>, so a rejection there bubbles to the caller instead of returning <code class=\"notranslate\">null</code>.</p>\n</li>\n<li>\n<p dir=\"auto\">In the audit-log table, the detailed cases cover invalid-string and missing timestamps but not non-string timestamps. <code class=\"notranslate\">toAuditLogEntry()</code> uses the same fallback branch for any non-string value, and section 5 already says both non-string and invalid-string cases must be tested, so the table should include that explicit row.</p>\n</li>\n</ol>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018983417","body":"Fixed in 2b172b6. Updated the happy-path row to list only the fields actually forwarded by the service (serverId, name, slug, type, visibility, topic, position); description is explicitly called out as not forwarded. Also updated the optional-fields-absent row to match.","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":3018983417,"pull_request_review_id":4040834386,"in_reply_to_id":3018928286,"created_at":"2026-03-31T23:35:32Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">Fixed in <a class=\"commit-link\" data-hovercard-type=\"commit\" data-hovercard-url=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6/hovercard\" href=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6\"><tt>2b172b6</tt></a>. Updated the happy-path row to list only the fields actually forwarded by the service (serverId, name, slug, type, visibility, topic, position); description is explicitly called out as not forwarded. Also updated the optional-fields-absent row to match.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#pullrequestreview-4040834386","body":"","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":4040834386,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:35:32Z","review":"COMMENTED","side":null,"line":null,"start_line":null,"path":null,"body_html":""},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018983660","body":"Fixed in 2b172b6. Added the missing server-lookup rejection path to both Section 3.2 (program paths) and Section 4.2 (test table) to cover the case where the initial publicGet('/servers/:slug') call rejects outside both try blocks and propagates to the caller.","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":3018983660,"pull_request_review_id":4040834834,"in_reply_to_id":3018928288,"created_at":"2026-03-31T23:35:39Z","review":null,"side":"RIGHT","line":46,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">Fixed in <a class=\"commit-link\" data-hovercard-type=\"commit\" data-hovercard-url=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6/hovercard\" href=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6\"><tt>2b172b6</tt></a>. Added the missing server-lookup rejection path to both Section 3.2 (program paths) and Section 4.2 (test table) to cover the case where the initial publicGet('/servers/:slug') call rejects outside both try blocks and propagates to the caller.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#pullrequestreview-4040834834","body":"","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":4040834834,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:35:40Z","review":"COMMENTED","side":null,"line":null,"start_line":null,"path":null,"body_html":""},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018984331","body":"Fixed in 2b172b6. Added an explicit non-string timestamp row (e.g. timestamp = 42) to the getAuditLog test table, covering all three fallback cases: non-string, invalid-string, and missing.","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":3018984331,"pull_request_review_id":4040835590,"in_reply_to_id":3018928290,"created_at":"2026-03-31T23:35:55Z","review":null,"side":"RIGHT","line":185,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">Fixed in <a class=\"commit-link\" data-hovercard-type=\"commit\" data-hovercard-url=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6/hovercard\" href=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6\"><tt>2b172b6</tt></a>. Added an explicit non-string timestamp row (e.g. timestamp = 42) to the getAuditLog test table, covering all three fallback cases: non-string, invalid-string, and missing.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#pullrequestreview-4040835590","body":"","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":4040835590,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:35:55Z","review":"COMMENTED","side":null,"line":null,"start_line":null,"path":null,"body_html":""},{"url":"https://github.com/acabrera04/Harmony/pull/276#issuecomment-4166364837","body":"> Re: comment 4040759622\n\nFixed in 2b172b6. All three findings addressed: (1) createChannel happy-path expectation now lists only the fields actually forwarded by the service; (2) getChannel server-lookup rejection path added to both program paths and test table; (3) non-string timestamp case added to getAuditLog table.","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":4166364837,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:36:02Z","review":null,"side":null,"line":null,"start_line":null,"path":null,"body_html":"<blockquote>\n<p dir=\"auto\">Re: comment 4040759622</p>\n</blockquote>\n<p dir=\"auto\">Fixed in <a class=\"commit-link\" data-hovercard-type=\"commit\" data-hovercard-url=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6/hovercard\" href=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6\"><tt>2b172b6</tt></a>. All three findings addressed: (1) createChannel happy-path expectation now lists only the fields actually forwarded by the service; (2) getChannel server-lookup rejection path added to both program paths and test table; (3) non-string timestamp case added to getAuditLog table.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018984890","body":"Fixed in 2b172b6. Replaced the broad 'Emit warn for missing required string fields' row with 'Warn only on missing/non-string core fields', explicitly listing the 4 guarded fields (id, channelId, actorId, action) and noting that oldValue, newValue, ipAddress, and userAgent do not trigger warnings.","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":3018984890,"pull_request_review_id":4040836269,"in_reply_to_id":3018915905,"created_at":"2026-03-31T23:36:08Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">Fixed in <a class=\"commit-link\" data-hovercard-type=\"commit\" data-hovercard-url=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6/hovercard\" href=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6\"><tt>2b172b6</tt></a>. Replaced the broad 'Emit warn for missing required string fields' row with 'Warn only on missing/non-string core fields', explicitly listing the 4 guarded fields (id, channelId, actorId, action) and noting that oldValue, newValue, ipAddress, and userAgent do not trigger warnings.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#pullrequestreview-4040836269","body":"","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":4040836269,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:36:08Z","review":"COMMENTED","side":null,"line":null,"start_line":null,"path":null,"body_html":""},{"url":"https://github.com/acabrera04/Harmony/pull/276#discussion_r3018985244","body":"Fixed in 2b172b6. Updated the optional-fields-absent row: removed the reference to 'description omitted' and replaced it with 'description is accepted in the input type but not forwarded to the mutation', making it clear description is silently ignored.","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":3018985244,"pull_request_review_id":4040836641,"in_reply_to_id":3018915923,"created_at":"2026-03-31T23:36:15Z","review":null,"side":"RIGHT","line":null,"start_line":null,"path":"docs/test-specs/frontend-channel-service-spec.md","body_html":"<p dir=\"auto\">Fixed in <a class=\"commit-link\" data-hovercard-type=\"commit\" data-hovercard-url=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6/hovercard\" href=\"https://github.com/acabrera04/Harmony/commit/2b172b6dc898fbc1bcc35bd714a5bbd077e05de6\"><tt>2b172b6</tt></a>. Updated the optional-fields-absent row: removed the reference to 'description omitted' and replaced it with 'description is accepted in the input type but not forwarded to the mutation', making it clear description is silently ignored.</p>"},{"url":"https://github.com/acabrera04/Harmony/pull/276#pullrequestreview-4040836641","body":"","user":{"login":"AvanishKulkarni","name":"AvanishKulkarni","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/55012494?v=4","id":55012494},"id":4040836641,"pull_request_review_id":null,"in_reply_to_id":null,"created_at":"2026-03-31T23:36:15Z","review":"COMMENTED","side":null,"line":null,"start_line":null,"path":null,"body_html":""}],"url":"https://github.com/acabrera04/Harmony/pull/276","title":"acabrera04/Harmony PR #276 comments","display_url":"https://github.com/acabrera04/Harmony/pull/276","display_title":"acabrera04/Harmony PR #276 comments"}
+````
+
+#### Tool: mcp__codex_apps__github_fetch_pr_patch
+
+```json
+{
+  "pr_number": 276,
+  "repo_full_name": "acabrera04/Harmony"
+}
+```
+
+Output:
+
+````text
+{"patches":[{"filename":"docs/test-specs/frontend-channel-service-spec.md","patch":"@@ -0,0 +1,242 @@\n+# Channel Service Test Specification (Frontend)\n+\n+## 1. Overview\n+\n+This document defines the English-language test specification for `harmony-frontend/src/services/channelService.ts`.\n+It covers all seven exported service functions:\n+\n+- `getChannels`\n+- `getChannel`\n+- `updateVisibility`\n+- `updateChannel`\n+- `createChannel`\n+- `getAuditLog`\n+- `deleteChannel`\n+\n+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.\n+\n+## 2. Shared Test Setup and Assumptions\n+\n+- Mock `trpcQuery` and `trpcMutate` from `@/lib/trpc-client` using Jest module mocking.\n+- Mock `publicGet` from `@/lib/trpc-client` for tests that exercise the public REST path.\n+- Reset all mocks between tests to ensure isolation.\n+- Use `console.warn` spies to assert that `toFrontendChannel` and `toAuditLogEntry` emit validation warnings for malformed API responses.\n+- The `getChannel` export is wrapped in React's `cache()`. Tests should call the function directly and mock the underlying transport layer rather than the cache wrapper.\n+- All resolved mock payloads must conform to the `Record<string, unknown>` shapes expected by the adapter functions; omit or corrupt individual fields to exercise validation warnings.\n+- `ChannelVisibility` enum values under test: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.\n+\n+## 3. Function Purposes and Program Paths\n+\n+### 3.1 `getChannels`\n+\n+Purpose: fetch all channels for a server (including PRIVATE channels) via the authenticated tRPC `channel.getChannels` endpoint.\n+\n+Program paths:\n+\n+- `trpcQuery` resolves with a non-empty array; each raw record is adapted and returned.\n+- `trpcQuery` resolves with `null` or `undefined`; the function returns `[]`.\n+- `trpcQuery` rejects; the error propagates to the caller uncaught.\n+\n+### 3.2 `getChannel`\n+\n+Purpose: return a single channel by server slug and channel slug, or `null` if not found. Tries the public REST endpoint first to support unauthenticated guest views, then falls back to authenticated tRPC.\n+\n+Program paths:\n+\n+- `publicGet` for the server resolves with `null`; function returns `null` immediately.\n+- `publicGet` for the server rejects; the rejection propagates uncaught to the caller (this call sits outside both `try` blocks).\n+- Server resolves; public channel list resolves and contains a matching slug; channel is returned with `visibility` hardcoded to `PUBLIC_INDEXABLE`.\n+- Server resolves; public channel list resolves with `null`; falls through to tRPC fallback.\n+- Server resolves; public channel list resolves but contains no matching slug; falls through to tRPC fallback.\n+- Server resolves; public channel list `publicGet` call throws; falls through to tRPC fallback.\n+- tRPC fallback resolves with channel data; channel is returned.\n+- tRPC fallback resolves with `null`/falsy; function returns `null`.\n+- tRPC fallback rejects; function catches the error, logs it, and returns `null`.\n+\n+### 3.3 `updateVisibility`\n+\n+Purpose: update a channel's visibility via the authenticated tRPC `channel.setVisibility` mutation. Returns `void`.\n+\n+Program paths:\n+\n+- `trpcMutate` resolves; function returns `void`.\n+- `trpcMutate` rejects; error propagates to the caller.\n+\n+### 3.4 `updateChannel`\n+\n+Purpose: update a channel's `name` and/or `topic` metadata via tRPC. Only defined patch keys are forwarded.\n+\n+Program paths:\n+\n+- Patch includes both `name` and `topic`; both are forwarded and the adapted result is returned.\n+- Patch includes only `name` (no `topic`); only `name` is forwarded.\n+- Patch includes only `topic` (no `name`); only `topic` is forwarded.\n+- Patch is empty (`{}`); neither key is forwarded; adapted result is still returned.\n+- `trpcMutate` rejects; error propagates to the caller.\n+\n+### 3.5 `createChannel`\n+\n+Purpose: create a new channel via tRPC `channel.createChannel` and return the adapted `Channel`.\n+\n+Program paths:\n+\n+- All required fields are provided; `trpcMutate` resolves; adapted channel is returned.\n+- `trpcMutate` rejects; error propagates to the caller.\n+\n+### 3.6 `getAuditLog`\n+\n+Purpose: fetch a paginated visibility audit log for a channel via tRPC `channel.getAuditLog`.\n+\n+Program paths:\n+\n+- `trpcQuery` resolves with a populated `entries` array and `total`; each entry is adapted and returned.\n+- `trpcQuery` resolves with an empty `entries` array; returns `{ entries: [], total: 0 }`.\n+- Options are partially provided (`limit` only, `offset` only, or `startDate` only); present keys are forwarded.\n+- Options are omitted entirely; query is called with only `serverId` and `channelId`.\n+- An entry has an invalid or missing `timestamp`; `toAuditLogEntry` falls back to epoch ISO string and emits a `console.warn`.\n+- `trpcQuery` rejects; error propagates to the caller.\n+\n+### 3.7 `deleteChannel`\n+\n+Purpose: delete a channel via tRPC and return `true` on success.\n+\n+Program paths:\n+\n+- `trpcMutate` resolves; function returns `true`.\n+- `trpcMutate` rejects; error propagates to the caller.\n+\n+## 4. Detailed Test Cases\n+\n+### 4.1 `getChannels`\n+\n+Description: fetches the full channel list for a server, adapting each record from the raw backend shape.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Return adapted channels for a server | `serverId = \"s1\"`; `trpcQuery` resolves with two valid raw channel records | Returns an array of two `Channel` objects with all fields correctly mapped |\n+| Return empty array when API returns null | `serverId = \"s1\"`; `trpcQuery` resolves with `null` | Returns `[]` |\n+| Return empty array when API returns undefined | `serverId = \"s1\"`; `trpcQuery` resolves with `undefined` | Returns `[]` |\n+| Propagate rejection to caller | `serverId = \"s1\"`; `trpcQuery` rejects with a network error | The promise rejects with the same error; caller receives it without masking |\n+\n+### 4.2 `getChannel`\n+\n+Description: fetches a single channel by slug pair, attempting the public REST endpoint before falling back to authenticated tRPC.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Return null when server lookup fails | `serverSlug = \"my-server\"`; `publicGet` for server resolves with `null` | Returns `null`; no further network calls are made |\n+| Propagate rejection when server lookup rejects | `serverSlug = \"my-server\"`; `publicGet` for server rejects with a network error | Promise rejects with the same error; rejection is not caught |\n+| Return channel from public endpoint on slug match | Server resolves; public channel list contains a record with matching `channelSlug` | Returns `Channel` with `visibility = PUBLIC_INDEXABLE`; `serverId` filled from server lookup |\n+| Supplement missing public fields with defaults | Public channel record omits `position` and `createdAt` | Returned channel has `position = 0` and `createdAt` equal to epoch ISO string |\n+| Fall through to tRPC when public channel list returns null | Server resolves; `publicGet` for channels resolves with `null`; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; does not log an error |\n+| Fall through to tRPC when slug not in public list | Server resolves; public channel list has no matching slug; tRPC resolves with channel data | Returns the tRPC-adapted `Channel` |\n+| Fall through to tRPC when public endpoint throws | Server resolves; public channels `publicGet` throws; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; thrown error is swallowed silently |\n+| Return null when tRPC resolves with falsy value | Server resolves; public endpoint miss; tRPC resolves with `null` | Returns `null` |\n+| Return null when tRPC rejects | Server resolves; public endpoint miss; tRPC rejects | Returns `null`; logs error via `console.error` |\n+| Correctly set visibility to PUBLIC_INDEXABLE for public hit | Server resolves; public list match with any `visibility` value in raw record | Returned channel always has `visibility = PUBLIC_INDEXABLE` regardless of raw field |\n+\n+### 4.3 `updateVisibility`\n+\n+Description: sends a visibility mutation to the backend with no return value.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Successfully set visibility to PUBLIC_INDEXABLE | `channelId = \"c1\"`, `visibility = PUBLIC_INDEXABLE`, `serverId = \"s1\"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with `{ serverId, channelId, visibility }` |\n+| Successfully set visibility to PUBLIC_NO_INDEX | `channelId = \"c1\"`, `visibility = PUBLIC_NO_INDEX`, `serverId = \"s1\"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |\n+| Successfully set visibility to PRIVATE | `channelId = \"c1\"`, `visibility = PRIVATE`, `serverId = \"s1\"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |\n+| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 403 error | Promise rejects with the same error |\n+\n+### 4.4 `updateChannel`\n+\n+Description: sends partial channel metadata updates, forwarding only the keys that are explicitly set.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Update both name and topic | `patch = { name: \"general\", topic: \"chat\" }`; `trpcMutate` resolves with a full channel record | Returns adapted `Channel`; mutation called with `name` and `topic` |\n+| Update name only | `patch = { name: \"general\" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `topic` key |\n+| Update topic only | `patch = { topic: \"new topic\" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `name` key |\n+| Empty patch sends no extra keys | `patch = {}`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called with only `serverId` and `channelId` |\n+| Propagate rejection to caller | Valid patch; `trpcMutate` rejects | Promise rejects with the underlying error |\n+\n+### 4.5 `createChannel`\n+\n+Description: creates a new channel and returns the backend-confirmed record.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Create channel with all fields | Full `Channel` object minus `id`, `createdAt`, `updatedAt`; `trpcMutate` resolves with full record | Returns adapted `Channel`; mutation called with `serverId`, `name`, `slug`, `type`, `visibility`, `topic`, and `position`; `description` is not forwarded |\n+| Create channel with optional fields absent | `topic` omitted; `description` is accepted in the input type but not forwarded to the mutation; `trpcMutate` resolves | Returns adapted `Channel`; `topic` passed as `undefined` in mutation args; `description` not present in mutation payload |\n+| Create channel with each visibility value | `visibility = PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, or `PRIVATE`; `trpcMutate` resolves | Returns adapted `Channel` with the correct `visibility` field |\n+| Propagate rejection to caller | Valid input; `trpcMutate` rejects | Promise rejects with the underlying error |\n+\n+### 4.6 `getAuditLog`\n+\n+Description: fetches a paginated audit log, adapting each entry and validating field types.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Return entries and total from API | `serverId`, `channelId`; `trpcQuery` resolves with two valid entries and `total = 2` | Returns `{ entries: [AuditLogEntry, AuditLogEntry], total: 2 }` |\n+| Return empty list | `serverId`, `channelId`; `trpcQuery` resolves with `{ entries: [], total: 0 }` | Returns `{ entries: [], total: 0 }` |\n+| Forward limit option | `options = { limit: 10 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, limit: 10 }` |\n+| Forward offset option | `options = { offset: 5 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, offset: 5 }` |\n+| Forward startDate option | `options = { startDate: \"2026-01-01T00:00:00.000Z\" }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, startDate: \"2026-01-01T00:00:00.000Z\" }` |\n+| Omit options when none provided | `options` not passed; `trpcQuery` resolves | `trpcQuery` called with only `serverId` and `channelId` |\n+| Fall back to epoch string for non-string timestamp | Entry has `timestamp = 42` (a number); `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |\n+| Fall back to epoch string for invalid timestamp | Entry has `timestamp = \"not-a-date\"`; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |\n+| Fall back to epoch string for missing timestamp | Entry has no `timestamp` field; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |\n+| Warn only on missing/non-string core fields | Entry has missing or non-string `id`, `channelId`, `actorId`, or `action`; `trpcQuery` resolves | Each problematic core field emits a `console.warn`; function still returns an entry; no warnings expected for `oldValue`, `newValue`, `ipAddress`, or `userAgent` |\n+| Propagate rejection to caller | Valid args; `trpcQuery` rejects | Promise rejects with the underlying error |\n+\n+### 4.7 `deleteChannel`\n+\n+Description: deletes a channel and signals success via a boolean return value.\n+\n+| Test Purpose | Inputs | Expected Output |\n+| --- | --- | --- |\n+| Return true on successful deletion | `channelId = \"c1\"`, `serverId = \"s1\"`; `trpcMutate` resolves | Returns `true`; `trpcMutate` called with `{ serverId, channelId }` |\n+| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 404 error | Promise rejects with the underlying error; `true` is never returned |\n+\n+## 5. Edge Cases to Explicitly Validate\n+\n+- `getChannels` must not suppress transport errors; callers that use the channel count for position computation depend on the error surfacing to avoid data corruption.\n+- `getChannel` uses `cache()` wrapping; test the inner async function directly by mocking at the transport layer.\n+- The public REST hit in `getChannel` always overrides the raw `visibility` field with `PUBLIC_INDEXABLE`; the test must confirm this even when the raw record contains a different value.\n+- Missing `position` and `createdAt` from public channel records are filled with defaults (`0` and epoch ISO); tests should assert these exact defaults.\n+- `updateChannel` must only forward `name` and `topic` when those keys are explicitly present in `patch`; the absence of a key must not result in the key being sent as `undefined` to the mutation.\n+- `toFrontendChannel` emits `console.warn` when any of its guarded fields (`id`, `serverId`, `slug`, `createdAt`) are missing or non-string; tests should cover at least one warning for each. `toAuditLogEntry` emits `console.warn` when any of its guarded fields (`id`, `channelId`, `actorId`, `action`) are missing or non-string; tests should likewise exercise each warning condition at least once. No warnings are emitted for `oldValue`, `newValue`, `ipAddress`, or `userAgent`.\n+- `toAuditLogEntry` falls back to an epoch ISO timestamp for any non-string or unparseable `timestamp` value; all three cases (non-string, invalid-string, missing) must be tested, and corresponding `console.warn` calls should be asserted.\n+- All three `ChannelVisibility` values (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) must appear in at least one test for `updateVisibility` and `createChannel`.\n+\n+## 6. Mock Strategy\n+\n+All external dependencies are mocked at the module level with `jest.mock`:\n+\n+```\n+jest.mock('@/lib/trpc-client', () => ({\n+  trpcQuery:  jest.fn(),\n+  trpcMutate: jest.fn(),\n+  publicGet:  jest.fn(),\n+}));\n+```\n+\n+Reset all mocks in `beforeEach` with `jest.resetAllMocks()` to prevent cross-test contamination.\n+\n+- **`trpcQuery`** — resolve with well-formed raw objects to test happy paths; reject with an `Error` to test propagation; resolve with `null`/`undefined` to test null-guard branches.\n+- **`trpcMutate`** — resolve to test `updateVisibility`, `updateChannel`, `createChannel`, and `deleteChannel` happy paths; reject to test error propagation in each.\n+- **`publicGet`** — resolve with a server object (containing at minimum `{ id: \"s1\" }`) to simulate a successful server lookup; resolve with `null` to test the early-return path; resolve with a channels payload or throw to test the public channel list branches.\n+- **`console.warn` / `console.error`** — use `jest.spyOn(console, 'warn')` and `jest.spyOn(console, 'error')` in tests that exercise validation warnings; restore spies in `afterEach`.\n+\n+## 7. Coverage Expectation\n+\n+The cases above are intended to cover:\n+\n+- all seven exported functions,\n+- every explicit null-guard and early-return branch,\n+- successful transport call paths and their return value adaption,\n+- all transport rejection paths and their propagation behavior,\n+- public-REST-to-tRPC fallback logic in `getChannel`,\n+- all three `ChannelVisibility` enum values,\n+- field-level validation warnings in `toFrontendChannel` and `toAuditLogEntry`, and\n+- optional field defaults (missing `position`, `createdAt`, `topic`).\n+\n+Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures (e.g., React `cache` internals) outside the service's direct branching logic."}],"url":"https://github.com/acabrera04/Harmony/pull/276","title":"acabrera04/Harmony#276 (patch)","display_url":"https://github.com/acabrera04/Harmony/pull/276","display_title":"acabrera04/Harmony#276 (patch)"}
+````
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/services/channelService.ts | nl -ba
+```
+
+Output:
+
+```text
+     1	/**
+     2	 * Channel Service (M2 — real API implementation)
+     3	 * Replaces mock in-memory store with backend API calls.
+     4	 * References: dev-spec-channel-visibility-toggle.md
+     5	 */
+     6	
+     7	import { cache } from 'react';
+     8	import { ChannelVisibility, type Channel } from '@/types';
+     9	import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+    10	
+    11	/** Maps the backend Prisma Channel shape to the frontend Channel type. */
+    12	function toFrontendChannel(raw: Record<string, unknown>): Channel {
+    13	  if (typeof raw.id !== 'string') console.warn('[toFrontendChannel] missing or non-string "id"');
+    14	  if (typeof raw.serverId !== 'string')
+    15	    console.warn('[toFrontendChannel] missing or non-string "serverId"');
+    16	  if (typeof raw.slug !== 'string')
+    17	    console.warn('[toFrontendChannel] missing or non-string "slug"');
+    18	  if (typeof raw.createdAt !== 'string')
+    19	    console.warn('[toFrontendChannel] missing or non-string "createdAt"');
+    20	  return {
+    21	    id: raw.id as string,
+    22	    serverId: raw.serverId as string,
+    23	    name: raw.name as string,
+    24	    slug: raw.slug as string,
+    25	    type: raw.type as Channel['type'],
+    26	    visibility: raw.visibility as ChannelVisibility,
+    27	    topic: (raw.topic as string | undefined) ?? undefined,
+    28	    position: (raw.position as number) ?? 0,
+    29	    description: raw.description as string | undefined,
+    30	    createdAt: raw.createdAt as string,
+    31	    updatedAt: raw.updatedAt as string | undefined,
+    32	  };
+    33	}
+    34	
+    35	/**
+    36	 * Returns all channels for a given server.
+    37	 * Uses tRPC authed endpoint for full channel list (including PRIVATE channels).
+    38	 * Errors propagate to the caller — callers that use the channel count (e.g.
+    39	 * createChannelAction position computation) must not silently receive [] on a
+    40	 * transient failure, which would corrupt channel ordering.
+    41	 */
+    42	export async function getChannels(serverId: string): Promise<Channel[]> {
+    43	  const data = await trpcQuery<Record<string, unknown>[]>('channel.getChannels', { serverId });
+    44	  return (data ?? []).map(toFrontendChannel);
+    45	}
+    46	
+    47	/**
+    48	 * Returns a single channel by server slug + channel slug, or null if not found.
+    49	 *
+    50	export const getChannel = cache(
+    51	  async (serverSlug: string, channelSlug: string): Promise<Channel | null> => {
+    52	    const serverData = await publicGet<Record<string, unknown>>(
+    53	      `/servers/${encodeURIComponent(serverSlug)}`,
+    54	    );
+    55	    if (!serverData) return null;
+    56	    const serverId = serverData.id as string;
+    57	
+    58	    try {
+    59	      const publicData = await publicGet<{ channels: Record<string, unknown>[] }>(
+    60	        `/servers/${encodeURIComponent(serverSlug)}/channels`,
+    61	      );
+    62	      if (publicData) {
+    63	        const match = publicData.channels.find(c => (c.slug as string) === channelSlug);
+    64	        if (match) {
+    65	          return toFrontendChannel({
+    66	            ...match,
+    67	            serverId,
+    68	            visibility: 'PUBLIC_INDEXABLE',
+    69	            position: (match.position as number | undefined) ?? 0,
+    70	            createdAt: (match.createdAt as string | undefined) ?? new Date(0).toISOString(),
+    71	          });
+    72	        }
+    73	      }
+    74	    } catch {
+    75	    }
+    76	
+    77	    try {
+    78	      const data = await trpcQuery<Record<string, unknown>>('channel.getChannel', {
+    79	        serverId,
+    80	        serverSlug,
+    81	        channelSlug,
+    82	      });
+    83	      if (!data) return null;
+    84	      return toFrontendChannel(data);
+    85	    } catch (error) {
+    86	      console.error(
+    87	        `[channelService.getChannel] API call failed for "${serverSlug}/${channelSlug}":`,
+    88	        error,
+    89	      );
+    90	      return null;
+    91	    }
+    92	  },
+    93	);
+    94	
+    95	/**
+    96	 * Updates the visibility of a channel via tRPC.
+    97	 * Returns the visibility change result (not a full Channel object).
+    98	 */
+    99	export async function updateVisibility(
+   100	  channelId: string,
+   101	  visibility: ChannelVisibility,
+   102	  serverId: string,
+   103	): Promise<void> {
+   104	  await trpcMutate('channel.setVisibility', {
+   105	    serverId,
+   106	    channelId,
+   107	    visibility,
+   108	  });
+   109	}
+   110	
+   111	/**
+   112	 * Updates editable metadata (name, topic) of a channel via tRPC.
+   113	 * Note: `description` is not forwarded — the backend only supports `name`, `topic`, and `position`.
+   114	 */
+   115	export async function updateChannel(
+   116	  channelId: string,
+   117	  serverId: string,
+   118	  patch: Partial<Pick<Channel, 'name' | 'topic'>>,
+   119	): Promise<Channel> {
+   120	  const data = await trpcMutate<Record<string, unknown>>('channel.updateChannel', {
+   121	    serverId,
+   122	    channelId,
+   123	    ...(patch.name !== undefined && { name: patch.name }),
+   124	    ...(patch.topic !== undefined && { topic: patch.topic }),
+   125	  });
+   126	  return toFrontendChannel(data);
+   127	}
+   128	
+   129	/**
+   130	 * Creates a new channel via tRPC.
+   131	 */
+   132	export async function createChannel(
+   133	  channel: Omit<Channel, 'id' | 'createdAt' | 'updatedAt'>,
+   134	): Promise<Channel> {
+   135	  const data = await trpcMutate<Record<string, unknown>>('channel.createChannel', {
+   136	    serverId: channel.serverId,
+   137	    name: channel.name,
+   138	    slug: channel.slug,
+   139	    type: channel.type,
+   140	    visibility: channel.visibility,
+   141	    topic: channel.topic,
+   142	    position: channel.position,
+   143	  });
+   144	  return toFrontendChannel(data);
+   145	}
+   146	
+   147	export interface AuditLogEntry {
+   148	  id: string;
+   149	  channelId: string;
+   150	  actorId: string;
+   151	  action: string;
+   152	  oldValue: Record<string, unknown>;
+   153	  newValue: Record<string, unknown>;
+   154	  timestamp: string;
+   155	  ipAddress: string;
+   156	  userAgent: string;
+   157	}
+   158	
+   159	export interface AuditLogPage {
+   160	  entries: AuditLogEntry[];
+   161	  total: number;
+   162	}
+   163	
+   164	/** Validates an audit log entry from the API, guarding against schema changes. */
+   165	function toAuditLogEntry(raw: Record<string, unknown>): AuditLogEntry {
+   166	  if (typeof raw.id !== 'string') console.warn('[toAuditLogEntry] missing or non-string "id"');
+   167	  if (typeof raw.channelId !== 'string')
+   168	    console.warn('[toAuditLogEntry] missing or non-string "channelId"');
+   169	  if (typeof raw.actorId !== 'string')
+   170	    console.warn('[toAuditLogEntry] missing or non-string "actorId"');
+   171	  if (typeof raw.action !== 'string')
+   172	    console.warn('[toAuditLogEntry] missing or non-string "action"');
+   173	  const ts = raw.timestamp;
+   174	  const validTimestamp =
+   175	    typeof ts === 'string' && !isNaN(new Date(ts).getTime())
+   176	      ? ts
+   177	      : (() => {
+   178	          console.warn('[toAuditLogEntry] missing or invalid "timestamp":', ts);
+   179	          return new Date(0).toISOString();
+   180	        })();
+   181	  return {
+   182	    id: raw.id as string,
+   183	    channelId: raw.channelId as string,
+   184	    actorId: raw.actorId as string,
+   185	    action: raw.action as string,
+   186	    oldValue: raw.oldValue as Record<string, unknown>,
+   187	    newValue: raw.newValue as Record<string, unknown>,
+   188	    timestamp: validTimestamp,
+   189	    ipAddress: raw.ipAddress as string,
+   190	    userAgent: raw.userAgent as string,
+   191	  };
+   192	}
+   193	
+   194	/**
+   195	 * Fetches paginated visibility audit log for a channel via tRPC.
+   196	 */
+   197	export async function getAuditLog(
+   198	  serverId: string,
+   199	  channelId: string,
+   200	  options: { limit?: number; offset?: number; startDate?: string } = {},
+   201	): Promise<AuditLogPage> {
+   202	  const data = await trpcQuery<{ entries: Record<string, unknown>[]; total: number }>(
+   203	    'channel.getAuditLog',
+   204	    { serverId, channelId, ...options },
+   205	  );
+   206	  return { entries: data.entries.map(toAuditLogEntry), total: data.total };
+   207	}
+   208	
+   209	/**
+   210	 * Deletes a channel by ID via tRPC. Returns true if deleted.
+   211	 */
+   212	export async function deleteChannel(channelId: string, serverId: string): Promise<boolean> {
+   213	  await trpcMutate('channel.deleteChannel', { serverId, channelId });
+   214	  return true;
+   215	}
+   216	
+   217	export { ChannelVisibility };
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:36:25.120Z
+
+The prior three findings are fixed in the new head. I’m doing one clean pass over the updated spec itself now to see whether any remaining gaps still matter for issue `#261` before I call it clean.
+
+#### Tool: exec_command
+
+```sh
+rtk git show 2b172b6dc898fbc1bcc35bd714a5bbd077e05de6:docs/test-specs/frontend-channel-service-spec.md | nl -ba
+```
+
+Output:
+
+```text
+fatal: path 'docs/test-specs/frontend-channel-service-spec.md' does not exist in '2b172b6dc898fbc1bcc35bd714a5bbd077e05de6'
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:36:31.162Z
+
+I don’t have the new commit object locally yet, so I’m fetching the PR branch to inspect the exact updated file with stable line numbers.
+
+#### Tool: exec_command
+
+```sh
+rtk git fetch origin codex/issue-261-frontend-channel-service-spec
+```
+
+Output:
+
+```text
+ok fetched (2 new refs)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git show origin/codex/issue-261-frontend-channel-service-spec:docs/test-specs/frontend-channel-service-spec.md | nl -ba
+```
+
+Output:
+
+````text
+     1	# Channel Service Test Specification (Frontend)
+     2	
+     3	## 1. Overview
+     4	
+     5	This document defines the English-language test specification for `harmony-frontend/src/services/channelService.ts`.
+     6	It covers all seven exported service functions:
+     7	
+     8	- `getChannels`
+     9	- `getChannel`
+    10	- `updateVisibility`
+    11	- `updateChannel`
+    12	- `createChannel`
+    13	- `getAuditLog`
+    14	- `deleteChannel`
+    15	
+    16	The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+    17	
+    18	## 2. Shared Test Setup and Assumptions
+    19	
+    20	- Mock `trpcQuery` and `trpcMutate` from `@/lib/trpc-client` using Jest module mocking.
+    21	- Mock `publicGet` from `@/lib/trpc-client` for tests that exercise the public REST path.
+    22	- Reset all mocks between tests to ensure isolation.
+    23	- Use `console.warn` spies to assert that `toFrontendChannel` and `toAuditLogEntry` emit validation warnings for malformed API responses.
+    24	- The `getChannel` export is wrapped in React's `cache()`. Tests should call the function directly and mock the underlying transport layer rather than the cache wrapper.
+    25	- All resolved mock payloads must conform to the `Record<string, unknown>` shapes expected by the adapter functions; omit or corrupt individual fields to exercise validation warnings.
+    26	- `ChannelVisibility` enum values under test: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.
+    27	
+    28	## 3. Function Purposes and Program Paths
+    29	
+    30	### 3.1 `getChannels`
+    31	
+    32	Purpose: fetch all channels for a server (including PRIVATE channels) via the authenticated tRPC `channel.getChannels` endpoint.
+    33	
+    34	Program paths:
+    35	
+    36	- `trpcQuery` resolves with a non-empty array; each raw record is adapted and returned.
+    37	- `trpcQuery` resolves with `null` or `undefined`; the function returns `[]`.
+    38	- `trpcQuery` rejects; the error propagates to the caller uncaught.
+    39	
+    40	### 3.2 `getChannel`
+    41	
+    42	Purpose: return a single channel by server slug and channel slug, or `null` if not found. Tries the public REST endpoint first to support unauthenticated guest views, then falls back to authenticated tRPC.
+    43	
+    44	Program paths:
+    45	
+    46	- `publicGet` for the server resolves with `null`; function returns `null` immediately.
+    47	- `publicGet` for the server rejects; the rejection propagates uncaught to the caller (this call sits outside both `try` blocks).
+    48	- Server resolves; public channel list resolves and contains a matching slug; channel is returned with `visibility` hardcoded to `PUBLIC_INDEXABLE`.
+    49	- Server resolves; public channel list resolves with `null`; falls through to tRPC fallback.
+    50	- Server resolves; public channel list resolves but contains no matching slug; falls through to tRPC fallback.
+    51	- Server resolves; public channel list `publicGet` call throws; falls through to tRPC fallback.
+    52	- tRPC fallback resolves with channel data; channel is returned.
+    53	- tRPC fallback resolves with `null`/falsy; function returns `null`.
+    54	- tRPC fallback rejects; function catches the error, logs it, and returns `null`.
+    55	
+    56	### 3.3 `updateVisibility`
+    57	
+    58	Purpose: update a channel's visibility via the authenticated tRPC `channel.setVisibility` mutation. Returns `void`.
+    59	
+    60	Program paths:
+    61	
+    62	- `trpcMutate` resolves; function returns `void`.
+    63	- `trpcMutate` rejects; error propagates to the caller.
+    64	
+    65	### 3.4 `updateChannel`
+    66	
+    67	Purpose: update a channel's `name` and/or `topic` metadata via tRPC. Only defined patch keys are forwarded.
+    68	
+    69	Program paths:
+    70	
+    71	- Patch includes both `name` and `topic`; both are forwarded and the adapted result is returned.
+    72	- Patch includes only `name` (no `topic`); only `name` is forwarded.
+    73	- Patch includes only `topic` (no `name`); only `topic` is forwarded.
+    74	- Patch is empty (`{}`); neither key is forwarded; adapted result is still returned.
+    75	- `trpcMutate` rejects; error propagates to the caller.
+    76	
+    77	### 3.5 `createChannel`
+    78	
+    79	Purpose: create a new channel via tRPC `channel.createChannel` and return the adapted `Channel`.
+    80	
+    81	Program paths:
+    82	
+    83	- All required fields are provided; `trpcMutate` resolves; adapted channel is returned.
+    84	- `trpcMutate` rejects; error propagates to the caller.
+    85	
+    86	### 3.6 `getAuditLog`
+    87	
+    88	Purpose: fetch a paginated visibility audit log for a channel via tRPC `channel.getAuditLog`.
+    89	
+    90	Program paths:
+    91	
+    92	- `trpcQuery` resolves with a populated `entries` array and `total`; each entry is adapted and returned.
+    93	- `trpcQuery` resolves with an empty `entries` array; returns `{ entries: [], total: 0 }`.
+    94	- Options are partially provided (`limit` only, `offset` only, or `startDate` only); present keys are forwarded.
+    95	- Options are omitted entirely; query is called with only `serverId` and `channelId`.
+    96	- An entry has an invalid or missing `timestamp`; `toAuditLogEntry` falls back to epoch ISO string and emits a `console.warn`.
+    97	- `trpcQuery` rejects; error propagates to the caller.
+    98	
+    99	### 3.7 `deleteChannel`
+   100	
+   101	Purpose: delete a channel via tRPC and return `true` on success.
+   102	
+   103	Program paths:
+   104	
+   105	- `trpcMutate` resolves; function returns `true`.
+   106	- `trpcMutate` rejects; error propagates to the caller.
+   107	
+   108	## 4. Detailed Test Cases
+   109	
+   110	### 4.1 `getChannels`
+   111	
+   112	Description: fetches the full channel list for a server, adapting each record from the raw backend shape.
+   113	
+   114	| Test Purpose | Inputs | Expected Output |
+   115	| --- | --- | --- |
+   116	| Return adapted channels for a server | `serverId = "s1"`; `trpcQuery` resolves with two valid raw channel records | Returns an array of two `Channel` objects with all fields correctly mapped |
+   117	| Return empty array when API returns null | `serverId = "s1"`; `trpcQuery` resolves with `null` | Returns `[]` |
+   118	| Return empty array when API returns undefined | `serverId = "s1"`; `trpcQuery` resolves with `undefined` | Returns `[]` |
+   119	| Propagate rejection to caller | `serverId = "s1"`; `trpcQuery` rejects with a network error | The promise rejects with the same error; caller receives it without masking |
+   120	
+   121	### 4.2 `getChannel`
+   122	
+   123	Description: fetches a single channel by slug pair, attempting the public REST endpoint before falling back to authenticated tRPC.
+   124	
+   125	| Test Purpose | Inputs | Expected Output |
+   126	| --- | --- | --- |
+   127	| Return null when server lookup fails | `serverSlug = "my-server"`; `publicGet` for server resolves with `null` | Returns `null`; no further network calls are made |
+   128	| Propagate rejection when server lookup rejects | `serverSlug = "my-server"`; `publicGet` for server rejects with a network error | Promise rejects with the same error; rejection is not caught |
+   129	| Return channel from public endpoint on slug match | Server resolves; public channel list contains a record with matching `channelSlug` | Returns `Channel` with `visibility = PUBLIC_INDEXABLE`; `serverId` filled from server lookup |
+   130	| Supplement missing public fields with defaults | Public channel record omits `position` and `createdAt` | Returned channel has `position = 0` and `createdAt` equal to epoch ISO string |
+   131	| Fall through to tRPC when public channel list returns null | Server resolves; `publicGet` for channels resolves with `null`; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; does not log an error |
+   132	| Fall through to tRPC when slug not in public list | Server resolves; public channel list has no matching slug; tRPC resolves with channel data | Returns the tRPC-adapted `Channel` |
+   133	| Fall through to tRPC when public endpoint throws | Server resolves; public channels `publicGet` throws; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; thrown error is swallowed silently |
+   134	| Return null when tRPC resolves with falsy value | Server resolves; public endpoint miss; tRPC resolves with `null` | Returns `null` |
+   135	| Return null when tRPC rejects | Server resolves; public endpoint miss; tRPC rejects | Returns `null`; logs error via `console.error` |
+   136	| Correctly set visibility to PUBLIC_INDEXABLE for public hit | Server resolves; public list match with any `visibility` value in raw record | Returned channel always has `visibility = PUBLIC_INDEXABLE` regardless of raw field |
+   137	
+   138	### 4.3 `updateVisibility`
+   139	
+   140	Description: sends a visibility mutation to the backend with no return value.
+   141	
+   142	| Test Purpose | Inputs | Expected Output |
+   143	| --- | --- | --- |
+   144	| Successfully set visibility to PUBLIC_INDEXABLE | `channelId = "c1"`, `visibility = PUBLIC_INDEXABLE`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with `{ serverId, channelId, visibility }` |
+   145	| Successfully set visibility to PUBLIC_NO_INDEX | `channelId = "c1"`, `visibility = PUBLIC_NO_INDEX`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |
+   146	| Successfully set visibility to PRIVATE | `channelId = "c1"`, `visibility = PRIVATE`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |
+   147	| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 403 error | Promise rejects with the same error |
+   148	
+   149	### 4.4 `updateChannel`
+   150	
+   151	Description: sends partial channel metadata updates, forwarding only the keys that are explicitly set.
+   152	
+   153	| Test Purpose | Inputs | Expected Output |
+   154	| --- | --- | --- |
+   155	| Update both name and topic | `patch = { name: "general", topic: "chat" }`; `trpcMutate` resolves with a full channel record | Returns adapted `Channel`; mutation called with `name` and `topic` |
+   156	| Update name only | `patch = { name: "general" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `topic` key |
+   157	| Update topic only | `patch = { topic: "new topic" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `name` key |
+   158	| Empty patch sends no extra keys | `patch = {}`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called with only `serverId` and `channelId` |
+   159	| Propagate rejection to caller | Valid patch; `trpcMutate` rejects | Promise rejects with the underlying error |
+   160	
+   161	### 4.5 `createChannel`
+   162	
+   163	Description: creates a new channel and returns the backend-confirmed record.
+   164	
+   165	| Test Purpose | Inputs | Expected Output |
+   166	| --- | --- | --- |
+   167	| Create channel with all fields | Full `Channel` object minus `id`, `createdAt`, `updatedAt`; `trpcMutate` resolves with full record | Returns adapted `Channel`; mutation called with `serverId`, `name`, `slug`, `type`, `visibility`, `topic`, and `position`; `description` is not forwarded |
+   168	| Create channel with optional fields absent | `topic` omitted; `description` is accepted in the input type but not forwarded to the mutation; `trpcMutate` resolves | Returns adapted `Channel`; `topic` passed as `undefined` in mutation args; `description` not present in mutation payload |
+   169	| Create channel with each visibility value | `visibility = PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, or `PRIVATE`; `trpcMutate` resolves | Returns adapted `Channel` with the correct `visibility` field |
+   170	| Propagate rejection to caller | Valid input; `trpcMutate` rejects | Promise rejects with the underlying error |
+   171	
+   172	### 4.6 `getAuditLog`
+   173	
+   174	Description: fetches a paginated audit log, adapting each entry and validating field types.
+   175	
+   176	| Test Purpose | Inputs | Expected Output |
+   177	| --- | --- | --- |
+   178	| Return entries and total from API | `serverId`, `channelId`; `trpcQuery` resolves with two valid entries and `total = 2` | Returns `{ entries: [AuditLogEntry, AuditLogEntry], total: 2 }` |
+   179	| Return empty list | `serverId`, `channelId`; `trpcQuery` resolves with `{ entries: [], total: 0 }` | Returns `{ entries: [], total: 0 }` |
+   180	| Forward limit option | `options = { limit: 10 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, limit: 10 }` |
+   181	| Forward offset option | `options = { offset: 5 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, offset: 5 }` |
+   182	| Forward startDate option | `options = { startDate: "2026-01-01T00:00:00.000Z" }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, startDate: "2026-01-01T00:00:00.000Z" }` |
+   183	| Omit options when none provided | `options` not passed; `trpcQuery` resolves | `trpcQuery` called with only `serverId` and `channelId` |
+   184	| Fall back to epoch string for non-string timestamp | Entry has `timestamp = 42` (a number); `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
+   185	| Fall back to epoch string for invalid timestamp | Entry has `timestamp = "not-a-date"`; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
+   186	| Fall back to epoch string for missing timestamp | Entry has no `timestamp` field; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
+   187	| Warn only on missing/non-string core fields | Entry has missing or non-string `id`, `channelId`, `actorId`, or `action`; `trpcQuery` resolves | Each problematic core field emits a `console.warn`; function still returns an entry; no warnings expected for `oldValue`, `newValue`, `ipAddress`, or `userAgent` |
+   188	| Propagate rejection to caller | Valid args; `trpcQuery` rejects | Promise rejects with the underlying error |
+   189	
+   190	### 4.7 `deleteChannel`
+   191	
+   192	Description: deletes a channel and signals success via a boolean return value.
+   193	
+   194	| Test Purpose | Inputs | Expected Output |
+   195	| --- | --- | --- |
+   196	| Return true on successful deletion | `channelId = "c1"`, `serverId = "s1"`; `trpcMutate` resolves | Returns `true`; `trpcMutate` called with `{ serverId, channelId }` |
+   197	| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 404 error | Promise rejects with the underlying error; `true` is never returned |
+   198	
+   199	## 5. Edge Cases to Explicitly Validate
+   200	
+   201	- `getChannels` must not suppress transport errors; callers that use the channel count for position computation depend on the error surfacing to avoid data corruption.
+   202	- `getChannel` uses `cache()` wrapping; test the inner async function directly by mocking at the transport layer.
+   203	- The public REST hit in `getChannel` always overrides the raw `visibility` field with `PUBLIC_INDEXABLE`; the test must confirm this even when the raw record contains a different value.
+   204	- Missing `position` and `createdAt` from public channel records are filled with defaults (`0` and epoch ISO); tests should assert these exact defaults.
+   205	- `updateChannel` must only forward `name` and `topic` when those keys are explicitly present in `patch`; the absence of a key must not result in the key being sent as `undefined` to the mutation.
+   206	- `toFrontendChannel` emits `console.warn` when any of its guarded fields (`id`, `serverId`, `slug`, `createdAt`) are missing or non-string; tests should cover at least one warning for each. `toAuditLogEntry` emits `console.warn` when any of its guarded fields (`id`, `channelId`, `actorId`, `action`) are missing or non-string; tests should likewise exercise each warning condition at least once. No warnings are emitted for `oldValue`, `newValue`, `ipAddress`, or `userAgent`.
+   207	- `toAuditLogEntry` falls back to an epoch ISO timestamp for any non-string or unparseable `timestamp` value; all three cases (non-string, invalid-string, missing) must be tested, and corresponding `console.warn` calls should be asserted.
+   208	- All three `ChannelVisibility` values (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) must appear in at least one test for `updateVisibility` and `createChannel`.
+   209	
+   210	## 6. Mock Strategy
+   211	
+   212	All external dependencies are mocked at the module level with `jest.mock`:
+   213	
+   214	```
+   215	jest.mock('@/lib/trpc-client', () => ({
+   216	  trpcQuery:  jest.fn(),
+   217	  trpcMutate: jest.fn(),
+   218	  publicGet:  jest.fn(),
+   219	}));
+   220	```
+   221	
+   222	Reset all mocks in `beforeEach` with `jest.resetAllMocks()` to prevent cross-test contamination.
+   223	
+   224	- **`trpcQuery`** — resolve with well-formed raw objects to test happy paths; reject with an `Error` to test propagation; resolve with `null`/`undefined` to test null-guard branches.
+   225	- **`trpcMutate`** — resolve to test `updateVisibility`, `updateChannel`, `createChannel`, and `deleteChannel` happy paths; reject to test error propagation in each.
+   226	- **`publicGet`** — resolve with a server object (containing at minimum `{ id: "s1" }`) to simulate a successful server lookup; resolve with `null` to test the early-return path; resolve with a channels payload or throw to test the public channel list branches.
+   227	- **`console.warn` / `console.error`** — use `jest.spyOn(console, 'warn')` and `jest.spyOn(console, 'error')` in tests that exercise validation warnings; restore spies in `afterEach`.
+   228	
+   229	## 7. Coverage Expectation
+   230	
+   231	The cases above are intended to cover:
+   232	
+   233	- all seven exported functions,
+   234	- every explicit null-guard and early-return branch,
+   235	- successful transport call paths and their return value adaption,
+   236	- all transport rejection paths and their propagation behavior,
+   237	- public-REST-to-tRPC fallback logic in `getChannel`,
+   238	- all three `ChannelVisibility` enum values,
+   239	- field-level validation warnings in `toFrontendChannel` and `toAuditLogEntry`, and
+   240	- optional field defaults (missing `position`, `createdAt`, `topic`).
+   241	
+   242	Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures (e.g., React `cache` internals) outside the service's direct branching logic.
+````
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:36:51.726Z
+
+No findings on the updated diff.
+
+The three blocking issues from the prior review are addressed in the current head `2b172b6`: the `createChannel` expectations now match the implementation, the uncaught server-lookup rejection path is documented for `getChannel`, and the audit-log table now includes the non-string timestamp fallback case. I also don’t see any new regressions in [docs/test-specs/frontend-channel-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/frontend-channel-service-spec.md) relative to [harmony-frontend/src/services/channelService.ts](/Users/allen/repos/Harmony/harmony-frontend/src/services/channelService.ts).
+
+Residual risk is low and limited to this being a docs-only PR, so the remaining gap is just that the spec itself is not executable verification. If you want, I can post a follow-up approval/“looks good now” review on the PR.
+
+### Turn 4: Yes do that, then use the codex logs export skill to export the logs of
+
+#### 👤 User Prompt
+
+- Time: 2026-03-31T23:37:28.372Z
+
+```text
+Yes do that, then use the codex logs export skill to export the logs of this chat 019d4628-b19f-7992-bfef-a6a018df474e to llm-logs/acabrera04-logs/acabrera04-tests/ in the same branch as the PR and push that
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:37:40.600Z
+
+Posting an approval on PR `#276`, then I’ll export this thread’s logs into the repo on the PR branch, verify the new file, commit it, and push. I’m loading the log-export skill first so I follow the repo’s expected workflow for conversation exports.
+
+#### Tool: exec_command
+
+```sh
+rtk read /Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md
+```
+
+Output:
+
+````text
+---
+name: codex-conversation-exporter
+description: Export Codex session logs to Markdown using the local codex-export CLI instead of reconstructing transcripts with model tokens.
+---
+
+# Codex Conversation Exporter
+
+Use this skill when the user asks to export Codex logs, save a Codex conversation, convert a session to Markdown, or archive a transcript locally.
+
+## Rules
+
+- Prefer the local `codex-export` CLI over reconstructing a transcript in-model.
+- If the user has not identified a session, run `codex-export list` first and show the relevant candidates.
+- Default to messages plus tool activity.
+- Include hidden system/developer prompts only when the user explicitly asks for them.
+- Write to a user-visible path unless the user asks for stdout or another destination.
+- Report the output path back to the user after a file export.
+
+## Command patterns
+
+List recent sessions:
+
+```bash
+codex-export list
+codex-export list --limit 10
+codex-export list --since 2026-03-30
+```
+
+Export by thread id:
+
+```bash
+codex-export export <thread-id>
+codex-export export <thread-id> --out ~/Desktop
+codex-export export <thread-id> --messages-only
+codex-export export <thread-id> --all
+codex-export export <thread-id> --include-hidden-prompts
+codex-export export <thread-id> --stdout
+```
+
+Export by rollout path:
+
+```bash
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl --out ~/Desktop
+```
+
+## Flag guide
+
+- `--out <file-or-dir>` writes to a specific file or directory.
+- `--stdout` prints the Markdown instead of writing a file.
+- `--messages-only` omits tool calls and tool outputs.
+- `--all` includes low-level tool metadata and raw wrappers that are hidden by default.
+- `--include-hidden-prompts` includes developer/system prompt layers.
+- `--since <date>` filters `list` results.
+- `--limit <n>` caps `list` results.
+
+## Agent behavior
+
+When the user says "export this conversation" without a thread id:
+
+1. Run `codex-export list`.
+2. Identify the most likely current session from title, cwd, and recency.
+3. Export it with the default mode unless the user requested a different output.
+4. Return the exact file path written.
+
+`codex-log-export` remains available as a compatibility alias.
+````
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short --branch
+```
+
+Output:
+
+```text
+## main...origin/main [behind 6]
+?? "P4: Backend Development | CS 485 AI-Assisted Software Engineering (Sp26).html"
+?? "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf"
+?? load-test.js
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git branch --show-current
+```
+
+Output:
+
+```text
+* 
+  main
+```
+
+#### Tool: update_plan
+
+- Explanation: Approving the updated PR, then exporting this Codex thread into the repo on the PR branch and pushing that addition without disturbing unrelated local files.
+
+- Plan:
+  - [in_progress] Post an approval review on PR #276 after confirming prior findings are fixed
+  - [pending] Check out the PR branch locally and export thread 019d4628-b19f-7992-bfef-a6a018df474e into llm-logs/acabrera04-logs/acabrera04-tests/
+  - [pending] Review the exported file, commit only the new log artifact, and push the branch
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: mcp__codex_apps__github_add_review_to_pr
+
+```json
+{
+  "action": "APPROVE",
+  "commit_id": "2b172b6dc898fbc1bcc35bd714a5bbd077e05de6",
+  "pr_number": 276,
+  "repo_full_name": "acabrera04/Harmony",
+  "review": "- [x] Prioritize Logic over Style: the earlier spec/implementation mismatches are corrected in the current head.\n- [x] Security First: docs-only change; no new auth, input-validation, or secret-handling surface.\n- [x] Architectural Alignment: the spec remains aligned with the current frontend service behavior.\n- [x] Issue Completion: the updated document now covers the previously missing `getChannel` rejection path and the audit-log timestamp fallback cases needed for `#261`.\n- [x] No Nitpicking: no remaining issues worth flagging.\n- [x] Avoid Repetition: prior concerns were addressed, and I am not repeating already-resolved feedback.\n- [x] Iterative Reviews: re-reviewed the new commit and confirmed the earlier findings are fixed.\n- [x] Prevent CI Failures: no product-code or docs issues remain that would obviously cause downstream test-spec drift.\n\nNo findings on the updated diff. The previously requested changes are addressed in `2b172b6`."
+}
+```
+
+Output:
+
+```text
+[{"type":"text","text":"Error code: INVALID_ARGUMENTError: Parameters failed connector schema validation: file_comments [required]: Missing required property (does not match constraints configured by your ChatGPT workspace admin. If the issue persists, instruct the user to contact their workspace admin.); file_comments [required]: Missing required property (does not match constraints configured by your ChatGPT workspace admin. If the issue persists, instruct the user to contact their workspace admin.)"}]
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:37:57.861Z
+
+The approval endpoint here requires an explicit `file_comments` field even when there are no inline comments. I’m retrying with an empty list.
+
+#### Tool: mcp__codex_apps__github_add_review_to_pr
+
+```json
+{
+  "action": "APPROVE",
+  "commit_id": "2b172b6dc898fbc1bcc35bd714a5bbd077e05de6",
+  "pr_number": 276,
+  "repo_full_name": "acabrera04/Harmony",
+  "review": "- [x] Prioritize Logic over Style: the earlier spec/implementation mismatches are corrected in the current head.\n- [x] Security First: docs-only change; no new auth, input-validation, or secret-handling surface.\n- [x] Architectural Alignment: the spec remains aligned with the current frontend service behavior.\n- [x] Issue Completion: the updated document now covers the previously missing `getChannel` rejection path and the audit-log timestamp fallback cases needed for `#261`.\n- [x] No Nitpicking: no remaining issues worth flagging.\n- [x] Avoid Repetition: prior concerns were addressed, and I am not repeating already-resolved feedback.\n- [x] Iterative Reviews: re-reviewed the new commit and confirmed the earlier findings are fixed.\n- [x] Prevent CI Failures: no product-code or docs issues remain that would obviously cause downstream test-spec drift.\n\nNo findings on the updated diff. The previously requested changes are addressed in `2b172b6`.",
+  "file_comments": []
+}
+```
+
+Output:
+
+```text
+{"success":true,"review_id":4040842534}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:38:15.308Z
+
+The PR is approved. I’m switching the worktree to the PR branch now, exporting thread `019d4628-b19f-7992-bfef-a6a018df474e` into the requested `llm-logs/...` folder, then I’ll stage only that new artifact and push it back to the same branch.
+
+#### Tool: exec_command
+
+```sh
+rtk git branch --list --all '*codex/issue-261-frontend-channel-service-spec*'
+```
+
+Output:
+
+```text
+* 
+  remote-only (1):
+    codex/issue-261-frontend-channel-service-spec
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git show --stat --oneline origin/codex/issue-261-frontend-channel-service-spec -1
+```
+
+Output:
+
+```text
+2b172b6 fix: address PR review findings on channel service spec
+ docs/test-specs/frontend-channel-service-spec.md | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git switch -c codex/issue-261-frontend-channel-service-spec --track origin/codex/issue-261-frontend-channel-service-spec
+```
+
+Output:
+
+```text
+Switched to a new branch 'codex/issue-261-frontend-channel-service-spec'
+branch 'codex/issue-261-frontend-channel-service-spec' set up to track 'origin/codex/issue-261-frontend-channel-service-spec'.
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-03-31T23:38:21.020Z
+
+Branch is set to `codex/issue-261-frontend-channel-service-spec`. Next step is the log export itself and a quick inspection of the generated file before I commit it.
+
+#### Tool: exec_command
+
+```sh
+mkdir -p llm-logs/acabrera04-logs/acabrera04-tests && codex-export export 019d4628-b19f-7992-bfef-a6a018df474e --out llm-logs/acabrera04-logs/acabrera04-tests
+```

--- a/llm-logs/backend/03-31-pr276.md
+++ b/llm-logs/backend/03-31-pr276.md
@@ -1,0 +1,424 @@
+ ▐▛███▜▌   Claude Code v2.1.87
+▝▜█████▛▘  Sonnet 4.6 · Claude Pro
+  ▘▘ ▝▝    ~/Documents/GitHub/Harmony
+
+❯ Complete https://github.com/acabrera04/Harmony/issues/261 in a new brnahc     
+
+⏺ Agent(Fetch GitHub issue 261)
+  ⎿  Done (1 tool use · 10.8k tokens · 7s)
+  (ctrl+o to expand)
+
+⏺ Now let me read the source file and check existing specs for formatting
+  reference.
+
+  Searched for 2 patterns, read 2 files (ctrl+o to expand)
+
+⏺ Let me check the ChannelVisibility type for the enum values.
+
+  Searched for 1 pattern, read 1 file (ctrl+o to expand)
+
+⏺ Now I have everything I need. Let me create the branch and write the spec.
+
+⏺ Bash(git checkout -b codex/issue-261-frontend-channel-service-spec)
+  ⎿  Switched to a new branch 'codex/issue-261-frontend-channel-service-spe
+     c'
+
+⏺ Bash(gh issue comment 261 --repo acabrera04/Harmony --body "**[AI Agent —
+      Starting]**…)
+  ⎿  https://github.com/acabrera04/Harmony/issues/261#issuecomment-41661226
+     66
+
+⏺ Write(docs/test-specs/frontend-channel-service-spec.md)
+  ⎿  Wrote 237 lines to docs/test-specs/frontend-channel-service-spec.md
+       1 # Channel Service Test Specification (Frontend)
+       2 
+       3 ## 1. Overview
+       4 
+       5 This document defines the English-language test specification fo
+         r `harmony-frontend/src/services/channelService.ts`.
+       6 It covers all seven exported service functions:
+       7 
+       8 - `getChannels`
+       9 - `getChannel`
+      10 - `updateVisibility`
+     … +227 lines (ctrl+o to expand)
+
+⏺ Bash(git add docs/test-specs/frontend-channel-service-spec.md && git commit -m
+       "$(cat <<'EOF'
+      docs: add frontend channel service test specification…)
+  ⎿  [codex/issue-261-frontend-channel-service-spec 7c62ee1] docs: add fron
+     tend channel service test specification
+      1 file changed, 237 insertions(+)
+      create mode 100644 docs/test-specs/frontend-channel-service-spec.md
+
+⏺ Bash(git push -u origin codex/issue-261-frontend-channel-service-spec)
+  ⎿  remote:
+     remote: Create a pull request for 'codex/issue-261-frontend-channel-se
+     rvice-spec' on GitHub by visiting:
+     … +8 lines (ctrl+o to expand)
+
+⏺ Bash(gh pr create --repo acabrera04/Harmony --title "docs: frontend channel
+      service test specification (#261)" --body "$(cat <<'EOF'
+      ## Summary…)
+  ⎿  Warning: 1 uncommitted change
+     https://github.com/acabrera04/Harmony/pull/276
+
+⏺ Bash(gh issue comment 261 --repo acabrera04/Harmony --body "**[AI Agent —
+      Complete]**…)
+  ⎿  https://github.com/acabrera04/Harmony/issues/261#issuecomment-41662171
+     93
+
+⏺ PR is open: https://github.com/acabrera04/Harmony/pull/276
+
+  Branch: codex/issue-261-frontend-channel-service-spec
+  Output: docs/test-specs/frontend-channel-service-spec.md
+
+  The spec covers:
+  - All 7 functions with purpose + every program path
+  - Test tables for happy paths, rejection propagation, and edge cases
+  - All 3 ChannelVisibility values (PUBLIC_INDEXABLE, PUBLIC_NO_INDEX, PRIVATE)
+  in updateVisibility and createChannel
+  - getChannel's public REST hit → slug miss → tRPC fallback → tRPC rejection
+  chain
+  - Adapter validation warnings (toFrontendChannel, toAuditLogEntry) including
+  the timestamp fallback
+  - Full mock strategy for trpcQuery, trpcMutate, and publicGet with
+  jest.resetAllMocks() isolation
+
+✻ Cooked for 2m 19s
+
+! git fetch                                                                     
+  ⎿  From https://github.com/acabrera04/Harmony
+      * [new branch]      test/issue-259-server-service-spec ->
+     origin/test/issue-259-server-service-spec
+
+❯ /resolve-reviews                                                              
+
+⏺ Bash(npx agent-reviews --unanswered --expanded 2>&1)
+  ⎿  Found 10 comments
+
+     === Comment [3018928286] ===
+     … +426 lines (ctrl+o to expand)
+
+  Read 1 file (ctrl+o to expand)
+
+⏺ Now I have a complete picture of all 10 comments. Here's my evaluation:
+
+  Human (acabrera04) — all ACTIONABLE:
+  1. [3018928286] createChannel "all provided fields" conflicts with service
+  code (description isn't forwarded)
+  2. [3018928288] getChannel missing server-lookup rejection path (outside both
+  try blocks)
+  3. [3018928290] getAuditLog table missing non-string timestamp case
+  4. [4040759622] Review summary of the above three
+
+  Copilot — TRUE POSITIVE:
+  5. [3018915905] Audit log "Emit warn" row too broad; only
+  id/channelId/actorId/action trigger warns
+  6. [3018915923] createChannel "optional fields absent" row still references
+  description as if it could be forwarded
+  7. [3018915940] getChannel missing publicGet(channels) → null case (distinct
+  from "no slug match")
+  8. [3018915889] Section 5 says toFrontendChannel warns for every missing field
+   — inaccurate; should list only the 4 guarded fields
+
+  Copilot — FALSE POSITIVE:
+  9. [3018915955] Suggests clearAllMocks() over resetAllMocks() — resetAllMocks
+  is intentional here to reset implementations between tests that need different
+   publicGet behaviors
+  10. [3018915879] Claims "double pipe table" rendering issue — the spec uses
+  correct single-pipe Markdown; bot is hallucinating this
+
+  Now applying all  ⎿  Interrupted · What should Claude do instead?
+
+❯ Address them and resolve the actual comments as you do                        
+
+  Read 1 file (ctrl+o to expand)
+
+⏺ Now I have everything I need. Making all fixes:
+
+⏺ Update(docs/test-specs/frontend-channel-service-spec.md)
+  ⎿  Added 2 lines
+      44  Program paths:
+      45  
+      46  - `publicGet` for the server resolves with `null`; function ret
+          urns `null` immediately.
+      47 +- `publicGet` for the server rejects; the rejection propagates 
+         +uncaught to the caller (this call sits outside both `try` block
+         +s).                                                            
+      48  - Server resolves; public channel list resolves and contains a 
+          matching slug; channel is returned with `visibility` hardcoded 
+          to `PUBLIC_INDEXABLE`.
+      49 +- Server resolves; public channel list resolves with `null`; fa
+         +lls through to tRPC fallback.                                  
+      50  - Server resolves; public channel list resolves but contains no
+           matching slug; falls through to tRPC fallback.
+      51  - Server resolves; public channel list `publicGet` call throws;
+           falls through to tRPC fallback.
+      52  - tRPC fallback resolves with channel data; channel is returned
+          .
+
+⏺ Update(docs/test-specs/frontend-channel-service-spec.md)
+  ⎿  Added 2 lines
+      125  | Test Purpose | Inputs | Expected Output |
+      126  | --- | --- | --- |
+      127  | Return null when server lookup fails | `serverSlug = "my-ser
+           ver"`; `publicGet` for server resolves with `null` | Returns `
+           null`; no further network calls are made |
+      128 +| Propagate rejection when server lookup rejects | `serverSlug
+          + = "my-server"`; `publicGet` for server rejects with a network
+          + error | Promise rejects with the same error; rejection is not
+          + caught |                                                     
+      129  | Return channel from public endpoint on slug match | Server r
+           esolves; public channel list contains a record with matching `
+           channelSlug` | Returns `Channel` with `visibility = PUBLIC_IND
+           EXABLE`; `serverId` filled from server lookup |
+      130  | Supplement missing public fields with defaults | Public chan
+           nel record omits `position` and `createdAt` | Returned channel
+            has `position = 0` and `createdAt` equal to epoch ISO string 
+           |
+      131 +| Fall through to tRPC when public channel list returns null |
+          + Server resolves; `publicGet` for channels resolves with `null
+          +`; tRPC resolves with channel data | Returns the tRPC-adapted 
+          +`Channel`; does not log an error |                            
+      132  | Fall through to tRPC when slug not in public list | Server r
+           esolves; public channel list has no matching slug; tRPC resolv
+           es with channel data | Returns the tRPC-adapted `Channel` |
+      133  | Fall through to tRPC when public endpoint throws | Server re
+           solves; public channels `publicGet` throws; tRPC resolves with
+            channel data | Returns the tRPC-adapted `Channel`; thrown err
+           or is swallowed silently |
+      134  | Return null when tRPC resolves with falsy value | Server res
+           olves; public endpoint miss; tRPC resolves with `null` | Retur
+           ns `null` |
+
+⏺ Update(docs/test-specs/frontend-channel-service-spec.md)
+  ⎿  Added 2 lines, removed 2 lines
+      164  
+      165  | Test Purpose | Inputs | Expected Output |
+      166  | --- | --- | --- |
+      167 -| Create channel with all fields | Full `Channel` object minus
+          - `id`, `createdAt`, `updatedAt`; `trpcMutate` resolves with fu
+          -ll record | Returns adapted `Channel`; mutation called with al
+          -l provided fields |                                           
+      168 -| Create channel with optional fields absent | `topic` and `de
+          -scription` omitted; `trpcMutate` resolves | Returns adapted `C
+          -hannel`; `topic` passed as `undefined` in mutation args |     
+      167 +| Create channel with all fields | Full `Channel` object minus
+          + `id`, `createdAt`, `updatedAt`; `trpcMutate` resolves with fu
+          +ll record | Returns adapted `Channel`; mutation called with `s
+          +erverId`, `name`, `slug`, `type`, `visibility`, `topic`, and `
+          +position`; `description` is not forwarded |                   
+      168 +| Create channel with optional fields absent | `topic` omitted
+          +; `description` is accepted in the input type but not forwarde
+          +d to the mutation; `trpcMutate` resolves | Returns adapted `Ch
+          +annel`; `topic` passed as `undefined` in mutation args; `descr
+          +iption` not present in mutation payload |                     
+      169  | Create channel with each visibility value | `visibility = PU
+           BLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, or `PRIVATE`; `trpcMutate`
+            resolves | Returns adapted `Channel` with the correct `visibi
+           lity` field |
+      170  | Propagate rejection to caller | Valid input; `trpcMutate` re
+           jects | Promise rejects with the underlying error |
+      171  
+
+⏺ Update(docs/test-specs/frontend-channel-service-spec.md)
+  ⎿  Added 2 lines, removed 1 line
+      181  | Forward offset option | `options = { offset: 5 }`; `trpcQuer
+           y` resolves | `trpcQuery` called with `{ serverId, channelId, 
+           offset: 5 }` |
+      182  | Forward startDate option | `options = { startDate: "2026-01-
+           01T00:00:00.000Z" }`; `trpcQuery` resolves | `trpcQuery` calle
+           d with `{ serverId, channelId, startDate: "2026-01-01T00:00:00
+           .000Z" }` |
+      183  | Omit options when none provided | `options` not passed; `trp
+           cQuery` resolves | `trpcQuery` called with only `serverId` and
+            `channelId` |
+      184 +| Fall back to epoch string for non-string timestamp | Entry h
+          +as `timestamp = 42` (a number); `trpcQuery` resolves | `AuditL
+          +ogEntry.timestamp` equals epoch ISO; `console.warn` emitted | 
+      185  | Fall back to epoch string for invalid timestamp | Entry has 
+           `timestamp = "not-a-date"`; `trpcQuery` resolves | `AuditLogEn
+           try.timestamp` equals epoch ISO; `console.warn` emitted |
+      186  | Fall back to epoch string for missing timestamp | Entry has 
+           no `timestamp` field; `trpcQuery` resolves | `AuditLogEntry.ti
+           mestamp` equals epoch ISO; `console.warn` emitted |
+      186 -| Emit warn for missing required string fields | Entry missing
+          - `id`, `channelId`, `actorId`, or `action`; `trpcQuery` resolv
+          -es | Each missing field emits a `console.warn`; function still
+          - returns an entry |                                           
+      187 +| Warn only on missing/non-string core fields | Entry has miss
+          +ing or non-string `id`, `channelId`, `actorId`, or `action`; `
+          +trpcQuery` resolves | Each problematic core field emits a `con
+          +sole.warn`; function still returns an entry; no warnings expec
+          +ted for `oldValue`, `newValue`, `ipAddress`, or `userAgent` | 
+      188  | Propagate rejection to caller | Valid args; `trpcQuery` reje
+           cts | Promise rejects with the underlying error |
+      189  
+      190  ### 4.7 `deleteChannel`
+
+⏺ Update(docs/test-specs/frontend-channel-service-spec.md)
+  ⎿  Added 2 lines, removed 2 lines
+      203  - The public REST hit in `getChannel` always overrides the raw
+            `visibility` field with `PUBLIC_INDEXABLE`; the test must con
+           firm this even when the raw record contains a different value.
+      204  - Missing `position` and `createdAt` from public channel recor
+           ds are filled with defaults (`0` and epoch ISO); tests should 
+           assert these exact defaults.
+      205  - `updateChannel` must only forward `name` and `topic` when th
+           ose keys are explicitly present in `patch`; the absence of a k
+           ey must not result in the key being sent as `undefined` to the
+            mutation.
+      206 -- `toFrontendChannel` and `toAuditLogEntry` emit `console.warn
+          -` for every missing required field; each warning path should b
+          -e exercised at least once.                                    
+      207 -- `toAuditLogEntry` falls back to an epoch ISO timestamp for a
+          -ny non-string or unparseable `timestamp` value; both non-strin
+          -g and invalid-string cases must be tested.                    
+      206 +- `toFrontendChannel` emits `console.warn` when any of its gua
+          +rded fields (`id`, `serverId`, `slug`, `createdAt`) are missin
+          +g or non-string; tests should cover at least one warning for e
+          +ach. `toAuditLogEntry` emits `console.warn` when any of its gu
+          +arded fields (`id`, `channelId`, `actorId`, `action`) are miss
+          +ing or non-string; tests should likewise exercise each warning
+          + condition at least once. No warnings are emitted for `oldValu
+          +e`, `newValue`, `ipAddress`, or `userAgent`.                  
+      207 +- `toAuditLogEntry` falls back to an epoch ISO timestamp for a
+          +ny non-string or unparseable `timestamp` value; all three case
+          +s (non-string, invalid-string, missing) must be tested, and co
+          +rresponding `console.warn` calls should be asserted.          
+      208  - All three `ChannelVisibility` values (`PUBLIC_INDEXABLE`, `P
+           UBLIC_NO_INDEX`, `PRIVATE`) must appear in at least one test f
+           or `updateVisibility` and `createChannel`.
+      209  
+      210  ## 6. Mock Strategy
+
+⏺ Update(docs/test-specs/frontend-channel-service-spec.md)
+  ⎿  Added 1 line, removed 1 line
+      237  - public-REST-to-tRPC fallback logic in `getChannel`,
+      238  - all three `ChannelVisibility` enum values,
+      239  - field-level validation warnings in `toFrontendChannel` and `
+           toAuditLogEntry`, and
+      240 -- optional field defaults (missing `position`, `createdAt`, `t
+          -opic`, `description`).                                        
+      240 +- optional field defaults (missing `position`, `createdAt`, `t
+          +opic`).                                                       
+      241  
+      242  Executing this specification should yield at least 80% coverag
+           e of the service's reachable execution paths, with the remaini
+           ng uncovered paths limited to low-level infrastructure failure
+           s (e.g., React `cache` internals) outside the service's direct
+            branching logic.
+
+⏺ Bash(git add docs/test-specs/frontend-channel-service-spec.md && git commit -m
+       "$(cat <<'EOF'
+      fix: address PR review findings on channel service spec…)
+  ⎿  [codex/issue-261-frontend-channel-service-spec 2b172b6] fix: address P
+     R review findings on channel service spec
+      1 file changed, 11 insertions(+), 6 deletions(-)
+
+⏺ Bash(git push)
+  ⎿  To https://github.com/acabrera04/Harmony.git
+        7c62ee1..2b172b6  codex/issue-261-frontend-channel-service-spec ->
+     codex/issue-261-frontend-channel-service-spec
+
+⏺ Now reply to all comments:
+
+⏺ Bash(npx agent-reviews --reply 3018928286 "Fixed in 2b172b6. Updated the
+      happy-path row to list only the fields actually forwarded by the service
+      (serverId, name, sl…)
+  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#discussion_r301898341
+     7
+     ✓ Thread resolved
+
+⏺ Bash(npx agent-reviews --reply 3018928288 "Fixed in 2b172b6. Added the missing
+       server-lookup rejection path to both Section 3.2 (program paths) and
+      Section 4.2 (test…)
+  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#discussion_r301898366
+     0
+     ✓ Thread resolved
+
+⏺ Bash(npx agent-reviews --reply 3018928290 "Fixed in 2b172b6. Added an explicit
+       non-string timestamp row (e.g. timestamp = 42) to the getAuditLog test
+      table, covering…)
+  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#discussion_r301898433
+     1
+     ✓ Thread resolved
+
+⏺ Bash(npx agent-reviews --reply 4040759622 "Fixed in 2b172b6. All three
+      findings addressed: (1) createChannel happy-path expectation now lists
+      only the fields actuall…)
+  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#issuecomment-41663648
+     37
+     Thread resolution skipped (not a review comment thread)
+
+⏺ Bash(npx agent-reviews --reply 3018915905 "Fixed in 2b172b6. Replaced the
+      broad 'Emit warn for missing required string fields' row with 'Warn only
+      on missing/non-str…)
+  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#discussion_r301898489
+     0
+     ✓ Thread resolved
+
+⏺ Bash(npx agent-reviews --reply 3018915923 "Fixed in 2b172b6. Updated the
+      optional-fields-absent row: removed the reference to 'description omitted'
+       and replaced it w…)
+  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#discussion_r301898524
+     4
+     ✓ Thread resolved
+
+⏺ Bash(npx agent-reviews --reply 3018915940 "Fixed in 2b172b6. Added an explicit
+       'Fall through to tRPC when public channel list returns null' test case to
+       Section 4.2,…)
+  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#discussion_r301898561
+     9
+     ✓ Thread resolved
+
+⏺ Bash(npx agent-reviews --reply 3018915889 "Fixed in 2b172b6. Updated Section 5
+       to name the specific guarded fields for each adapter: toFrontendChannel
+      warns on id/se…)
+  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#discussion_r301898593
+     8
+     ✓ Thread resolved
+
+⏺ Bash(npx agent-reviews --reply 3018915955 "Won't fix: jest.resetAllMocks() is
+      intentional here. getChannel tests need publicGet to return a server
+      object on the firs…)  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#discussion_r301898633
+     3
+     ✓ Thread resolved
+
+⏺ Bash(npx agent-reviews --reply 3018915879 "Won't fix: the tables already use
+      single leading pipes (e.g. '| Test Purpose | Inputs | Expected Output |').
+       The rendered…)
+  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#discussion_r301898661
+     2
+     ✓ Thread resolved
+
+⏺ Now starting Phase 2 — watch for new comments:
+
+⏺ Bash(npx agent-reviews --watch 2>&1)
+  ⎿  === PR Comments Watch Mode ===
+     PR #276: https://github.com/acabrera04/Harmony/pull/276
+     Polling every 30s, exit after 600s of inactivity
+     … +70 lines (ctrl+o to expand)
+  ⎿  (timeout 11m)
+
+⏺ PR got approved. Reply to the approval review, then watch once more:
+
+⏺ Bash(npx agent-reviews --reply 4040842534 "Thanks for the thorough re-review.
+      All findings are addressed in 2b172b6." 2>&1)
+  ⎿  ✓ Reply posted successfully
+       https://github.com/acabrera04/Harmony/pull/276#issuecomment-41663770
+     02
+
+⏺ Bash(npx agent-reviews --watch 2>&1)
+  ⎿  Interrupted · What should Claude do instead?


### PR DESCRIPTION
## Summary

- Adds `docs/test-specs/frontend-channel-service-spec.md` for `harmony-frontend/src/services/channelService.ts`
- Covers all 7 exported functions: `getChannels`, `getChannel`, `updateVisibility`, `updateChannel`, `createChannel`, `getAuditLog`, `deleteChannel`
- Includes mock strategy for `trpcQuery`, `trpcMutate`, and `publicGet`
- Documents all three `ChannelVisibility` enum edge cases (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`)
- Covers public REST → tRPC fallback paths in `getChannel`, validation warning branches in adapters, and optional field defaults

## Test plan

- [ ] All 7 functions listed with purpose and program paths
- [ ] Happy path covered for each function
- [ ] Error/rejection propagation covered for each function
- [ ] Visibility enum edge cases documented and tested in `updateVisibility` and `createChannel`
- [ ] Public REST hit vs. fallback vs. server-not-found paths covered for `getChannel`
- [ ] `toAuditLogEntry` timestamp fallback and missing-field warnings covered
- [ ] Mock strategy documented with reset pattern

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)