### PR TITLE
[codex] Enable repo-root Jest workflow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "jest.virtualFolders": [
+    {
+      "name": "backend",
+      "rootPath": "harmony-backend",
+      "jestCommandLine": "npm test --"
+    },
+    {
+      "name": "frontend",
+      "rootPath": "harmony-frontend",
+      "jestCommandLine": "npm test --",
+      "useJest30": true
+    }
+  ]
+}

--- a/harmony-backend/tests/tsconfig.json
+++ b/harmony-backend/tests/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.test.json",
+  "include": ["./**/*.ts", "../src/**/*.ts"],
+  "exclude": ["../node_modules", "../dist"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "harmony",
+  "private": true,
+  "scripts": {
+    "test": "node ./scripts/run-root-jest.cjs",
+    "jest": "node ./scripts/run-root-jest.cjs",
+    "test:backend": "npm --prefix harmony-backend test --",
+    "test:frontend": "npm --prefix harmony-frontend test --"
+  }
+}

--- a/scripts/run-root-jest.cjs
+++ b/scripts/run-root-jest.cjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const repoRoot = path.resolve(__dirname, "..");
+// The repo currently has separate backend/frontend Jest installs on different majors,
+// so the root runner delegates to each package's local CLI instead of sharing one config.
+const projects = [
+  { name: "backend", dir: "harmony-backend" },
+  { name: "frontend", dir: "harmony-frontend" },
+];
+const rawArgs = process.argv.slice(2);
+
+function matchProjectPath(arg) {
+  if (arg.startsWith("-")) {
+    return null;
+  }
+
+  const absolutePath = path.isAbsolute(arg)
+    ? path.normalize(arg)
+    : path.resolve(repoRoot, arg);
+
+  if (!fs.existsSync(absolutePath)) {
+    return null;
+  }
+
+  for (const project of projects) {
+    const projectRoot = path.resolve(repoRoot, project.dir);
+
+    if (
+      absolutePath === projectRoot ||
+      absolutePath.startsWith(`${projectRoot}${path.sep}`)
+    ) {
+      return {
+        projectName: project.name,
+        relativePath: path.relative(projectRoot, absolutePath) || ".",
+      };
+    }
+  }
+
+  return null;
+}
+
+const matchedProjectNames = new Set();
+
+for (const arg of rawArgs) {
+  const match = matchProjectPath(arg);
+  if (match) {
+    matchedProjectNames.add(match.projectName);
+  }
+}
+
+const selectedProjects =
+  matchedProjectNames.size > 0
+    ? projects.filter((project) => matchedProjectNames.has(project.name))
+    : projects;
+
+const projectArgs = new Map(
+  selectedProjects.map((project) => [project.name, []]),
+);
+
+for (const arg of rawArgs) {
+  const match = matchProjectPath(arg);
+
+  if (match && projectArgs.has(match.projectName)) {
+    projectArgs.get(match.projectName).push(match.relativePath);
+    continue;
+  }
+
+  for (const project of selectedProjects) {
+    projectArgs.get(project.name).push(arg);
+  }
+}
+
+let exitCode = 0;
+
+for (const project of selectedProjects) {
+  const projectRoot = path.resolve(repoRoot, project.dir);
+  const args = projectArgs.get(project.name);
+
+  if (selectedProjects.length > 1) {
+    console.log(`\n[${project.name}] running jest in ${project.dir}`);
+  }
+
+  const result = spawnSync("npm", ["test", "--", ...args], {
+    cwd: projectRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    exitCode = result.status ?? 1;
+  }
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
## Summary
- add a repo-root `package.json` and root Jest dispatcher so `npm test -- <path>` works from the repository root
- add VS Code Jest virtual-folder settings for the backend and frontend package roots
- add a backend test-folder `tsconfig.json` so TypeScript attaches backend test files to a Jest-aware project

## Why
Looking at test files from the repo root produced two separate problems:
1. there was no root-level Jest entrypoint for VS Code or terminal usage
2. backend test files were still excluded from the nearest configured TypeScript project, so `describe`, `it`, `expect`, and `beforeAll` showed as editor errors even after Jest discovery worked

## Impact
- root-level Jest commands now route to the correct package-local Jest install
- VS Code can discover backend and frontend tests from the repo root
- backend tests pick up Jest globals in the editor without red squiggles after a TS server reload

## Validation
- `./harmony-backend/node_modules/.bin/prettier --check package.json scripts/run-root-jest.cjs harmony-backend/tests/tsconfig.json .vscode/settings.json`
- `npm test -- --runInBand harmony-backend/tests/app.test.ts`
- `npm test -- --runInBand harmony-frontend/src/__tests__/utils.test.ts`
- `./node_modules/.bin/tsc -p tests/tsconfig.json --noEmit` (from `harmony-backend`)
