### PR TITLE
[codex] Add true E2E auth coverage

### DIFF
--- a/.github/workflows/run-frontend-e2e.yml
+++ b/.github/workflows/run-frontend-e2e.yml
@@ -1,0 +1,50 @@
+name: Frontend E2E
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  frontend-e2e:
+    name: Run Frontend E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            harmony-frontend/package-lock.json
+            harmony-backend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: harmony-frontend
+        run: npm ci
+
+      - name: Install backend dependencies
+        working-directory: harmony-backend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: harmony-frontend
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Run frontend E2E tests
+        working-directory: harmony-frontend
+        run: npm run test:e2e
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            harmony-frontend/playwright-report
+            harmony-frontend/test-results
+          if-no-files-found: ignore

--- a/.github/workflows/run-frontend-e2e.yml
+++ b/.github/workflows/run-frontend-e2e.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: harmony-frontend
-        run: npx playwright install --with-deps chromium webkit
+        run: npx playwright install --with-deps chromium
 
       - name: Run frontend E2E tests
         working-directory: harmony-frontend

--- a/harmony-backend/docker-compose.e2e.yml
+++ b/harmony-backend/docker-compose.e2e.yml
@@ -1,0 +1,27 @@
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: harmony
+      POSTGRES_PASSWORD: harmony
+      POSTGRES_DB: harmony_e2e
+    ports:
+      - '55432:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U harmony -d harmony_e2e']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: 'redis-server --requirepass e2esecret'
+    ports:
+      - '56379:6379'
+    healthcheck:
+      test: ['CMD-SHELL', 'redis-cli -a e2esecret ping | grep PONG']
+      interval: 5s
+      timeout: 5s
+      retries: 20

--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -13,9 +13,11 @@ import { attachmentRouter } from './routes/attachment.router';
 
 // ─── Auth rate limiters ───────────────────────────────────────────────────────
 
+const isE2E = process.env.NODE_ENV === 'e2e';
+
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 10,
+  max: isE2E ? 1000 : 10,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many login attempts. Please try again later.' },
@@ -31,7 +33,7 @@ const registerLimiter = rateLimit({
 
 const refreshLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 30,
+  max: isE2E ? 1000 : 30,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many token refresh attempts. Please try again later.' },

--- a/harmony-frontend/.gitignore
+++ b/harmony-frontend/.gitignore
@@ -2,6 +2,10 @@
 
 # dependencies
 /node_modules
+/.next
+/playwright-report
+/test-results
+/.cache/ms-playwright
 /.pnp
 .pnp.*
 .yarn/*

--- a/harmony-frontend/package-lock.json
+++ b/harmony-frontend/package-lock.json
@@ -17,6 +17,7 @@
         "twilio-video": "3.0.0-preview.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -2259,6 +2260,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -9130,6 +9147,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/harmony-frontend/package.json
+++ b/harmony-frontend/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "test": "jest --forceExit",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
@@ -22,6 +24,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@playwright/test": "^1.55.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/harmony-frontend/playwright.config.ts
+++ b/harmony-frontend/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+import { BACKEND_PORT, FRONTEND_URL, frontendEnv } from './tests/e2e/support/stack.shared.mjs';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: FRONTEND_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
+  ],
+  webServer: [
+    {
+      command: 'node tests/e2e/support/start-backend-e2e.mjs',
+      // Always restart the backend launcher locally so each run gets a fresh reset+seed.
+      reuseExistingServer: false,
+      timeout: 120_000,
+      url: `http://localhost:${BACKEND_PORT}/health`,
+    },
+    {
+      command: 'npm run dev',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      url: `${FRONTEND_URL}/auth/login`,
+      env: frontendEnv(),
+    },
+  ],
+});

--- a/harmony-frontend/playwright.config.ts
+++ b/harmony-frontend/playwright.config.ts
@@ -1,6 +1,31 @@
 import { defineConfig, devices } from '@playwright/test';
 import { BACKEND_PORT, FRONTEND_URL, frontendEnv } from './tests/e2e/support/stack.shared.mjs';
 
+const frontendCommand = process.env.CI ? 'npm run build && npm run start' : 'npm run dev';
+const projects = process.env.CI
+  ? [
+      {
+        name: 'chromium',
+        use: {
+          ...devices['Desktop Chrome'],
+        },
+      },
+    ]
+  : [
+      {
+        name: 'chromium',
+        use: {
+          ...devices['Desktop Chrome'],
+        },
+      },
+      {
+        name: 'webkit',
+        use: {
+          ...devices['Desktop Safari'],
+        },
+      },
+    ];
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: !process.env.CI,
@@ -14,20 +39,7 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },
-  projects: [
-    {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-      },
-    },
-    {
-      name: 'webkit',
-      use: {
-        ...devices['Desktop Safari'],
-      },
-    },
-  ],
+  projects,
   webServer: [
     {
       command: 'node tests/e2e/support/start-backend-e2e.mjs',
@@ -37,9 +49,9 @@ export default defineConfig({
       url: `http://localhost:${BACKEND_PORT}/health`,
     },
     {
-      command: 'npm run dev',
+      command: frontendCommand,
       reuseExistingServer: !process.env.CI,
-      timeout: 120_000,
+      timeout: process.env.CI ? 240_000 : 120_000,
       url: `${FRONTEND_URL}/auth/login`,
       env: frontendEnv(),
     },

--- a/harmony-frontend/playwright.config.ts
+++ b/harmony-frontend/playwright.config.ts
@@ -3,9 +3,10 @@ import { BACKEND_PORT, FRONTEND_URL, frontendEnv } from './tests/e2e/support/sta
 
 export default defineConfig({
   testDir: './tests/e2e',
-  fullyParallel: true,
+  fullyParallel: !process.env.CI,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
     baseURL: FRONTEND_URL,

--- a/harmony-frontend/tests/e2e/auth.spec.ts
+++ b/harmony-frontend/tests/e2e/auth.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import {
+  DEV_ADMIN_EMAIL,
+  DEV_ADMIN_PASSWORD,
+  DEFAULT_JOIN_SERVER_SLUG,
+  SEEDED_PRIVATE_CHANNEL,
+  SEEDED_PUBLIC_CHANNEL,
+  SIGNUP_USER,
+} from './support/stack.shared.mjs';
+
+async function signUpMember(page: Page, testInfo: TestInfo) {
+  const { project, retry } = testInfo;
+  const normalizedProject = project.name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase();
+  const normalizedRetry = `r${retry}`;
+  const emailLocalPart = `${SIGNUP_USER.username}-${normalizedProject}-${normalizedRetry}`.replace(
+    /_/g,
+    '-',
+  );
+  const email = `${emailLocalPart}@harmony.test`;
+  const username = `${SIGNUP_USER.username}_${normalizedProject}_${normalizedRetry}`.slice(0, 32);
+
+  await page.goto('/auth/signup');
+  await page.getByLabel(/^Email/).fill(email);
+  await page.getByLabel(/^Username/).fill(username);
+  await page.getByLabel('Display Name').fill(SIGNUP_USER.displayName);
+  await page.getByLabel(/^Password/).fill(SIGNUP_USER.password);
+  await page.getByRole('button', { name: 'Continue' }).click();
+}
+
+test.describe('True E2E auth and access flows', () => {
+  test('guest can read a seeded public channel', async ({ page }) => {
+    await page.goto(`/c/${SEEDED_PUBLIC_CHANNEL.serverSlug}/${SEEDED_PUBLIC_CHANNEL.channelSlug}`);
+
+    await expect(
+      page.getByRole('banner').getByText(SEEDED_PUBLIC_CHANNEL.serverName, { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: SEEDED_PUBLIC_CHANNEL.channelName, exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText(SEEDED_PUBLIC_CHANNEL.welcomeText).first()).toBeVisible();
+    await expect(page.getByLabel('Join server promotion')).toBeVisible();
+  });
+
+  test('guest is denied access to a private channel', async ({ page }) => {
+    await page.goto(
+      `/c/${SEEDED_PRIVATE_CHANNEL.serverSlug}/${SEEDED_PRIVATE_CHANNEL.channelSlug}`,
+    );
+
+    await expect(page.getByText('This channel is private')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Create Account' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Log In' })).toHaveAttribute(
+      'href',
+      new RegExp(
+        `returnUrl=%2Fc%2F${SEEDED_PRIVATE_CHANNEL.serverSlug}%2F${SEEDED_PRIVATE_CHANNEL.channelSlug}$`,
+      ),
+    );
+  });
+
+  test('dev admin can log in through the real backend and access a private channel', async ({
+    page,
+  }) => {
+    await page.goto(
+      `/channels/${SEEDED_PRIVATE_CHANNEL.serverSlug}/${SEEDED_PRIVATE_CHANNEL.channelSlug}`,
+    );
+
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/auth/login\\?returnUrl=%2Fchannels%2F${SEEDED_PRIVATE_CHANNEL.serverSlug}%2F${SEEDED_PRIVATE_CHANNEL.channelSlug}$`,
+      ),
+    );
+
+    await page.getByLabel('Email').fill(DEV_ADMIN_EMAIL);
+    await page.getByLabel('Password').fill(DEV_ADMIN_PASSWORD);
+    await page.getByRole('button', { name: 'Log In' }).click();
+
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/channels/${SEEDED_PRIVATE_CHANNEL.serverSlug}/${SEEDED_PRIVATE_CHANNEL.channelSlug}$`,
+      ),
+    );
+    await expect(page.getByLabel(`Message #${SEEDED_PRIVATE_CHANNEL.channelName}`)).toBeVisible();
+  });
+
+  test('newly registered users join the seeded default server and land on the authenticated channel view', async ({
+    page,
+  }, testInfo) => {
+    await signUpMember(page, testInfo);
+
+    await expect(page).toHaveURL(
+      new RegExp(`/channels/${DEFAULT_JOIN_SERVER_SLUG}/${SEEDED_PUBLIC_CHANNEL.channelSlug}$`),
+    );
+    await expect(page.getByLabel(`Message #${SEEDED_PUBLIC_CHANNEL.channelName}`)).toBeVisible();
+    await expect(page.getByText(SEEDED_PUBLIC_CHANNEL.welcomeText).first()).toBeVisible();
+  });
+});

--- a/harmony-frontend/tests/e2e/auth.spec.ts
+++ b/harmony-frontend/tests/e2e/auth.spec.ts
@@ -24,14 +24,15 @@ function getPrivateChannelPath() {
   return `/channels/${SEEDED_PRIVATE_CHANNEL.serverSlug}/${SEEDED_PRIVATE_CHANNEL.channelSlug}`;
 }
 
+const NAVIGATION_TIMEOUT_MS = 15_000;
+
 async function signUpMember(page: Page, testInfo: TestInfo) {
   const { project, retry } = testInfo;
-  const normalizedProject = sanitizeIdentifier(project.name);
-  const normalizedTitle = sanitizeIdentifier(testInfo.title).slice(0, 24);
-  const normalizedRetry = `r${retry}`;
-  const emailLocalPart = `${SIGNUP_USER.username}-${normalizedProject}-${normalizedTitle}-${normalizedRetry}`.replace(/_/g, '-');
+  const normalizedProject = sanitizeIdentifier(project.name).slice(0, 8);
+  const uniqueSuffix = `${normalizedProject}-${retry}-${Date.now().toString(36)}`;
+  const emailLocalPart = `${SIGNUP_USER.username}-${uniqueSuffix}`.replace(/_/g, '-');
   const email = `${emailLocalPart}@harmony.test`;
-  const username = `${SIGNUP_USER.username}_${normalizedProject}_${normalizedTitle}_${normalizedRetry}`.slice(0, 32);
+  const username = `${SIGNUP_USER.username}_${uniqueSuffix}`.slice(0, 32);
 
   await page.goto('/auth/signup');
   await page.getByLabel(/^Email/).fill(email);
@@ -46,13 +47,16 @@ async function logInDevAdmin(page: Page, destination = getPrivateChannelPath()) 
 
   await expect(page).toHaveURL(
     new RegExp(`/auth/login\\?returnUrl=${encodeURIComponent(destination)}$`),
+    { timeout: NAVIGATION_TIMEOUT_MS },
   );
 
   await page.getByLabel('Email').fill(DEV_ADMIN_EMAIL);
   await page.getByLabel('Password').fill(DEV_ADMIN_PASSWORD);
   await page.getByRole('button', { name: 'Log In' }).click();
 
-  await expect(page).toHaveURL(new RegExp(`${escapeForRegExp(destination)}$`));
+  await expect(page).toHaveURL(new RegExp(`${escapeForRegExp(destination)}$`), {
+    timeout: NAVIGATION_TIMEOUT_MS,
+  });
 }
 
 test.describe('True E2E auth and access flows', () => {
@@ -98,6 +102,7 @@ test.describe('True E2E auth and access flows', () => {
 
     await expect(page).toHaveURL(
       new RegExp(`/channels/${DEFAULT_JOIN_SERVER_SLUG}/${SEEDED_PUBLIC_CHANNEL.channelSlug}$`),
+      { timeout: NAVIGATION_TIMEOUT_MS },
     );
     await expect(page.getByLabel(`Message #${SEEDED_PUBLIC_CHANNEL.channelName}`)).toBeVisible();
     await expect(page.getByText(SEEDED_PUBLIC_CHANNEL.welcomeText).first()).toBeVisible();
@@ -111,7 +116,9 @@ test.describe('True E2E auth and access flows', () => {
     await logInDevAdmin(page, privateChannelPath);
     await page.reload();
 
-    await expect(page).toHaveURL(new RegExp(`${escapeForRegExp(privateChannelPath)}$`));
+    await expect(page).toHaveURL(new RegExp(`${escapeForRegExp(privateChannelPath)}$`), {
+      timeout: NAVIGATION_TIMEOUT_MS,
+    });
     await expect(page.getByLabel(`Message #${SEEDED_PRIVATE_CHANNEL.channelName}`)).toBeVisible();
   });
 
@@ -141,6 +148,7 @@ test.describe('True E2E auth and access flows', () => {
     await page.getByLabel('User Settings').click();
     await expect(page).toHaveURL(
       new RegExp(`/settings\\?returnTo=${encodeURIComponent(getPrivateChannelPath())}$`),
+      { timeout: NAVIGATION_TIMEOUT_MS },
     );
 
     await page
@@ -152,7 +160,9 @@ test.describe('True E2E auth and access flows', () => {
       .getByRole('button', { name: 'Log Out', exact: true })
       .click();
 
-    await expect(page).toHaveURL(new RegExp(`${escapeForRegExp(getPublicChannelPath())}$`));
+    await expect(page).toHaveURL(new RegExp(`${escapeForRegExp(getPublicChannelPath())}$`), {
+      timeout: NAVIGATION_TIMEOUT_MS,
+    });
     await expect(page.getByLabel('Join server promotion')).toBeVisible();
     await expect(
       page.getByRole('link', {

--- a/harmony-frontend/tests/e2e/auth.spec.ts
+++ b/harmony-frontend/tests/e2e/auth.spec.ts
@@ -8,16 +8,30 @@ import {
   SIGNUP_USER,
 } from './support/stack.shared.mjs';
 
+function sanitizeIdentifier(value: string) {
+  return value.replace(/[^a-z0-9_-]/gi, '-').toLowerCase();
+}
+
+function escapeForRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getPublicChannelPath() {
+  return `/c/${SEEDED_PUBLIC_CHANNEL.serverSlug}/${SEEDED_PUBLIC_CHANNEL.channelSlug}`;
+}
+
+function getPrivateChannelPath() {
+  return `/channels/${SEEDED_PRIVATE_CHANNEL.serverSlug}/${SEEDED_PRIVATE_CHANNEL.channelSlug}`;
+}
+
 async function signUpMember(page: Page, testInfo: TestInfo) {
   const { project, retry } = testInfo;
-  const normalizedProject = project.name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase();
+  const normalizedProject = sanitizeIdentifier(project.name);
+  const normalizedTitle = sanitizeIdentifier(testInfo.title).slice(0, 24);
   const normalizedRetry = `r${retry}`;
-  const emailLocalPart = `${SIGNUP_USER.username}-${normalizedProject}-${normalizedRetry}`.replace(
-    /_/g,
-    '-',
-  );
+  const emailLocalPart = `${SIGNUP_USER.username}-${normalizedProject}-${normalizedTitle}-${normalizedRetry}`.replace(/_/g, '-');
   const email = `${emailLocalPart}@harmony.test`;
-  const username = `${SIGNUP_USER.username}_${normalizedProject}_${normalizedRetry}`.slice(0, 32);
+  const username = `${SIGNUP_USER.username}_${normalizedProject}_${normalizedTitle}_${normalizedRetry}`.slice(0, 32);
 
   await page.goto('/auth/signup');
   await page.getByLabel(/^Email/).fill(email);
@@ -27,9 +41,23 @@ async function signUpMember(page: Page, testInfo: TestInfo) {
   await page.getByRole('button', { name: 'Continue' }).click();
 }
 
+async function logInDevAdmin(page: Page, destination = getPrivateChannelPath()) {
+  await page.goto(destination);
+
+  await expect(page).toHaveURL(
+    new RegExp(`/auth/login\\?returnUrl=${encodeURIComponent(destination)}$`),
+  );
+
+  await page.getByLabel('Email').fill(DEV_ADMIN_EMAIL);
+  await page.getByLabel('Password').fill(DEV_ADMIN_PASSWORD);
+  await page.getByRole('button', { name: 'Log In' }).click();
+
+  await expect(page).toHaveURL(new RegExp(`${escapeForRegExp(destination)}$`));
+}
+
 test.describe('True E2E auth and access flows', () => {
   test('guest can read a seeded public channel', async ({ page }) => {
-    await page.goto(`/c/${SEEDED_PUBLIC_CHANNEL.serverSlug}/${SEEDED_PUBLIC_CHANNEL.channelSlug}`);
+    await page.goto(getPublicChannelPath());
 
     await expect(
       page.getByRole('banner').getByText(SEEDED_PUBLIC_CHANNEL.serverName, { exact: true }),
@@ -59,25 +87,7 @@ test.describe('True E2E auth and access flows', () => {
   test('dev admin can log in through the real backend and access a private channel', async ({
     page,
   }) => {
-    await page.goto(
-      `/channels/${SEEDED_PRIVATE_CHANNEL.serverSlug}/${SEEDED_PRIVATE_CHANNEL.channelSlug}`,
-    );
-
-    await expect(page).toHaveURL(
-      new RegExp(
-        `/auth/login\\?returnUrl=%2Fchannels%2F${SEEDED_PRIVATE_CHANNEL.serverSlug}%2F${SEEDED_PRIVATE_CHANNEL.channelSlug}$`,
-      ),
-    );
-
-    await page.getByLabel('Email').fill(DEV_ADMIN_EMAIL);
-    await page.getByLabel('Password').fill(DEV_ADMIN_PASSWORD);
-    await page.getByRole('button', { name: 'Log In' }).click();
-
-    await expect(page).toHaveURL(
-      new RegExp(
-        `/channels/${SEEDED_PRIVATE_CHANNEL.serverSlug}/${SEEDED_PRIVATE_CHANNEL.channelSlug}$`,
-      ),
-    );
+    await logInDevAdmin(page);
     await expect(page.getByLabel(`Message #${SEEDED_PRIVATE_CHANNEL.channelName}`)).toBeVisible();
   });
 
@@ -91,5 +101,63 @@ test.describe('True E2E auth and access flows', () => {
     );
     await expect(page.getByLabel(`Message #${SEEDED_PUBLIC_CHANNEL.channelName}`)).toBeVisible();
     await expect(page.getByText(SEEDED_PUBLIC_CHANNEL.welcomeText).first()).toBeVisible();
+  });
+
+  test('authenticated sessions survive a full page reload on protected routes', async ({
+    page,
+  }) => {
+    const privateChannelPath = getPrivateChannelPath();
+
+    await logInDevAdmin(page, privateChannelPath);
+    await page.reload();
+
+    await expect(page).toHaveURL(new RegExp(`${escapeForRegExp(privateChannelPath)}$`));
+    await expect(page.getByLabel(`Message #${SEEDED_PRIVATE_CHANNEL.channelName}`)).toBeVisible();
+  });
+
+  test('authenticated users can send a real message through the backend', async ({
+    page,
+  }, testInfo) => {
+    const messageInput = page.getByLabel(`Message #${SEEDED_PRIVATE_CHANNEL.channelName}`);
+    const messageLog = page.getByRole('log', {
+      name: `Messages in #${SEEDED_PRIVATE_CHANNEL.channelName}`,
+    });
+    const messageText = `E2E message ${sanitizeIdentifier(testInfo.project.name)} ${Date.now()}`;
+
+    await logInDevAdmin(page);
+
+    await messageInput.fill(messageText);
+    await messageInput.press('Enter');
+
+    await expect(messageInput).toHaveValue('');
+    await expect(messageLog.getByText(messageText)).toBeVisible();
+  });
+
+  test('logging out from an authenticated route returns the user to a guest-safe channel', async ({
+    page,
+  }) => {
+    await logInDevAdmin(page);
+
+    await page.getByLabel('User Settings').click();
+    await expect(page).toHaveURL(
+      new RegExp(`/settings\\?returnTo=${encodeURIComponent(getPrivateChannelPath())}$`),
+    );
+
+    await page
+      .getByRole('navigation', { name: 'Settings navigation' })
+      .getByRole('button', { name: 'Log Out', exact: true })
+      .click();
+    await page
+      .getByRole('main', { name: 'Settings content' })
+      .getByRole('button', { name: 'Log Out', exact: true })
+      .click();
+
+    await expect(page).toHaveURL(new RegExp(`${escapeForRegExp(getPublicChannelPath())}$`));
+    await expect(page.getByLabel('Join server promotion')).toBeVisible();
+    await expect(
+      page.getByRole('link', {
+        name: 'Log In',
+      }),
+    ).toBeVisible();
   });
 });

--- a/harmony-frontend/tests/e2e/support/stack.shared.mjs
+++ b/harmony-frontend/tests/e2e/support/stack.shared.mjs
@@ -1,0 +1,127 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const FRONTEND_PORT = 3100;
+export const BACKEND_PORT = 4100;
+export const POSTGRES_PORT = 55432;
+export const REDIS_PORT = 56379;
+
+export const FRONTEND_URL = `http://localhost:${FRONTEND_PORT}`;
+export const BACKEND_URL = `http://localhost:${BACKEND_PORT}`;
+export const DATABASE_URL = `postgresql://harmony:harmony@localhost:${POSTGRES_PORT}/harmony_e2e`;
+export const REDIS_URL = `redis://:e2esecret@localhost:${REDIS_PORT}`;
+
+export const DEV_ADMIN_EMAIL = 'admin@harmony.dev';
+export const DEV_ADMIN_PASSWORD = 'admin';
+
+export const SIGNUP_USER = {
+  username: 'e2e_member',
+  displayName: 'E2E Member',
+  password: 'password123',
+};
+
+export function cleanEnv(env = process.env) {
+  return Object.fromEntries(Object.entries(env).filter(([, value]) => typeof value === 'string'));
+}
+
+export function frontendEnv(env = process.env) {
+  return {
+    ...cleanEnv(env),
+    PORT: String(FRONTEND_PORT),
+    NEXT_PUBLIC_API_URL: BACKEND_URL,
+  };
+}
+
+export function backendEnv(env = process.env) {
+  return {
+    ...cleanEnv(env),
+    PORT: String(BACKEND_PORT),
+    DATABASE_URL,
+    REDIS_URL,
+    FRONTEND_URL,
+    JWT_ACCESS_SECRET: 'harmony-e2e-access-secret',
+    JWT_REFRESH_SECRET: 'harmony-e2e-refresh-secret',
+    JWT_ACCESS_EXPIRES_IN: '15m',
+    JWT_REFRESH_EXPIRES_DAYS: '7',
+    TWILIO_MOCK: 'true',
+    LOCAL_UPLOAD_BASE_URL: BACKEND_URL,
+  };
+}
+
+export function resolveE2EPaths(cwd = process.cwd()) {
+  const repoRoot = path.resolve(cwd, '..');
+  const backendDir = path.join(repoRoot, 'harmony-backend');
+
+  return {
+    repoRoot,
+    backendDir,
+    composeFile: path.join(backendDir, 'docker-compose.e2e.yml'),
+    composeProject: 'harmony-e2e',
+  };
+}
+
+function loadSeedSnapshot() {
+  const { backendDir } = resolveE2EPaths();
+  const seedPath = path.join(backendDir, 'src/dev/mock-seed-data.json');
+  try {
+    return JSON.parse(fs.readFileSync(seedPath, 'utf8'));
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(
+        `Missing E2E seed snapshot at ${seedPath}. Ensure the Harmony backend mock seed files are present before running Playwright.`,
+      );
+    }
+
+    throw error;
+  }
+}
+
+const snapshot = loadSeedSnapshot();
+
+// Registration auto-joins this server in backend auth.service; keep this value
+// aligned with that backend contract and fail fast in launcher preflight if it drifts.
+export const DEFAULT_JOIN_SERVER_SLUG = 'harmony-hq';
+
+const defaultJoinServer = snapshot.servers.find(server => server.slug === DEFAULT_JOIN_SERVER_SLUG);
+if (!defaultJoinServer) {
+  throw new Error(
+    `Seed snapshot is missing the default join server slug "${DEFAULT_JOIN_SERVER_SLUG}".`,
+  );
+}
+
+const publicChannel = snapshot.channels.find(
+  channel => channel.serverId === defaultJoinServer.id && channel.visibility === 'PUBLIC_INDEXABLE',
+);
+if (!publicChannel) {
+  throw new Error(
+    `Seed snapshot is missing a public channel for server "${DEFAULT_JOIN_SERVER_SLUG}".`,
+  );
+}
+
+const privateChannel = snapshot.channels.find(
+  channel => channel.serverId === defaultJoinServer.id && channel.visibility === 'PRIVATE',
+);
+if (!privateChannel) {
+  throw new Error(
+    `Seed snapshot is missing a private channel for server "${DEFAULT_JOIN_SERVER_SLUG}".`,
+  );
+}
+
+const welcomeMessage = snapshot.messages.find(message => message.channelId === publicChannel.id);
+if (!welcomeMessage) {
+  throw new Error(`Seed snapshot is missing a message for public channel "${publicChannel.slug}".`);
+}
+
+export const SEEDED_PUBLIC_CHANNEL = {
+  serverSlug: defaultJoinServer.slug,
+  serverName: defaultJoinServer.name,
+  channelSlug: publicChannel.slug,
+  channelName: publicChannel.name,
+  welcomeText: welcomeMessage.content,
+};
+
+export const SEEDED_PRIVATE_CHANNEL = {
+  serverSlug: defaultJoinServer.slug,
+  channelName: privateChannel.name,
+  channelSlug: privateChannel.slug,
+};

--- a/harmony-frontend/tests/e2e/support/start-backend-e2e.mjs
+++ b/harmony-frontend/tests/e2e/support/start-backend-e2e.mjs
@@ -1,0 +1,168 @@
+import { execFileSync, spawn } from 'node:child_process';
+import {
+  backendEnv,
+  BACKEND_URL,
+  DEV_ADMIN_EMAIL,
+  DEV_ADMIN_PASSWORD,
+  DATABASE_URL,
+  DEFAULT_JOIN_SERVER_SLUG,
+  resolveE2EPaths,
+  SEEDED_PRIVATE_CHANNEL,
+  SEEDED_PUBLIC_CHANNEL,
+} from './stack.shared.mjs';
+
+const { backendDir, composeFile, composeProject } = resolveE2EPaths();
+let setupFinished = false;
+let teardownFinished = false;
+let backend;
+let fatalExitCode = 0;
+
+function run(command, args, env = process.env) {
+  execFileSync(command, args, {
+    cwd: backendDir,
+    env,
+    stdio: 'inherit',
+  });
+}
+
+function teardownInfra() {
+  if (teardownFinished || !setupFinished) return;
+  teardownFinished = true;
+  run('docker', ['compose', '-f', composeFile, '-p', composeProject, 'down', '-v']);
+}
+
+async function waitForCondition(check, label, timeoutMs = 30_000) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      if (await check()) return;
+    } catch {}
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`Timed out waiting for ${label}.`);
+}
+
+async function waitFor(url, predicate, label, timeoutMs = 30_000) {
+  await waitForCondition(async () => {
+    const response = await fetch(url);
+    return predicate(response);
+  }, label, timeoutMs);
+}
+
+async function verifySeedPreconditions() {
+  await waitFor(`${BACKEND_URL}/health`, async response => response.ok, 'backend health check');
+
+  await waitFor(
+    `${BACKEND_URL}/api/public/servers/${DEFAULT_JOIN_SERVER_SLUG}`,
+    async response => {
+      if (!response.ok) return false;
+      const body = await response.json();
+      return body.slug === DEFAULT_JOIN_SERVER_SLUG;
+    },
+    'default join server fixture',
+  );
+
+  await waitFor(
+    `${BACKEND_URL}/api/public/servers/${SEEDED_PUBLIC_CHANNEL.serverSlug}/channels/${SEEDED_PUBLIC_CHANNEL.channelSlug}`,
+    async response => {
+      if (!response.ok) return false;
+      const body = await response.json();
+      return body.slug === SEEDED_PUBLIC_CHANNEL.channelSlug;
+    },
+    'public channel fixture',
+  );
+
+  await waitFor(
+    `${BACKEND_URL}/api/public/servers/${SEEDED_PRIVATE_CHANNEL.serverSlug}/channels/${SEEDED_PRIVATE_CHANNEL.channelSlug}`,
+    async response => response.status === 403,
+    'private channel fixture',
+  );
+
+  await waitForCondition(async () => {
+    const loginResponse = await fetch(`${BACKEND_URL}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: DEV_ADMIN_EMAIL,
+        password: DEV_ADMIN_PASSWORD,
+      }),
+    });
+
+    if (!loginResponse.ok) {
+      return false;
+    }
+
+    const authPayload = await loginResponse.json();
+    return (
+      typeof authPayload.accessToken === 'string' &&
+      typeof authPayload.refreshToken === 'string'
+    );
+  }, 'dev admin login fixture');
+}
+
+function handleFatal(error) {
+  console.error(error);
+  fatalExitCode = 1;
+  if (backend) {
+    backend.kill('SIGTERM');
+    return;
+  }
+
+  teardownInfra();
+  process.exit(fatalExitCode);
+}
+
+async function main() {
+  run('docker', ['compose', '-f', composeFile, '-p', composeProject, 'up', '-d', '--wait']);
+  setupFinished = true;
+
+  run('npx', ['prisma', 'migrate', 'reset', '--force', '--skip-generate', '--skip-seed'], {
+    ...process.env,
+    DATABASE_URL,
+  });
+  run('npm', ['run', 'db:seed:mock'], {
+    ...process.env,
+    DATABASE_URL,
+  });
+
+  backend = spawn('npm', ['run', 'dev'], {
+    cwd: backendDir,
+    env: {
+      ...backendEnv(),
+      NODE_ENV: 'e2e',
+    },
+    stdio: 'inherit',
+  });
+
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+      backend.kill(signal);
+    });
+  }
+
+  process.on('uncaughtException', handleFatal);
+  process.on('unhandledRejection', handleFatal);
+
+  await verifySeedPreconditions();
+
+  backend.on('exit', (code, signal) => {
+    teardownInfra();
+
+    if (fatalExitCode !== 0) {
+      process.exit(fatalExitCode);
+      return;
+    }
+
+    if (signal) {
+      process.exit(0);
+      return;
+    }
+
+    process.exit(code ?? 0);
+  });
+}
+
+void main().catch(handleFatal);

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -18,6 +18,18 @@ Shared knowledge base for the Harmony team. Add an entry whenever a mistake is c
 
 <!-- Most recent entries at the top -->
 
+**Date:** 2026-04-04  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I assumed serial CI workers and relaxed auth throttles were enough, but the WebKit-only auth flake was still tied to running the Next frontend in dev mode inside GitHub Actions.  
+**Rule / Fix:** For browser E2E in CI, prefer production-style frontend serving (`build + start`) over `next dev`; dev-mode tooling can introduce non-product flakiness that hides the real signal of the suite.
+
+**Date:** 2026-04-04  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I kept a browser matrix in the PR-gating CI path even after reproducing that only WebKit was flaky under CI-mode E2E, which blocked the suite without proving a product defect.  
+**Rule / Fix:** Keep every-PR E2E checks focused on the stable smoke browser for this repo, and move additional browser coverage like WebKit to non-blocking or follow-up coverage until the browser-specific flake has a rooted product cause.
+
 **Date:** 2026-04-01  
 **Caught by:** [Human: @acabrera04]  
 **Related Issue:** N/A  

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -17,3 +17,21 @@ Shared knowledge base for the Harmony team. Add an entry whenever a mistake is c
 ## Log
 
 <!-- Most recent entries at the top -->
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The E2E suite mixed selector expectations based on route slugs with UI labels rendered from channel display names, and one startup preflight used a one-shot auth check while the rest of setup retried.  
+**Rule / Fix:** E2E assertions must target the exact accessibility text the UI renders, not adjacent seed identifiers, and all backend readiness checks should share the same retry semantics so cold-start timing does not create false failures.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** E2E preflight initially verified seeded content but skipped critical auth assumptions, and the shared E2E helper encoded environment defaults too implicitly.  
+**Rule / Fix:** E2E preconditions must verify every special-case fixture the suite depends on, including auth overrides, and shared test helpers should avoid hidden runtime defaults like hardcoded `NODE_ENV`.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The first true-E2E pass duplicated stack constants across TS and Node launcher files and allowed local server reuse, which made reruns stateful and brittle.  
+**Rule / Fix:** For stateful E2E stacks, keep shared ports/URLs/test credentials in one cross-runtime JS module and force the backend launcher to restart/reset locally unless there is an explicit reason to preserve state.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -18,6 +18,12 @@ Shared knowledge base for the Harmony team. Add an entry whenever a mistake is c
 
 <!-- Most recent entries at the top -->
 
+**Date:** 2026-04-01  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The new E2E suite passed locally but still failed in CI because production-style auth rate limits and full worker parallelism interacted badly with concurrent browser runs.  
+**Rule / Fix:** When adding full-stack E2E to CI, review backend throttles and shared-state assumptions explicitly; either relax them for `NODE_ENV=e2e` or reduce CI concurrency so auth/setup traffic cannot invalidate the suite.
+
 **Date:** 2026-03-31  
 **Caught by:** [AI Agent: Claude]  
 **Related Issue:** N/A  


### PR DESCRIPTION
## What changed

This PR replaces the mocked frontend-only auth flow tests with a true end-to-end Playwright harness.

It adds an isolated backend stack for E2E runs with Docker Compose Postgres and Redis, a backend launcher that resets Prisma, seeds mock data, starts the real backend, and verifies critical fixtures before the suite runs. On the frontend side, it adds Playwright configuration plus browser-driven auth/access tests for public-channel guest access, private-channel denial, dev-admin login to a protected route, and signup joining the seeded default server.

## Why

The previous browser tests only proved frontend behavior against a stubbed backend contract. That left gaps around real auth, redirects, seeded fixtures, and local rerun safety. The new setup exercises the real frontend and backend together against isolated infrastructure.

## Impact

Developers can now run `npm run test:e2e` in `harmony-frontend` and get full-stack verification across Chromium and WebKit without touching the shared dev database. The suite also fails earlier and more clearly when seeded fixtures or special-case auth assumptions drift.

## Root cause addressed

The testing gap came from relying on a mock backend for flows that are fundamentally integration-sensitive: login, signup, return URLs, private/public access control, and seeded server membership behavior.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:e2e`
