### PR TITLE
[codex] Export thread 019d54bf-2a86-7f53-9d5f-d7ce42895cb3 log

### DIFF
--- a/llm-logs/acabrera04-logs/acabrera04-tests/019d54bf-2a86-7f53-9d5f-d7ce42895cb3.md
+++ b/llm-logs/acabrera04-logs/acabrera04-tests/019d54bf-2a86-7f53-9d5f-d7ce42895cb3.md
@@ -1,0 +1,12070 @@
+# Codex Conversation Export
+
+## Metadata
+
+- Thread ID: 019d54bf-2a86-7f53-9d5f-d7ce42895cb3
+- Timestamp: 2026-04-03T19:08:27.657Z
+- CWD: /Users/allen/repos/Harmony
+- Source: vscode
+- Model Provider: openai
+- Model: gpt-5.4
+- Reasoning Effort: high
+- Rollout Path: /Users/allen/.codex/sessions/2026/04/03/rollout-2026-04-03T15-08-27-019d54bf-2a86-7f53-9d5f-d7ce42895cb3.jsonl
+
+## Transcript
+
+### Turn 1: Pull from main and check our progress towards [P5: Testing | CS 485
+
+#### 👤 User Prompt
+
+- Time: 2026-04-03T19:08:38.875Z
+
+```text
+Pull from main and check our progress towards [P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf](P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26\).pdf)
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:08:51.534Z
+
+I’m checking the repo state, the workflow rules, and the assignment PDF first so I can update from `main` safely and measure progress against the actual testing requirements.
+
+#### Tool: exec_command
+
+```sh
+pwd && rtk git status --short --branch
+```
+
+Output:
+
+```text
+/Users/allen/repos/Harmony
+## main...origin/main
+?? "P4: Backend Development | CS 485 AI-Assisted Software Engineering (Sp26).html"
+?? "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf"
+?? harmony-backend/coverage/
+?? load-test.js
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read WORKFLOW.md
+```
+
+Output:
+
+````text
+## Workflow Orchestration
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean 
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop 
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests - then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+This project uses a **hybrid approach**: `tasks/todo.md` for AI context, GitHub Issues as the canonical tracker on the Harmony Project Board (course requirement).
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items (local scratch pad for AI context)
+2. **Identify the Issue**: If the task maps to an existing GitHub Issue, note the issue number at the top of `tasks/todo.md`
+3. **Announce Start**: Post an opening comment to the issue — `gh issue comment <number> --body "..."` — describing what will be done
+4. **Track Progress**: Mark items complete in `tasks/todo.md` as you go; post a comment to the issue at meaningful milestones (e.g., after a major step or when blocked)
+5. **Explain Changes**: High-level summary at each step
+6. **Document Results**: Add a review section to `tasks/todo.md` and post a final summary comment to the issue when complete
+7. **Capture Lessons**: Update `tasks/lessons.md` after corrections. Post the new lessons learned as a comment to the issue.
+
+### Issue Comment Format
+Use this structure for issue comments to keep the audit trail readable:
+
+```
+**[AI Agent — <Step>]**
+
+<What was done or decided>
+
+<Any blockers, decisions, or next steps>
+```
+
+Example steps: `Starting`, `In Progress`, `Blocked`, `Complete`
+
+## Core Principles
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
+- **Lean Context Files**: Keep AGENTS.md and similar files to only non-obvious, non-discoverable essentials. Research shows context file bloat decreases task success rates and increases inference cost by 20%+ with 2–4 extra steps per task (Gloaguen et al., 2026).
+
+#### Taken from https://x.com/mdancho84/status/2023738764841894352
+
+Gloaguen, T., Mündler, N., Müller, M., Raychev, V., & Vechev, M. (2026, February 12). Evaluating AGENTS.MD: Are Repository-Level context Files helpful for coding agents? arXiv.org. https://arxiv.org/abs/2602.11988
+````
+
+#### Tool: exec_command
+
+```sh
+rtk read /Users/allen/.agents/skills/pdf/SKILL.md
+```
+
+Output:
+
+````text
+---
+name: pdf
+description: Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
+license: Proprietary. LICENSE.txt has complete terms
+---
+
+# PDF Processing Guide
+
+## Overview
+
+This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see REFERENCE.md. If you need to fill out a PDF form, read FORMS.md and follow its instructions.
+
+## Quick Start
+
+```python
+from pypdf import PdfReader, PdfWriter
+
+# Read a PDF
+reader = PdfReader("document.pdf")
+print(f"Pages: {len(reader.pages)}")
+
+# Extract text
+text = ""
+for page in reader.pages:
+    text += page.extract_text()
+```
+
+## Python Libraries
+
+### pypdf - Basic Operations
+
+#### Merge PDFs
+```python
+from pypdf import PdfWriter, PdfReader
+
+writer = PdfWriter()
+for pdf_file in ["doc1.pdf", "doc2.pdf", "doc3.pdf"]:
+    reader = PdfReader(pdf_file)
+    for page in reader.pages:
+        writer.add_page(page)
+
+with open("merged.pdf", "wb") as output:
+    writer.write(output)
+```
+
+#### Split PDF
+```python
+reader = PdfReader("input.pdf")
+for i, page in enumerate(reader.pages):
+    writer = PdfWriter()
+    writer.add_page(page)
+    with open(f"page_{i+1}.pdf", "wb") as output:
+        writer.write(output)
+```
+
+#### Extract Metadata
+```python
+reader = PdfReader("document.pdf")
+meta = reader.metadata
+print(f"Title: {meta.title}")
+print(f"Author: {meta.author}")
+print(f"Subject: {meta.subject}")
+print(f"Creator: {meta.creator}")
+```
+
+#### Rotate Pages
+```python
+reader = PdfReader("input.pdf")
+writer = PdfWriter()
+
+page = reader.pages[0]
+page.rotate(90)  # Rotate 90 degrees clockwise
+writer.add_page(page)
+
+with open("rotated.pdf", "wb") as output:
+    writer.write(output)
+```
+
+### pdfplumber - Text and Table Extraction
+
+#### Extract Text with Layout
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    for page in pdf.pages:
+        text = page.extract_text()
+        print(text)
+```
+
+#### Extract Tables
+```python
+with pdfplumber.open("document.pdf") as pdf:
+    for i, page in enumerate(pdf.pages):
+        tables = page.extract_tables()
+        for j, table in enumerate(tables):
+            print(f"Table {j+1} on page {i+1}:")
+            for row in table:
+                print(row)
+```
+
+#### Advanced Table Extraction
+```python
+import pandas as pd
+
+with pdfplumber.open("document.pdf") as pdf:
+    all_tables = []
+    for page in pdf.pages:
+        tables = page.extract_tables()
+        for table in tables:
+            if table:  # Check if table is not empty
+                df = pd.DataFrame(table[1:], columns=table[0])
+                all_tables.append(df)
+
+# Combine all tables
+if all_tables:
+    combined_df = pd.concat(all_tables, ignore_index=True)
+    combined_df.to_excel("extracted_tables.xlsx", index=False)
+```
+
+### reportlab - Create PDFs
+
+#### Basic PDF Creation
+```python
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+c = canvas.Canvas("hello.pdf", pagesize=letter)
+width, height = letter
+
+# Add text
+c.drawString(100, height - 100, "Hello World!")
+c.drawString(100, height - 120, "This is a PDF created with reportlab")
+
+# Add a line
+c.line(100, height - 140, 400, height - 140)
+
+# Save
+c.save()
+```
+
+#### Create PDF with Multiple Pages
+```python
+from reportlab.lib.pagesizes import letter
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, PageBreak
+from reportlab.lib.styles import getSampleStyleSheet
+
+doc = SimpleDocTemplate("report.pdf", pagesize=letter)
+styles = getSampleStyleSheet()
+story = []
+
+# Add content
+title = Paragraph("Report Title", styles['Title'])
+story.append(title)
+story.append(Spacer(1, 12))
+
+body = Paragraph("This is the body of the report. " * 20, styles['Normal'])
+story.append(body)
+story.append(PageBreak())
+
+# Page 2
+story.append(Paragraph("Page 2", styles['Heading1']))
+story.append(Paragraph("Content for page 2", styles['Normal']))
+
+# Build PDF
+doc.build(story)
+```
+
+#### Subscripts and Superscripts
+
+**IMPORTANT**: Never use Unicode subscript/superscript characters (₀₁₂₃₄₅₆₇₈₉, ⁰¹²³⁴⁵⁶⁷⁸⁹) in ReportLab PDFs. The built-in fonts do not include these glyphs, causing them to render as solid black boxes.
+
+Instead, use ReportLab's XML markup tags in Paragraph objects:
+```python
+from reportlab.platypus import Paragraph
+from reportlab.lib.styles import getSampleStyleSheet
+
+styles = getSampleStyleSheet()
+
+# Subscripts: use <sub> tag
+chemical = Paragraph("H<sub>2</sub>O", styles['Normal'])
+
+# Superscripts: use <super> tag
+squared = Paragraph("x<super>2</super> + y<super>2</super>", styles['Normal'])
+```
+
+For canvas-drawn text (not Paragraph objects), manually adjust font the size and position rather than using Unicode subscripts/superscripts.
+
+## Command-Line Tools
+
+### pdftotext (poppler-utils)
+```bash
+# Extract text
+pdftotext input.pdf output.txt
+
+# Extract text preserving layout
+pdftotext -layout input.pdf output.txt
+
+# Extract specific pages
+pdftotext -f 1 -l 5 input.pdf output.txt  # Pages 1-5
+```
+
+### qpdf
+```bash
+# Merge PDFs
+qpdf --empty --pages file1.pdf file2.pdf -- merged.pdf
+
+# Split pages
+qpdf input.pdf --pages . 1-5 -- pages1-5.pdf
+qpdf input.pdf --pages . 6-10 -- pages6-10.pdf
+
+# Rotate pages
+qpdf input.pdf output.pdf --rotate=+90:1  # Rotate page 1 by 90 degrees
+
+# Remove password
+qpdf --password=mypassword --decrypt encrypted.pdf decrypted.pdf
+```
+
+### pdftk (if available)
+```bash
+# Merge
+pdftk file1.pdf file2.pdf cat output merged.pdf
+
+# Split
+pdftk input.pdf burst
+
+# Rotate
+pdftk input.pdf rotate 1east output rotated.pdf
+```
+
+## Common Tasks
+
+### Extract Text from Scanned PDFs
+```python
+# Requires: pip install pytesseract pdf2image
+import pytesseract
+from pdf2image import convert_from_path
+
+# Convert PDF to images
+images = convert_from_path('scanned.pdf')
+
+# OCR each page
+text = ""
+for i, image in enumerate(images):
+    text += f"Page {i+1}:\n"
+    text += pytesseract.image_to_string(image)
+    text += "\n\n"
+
+print(text)
+```
+
+### Add Watermark
+```python
+from pypdf import PdfReader, PdfWriter
+
+# Create watermark (or load existing)
+watermark = PdfReader("watermark.pdf").pages[0]
+
+# Apply to all pages
+reader = PdfReader("document.pdf")
+writer = PdfWriter()
+
+for page in reader.pages:
+    page.merge_page(watermark)
+    writer.add_page(page)
+
+with open("watermarked.pdf", "wb") as output:
+    writer.write(output)
+```
+
+### Extract Images
+```bash
+# Using pdfimages (poppler-utils)
+pdfimages -j input.pdf output_prefix
+
+# This extracts all images as output_prefix-000.jpg, output_prefix-001.jpg, etc.
+```
+
+### Password Protection
+```python
+from pypdf import PdfReader, PdfWriter
+
+reader = PdfReader("input.pdf")
+writer = PdfWriter()
+
+for page in reader.pages:
+    writer.add_page(page)
+
+# Add password
+writer.encrypt("userpassword", "ownerpassword")
+
+with open("encrypted.pdf", "wb") as output:
+    writer.write(output)
+```
+
+## Quick Reference
+
+| Task | Best Tool | Command/Code |
+|------|-----------|--------------|
+| Merge PDFs | pypdf | `writer.add_page(page)` |
+| Split PDFs | pypdf | One page per file |
+| Extract text | pdfplumber | `page.extract_text()` |
+| Extract tables | pdfplumber | `page.extract_tables()` |
+| Create PDFs | reportlab | Canvas or Platypus |
+| Command line merge | qpdf | `qpdf --empty --pages ...` |
+| OCR scanned PDFs | pytesseract | Convert to image first |
+| Fill PDF forms | pdf-lib or pypdf (see FORMS.md) | See FORMS.md |
+
+## Next Steps
+
+- For advanced pypdfium2 usage, see REFERENCE.md
+- For JavaScript libraries (pdf-lib), see REFERENCE.md
+- If you need to fill out a PDF form, follow the instructions in FORMS.md
+- For troubleshooting guides, see REFERENCE.md
+````
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:09:05.672Z
+
+I found the repo on local `main` with only untracked files, so a fast-forward pull is safe. Next I’m syncing with `origin/main` and extracting the assignment requirements from the PDF so I can compare them against the current test setup.
+
+#### Tool: exec_command
+
+```sh
+dcg explain "git pull --ff-only origin main"
+```
+
+Output:
+
+```text
+══════════════════════════════════════════════════════════════════
+DCG EXPLAIN
+══════════════════════════════════════════════════════════════════
+
+Decision: ALLOW
+Latency:  11ms
+
+─── Command ───────────────────────────────────────────────────────
+Input:      git pull --ff-only origin main
+
+─── Pipeline Trace ────────────────────────────────────────────────
+full_evaluation    (    11ms) quick-rejected (no keywords)
+
+══════════════════════════════════════════════════════════════════
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git fetch origin
+```
+
+Output:
+
+```text
+ok fetched (2 new refs)
+```
+
+#### Tool: exec_command
+
+```sh
+pdftotext -layout "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf" -
+```
+
+Output:
+
+```text
+zsh:1: command not found: pdftotext
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read README.md
+```
+
+Output:
+
+```text
+# Harmony
+A search engine indexible chat application
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:09:17.922Z
+
+`pdftotext` isn’t installed here, so I’m falling back to Python-based PDF extraction. I’m also checking whether `main` is behind after the fetch and locating the frontend/backend test surfaces I’ll compare against the assignment.
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short --branch
+```
+
+Output:
+
+```text
+## main...origin/main [behind 15]
+?? "P4: Backend Development | CS 485 AI-Assisted Software Engineering (Sp26).html"
+?? "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf"
+?? harmony-backend/coverage/
+?? load-test.js
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git pull --ff-only origin main
+```
+
+Output:
+
+```text
+ok ✓ 11 files +6189 -0
+```
+
+#### Tool: exec_command
+
+```sh
+python3 - <<'PY'
+from pathlib import Path
+from pypdf import PdfReader
+path = Path("P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf")
+reader = PdfReader(str(path))
+print(f'PAGES={len(reader.pages)}')
+for i, page in enumerate(reader.pages, 1):
+    text = page.extract_text() or ''
+    print(f'\n--- PAGE {i} ---\n')
+    print(text[:12000])
+PY
+```
+
+Output:
+
+```text
+Traceback (most recent call last):
+  File "<stdin>", line 2, in <module>
+ModuleNotFoundError: No module named 'pypdf'
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "\"test\"|\"vitest\"|\"jest\"|\"playwright\"|\"coverage\"" package.json harmony-frontend/package.json harmony-backend/package.json
+```
+
+Output:
+
+```text
+🔍 4 in 2F:
+
+📄 harmony-backend/package.json (2):
+    10: "test": "jest",
+    48: "jest": "^29.7.0",
+
+📄 harmony-frontend/package.json (2):
+     9: "test": "jest --forceExit",
+    35: "jest": "^30.3.0",
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:09:29.462Z
+
+`main` was 15 commits behind and is now fast-forwarded. I’m enumerating the actual test suites and coverage artifacts next, and I’m trying a second PDF extraction path since neither `pdftotext` nor `pypdf` is available.
+
+#### Tool: exec_command
+
+```sh
+which mutool || which pdfinfo || which qpdf || which mdls
+```
+
+Output:
+
+```text
+mutool not found
+pdfinfo not found
+qpdf not found
+/usr/bin/mdls
+```
+
+#### Tool: exec_command
+
+```sh
+mdls -name kMDItemTextContent "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf"
+```
+
+Output:
+
+```text
+kMDItemTextContent = (null)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony-backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "lint": "eslint src tests",
+    "test": "jest",
+    "db:seed:mock": "prisma db seed",
+    "db:seed:demo": "tsx src/dev/demoSeed.ts"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.22.0",
+    "@trpc/server": "^11.0.0",
+    "bcryptjs": "^3.0.3",
+    "cors": "^2.8.5",
+    "express": "^4.21.2",
+    "express-rate-limit": "^8.3.0",
+    "file-type": "^21.3.2",
+    "helmet": "^8.1.0",
+    "ioredis": "^5.10.0",
+    "jsonwebtoken": "^9.0.3",
+    "multer": "^2.1.1",
+    "serverless-http": "^3.2.0",
+    "twilio": "^5.13.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/ioredis": "^4.28.10",
+    "@types/jest": "^29.5.14",
+    "@types/jsonwebtoken": "^9.0.10",
+    "@types/multer": "^2.1.0",
+    "@types/node": "^20.17.19",
+    "@types/supertest": "^6.0.2",
+    "@typescript-eslint/eslint-plugin": "^8.26.0",
+    "@typescript-eslint/parser": "^8.26.0",
+    "dotenv": "^17.3.1",
+    "eslint": "^9.22.0",
+    "eslint-config-prettier": "^10.1.1",
+    "jest": "^29.7.0",
+    "prettier": "^3.5.3",
+    "prisma": "^5.22.0",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.6",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "jest --forceExit",
+    "lint": "eslint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "axios": "^1.13.5",
+    "clsx": "^2.1.1",
+    "next": "16.1.6",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.4.1",
+    "twilio-video": "3.0.0-preview.3"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "16.1.6",
+    "eslint-config-prettier": "^10.1.8",
+    "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
+    "prettier": "^3.8.1",
+    "tailwindcss": "^4",
+    "ts-jest": "^29.4.6",
+    "typescript": "5.9.3"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rg --files -g '*test*' -g '*spec*' harmony-backend harmony-frontend
+```
+
+Output:
+
+```text
+harmony-frontend/src/__tests__/useServerEvents.test.tsx
+harmony-frontend/src/__tests__/trpc-client.test.ts
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx
+harmony-frontend/src/__tests__/useChannelEvents.test.tsx
+harmony-frontend/src/__tests__/channelService.test.ts
+harmony-frontend/src/__tests__/middleware.test.ts
+harmony-frontend/src/__tests__/useServerListSync.test.tsx
+harmony-frontend/src/__tests__/utils.test.ts
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts
+harmony-backend/tsconfig.test.json
+harmony-backend/tests/channel.service.events.test.ts
+harmony-backend/tests/message.service.test.ts
+harmony-backend/tests/channel.service.test.ts
+harmony-backend/tests/eventBus.test.ts
+harmony-backend/tests/auditLog.service.test.ts
+harmony-backend/tests/voice.service.test.ts
+harmony-backend/tests/mock-seed.test.ts
+harmony-backend/tests/rate-limit.middleware.test.ts
+harmony-backend/tests/events.router.server.test.ts
+harmony-backend/tests/events.router.visibility.test.ts
+harmony-backend/tests/auth.test.ts
+harmony-backend/tests/schema.test.ts
+harmony-backend/tests/auth.service.init.test.ts
+harmony-backend/tests/attachment.router.test.ts
+harmony-backend/tests/app.test.ts
+harmony-backend/tests/attachment.service.test.ts
+harmony-backend/tests/indexing.service.test.ts
+harmony-backend/tests/public.router.test.ts
+harmony-backend/tests/message.replies.test.ts
+harmony-backend/tests/events.router.member.test.ts
+harmony-backend/tests/visibility.service.test.ts
+harmony-backend/tests/server.test.ts
+harmony-backend/tests/trpc.error-formatter.test.ts
+harmony-backend/tests/serverMember.test.ts
+harmony-backend/tests/permission.service.test.ts
+harmony-backend/tests/channel.getAuditLog.test.ts
+harmony-backend/tests/cache.middleware.test.ts
+harmony-backend/tests/events.router.test.ts
+harmony-backend/tests/demo-seed.test.ts
+harmony-backend/tests/cache.service.test.ts
+harmony-backend/tests/user.service.test.ts
+harmony-backend/tests/trpc.permission.middleware.test.ts
+harmony-backend/tests/message.service.events.test.ts
+harmony-backend/tests/reaction.test.ts
+harmony-backend/tests/events.router.status.test.ts
+harmony-backend/tests/events.router.sse-server-updated.test.ts
+harmony-backend/tests/auth.service.test.ts
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:09:39.095Z
+
+I’ve got the current test inventory. The remaining blocker is reading the assignment PDF cleanly, so I’m probing a couple of locally available parsers and then I’ll map the repo’s current tests against the assignment sections.
+
+#### Tool: exec_command
+
+```sh
+python3 - <<'PY'
+mods = ['PyPDF2','pdfplumber','fitz','pymupdf']
+for m in mods:
+    try:
+        __import__(m)
+        print(m, 'OK')
+    except Exception as e:
+        print(m, 'NO', type(e).__name__)
+PY
+```
+
+Output:
+
+```text
+PyPDF2 NO ModuleNotFoundError
+pdfplumber NO ModuleNotFoundError
+fitz NO ModuleNotFoundError
+pymupdf NO ModuleNotFoundError
+```
+
+#### Tool: exec_command
+
+```sh
+strings -n 8 "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf" | head -n 200
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+ls -la
+```
+
+Output:
+
+```text
+total 1320
+drwxr-xr-x@ 29 allen  staff     928 Apr  3 15:09 .
+drwxr-xr-x@ 23 allen  staff     736 Apr  1 20:11 ..
+-rw-r--r--@  1 allen  staff    6148 Mar 23 00:24 .DS_Store
+drwxr-xr-x@  6 allen  staff     192 Mar 29 20:48 .claude
+drwxr-xr-x@  8 allen  staff     256 Mar 23 00:03 .entire
+drwxr-xr-x@ 17 allen  staff     544 Apr  3 15:09 .git
+drwxr-xr-x@  5 allen  staff     160 Mar 10 18:09 .github
+-rw-r--r--@  1 allen  staff      66 Mar  7 14:48 .gitignore
+drwxr-xr-x@  2 allen  staff      64 Feb 18 13:23 .playwright
+drwxr-xr-x@ 15 allen  staff     480 Feb 24 13:17 .playwright-cli
+drwxr-xr-x@  3 allen  staff      96 Apr  3 15:09 .vscode
+-rw-r--r--@  1 allen  staff    1996 Mar 15 20:57 AGENTS.md
+-rw-r--r--@  1 allen  staff      11 Mar  8 13:51 CLAUDE.md
+-rw-r--r--@  1 allen  staff   21174 Mar 20 15:29 P4: Backend Development | CS 485 AI-Assisted Software Engineering (Sp26).html
+-rw-r--r--@  1 allen  staff   71704 Mar 29 16:36 P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf
+-rw-r--r--@  1 allen  staff      53 Feb 12 13:09 README.md
+-rw-r--r--@  1 allen  staff    3806 Feb 28 21:10 WORKFLOW.md
+-rw-r--r--@  1 allen  staff  519704 Feb 16 12:03 dev-spec-guidelines.pdf
+drwxr-xr-x@  9 allen  staff     288 Mar 31 18:56 docs
+drwxr-xr-x@ 12 allen  staff     384 Mar 22 22:42 dogfood-output
+drwxr-xr-x@ 22 allen  staff     704 Apr  1 11:59 harmony-backend
+drwxr-xr-x@ 23 allen  staff     736 Apr  1 11:58 harmony-frontend
+drwxr-xr-x@ 24 allen  staff     768 Mar 31 18:56 llm-logs
+-rw-r--r--@  1 allen  staff   20599 Mar 22 19:54 load-test.js
+drwxr-xr-x@  9 allen  staff     288 Mar  1 19:08 mockups
+-rw-r--r--@  1 allen  staff     280 Apr  3 15:09 package.json
+drwxr-xr-x@  6 allen  staff     192 Mar 30 10:17 planning
+drwxr-xr-x@  3 allen  staff      96 Apr  3 15:09 scripts
+drwxr-xr-x@  3 allen  staff      96 Mar 31 18:56 tasks
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "coverage|collectCoverage|coverageThreshold|lcov|istanbul" harmony-backend harmony-frontend
+```
+
+Output:
+
+```text
+Total output lines: 522
+
+harmony-frontend/bun.lock:114:    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
+harmony-frontend/bun.lock:210:    "@istanbuljs/load-nyc-config": ["@istanbuljs/load-nyc-config@1.1.0", "", { "dependencies": { "camelcase": "^5.3.1", "find-up": "^4.1.0", "get-package-type": "^0.1.0", "js-yaml": "^3.13.1", "resolve-from": "^5.0.0" } }, "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ=="],
+harmony-frontend/bun.lock:212:    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
+harmony-frontend/bun.lock:236:    "@jest/reporters": ["@jest/reporters@30.3.0", "", { "dependencies": { "@bcoe/v8-coverage": "^0.2.3", "@jest/console": "30.3.0", "@jest/test-result": "30.3.0", "@jest/transform": "30.3.0", "@jest/types": "30.3.0", "@jridgewell/trace-mapping": "^0.3.25", "@types/node": "*", "chalk": "^4.1.2", "collect-v8-coverage": "^1.0.2", "exit-x": "^0.2.2", "glob": "^10.5.0", "graceful-fs": "^4.2.11", "istanbul-lib-coverage": "^3.0.0", "istanbul-lib-instrument": "^6.0.0", "istanbul-lib-report": "^3.0.0", "istanbul-lib-source-maps": "^5.0.0", "istanbul-reports": "^3.1.3", "jest-message-util": "30.3.0", "jest-util": "30.3.0", "jest-worker": "30.3.0", "slash": "^3.0.0", "string-length": "^4.0.2", "v8-to-istanbul": "^9.0.1" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"] }, "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw=="],
+harmony-frontend/bun.lock:244:    "@jest/test-result": ["@jest/test-result@30.3.0", "", { "dependencies": { "@jest/console": "30.3.0", "@jest/types": "30.3.0", "@types/istanbul-lib-coverage": "^2.0.6", "collect-v8-coverage": "^1.0.2" } }, "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ=="],
+harmony-frontend/bun.lock:248:    "@jest/transform": ["@jest/transform@30.3.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@jest/types": "30.3.0", "@jridgewell/trace-mapping": "^0.3.25", "babel-plugin-istanbul": "^7.0.1", "chalk": "^4.1.2", "convert-source-map": "^2.0.0", "fast-json-stable-stringify": "^2.1.0", "graceful-fs": "^4.2.11", "jest-haste-map": "30.3.0", "jest-regex-util": "30.0.1", "jest-util": "30.3.0", "pirates": "^4.0.7", "slash": "^3.0.0", "write-file-atomic": "^5.0.1" } }, "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A=="],
+harmony-frontend/bun.lock:250:    "@jest/types": ["@jest/types@30.3.0", "", { "dependencies": { "@jest/pattern": "30.0.1", "@jest/schemas": "30.0.5", "@types/istanbul-lib-coverage": "^2.0.6", "@types/istanbul-reports": "^3.0.4", "@types/node": "*", "@types/yargs": "^17.0.33", "chalk": "^4.1.2" } }, "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw=="],
+harmony-frontend/bun.lock:358:    "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
+harmony-frontend/bun.lock:360:    "@types/istanbul-lib-report": ["@types/istanbul-lib-report@3.0.3", "", { "dependencies": { "@types/istanbul-lib-coverage": "*" } }, "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA=="],
+harmony-frontend/bun.lock:362:    "@types/istanbul-reports": ["@types/istanbul-reports@3.0.4", "", { "dependencies": { "@types/istanbul-lib-report": "*" } }, "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ=="],
+harmony-frontend/bun.lock:496:    "babel-jest": ["babel-jest@30.3.0", "", { "dependencies": { "@jest/transform": "30.3.0", "@types/babel__core": "^7.20.5", "babel-plugin-istanbul": "^7.0.1", "babel-preset-jest": "30.3.0", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "slash": "^3.0.0" }, "peerDependencies": { "@babel/core": "^7.11.0 || ^8.0.0-0" } }, "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ=="],
+harmony-frontend/bun.lock:498:    "babel-plugin-istanbul": ["babel-plugin-istanbul@7.0.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-instrument": "^6.0.2", "test-exclude": "^6.0.0" } }, "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA=="],
+harmony-frontend/bun.lock:550:    "collect-v8-coverage": ["collect-v8-coverage@1.0.3", "", {}, "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw=="],
+harmony-frontend/bun.lock:874:    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+harmony-frontend/bun.lock:876:    "istanbul-lib-instrument": ["istanbul-lib-instrument@6.0.3", "", { "dependencies": { "@babel/core": "^7.23.9", "@babel/parser": "^7.23.9", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-coverage": "^3.2.0", "semver": "^7.5.4" } }, "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q=="],
+harmony-frontend/bun.lock:878:    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+harmony-frontend/bun.lock:880:    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+harmony-frontend/bun.lock:882:    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+harmony-frontend/bun.lock:928:    "jest-runtime": ["jest-runtime@30.3.0", "", { "dependencies": { "@jest/environment": "30.3.0", "@jest/fake-timers": "30.3.0", "@jest/globals": "30.3.0", "@jest/source-map": "30.0.1", "@jest/test-result": "30.3.0", "@jest/transform": "30.3.0", "@jest/types": "30.3.0", "@types/node": "*", "chalk": "^4.1.2", "cjs-module-lexer": "^2.1.0", "collect-v8-coverage": "^1.0.2", "glob": "^10.5.0", "graceful-fs": "^4.2.11", "jest-haste-map": "30.3.0", "jest-message-util": "30.3.0", "jest-mock": "30.3.0", "jest-regex-util": "30.0.1", "jest-resolve": "30.3.0", "jest-snapshot": "30.3.0", "jest-util": "30.3.0", "slash": "^3.0.0", "strip-bom": "^4.0.0" } }, "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng=="],
+harmony-frontend/bun.lock:1264:    "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
+harmony-frontend/bun.lock:1322:    "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
+harmony-frontend/bun.lock:1396:    "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+harmony-frontend/bun.lock:1398:    "@istanbuljs/load-nyc-config/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+harmony-frontend/bun.lock:1400:    "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+harmony-frontend/bun.lock:1402:    "@istanbuljs/load-nyc-config/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+harmony-frontend/bun.lock:1476:    "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+harmony-frontend/bun.lock:1478:    "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+harmony-frontend/bun.lock:1488:    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+harmony-frontend/bun.lock:1492:    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+harmony-backend/src/services/auth.service.ts:16:  // istanbul ignore next -- NODE_ENV guard makes this unreachable in Jest (ts-jest transform cache)
+harmony-backend/src/services/auth.service.ts:25:  // istanbul ignore next -- NODE_ENV guard makes this unreachable in Jest (ts-jest transform cache)
+harmony-frontend/package-lock.json:579:    "node_modules/@bcoe/v8-coverage": {
+harmony-frontend/package-lock.json:581:      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+harmony-frontend/package-lock.json:1414:    "node_modules/@istanbuljs/load-nyc-config": {
+harmony-frontend/package-lock.json:1416:      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+harmony-frontend/package-lock.json:1431:    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+harmony-frontend/package-lock.json:1441:    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+harmony-frontend/package-lock.json:1455:    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+harmony-frontend/package-lock.json:1469:    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+harmony-frontend/package-lock.json:1482:    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+harmony-frontend/package-lock.json:1498:    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+harmony-frontend/package-lock.json:1511:    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+harmony-frontend/package-lock.json:1521:    "node_modules/@istanbuljs/schema": {
+harmony-frontend/package-lock.json:1523:      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+harmony-frontend/package-lock.json:1828:        "@bcoe/v8-coverage": "^0.2.3",
+harmony-frontend/package-lock.json:1836:        "collect-v8-coverage": "^1.0.2",
+harmony-frontend/package-lock.json:1840:        "istanbul-lib-coverage": "^3.0.0",
+harmony-frontend/package-lock.json:1841:        "istanbul-lib-instrument": "^6.0.0",
+harmony-frontend/package-lock.json:1842:        "istanbul-lib-report": "^3.0.0",
+harmony-frontend/package-lock.json:1843:        "istanbul-lib-source-maps": "^5.0.0",
+harmony-frontend/package-lock.json:1844:        "istanbul-reports": "^3.1.3",
+harmony-frontend/package-lock.json:1850:        "v8-to-istanbul": "^9.0.1"
+harmony-frontend/package-lock.json:1917:        "@types/istanbul-lib-coverage": "^2.0.6",
+harmony-frontend/package-lock.json:1918:        "collect-v8-coverage": "^1.0.2"
+harmony-frontend/package-lock.json:1950:        "babel-plugin-istanbul": "^7.0.1",
+harmony-frontend/package-lock.json:1975:        "@types/istanbul-lib-coverage": "^2.0.6",
+harmony-frontend/package-lock.json:1976:        "@types/istanbul-reports": "^3.0.4",
+harmony-frontend/package-lock.json:2810:    "node_modules/@types/istanbul-lib-coverage": {
+harmony-frontend/package-lock.json:2812:      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+harmony-frontend/package-lock.json:2817:    "node_modules/@types/istanbul-lib-report": {
+harmony-frontend/package-lock.json:2819:      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+harmony-frontend/package-lock.json:2824:        "@types/istanbul-lib-coverage": "*"
+harmony-frontend/package-lock.json:2827:    "node_modules/@types/istanbul-reports": {
+harmony-frontend/package-lock.json:2829:      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+harmony-frontend/package-lock.json:2834:        "@types/istanbul-lib-report": "*"
+harmony-frontend/package-lock.json:3889:        "babel-plugin-istanbul": "^7.0.1",
+harmony-frontend/package-lock.json:3902:    "node_modules/babel-plugin-istanbul": {
+harmony-frontend/package-lock.json:3904:      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+harmony-frontend/package-lock.json:3913:        "@istanbuljs/load-nyc-config": "^1.0.0",
+harmony-frontend/package-lock.json:3914:        "@istanbuljs/schema": "^0.1.3",
+harmony-frontend/package-lock.json:3915:        "istanbul-lib-instrument": "^6.0.2",
+harmony-frontend/package-lock.json:4314:    "node_modules/collect-v8-coverage": {
+harmony-frontend/package-lock.json:4316:      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+harmony-frontend/package-lock.json:6724:    "node_modules/istanbul-lib-coverage": {
+harmony-frontend/package-lock.json:6726:      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+harmony-frontend/package-lock.json:6734:    "node_modules/istanbul-lib-instrument": {
+harmony-frontend/package-lock.json:6736:      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+harmony-frontend/package-lock.json:6743:        "@istanbuljs/schema": "^0.1.3",
+harmony-frontend/package-lock.json:6744:        "istanbul-lib-coverage": "^3.2.0",
+harmony-frontend/package-lock.json:6751:    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+harmony-frontend/package-lock.json:6764:    "node_modules/istanbul-lib-report": {
+harmony-frontend/package-lock.json:6766:      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+harmony-frontend/package-lock.json:6771:        "istanbul-lib-coverage": "^3.0.0",
+harmony-frontend/package-lock.json:6779:    "node_modules/istanbul-lib-source-maps": {
+harmony-frontend/package-lock.json:6781:      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+harmony-frontend/package-lock.json:6788:        "istanbul-lib-coverage": "^3.0.0"
+harmony-frontend/package-lock.json:6794:    "node_modules/istanbul-reports": {
+harmony-frontend/package-lock.json:6796:      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+harmony-frontend/package-lock.json:6802:        "istanbul-lib-report": "^3.0.0"
+harmony-frontend/package-lock.json:7563:        "collect-v8-coverage": "^1.0.2",
+harmony-frontend/package-lock.json:10297:        "@istanbuljs/schema": "^0.1.2",
+harmony-frontend/package-lock.json:10882:  …9903 tokens truncated…ndex.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/lib/storage/index.ts.html:78:<a name='L13'></a><a href='#L13'>13</a></td><td class="line-coverage quiet"><span class="cline-any cline-neutral">&nbsp;</span>
+harmony-backend/coverage/lcov-report/src/lib/storage/index.ts.html:107:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/lib/storage/index.ts.html:108:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/db/redis.ts.html:6:    <title>Code coverage report for src/db/redis.ts</title>
+harmony-backend/coverage/lcov-report/src/db/redis.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/db/redis.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/db/redis.ts.html:80:<a name='L15'></a><a href='#L15'>15</a></td><td class="line-coverage quiet"><span class="cline-any cline-yes">26x</span>
+harmony-backend/coverage/lcov-report/src/db/redis.ts.html:113:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/db/redis.ts.html:114:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/lib/storage/index.html:6:    <title>Code coverage report for src/lib/storage</title>
+harmony-backend/coverage/lcov-report/src/lib/storage/index.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/lib/storage/index.html:66:<table class="coverage-summary">
+harmony-backend/coverage/lcov-report/src/lib/storage/index.html:117:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/lib/storage/index.html:118:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/services/reaction.service.ts.html:6:    <title>Code coverage report for src/services/reaction.service.ts</title>
+harmony-backend/coverage/lcov-report/src/services/reaction.service.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/services/reaction.service.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/services/reaction.service.ts.html:266:<a name='L201'></a><a href='#L201'>201</a></td><td class="line-coverage quiet"><span class="cline-any cline-yes">14x</span>
+harmony-backend/coverage/lcov-report/src/services/reaction.service.ts.html:671:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/services/reaction.service.ts.html:672:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/routes/seo.router.ts.html:6:    <title>Code coverage report for src/routes/seo.router.ts</title>
+harmony-backend/coverage/lcov-report/src/routes/seo.router.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/routes/seo.router.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/routes/seo.router.ts.html:124:<a name='L59'></a><a href='#L59'>59</a></td><td class="line-coverage quiet"><span class="cline-any cline-neutral">&nbsp;</span>
+harmony-backend/coverage/lcov-report/src/routes/seo.router.ts.html:245:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/routes/seo.router.ts.html:246:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/services/permission.service.ts.html:6:    <title>Code coverage report for src/services/permission.service.ts</title>
+harmony-backend/coverage/lcov-report/src/services/permission.service.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/services/permission.service.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/services/permission.service.ts.html:195:<a name='L130'></a><a href='#L130'>130</a></td><td class="line-coverage quiet"><span class="cline-any cline-neutral">&nbsp;</span>
+harmony-backend/coverage/lcov-report/src/services/permission.service.ts.html:458:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/services/permission.service.ts.html:459:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/routes/events.router.ts.html:6:    <title>Code coverage report for src/routes/events.router.ts</title>
+harmony-backend/coverage/lcov-report/src/routes/events.router.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/routes/events.router.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/routes/events.router.ts.html:510:<a name='L445'></a><a href='#L445'>445</a></td><td class="line-coverage quiet"><span class="cline-any cline-neutral">&nbsp;</span>
+harmony-backend/coverage/lcov-report/src/routes/events.router.ts.html:1403:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/routes/events.router.ts.html:1404:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/lib/storage/local.provider.ts.html:6:    <title>Code coverage report for src/lib/storage/local.provider.ts</title>
+harmony-backend/coverage/lcov-report/src/lib/storage/local.provider.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/lib/storage/local.provider.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/lib/storage/local.provider.ts.html:139:<a name='L74'></a><a href='#L74'>74</a></td><td class="line-coverage quiet"><span class="cline-any cline-yes">13x</span>
+harmony-backend/coverage/lcov-report/src/lib/storage/local.provider.ts.html:290:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/lib/storage/local.provider.ts.html:291:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/db/index.html:6:    <title>Code coverage report for src/db</title>
+harmony-backend/coverage/lcov-report/src/db/index.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/db/index.html:66:<table class="coverage-summary">
+harmony-backend/coverage/lcov-report/src/db/index.html:117:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/db/index.html:118:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/events/eventBus.ts.html:6:    <title>Code coverage report for src/events/eventBus.ts</title>
+harmony-backend/coverage/lcov-report/src/events/eventBus.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/events/eventBus.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/events/eventBus.ts.html:218:<a name='L153'></a><a href='#L153'>153</a></td><td class="line-coverage quiet"><span class="cline-any cline-neutral">&nbsp;</span>
+harmony-backend/coverage/lcov-report/src/events/eventBus.ts.html:527:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/events/eventBus.ts.html:528:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/services/channel.service.ts.html:6:    <title>Code coverage report for src/services/channel.service.ts</title>
+harmony-backend/coverage/lcov-report/src/services/channel.service.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/services/channel.service.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/services/channel.service.ts.html:239:<a name='L174'></a><a href='#L174'>174</a></td><td class="line-coverage quiet"><span class="cline-any cline-yes">16x</span>
+harmony-backend/coverage/lcov-report/src/services/channel.service.ts.html:590:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/services/channel.service.ts.html:591:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/routes/public.router.ts.html:6:    <title>Code coverage report for src/routes/public.router.ts</title>
+harmony-backend/coverage/lcov-report/src/routes/public.router.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/routes/public.router.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/routes/public.router.ts.html:374:<a name='L309'></a><a href='#L309'>309</a></td><td class="line-coverage quiet"><span class="cline-any cline-yes">13x</span>
+harmony-backend/coverage/lcov-report/src/routes/public.router.ts.html:995:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/routes/public.router.ts.html:996:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/routes/attachment.router.ts.html:6:    <title>Code coverage report for src/routes/attachment.router.ts</title>
+harmony-backend/coverage/lcov-report/src/routes/attachment.router.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/routes/attachment.router.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/routes/attachment.router.ts.html:193:<a name='L128'></a><a href='#L128'>128</a></td><td class="line-coverage quiet"><span class="cline-any cline-yes">13x</span>
+harmony-backend/coverage/lcov-report/src/routes/attachment.router.ts.html:452:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/routes/attachment.router.ts.html:453:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/services/voice.service.ts.html:6:    <title>Code coverage report for src/services/voice.service.ts</title>
+harmony-backend/coverage/lcov-report/src/services/voice.service.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/services/voice.service.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/services/voice.service.ts.html:368:<a name='L303'></a><a href='#L303'>303</a></td><td class="line-coverage quiet"><span class="cline-any cline-neutral">&nbsp;</span>
+harmony-backend/coverage/lcov-report/src/services/voice.service.ts.html:977:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/services/voice.service.ts.html:978:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/events/eventTypes.ts.html:6:    <title>Code coverage report for src/events/eventTypes.ts</title>
+harmony-backend/coverage/lcov-report/src/events/eventTypes.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/events/eventTypes.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/events/eventTypes.ts.html:240:<a name='L175'></a><a href='#L175'>175</a></td><td class="line-coverage quiet"><span class="cline-any cline-neutral">&nbsp;</span>
+harmony-backend/coverage/lcov-report/src/events/eventTypes.ts.html:593:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/events/eventTypes.ts.html:594:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/routes/auth.router.ts.html:6:    <title>Code coverage report for src/routes/auth.router.ts</title>
+harmony-backend/coverage/lcov-report/src/routes/auth.router.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/routes/auth.router.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/routes/auth.router.ts.html:214:<a name='L149'></a><a href='#L149'>149</a></td><td class="line-coverage quiet"><span class="cline-any cline-yes">13x</span>
+harmony-backend/coverage/lcov-report/src/routes/auth.router.ts.html:515:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/routes/auth.router.ts.html:516:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/db/prisma.ts.html:6:    <title>Code coverage report for src/db/prisma.ts</title>
+harmony-backend/coverage/lcov-report/src/db/prisma.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/db/prisma.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/db/prisma.ts.html:75:<a name='L10'></a><a href='#L10'>10</a></td><td class="line-coverage quiet"><span class="cline-any cline-yes">17x</span>
+harmony-backend/coverage/lcov-report/src/db/prisma.ts.html:98:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/db/prisma.ts.html:99:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/routes/index.html:6:    <title>Code coverage report for src/routes</title>
+harmony-backend/coverage/lcov-report/src/routes/index.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/routes/index.html:66:<table class="coverage-summary">
+harmony-backend/coverage/lcov-report/src/routes/index.html:162:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/routes/index.html:163:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/services/message.service.ts.html:6:    <title>Code coverage report for src/services/message.service.ts</title>
+harmony-backend/coverage/lcov-report/src/services/message.service.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/services/message.service.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/services/message.service.ts.html:604:<a name='L539'></a><a href='#L539'>539</a></td><td class="line-coverage quiet"><span class="cline-any cline-yes">16x</span>
+harmony-backend/coverage/lcov-report/src/services/message.service.ts.html:1685:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/services/message.service.ts.html:1686:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+harmony-backend/coverage/lcov-report/src/services/server.service.ts.html:6:    <title>Code coverage report for src/services/server.service.ts</title>
+harmony-backend/coverage/lcov-report/src/services/server.service.ts.html:13:        .coverage-summary .sorter {
+harmony-backend/coverage/lcov-report/src/services/server.service.ts.html:65:    <pre><table class="coverage">
+harmony-backend/coverage/lcov-report/src/services/server.service.ts.html:273:<a name='L208'></a><a href='#L208'>208</a></td><td class="line-coverage quiet"><span class="cline-any cline-yes">13x</span>
+harmony-backend/coverage/lcov-report/src/services/server.service.ts.html:692:                Code coverage generated by
+harmony-backend/coverage/lcov-report/src/services/server.service.ts.html:693:                <a href="https://istanbul.js.org/" target="_blank" rel="noopener noreferrer">istanbul</a>
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 95485,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'strings -n 8 "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf" | head -n 200'
+Chunk ID: 44dbcc
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 2041
+Output:
+%PDF-1.3
+<< /Filter /FlateDecode /Length 20720 >>
+e5P:nExU
+RF8Le{uNg
+;F(|hU j
+endstream
+<< /Type /Page /Parent 2 0 R /Resources 4 0 R /Contents 3 0 R /MediaBox [0 0 1309 4738]
+/Annots 7 0 R >>
+<< /ProcSet [ /PDF /Text ] /ColorSpace << /Cs1 5 0 R >> /Font << /TT1 6 0 R
+/TT2 9 0 R /TT5 35 0 R /TT3 22 0 R /TT4 34 0 R /TT7 41 0 R /TT6 40 0 R /TT8
+43 0 R /TT9 48 0 R >> /Shading << /Sh1 17 0 R /Sh2 21 0 R >> >>
+[ 8 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 18 0 R 19 0 R 20 0 R
+23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R
+36 0 R 37 0 R 38 0 R 39 0 R 42 0 R 44 0 R 45 0 R 46 0 R 47 0 R 49 0 R 50 0 R
+51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R 57 0 R 58 0 R 59 0 R 60 0 R 61 0 R
+62 0 R 63 0 R 64 0 R ]
+17 0 obj
+<< /ColorSpace 5 0 R /ShadingType 2 /Coords [ 252 0 0 0 ] /Domain [ 0 1 ]
+/Extend [ true true ] /Function 65 0 R >>
+21 0 obj
+<< /ColorSpace 5 0 R /ShadingType 2 /Coords [ 252 0 0 0 ] /Domain [ 0 1 ]
+/Extend [ true true ] /Function 66 0 R >>
+67 0 obj
+<< /N 3 /Alternate /DeviceRGB /Length 2612 /Filter /FlateDecode >>
+TIj"]&=&
+SwBOK/X/_
+endstream
+[ /ICCBased 67 0 R ]
+65 0 obj
+<< /FunctionType 0 /BitsPerSample 8 /Size [ 1365 ] /Domain [ 0 1 ] /Range
+[ 0 1 0 1 0 1 ] /Length 47 /Filter /FlateDecode >>
+endstream
+66 0 obj
+<< /FunctionType 0 /BitsPerSample 8 /Size [ 1365 ] /Domain [ 0 1 ] /Range
+[ 0 1 0 1 0 1 ] /Length 47 /Filter /FlateDecode >>
+endstream
+<< /Type /Pages /MediaBox [0 0 1309 4738] /Count 1 /Kids [ 1 0 R ] >>
+68 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+69 0 obj
+<< /CreationDate (D:20260329203629Z00'00') /Producer (macOS Version 26.3.1 \(a\) \(Build 25D771280a\) Quartz PDFContext)
+/ModDate (D:20260329203629Z00'00') >>
+64 0 obj
+<< /Dest 70 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [649.8594 193.5 722.7344 211.5]
+63 0 obj
+<< /Dest 71 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 746.5 418.5 776.5]
+62 0 obj
+<< /Dest 70 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 1099 418.5 1121]
+61 0 obj
+<< /Dest 72 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 1296 418.5 1311]
+60 0 obj
+<< /A 73 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [842.7656 1590 972.3906 1608]
+73 0 obj
+<< /Type /Action /S /URI /URI 74 0 R >>
+74 0 obj
+(https://code.visualstudio.com/api/working-with-extensions/continuous-integration)
+59 0 obj
+<< /A 75 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [814.9375 1619 974.2656 1637]
+75 0 obj
+<< /Type /Action /S /URI /URI 76 0 R >>
+76 0 obj
+(https://www.dennisokeeffe.com/blog/2021-10-27-jest-with-github-actions)
+58 0 obj
+<< /Dest 77 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 1876.5 418.5 1898.5]
+57 0 obj
+<< /A 78 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [656.2656 1970.5 724.3594 1988.5]
+78 0 obj
+<< /Type /Action /S /URI /URI 79 0 R >>
+79 0 obj
+(https://www.testim.io/blog/mocha-code-coverage-how-to-use-instanbul-to-get-going/)
+56 0 obj
+<< /A 80 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [637.8125 1999.5 705.9062 2017.5]
+80 0 obj
+<< /Type /Action /S /URI /URI 81 0 R >>
+81 0 obj
+(https://medium.com/@blturner3527/code-coverage-and-testing-with-jest-9641b5d0e0bc)
+55 0 obj
+<< /Dest 82 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 2091 418.5 2113]
+54 0 obj
+<< /Dest 83 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 2285.5 418.5 2307.5]
+53 0 obj
+<< /A 84 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [533.9219 2586.5 592.8125 2604.5]
+84 0 obj
+<< /Type /Action /S /URI /URI 85 0 R >>
+85 0 obj
+(https://sinonjs.org/)
+52 0 obj
+<< /A 86 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [442.5 2615.5 473.1094 2633.5]
+86 0 obj
+<< /Type /Action /S /URI /URI 87 0 R >>
+87 0 obj
+(https://jestjs.io/docs/mock-functions)
+51 0 obj
+<< /Dest 88 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 2889 418.5 2911]
+50 0 obj
+<< /Dest 89 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 3133.5 418.5 3155.5]
+49 0 obj
+<< /Dest 90 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 3353 418.5 3375]
+47 0 obj
+<< /Dest 91 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 3881 418.5 3911]
+46 0 obj
+<< /Dest 92 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 4318 418.5 4348]
+45 0 obj
+<< /Dest 93 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 4475 418.5 4505]
+44 0 obj
+<< /Dest 94 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 4541 418.5 4586]
+42 0 obj
+<< /Dest 95 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [394.5 4604 418.5 4634]
+39 0 obj
+<< /A 96 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [418.5 34.5 1145.547 68.5]
+96 0 obj
+<< /Type /Action /S /URI /URI 97 0 R >>
+97 0 obj
+(https://creativecommons.org/licenses/by-sa/4.0/)
+38 0 obj
+<< /A 98 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [450.2188 2747.5 745.7969 2765.5]
+98 0 obj
+<< /Type /Action /S /URI /URI 99 0 R >>
+99 0 obj
+(https://code.visualstudio.com/api/working-with-extensions/testing-extension)
+37 0 obj
+<< /A 100 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [943.6094 2863.5 974.2188 2881.5]
+100 0 obj
+<< /Type /Action /S /URI /URI 101 0 R >>
+101 0 obj
+(https://jestjs.io/)
+36 0 obj
+<< /A 102 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [418.5 4647 458.6094 4662]
+102 0 obj
+<< /Type /Action /S /URI /URI 103 0 R >>
+103 0 obj
+(https://kelloggm.github.io/martinjkellogg.com/teaching/cs485-sp26/projects/)
+33 0 obj
+<< /A 104 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [1059.047 4679 1170.5 4738]
+104 0 obj
+<< /Type /Action /S /URI /URI 105 0 R >>
+105 0 obj
+(https://njit.instructure.com/courses/64184)
+32 0 obj
+<< /A 106 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [914.8438 4679 1059.047 4738]
+106 0 obj
+<< /Type /Action /S /URI /URI 107 0 R >>
+107 0 obj
+(https://njit.instructure.com/courses/64185)
+31 0 obj
+<< /A 108 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [839.5 4679 914.8438 4738]
+108 0 obj
+<< /Type /Action /S /URI /URI 109 0 R >>
+109 0 obj
+(https://discord.com/channels/1462907670855159891/1462907671735832585)
+30 0 obj
+<< /A 110 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [121.5 4110 385.5 4142]
+110 0 obj
+<< /Type /Action /S /URI /URI 111 0 R >>
+111 0 obj
+(https://kelloggm.github.io/martinjkellogg.com/teaching/cs485-sp26/about/)
+29 0 obj
+<< /A 112 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [121.5 4142 385.5 4174]
+112 0 obj
+<< /Type /Action /S /URI /URI 113 0 R >>
+113 0 obj
+(https://kelloggm.github.io/martinjkellogg.com/teaching/cs485-sp26/staff/)
+28 0 obj
+<< /A 114 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [121.5 4174 385.5 4206]
+114 0 obj
+<< /Type /Action /S /URI /URI 115 0 R >>
+115 0 obj
+(https://kelloggm.github.io/martinjkellogg.com/teaching/cs485-sp26/calendar/)
+27 0 obj
+<< /A 116 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [353.5 4206 385.5 4238]
+116 0 obj
+<< /Type /Action /S /URI /URI 117 0 R >>
+117 0 obj
+(https://kelloggm.github.io/martinjkellogg.com/teaching/cs485-sp26/projects/p5.html#)
+26 0 obj
+<< /A 118 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [121.5 4206 385.5 4238]
+118 0 obj
+<< /Type /Action /S /URI /URI 119 0 R >>
+119 0 obj
+(https://kelloggm.github.io/martinjkellogg.com/teaching/cs485-sp26/tutorials/)
+25 0 obj
+<< /A 120 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [133.5 4238 385.5 4294]
+120 0 obj
+<< /Type /Action /S /URI /URI 121 0 R >>
+121 0 obj
+(https://kelloggm.github.io/martinjkellogg.com/teaching/cs485-sp26/projects/p7.html)
+24 0 obj
+<< /A 122 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [133.5 4294 385.5 4326]
+122 0 obj
+<< /Type /Action /S /URI /URI 123 0 R >>
+123 0 obj
+(https://kelloggm.github.io/martinjkellogg.com/teaching/cs485-sp26/projects/p6.html)
+23 0 obj
+<< /A 124 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [133.5 4326 385.5 4358]
+124 0 obj
+<< /Type /Action /S /URI /URI 125 0 R >>
+125 0 obj
+(https://kelloggm.github.io/martinjkellogg.com/teaching/cs485-sp26/projects/p5.html)
+20 0 obj
+<< /A 126 0 R /Border [ 0 0 0 ] /Type /Annot /Subtype /Link /Rect [133.5 4358 385.5 4390]
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:10:05.208Z
+
+I’ve recovered the assignment requirements from the course page the PDF links to. Now I’m checking the concrete deliverables: spec docs, four target test files, coverage evidence, CI workflows, and whether frontend/backend tests still pass after the pull.
+
+#### Tool: exec_command
+
+```sh
+rtk read package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony",
+  "private": true,
+  "scripts": {
+    "test": "node ./scripts/run-root-jest.cjs",
+    "jest": "node ./scripts/run-root-jest.cjs",
+    "test:backend": "npm --prefix harmony-backend test --",
+    "test:frontend": "npm --prefix harmony-frontend test --"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rg --files .github/workflows docs planning tasks harmony-backend/tests harmony-frontend/src/__tests__
+```
+
+Output:
+
+```text
+tasks/lessons.md
+docs/unified-backend-architecture.md
+docs/dev-spec-channel-visibility-toggle.md
+docs/dev-spec-guest-public-channel-view.md
+docs/p4-backend-modules.md
+harmony-backend/tests/attachment.service.test.ts
+harmony-backend/tests/indexing.service.test.ts
+harmony-backend/tests/public.router.test.ts
+harmony-backend/tests/message.replies.test.ts
+harmony-backend/tests/events.router.member.test.ts
+harmony-backend/tests/visibility.service.test.ts
+harmony-backend/tests/server.test.ts
+harmony-backend/tests/trpc.error-formatter.test.ts
+harmony-backend/tests/serverMember.test.ts
+harmony-backend/tests/permission.service.test.ts
+harmony-backend/tests/channel.getAuditLog.test.ts
+harmony-backend/tests/cache.middleware.test.ts
+harmony-backend/tests/events.router.test.ts
+harmony-backend/tests/tsconfig.json
+harmony-backend/tests/demo-seed.test.ts
+harmony-backend/tests/cache.service.test.ts
+harmony-backend/tests/user.service.test.ts
+harmony-backend/tests/trpc.permission.middleware.test.ts
+harmony-backend/tests/message.service.events.test.ts
+harmony-backend/tests/reaction.test.ts
+harmony-backend/tests/events.router.status.test.ts
+harmony-backend/tests/events.router.sse-server-updated.test.ts
+harmony-backend/tests/auth.service.test.ts
+harmony-backend/tests/channel.service.events.test.ts
+harmony-backend/tests/message.service.test.ts
+harmony-backend/tests/channel.service.test.ts
+harmony-backend/tests/eventBus.test.ts
+harmony-backend/tests/auditLog.service.test.ts
+harmony-backend/tests/voice.service.test.ts
+harmony-backend/tests/mock-seed.test.ts
+harmony-backend/tests/rate-limit.middleware.test.ts
+harmony-backend/tests/events.router.server.test.ts
+harmony-backend/tests/events.router.visibility.test.ts
+harmony-backend/tests/auth.test.ts
+harmony-backend/tests/schema.test.ts
+harmony-backend/tests/auth.service.init.test.ts
+harmony-backend/tests/attachment.router.test.ts
+harmony-backend/tests/app.test.ts
+docs/design-brief/channel-visibility-toggle/design-brief.md
+planning/SPRINT_2_PLAN.md
+planning/SPRINT_3_PLAN.md
+docs/dev-spec-seo-meta-tag-generation.md
+planning/Create_Sprint_Plan.md
+planning/P1_ Requirements Engineering.md
+docs/test-specs/server-service-spec.md
+docs/test-specs/frontend-server-service-spec.md
+docs/test-specs/server-member-service-spec.md
+docs/test-specs/auth-service-spec.md
+docs/test-specs/frontend-channel-service-spec.md
+docs/design-brief/guest-public-channel-view/design-brief.md
+.github/workflows/ci.yml
+.github/workflows/demo-seed.yml
+.github/workflows/run-backend-tests.yml
+.github/workflows/discord-forum-pr.yml
+.github/workflows/run-frontend-tests.yml
+.github/workflows/claude-review.yml
+harmony-frontend/src/__tests__/utils.test.ts
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts
+harmony-frontend/src/__tests__/middleware.test.ts
+harmony-frontend/src/__tests__/useServerListSync.test.tsx
+harmony-frontend/src/__tests__/channelService.test.ts
+harmony-frontend/src/__tests__/useServerEvents.test.tsx
+harmony-frontend/src/__tests__/trpc-client.test.ts
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx
+harmony-frontend/src/__tests__/useChannelEvents.test.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "P5|test specification|testing specification|code coverage|run-frontend-tests|run-backend-tests|reflection" docs planning tasks README.md harmony-backend harmony-frontend .github/workflows
+```
+
+Output:
+
+```text
+docs/unified-backend-architecture.md:131:| M-B7 | Background Workers | Server | Shared | *(Not built in P4 — deferred to P5/P6; includes search engine pings and async regeneration jobs)* | — |
+docs/test-specs/server-service-spec.md:5:This document defines the English-language test specification for `harmony-backend/src/services/server.service.ts`.
+docs/test-specs/frontend-channel-service-spec.md:5:This document defines the English-language test specification for `harmony-frontend/src/services/channelService.ts`.
+docs/test-specs/frontend-server-service-spec.md:5:This document defines the English-language test specification for `harmony-frontend/src/services/serverService.ts`.
+harmony-frontend/src/__tests__/channelService.test.ts:3: * Issue #266 — Sprint 3 (P5 Testing)
+planning/SPRINT_3_PLAN.md:6:**Assignment:** P5: Testing
+planning/SPRINT_3_PLAN.md:41:- Target 80%+ code coverage of all execution paths
+planning/SPRINT_3_PLAN.md:51:- Target 80%+ code coverage of all execution paths
+planning/SPRINT_3_PLAN.md:62:- Target 80%+ code coverage of all execution paths
+planning/SPRINT_3_PLAN.md:73:- Target 80%+ code coverage of all execution paths
+planning/SPRINT_3_PLAN.md:79:- Create `.github/workflows/run-frontend-tests.yml`
+planning/SPRINT_3_PLAN.md:82:- Create `.github/workflows/run-backend-tests.yml`
+planning/SPRINT_3_PLAN.md:101:- **Acceptance criteria:** 80%+ code coverage (run Jest with `--coverage`), capture coverage report for submission
+planning/SPRINT_3_PLAN.md:112:- **Acceptance criteria:** 80%+ code coverage (run Jest with `--coverage`), capture coverage report for submission
+planning/SPRINT_3_PLAN.md:123:- **Acceptance criteria:** 80%+ code coverage (run Jest with `--coverage`), capture coverage report for submission
+planning/SPRINT_3_PLAN.md:134:- **Acceptance criteria:** 80%+ code coverage (run Jest with `--coverage`), capture coverage report for submission
+planning/SPRINT_3_PLAN.md:147:- Note: 500-word reflection is written collaboratively as a group
+planning/SPRINT_3_PLAN.md:175:Note: 500-word reflection is a group effort, not tracked as an individual issue.
+planning/SPRINT_3_PLAN.md:185:| April 3 (Thu) | README updated, reflection draft |
+harmony-frontend/package-lock.json:1191:      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+harmony-frontend/package-lock.json:2243:      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+harmony-frontend/package-lock.json:4324:      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+harmony-frontend/package-lock.json:4420:      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+harmony-frontend/package-lock.json:5298:      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+harmony-frontend/package-lock.json:5939:      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+harmony-frontend/package-lock.json:6102:      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+harmony-frontend/package-lock.json:7928:      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+harmony-frontend/package-lock.json:8422:      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+harmony-frontend/package-lock.json:8510:      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+harmony-frontend/package-lock.json:8545:      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+harmony-frontend/package-lock.json:9202:      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+harmony-frontend/package-lock.json:9423:      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+harmony-frontend/package-lock.json:9826:      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+harmony-frontend/package-lock.json:10272:      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+docs/test-specs/server-member-service-spec.md:5:This document defines the English-language test specification for `harmony-backend/src/services/serverMember.service.ts`.
+harmony-frontend/bun.lock:188:    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+harmony-frontend/bun.lock:292:    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+harmony-frontend/bun.lock:552:    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+harmony-frontend/bun.lock:572:    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+harmony-frontend/bun.lock:666:    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+harmony-frontend/bun.lock:758:    "handlebars": ["handlebars@4.7.8", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ=="],
+harmony-frontend/bun.lock:784:    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+harmony-frontend/bun.lock:956:    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+harmony-frontend/bun.lock:1022:    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+harmony-frontend/bun.lock:1038:    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+harmony-frontend/bun.lock:1044:    "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": "lib/cli.js" }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
+harmony-frontend/bun.lock:1154:    "resolve-cwd": ["resolve-cwd@3.0.0", "", { "dependencies": { "resolve-from": "^5.0.0" } }, "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg=="],
+harmony-frontend/bun.lock:1204:    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+harmony-frontend/bun.lock:1260:    "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
+harmony-frontend/bun.lock:1408:    "@testing-library/dom/pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+docs/test-specs/auth-service-spec.md:5:This document defines the English-language test specification for `harmony-backend/src/services/auth.service.ts`.
+harmony-backend/package-lock.json:2103:      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+harmony-backend/package-lock.json:2997:      "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
+harmony-backend/package-lock.json:3110:      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+harmony-backend/package-lock.json:3765:      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+harmony-backend/package-lock.json:4441:      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+harmony-backend/package-lock.json:5057:      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+harmony-backend/package-lock.json:5524:      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+harmony-backend/package-lock.json:6524:      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+harmony-backend/package-lock.json:6810:      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+```
+
+#### Tool: exec_command
+
+```sh
+find .github/workflows -maxdepth 1 -type f | sort
+```
+
+Output:
+
+```text
+.github/workflows/ci.yml
+.github/workflows/claude-review.yml
+.github/workflows/demo-seed.yml
+.github/workflows/discord-forum-pr.yml
+.github/workflows/run-backend-tests.yml
+.github/workflows/run-frontend-tests.yml
+```
+
+#### Tool: exec_command
+
+```sh
+find harmony-backend/coverage -maxdepth 2 \( -name 'coverage-summary.json' -o -name 'lcov.info' -o -name 'index.html' \) | sort | head -n 50
+```
+
+Output:
+
+```text
+harmony-backend/coverage/lcov-report/index.html
+harmony-backend/coverage/lcov.info
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:10:15.519Z
+
+The repo already has the obvious P5 scaffolding: test-spec docs and both workflow files. I’m reading the workflow/README/config details now and then I’ll validate the actual state by running the frontend and backend test suites.
+
+#### Tool: exec_command
+
+```sh
+rtk read .github/workflows/run-frontend-tests.yml
+```
+
+Output:
+
+```text
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  frontend-tests:
+    name: Run Frontend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: harmony-frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: harmony-frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        run: npm test
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read .github/workflows/run-backend-tests.yml
+```
+
+Output:
+
+```text
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  backend-tests:
+    name: Run Backend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: harmony-backend
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: harmony
+          POSTGRES_PASSWORD: harmony
+          POSTGRES_DB: harmony_dev
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://harmony:harmony@localhost:5432/harmony_dev
+      REDIS_URL: redis://localhost:6379
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: harmony-backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Run migrations
+        run: npx prisma migrate deploy
+
+      - name: Run backend tests
+        run: npm test
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read docs/test-specs/frontend-channel-service-spec.md
+```
+
+Output:
+
+````text
+# Channel Service Test Specification (Frontend)
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-frontend/src/services/channelService.ts`.
+It covers all seven exported service functions:
+
+- `getChannels`
+- `getChannel`
+- `updateVisibility`
+- `updateChannel`
+- `createChannel`
+- `getAuditLog`
+- `deleteChannel`
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Mock `trpcQuery` and `trpcMutate` from `@/lib/trpc-client` using Jest module mocking.
+- Mock `publicGet` from `@/lib/trpc-client` for tests that exercise the public REST path.
+- Reset all mocks between tests to ensure isolation.
+- Use `console.warn` spies to assert that `toFrontendChannel` and `toAuditLogEntry` emit validation warnings for malformed API responses.
+- The `getChannel` export is wrapped in React's `cache()`. Tests should call the function directly and mock the underlying transport layer rather than the cache wrapper.
+- All resolved mock payloads must conform to the `Record<string, unknown>` shapes expected by the adapter functions; omit or corrupt individual fields to exercise validation warnings.
+- `ChannelVisibility` enum values under test: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `getChannels`
+
+Purpose: fetch all channels for a server (including PRIVATE channels) via the authenticated tRPC `channel.getChannels` endpoint.
+
+Program paths:
+
+- `trpcQuery` resolves with a non-empty array; each raw record is adapted and returned.
+- `trpcQuery` resolves with `null` or `undefined`; the function returns `[]`.
+- `trpcQuery` rejects; the error propagates to the caller uncaught.
+
+### 3.2 `getChannel`
+
+Purpose: return a single channel by server slug and channel slug, or `null` if not found. Tries the public REST endpoint first to support unauthenticated guest views, then falls back to authenticated tRPC.
+
+Program paths:
+
+- `publicGet` for the server resolves with `null`; function returns `null` immediately.
+- `publicGet` for the server rejects; the rejection propagates uncaught to the caller (this call sits outside both `try` blocks).
+- Server resolves; public channel list resolves and contains a matching slug; channel is returned with `visibility` hardcoded to `PUBLIC_INDEXABLE`.
+- Server resolves; public channel list resolves with `null`; falls through to tRPC fallback.
+- Server resolves; public channel list resolves but contains no matching slug; falls through to tRPC fallback.
+- Server resolves; public channel list `publicGet` call throws; falls through to tRPC fallback.
+- tRPC fallback resolves with channel data; channel is returned.
+- tRPC fallback resolves with `null`/falsy; function returns `null`.
+- tRPC fallback rejects; function catches the error, logs it, and returns `null`.
+
+### 3.3 `updateVisibility`
+
+Purpose: update a channel's visibility via the authenticated tRPC `channel.setVisibility` mutation. Returns `void`.
+
+Program paths:
+
+- `trpcMutate` resolves; function returns `void`.
+- `trpcMutate` rejects; error propagates to the caller.
+
+### 3.4 `updateChannel`
+
+Purpose: update a channel's `name` and/or `topic` metadata via tRPC. Only defined patch keys are forwarded.
+
+Program paths:
+
+- Patch includes both `name` and `topic`; both are forwarded and the adapted result is returned.
+- Patch includes only `name` (no `topic`); only `name` is forwarded.
+- Patch includes only `topic` (no `name`); only `topic` is forwarded.
+- Patch is empty (`{}`); neither key is forwarded; adapted result is still returned.
+- `trpcMutate` rejects; error propagates to the caller.
+
+### 3.5 `createChannel`
+
+Purpose: create a new channel via tRPC `channel.createChannel` and return the adapted `Channel`.
+
+Program paths:
+
+- All required fields are provided; `trpcMutate` resolves; adapted channel is returned.
+- `trpcMutate` rejects; error propagates to the caller.
+
+### 3.6 `getAuditLog`
+
+Purpose: fetch a paginated visibility audit log for a channel via tRPC `channel.getAuditLog`.
+
+Program paths:
+
+- `trpcQuery` resolves with a populated `entries` array and `total`; each entry is adapted and returned.
+- `trpcQuery` resolves with an empty `entries` array; returns `{ entries: [], total: 0 }`.
+- Options are partially provided (`limit` only, `offset` only, or `startDate` only); present keys are forwarded.
+- Options are omitted entirely; query is called with only `serverId` and `channelId`.
+- An entry has an invalid or missing `timestamp`; `toAuditLogEntry` falls back to epoch ISO string and emits a `console.warn`.
+- `trpcQuery` rejects; error propagates to the caller.
+
+### 3.7 `deleteChannel`
+
+Purpose: delete a channel via tRPC and return `true` on success.
+
+Program paths:
+
+- `trpcMutate` resolves; function returns `true`.
+- `trpcMutate` rejects; error propagates to the caller.
+
+## 4. Detailed Test Cases
+
+### 4.1 `getChannels`
+
+Description: fetches the full channel list for a server, adapting each record from the raw backend shape.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return adapted channels for a server | `serverId = "s1"`; `trpcQuery` resolves with two valid raw channel records | Returns an array of two `Channel` objects with all fields correctly mapped |
+| Return empty array when API returns null | `serverId = "s1"`; `trpcQuery` resolves with `null` | Returns `[]` |
+| Return empty array when API returns undefined | `serverId = "s1"`; `trpcQuery` resolves with `undefined` | Returns `[]` |
+| Propagate rejection to caller | `serverId = "s1"`; `trpcQuery` rejects with a network error | The promise rejects with the same error; caller receives it without masking |
+
+### 4.2 `getChannel`
+
+Description: fetches a single channel by slug pair, attempting the public REST endpoint before falling back to authenticated tRPC.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return null when server lookup fails | `serverSlug = "my-server"`; `publicGet` for server resolves with `null` | Returns `null`; no further network calls are made |
+| Propagate rejection when server lookup rejects | `serverSlug = "my-server"`; `publicGet` for server rejects with a network error | Promise rejects with the same error; rejection is not caught |
+| Return channel from public endpoint on slug match | Server resolves; public channel list contains a record with matching `channelSlug` | Returns `Channel` with `visibility = PUBLIC_INDEXABLE`; `serverId` filled from server lookup |
+| Supplement missing public fields with defaults | Public channel record omits `position` and `createdAt` | Returned channel has `position = 0` and `createdAt` equal to epoch ISO string |
+| Fall through to tRPC when public channel list returns null | Server resolves; `publicGet` for channels resolves with `null`; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; does not log an error |
+| Fall through to tRPC when slug not in public list | Server resolves; public channel list has no matching slug; tRPC resolves with channel data | Returns the tRPC-adapted `Channel` |
+| Fall through to tRPC when public endpoint throws | Server resolves; public channels `publicGet` throws; tRPC resolves with channel data | Returns the tRPC-adapted `Channel`; thrown error is swallowed silently |
+| Return null when tRPC resolves with falsy value | Server resolves; public endpoint miss; tRPC resolves with `null` | Returns `null` |
+| Return null when tRPC rejects | Server resolves; public endpoint miss; tRPC rejects | Returns `null`; logs error via `console.error` |
+| Correctly set visibility to PUBLIC_INDEXABLE for public hit | Server resolves; public list match with any `visibility` value in raw record | Returned channel always has `visibility = PUBLIC_INDEXABLE` regardless of raw field |
+
+### 4.3 `updateVisibility`
+
+Description: sends a visibility mutation to the backend with no return value.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Successfully set visibility to PUBLIC_INDEXABLE | `channelId = "c1"`, `visibility = PUBLIC_INDEXABLE`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with `{ serverId, channelId, visibility }` |
+| Successfully set visibility to PUBLIC_NO_INDEX | `channelId = "c1"`, `visibility = PUBLIC_NO_INDEX`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |
+| Successfully set visibility to PRIVATE | `channelId = "c1"`, `visibility = PRIVATE`, `serverId = "s1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with correct args |
+| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 403 error | Promise rejects with the same error |
+
+### 4.4 `updateChannel`
+
+Description: sends partial channel metadata updates, forwarding only the keys that are explicitly set.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Update both name and topic | `patch = { name: "general", topic: "chat" }`; `trpcMutate` resolves with a full channel record | Returns adapted `Channel`; mutation called with `name` and `topic` |
+| Update name only | `patch = { name: "general" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `topic` key |
+| Update topic only | `patch = { topic: "new topic" }`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called without `name` key |
+| Empty patch sends no extra keys | `patch = {}`; `trpcMutate` resolves | Returns adapted `Channel`; mutation called with only `serverId` and `channelId` |
+| Propagate rejection to caller | Valid patch; `trpcMutate` rejects | Promise rejects with the underlying error |
+
+### 4.5 `createChannel`
+
+Description: creates a new channel and returns the backend-confirmed record.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Create channel with all fields | Full `Channel` object minus `id`, `createdAt`, `updatedAt`; `trpcMutate` resolves with full record | Returns adapted `Channel`; mutation called with `serverId`, `name`, `slug`, `type`, `visibility`, `topic`, and `position`; `description` is not forwarded |
+| Create channel with optional fields absent | `topic` omitted; `description` is accepted in the input type but not forwarded to the mutation; `trpcMutate` resolves | Returns adapted `Channel`; `topic` passed as `undefined` in mutation args; `description` not present in mutation payload |
+| Create channel with each visibility value | `visibility = PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, or `PRIVATE`; `trpcMutate` resolves | Returns adapted `Channel` with the correct `visibility` field |
+| Propagate rejection to caller | Valid input; `trpcMutate` rejects | Promise rejects with the underlying error |
+
+### 4.6 `getAuditLog`
+
+Description: fetches a paginated audit log, adapting each entry and validating field types.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return entries and total from API | `serverId`, `channelId`; `trpcQuery` resolves with two valid entries and `total = 2` | Returns `{ entries: [AuditLogEntry, AuditLogEntry], total: 2 }` |
+| Return empty list | `serverId`, `channelId`; `trpcQuery` resolves with `{ entries: [], total: 0 }` | Returns `{ entries: [], total: 0 }` |
+| Forward limit option | `options = { limit: 10 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, limit: 10 }` |
+| Forward offset option | `options = { offset: 5 }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, offset: 5 }` |
+| Forward startDate option | `options = { startDate: "2026-01-01T00:00:00.000Z" }`; `trpcQuery` resolves | `trpcQuery` called with `{ serverId, channelId, startDate: "2026-01-01T00:00:00.000Z" }` |
+| Omit options when none provided | `options` not passed; `trpcQuery` resolves | `trpcQuery` called with only `serverId` and `channelId` |
+| Fall back to epoch string for non-string timestamp | Entry has `timestamp = 42` (a number); `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
+| Fall back to epoch string for invalid timestamp | Entry has `timestamp = "not-a-date"`; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
+| Fall back to epoch string for missing timestamp | Entry has no `timestamp` field; `trpcQuery` resolves | `AuditLogEntry.timestamp` equals epoch ISO; `console.warn` emitted |
+| Warn only on missing/non-string core fields | Entry has missing or non-string `id`, `channelId`, `actorId`, or `action`; `trpcQuery` resolves | Each problematic core field emits a `console.warn`; function still returns an entry; no warnings expected for `oldValue`, `newValue`, `ipAddress`, or `userAgent` |
+| Propagate rejection to caller | Valid args; `trpcQuery` rejects | Promise rejects with the underlying error |
+
+### 4.7 `deleteChannel`
+
+Description: deletes a channel and signals success via a boolean return value.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return true on successful deletion | `channelId = "c1"`, `serverId = "s1"`; `trpcMutate` resolves | Returns `true`; `trpcMutate` called with `{ serverId, channelId }` |
+| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 404 error | Promise rejects with the underlying error; `true` is never returned |
+
+## 5. Edge Cases to Explicitly Validate
+
+- `getChannels` must not suppress transport errors; callers that use the channel count for position computation depend on the error surfacing to avoid data corruption.
+- `getChannel` uses `cache()` wrapping; test the inner async function directly by mocking at the transport layer.
+- The public REST hit in `getChannel` always overrides the raw `visibility` field with `PUBLIC_INDEXABLE`; the test must confirm this even when the raw record contains a different value.
+- Missing `position` and `createdAt` from public channel records are filled with defaults (`0` and epoch ISO); tests should assert these exact defaults.
+- `updateChannel` must only forward `name` and `topic` when those keys are explicitly present in `patch`; the absence of a key must not result in the key being sent as `undefined` to the mutation.
+- `toFrontendChannel` emits `console.warn` when any of its guarded fields (`id`, `serverId`, `slug`, `createdAt`) are missing or non-string; tests should cover at least one warning for each. `toAuditLogEntry` emits `console.warn` when any of its guarded fields (`id`, `channelId`, `actorId`, `action`) are missing or non-string; tests should likewise exercise each warning condition at least once. No warnings are emitted for `oldValue`, `newValue`, `ipAddress`, or `userAgent`.
+- `toAuditLogEntry` falls back to an epoch ISO timestamp for any non-string or unparseable `timestamp` value; all three cases (non-string, invalid-string, missing) must be tested, and corresponding `console.warn` calls should be asserted.
+- All three `ChannelVisibility` values (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) must appear in at least one test for `updateVisibility` and `createChannel`.
+
+## 6. Mock Strategy
+
+All external dependencies are mocked at the module level with `jest.mock`:
+
+```
+jest.mock('@/lib/trpc-client', () => ({
+  trpcQuery:  jest.fn(),
+  trpcMutate: jest.fn(),
+  publicGet:  jest.fn(),
+}));
+```
+
+Reset all mocks in `beforeEach` with `jest.resetAllMocks()` to prevent cross-test contamination.
+
+- **`trpcQuery`** — resolve with well-formed raw objects to test happy paths; reject with an `Error` to test propagation; resolve with `null`/`undefined` to test null-guard branches.
+- **`trpcMutate`** — resolve to test `updateVisibility`, `updateChannel`, `createChannel`, and `deleteChannel` happy paths; reject to test error propagation in each.
+- **`publicGet`** — resolve with a server object (containing at minimum `{ id: "s1" }`) to simulate a successful server lookup; resolve with `null` to test the early-return path; resolve with a channels payload or throw to test the public channel list branches.
+- **`console.warn` / `console.error`** — use `jest.spyOn(console, 'warn')` and `jest.spyOn(console, 'error')` in tests that exercise validation warnings; restore spies in `afterEach`.
+
+## 7. Coverage Expectation
+
+The cases above are intended to cover:
+
+- all seven exported functions,
+- every explicit null-guard and early-return branch,
+- successful transport call paths and their return value adaption,
+- all transport rejection paths and their propagation behavior,
+- public-REST-to-tRPC fallback logic in `getChannel`,
+- all three `ChannelVisibility` enum values,
+- field-level validation warnings in `toFrontendChannel` and `toAuditLogEntry`, and
+- optional field defaults (missing `position`, `createdAt`, `topic`).
+
+Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures (e.g., React `cache` internals) outside the service's direct branching logic.
+````
+
+#### Tool: exec_command
+
+```sh
+rtk read docs/test-specs/frontend-server-service-spec.md
+```
+
+Output:
+
+````text
+Total output lines: 401
+
+# Server Service Test Specification (Frontend)
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-frontend/src/services/serverService.ts`.
+It covers all eleven exported service functions:
+
+- `getServers`
+- `getServer`
+- `getServerAuthenticated`
+- `getServerMembers`
+- `updateServer`
+- `deleteServer`
+- `joinServer`
+- `createServer`
+- `getServerMembersWithRole`
+- `changeMemberRole`
+- `removeMember`
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Mock `trpcQuery` and `trpcMutate` from `@/lib/trpc-client` using Jest module mocking.
+- Mock `publicGet` from `@/lib/trpc-client` for tests that exercise the public REST path in `getServer`.
+- Reset all mocks between tests to ensure isolation.
+- Use `console.warn` spies to assert that `toFrontendServer` emits validation warnings for malformed API responses.
+- The `getServer` export is wrapped in React's `cache()`. Tests should call the function directly and mock the underlying transport layer rather than the cache wrapper.
+- All resolved mock payloads must conform to the `Record<string, unknown>` shapes expected by the adapter functions; omit or corrupt individual fields to exercise validation warnings.
+- `toFrontendServer` emits `console.warn` when `id`, `slug`, or `createdAt` are missing or non-string.
+- `toFrontendMember` maps unknown backend role strings to `'member'` and unknown status strings to `'offline'`.
+- Role values under test for `changeMemberRole`: `'ADMIN'`, `'MODERATOR'`, `'MEMBER'`.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `getServers`
+
+Purpose: fetch all public servers from the backend via the authenticated tRPC `server.getServers` endpoint.
+
+Program paths:
+
+- `trpcQuery` resolves with a non-empty array; each raw record is adapted through `toFrontendServer` and returned.
+- `trpcQuery` resolves with `null` (backend procedure returns null); the null-guard (`data ?? []`) causes the function to return `[]`.
+- `trpcQuery` rejects; the error propagates to the caller uncaught.
+
+### 3.2 `getServer`
+
+Purpose: return a single server by its slug via the public REST endpoint, or `null` if the server is not found or the request fails. Wrapped in React's `cache()`.
+
+Program paths:
+
+- `publicGet` resolves with a valid server record; adapted `Server` is returned.
+- `publicGet` resolves with `null` (e.g., 404); the null-guard (`if (!data) return null`) causes the function to return `null`.
+- `publicGet` rejects with any error (e.g., network failure, 401, 403); the `catch` block logs via `console.error` and returns `null`.
+
+### 3.3 `getServerAuthenticated`
+
+Purpose: fetch a single server by slug via the authenticated tRPC `server.getServer` endpoint, ensuring `ownerId` is populated. Returns `null` if not found or if the request fails.
+
+Program paths:
+
+- `trpcQuery` resolves with a valid server record; adapted `Server` is returned.
+- `trpcQuery` resolves with `null` or a falsy value; the null-guard (`if (!data) return null`) causes the function to return `null`.
+- `trpcQuery` rejects; the `catch` block swallows the error and returns `null`.
+
+### 3.4 `getServerMembers`
+
+Purpose: return all members of a server as `User[]` via the authenticated tRPC `server.getMembers` endpoint. Returns `[]` on any failure to support unauthenticated callers (e.g., guest views).
+
+Program paths:
+
+- `trpcQuery` resolves with a non-empty array; each record is adapted through `toFrontendMember` and returned.
+- `trpcQuery` resolves with `null` (backend procedure returns null); the null-guard (`data ?? []`) causes the function to return `[]`.
+- `trpcQuery` rejects; the `catch` block logs via `console.warn` and returns `[]`.
+
+### 3.5 `updateServer`
+
+Purpose: update editable metadata (`name`, `description`, `icon`, `isPublic`) of a server via the tRPC `server.updateServer` mutation. Only patch keys that are explicitly defined are forwarded.
+
+Program paths:
+
+- Patch includes all four editable fields; all are forwarded and the adapted result is returned.
+- Patch includes a strict subset of fields; only defined keys are forwarded to the mutation.
+- Patch is empty (`{}`); no extra keys are forwarded; the adapted result is still returned.
+- `trpcMutate` rejects; the error propagates to the caller uncaught.
+
+### 3.6 `deleteServer`
+
+Purpose: delete a server by ID via the tRPC `server.deleteServer` mutation. Returns `true` unconditionally on success.
+
+Program paths:
+
+- `trpcMutate` resolves; function returns `true`.
+- `trpcMutate` rejects; the error propagates to the caller uncaught.
+
+### 3.7 `joinServer`
+
+Purpose: join a public server by server ID via the tRPC `serverMember.joinServer` mutation. Returns `void`. Throws if the server is private or the caller is already a member.
+
+Program paths:
+
+- `trpcMutate` resolves; function returns `void`.
+- `trpcMutate` rejects (e.g., private server, already a member); the error propagates to the caller uncaught.
+
+### 3.8 `createServer`
+
+Purpose: create a new server via the tRPC `server.createServer` mutation. Returns the backend-confirmed `Server`. The backend auto-creates a default "general" channel. `isPublic` defaults to `false` when omitted from the input.
+
+Program paths:
+
+- `input.isPublic` is provided; all three fields (`name`, `description`, `isPublic`) are forwarded and the adapted result is returned.
+- `input.isPublic` is omitted; `isPublic` is forwarded as `false` to the mutation.
+- `trpcMutate` rejects; the error propagates to the caller uncaught.
+
+### 3.9 `getServerMembersWithRole`
+
+Purpose: return all members of a server as `ServerMemberInfo[]` via the authenticated tRPC `serverMember.getMembers` endpoint, including role and join timestamp.
+
+Program paths:
+
+- `trpcQuery` resolves with a non-empty array; each record is mapped to `ServerMemberInfo` with all fields correctly set.
+- `trpcQuery` resolves with `null` (backend procedure returns null); the null-guard (`data ?? []`) causes the function to return `[]`.
+- An entry has an unrecognised `role` string; `BACKEND_ROLE_MAP` lookup returns `undefined` and the fallback `'member'` is used.
+- `trpcQuery` rejects; the error propagates to the caller uncaught.
+
+### 3.10 `changeMemberRole`
+
+Purpose: change the role of a server member via the tRPC `serverMember.changeRole` mutation. Returns `void`.
+
+Program paths:
+
+- `trpcMutate` resolves; function returns `void`.
+- `trpcMutate` rejects; the error propagates to the caller uncaught.
+
+### 3.11 `removeMember`
+
+Purpose: remove a member from a server via the tRPC `serverMember.removeMember` mutation. Returns `void`.
+
+Program paths:
+
+- `trpcMutate` resolves; function returns `void`.
+- `trpcMutate` rejects; the error propagates to the caller uncaught.
+
+## 4. Detailed Test Cases
+
+### 4.1 `getServers`
+
+Description: fetches the full list of public servers, adapting each record from the raw backend shape.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return adapted servers for valid API response | `trpcQuery` resolves with two valid raw server records | Returns an array of two `Server` objects with all fields correctly mapped |
+| Return empty array when API returns null | `trpcQuery` resolves with `null` (backend returns null for empty result) | Returns `[]` |
+| Propagate rejection to caller | `trpcQuery` rejects with a network error | The promise rejects with the same error; caller receives it without masking |
+| Propagate 401 unauthorized rejection | `trpcQuery` rejects with a 401 error (unauthenticated caller) | The promise rejects with the 401 error; caller is responsible for redirecting to login |
+| Map iconUrl to icon field | Raw record has `iconUrl: "https://example.com/icon.png"` and no `icon` field | Returned `Server.icon` equals `"https://example.com/icon.png"` |
+| Default memberCount to 0 when absent | Raw record omits `memberCount` | Returned `Server.memberCount` equals `0` |
+
+### 4.2 `getServer`
+
+Description: fetches a single server by slug via the public REST endpoint; all failures return `null` rather than propagating.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return adapted server for valid API response | `slug = "my-server"`; `publicGet` resolves with a full raw server record | Returns a `Server` with all fields correctly mapped |
+| Return null for 404 (publicGet resolves null) | `slug = "my-server"`; `publicGet` resolves with `null` | Returns `null`; no further processing occurs |
+| Return null when API rejects with network error | `slug = "my-server"`; `publicGet` rejects with a network error | Returns `null`; error is logged via `console.error`; promise does not reject |
+| Return null when API rejects with 401 | `slug = "my-server"`; `publicGet` rejects with a 401 error | Returns `null`; error is logged via `console.error`; promise does not reject |
+| URL-encodes the slug | `slug = "my server"`; `publicGet` resolves with a valid record | `publicGet` is called with `/servers/my%20server` |
+| Warn on missing id field | Raw record omits `id`; `publicGet` resolves | Returns a `Server`; `console.warn` is emitted mentioning `"id"` |
+| Warn on missing slug field | Raw record omits `slug`; `publicGet` resolves | Returns a `Server`; `console.warn` is emitted mentioning `"slug"` |
+| Warn on missing createdAt field | Raw record omits `createdAt`; `publicGet` resolves | Returns a `Server`; `console.warn` is emitted mentioning `"createdAt"` |
+
+### 4.3 `getServerAuthenticated`
+
+Description: fetches a single server via the authenticated tRPC endpoint; silently returns `null` on all failures.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return adapted server for valid API response | `slug = "my-server"`; `trpcQuery` resolves with a full raw server record | Returns a `Server` with `ownerId` populated |
+| Return null when API returns null | `slug = "my-server"`; `trpcQuery` resolves wi…1631 tokens truncated…ir role and join date as `ServerMemberInfo[]`.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return adapted member info for valid response | `serverId = "s1"`; `trpcQuery` resolves with two valid raw member records | Returns an array of two `ServerMemberInfo` objects with all fields correctly mapped |
+| Return empty array when API returns null | `serverId = "s1"`; `trpcQuery` resolves with `null` (backend returns null for empty result) | Returns `[]` |
+| Map OWNER role to owner | Raw entry has `role: "OWNER"` | Returned `ServerMemberInfo.role` equals `"owner"` |
+| Map MODERATOR role to moderator | Raw entry has `role: "MODERATOR"` | Returned `ServerMemberInfo.role` equals `"moderator"` |
+| Map unknown role to member fallback | Raw entry has `role: "SUPERUSER"` | Returned `ServerMemberInfo.role` equals `"member"` |
+| Preserve null avatarUrl | Raw entry's user has `avatarUrl: null` | Returned `ServerMemberInfo.avatarUrl` equals `null` |
+| Forward displayName from user | Raw entry's user has `displayName: "Alice"` | Returned `ServerMemberInfo.displayName` equals `"Alice"` |
+| Null-coerce missing displayName | Raw entry's user has `displayName: undefined` | Returned `ServerMemberInfo.displayName` equals `null` |
+| Propagate 401 unauthorized rejection | `trpcQuery` rejects with a 401 error | Promise rejects with the underlying error |
+| Propagate rejection to caller | `trpcQuery` rejects with a network error | Promise rejects with the underlying error |
+
+### 4.10 `changeMemberRole`
+
+Description: changes a server member's role via a tRPC mutation.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Change role to ADMIN | `serverId = "s1"`, `targetUserId = "u1"`, `newRole = "ADMIN"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with `{ serverId, targetUserId, newRole: "ADMIN" }` |
+| Change role to MODERATOR | `serverId = "s1"`, `targetUserId = "u1"`, `newRole = "MODERATOR"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with `{ serverId, targetUserId, newRole: "MODERATOR" }` |
+| Change role to MEMBER | `serverId = "s1"`, `targetUserId = "u1"`, `newRole = "MEMBER"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with `{ serverId, targetUserId, newRole: "MEMBER" }` |
+| Propagate 401 unauthorized rejection | Valid args; `trpcMutate` rejects with a 401 error | Promise rejects with the underlying error |
+| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 403 error | Promise rejects with the underlying error |
+
+### 4.11 `removeMember`
+
+Description: removes a server member via a tRPC mutation.
+
+| Test Purpose | Inputs | Expected Output |
+| --- | --- | --- |
+| Return void on successful removal | `serverId = "s1"`, `targetUserId = "u1"`; `trpcMutate` resolves | Promise resolves to `undefined`; `trpcMutate` called with `{ serverId: "s1", targetUserId: "u1" }` |
+| Propagate 401 unauthorized rejection | Valid args; `trpcMutate` rejects with a 401 error | Promise rejects with the underlying error |
+| Propagate rejection to caller | Valid args; `trpcMutate` rejects with a 404 error | Promise rejects with the underlying error |
+
+## 5. Edge Cases to Explicitly Validate
+
+- `getServers` must not suppress transport errors; callers depend on the rejection surfacing so they can display an error state rather than silently rendering an empty list.
+- `getServer` uses `cache()` wrapping; tests should call the exported function directly and mock at the transport layer (`publicGet`) rather than trying to bypass or reset the cache.
+- `getServer` URL-encodes the slug before passing it to `publicGet`; test with a slug that contains a space or special character to confirm `encodeURIComponent` is applied.
+- `getServerAuthenticated` swallows all errors silently (no logging) unlike `getServer` which logs via `console.error`; tests should confirm no `console.error` call occurs in the error path for `getServerAuthenticated`.
+- `getServerMembers` explicitly logs a warning on failure via `console.warn`; tests should spy on `console.warn` and assert it is called with a message containing `'getServerMembers'`.
+- `toFrontendServer` emits `console.warn` for non-string `id`, `slug`, and `createdAt`; at least one test for each missing field should assert the warning is emitted.
+- `toFrontendServer` prefers `iconUrl` over `icon` when both are present in the raw record; one test should supply both and confirm `iconUrl` wins.
+- `toFrontendServer` defaults `memberCount` to `0` when the field is absent; at least one test should assert this default.
+- `updateServer` must only forward `name`, `description`, `iconUrl` (mapped from `icon`), and `isPublic` when those keys are explicitly present in `patch`; the absence of a key must not result in the key being sent as `undefined` to the mutation.
+- `createServer` always forwards `isPublic` to the mutation, defaulting to `false` when the caller omits it; confirm `false` is an explicit argument, not a missing key.
+- `getServerMembersWithRole` uses `BACKEND_ROLE_MAP` for role translation; an unrecognised role string must produce `'member'` via the `?? 'member'` fallback; this path must be covered by at least one test.
+- `toFrontendMember` uses `?? 'member'` for unknown roles and `?? 'offline'` for unknown statuses; both fallbacks must be exercised.
+- All three editable role values (`'ADMIN'`, `'MODERATOR'`, `'MEMBER'`) must appear in at least one test for `changeMemberRole`.
+
+## 6. Mock Strategy
+
+> **Note on `apiClient` / `ApiClient`:** Issue #260 describes the mock strategy in terms of `apiClient` / `ApiClient`. `serverService.ts` does not import `ApiClient` directly — it uses the lower-level transport helpers `trpcQuery`, `trpcMutate`, and `publicGet` exported from `@/lib/trpc-client`. This spec mocks those helpers instead, which is the correct point of interception for this service.
+
+All external dependencies are mocked at the module level with `jest.mock`:
+
+```
+jest.mock('@/lib/trpc-client', () => ({
+  trpcQuery:  jest.fn(),
+  trpcMutate: jest.fn(),
+  publicGet:  jest.fn(),
+}));
+```
+
+Reset all mocks in `beforeEach` with `jest.resetAllMocks()` to prevent cross-test contamination.
+
+- **`trpcQuery`** — resolve with well-formed raw objects to test happy paths; reject with an `Error` (or a typed error with a `status` code for 401/403/404) to test propagation; resolve with `null` to test null-guard branches in `getServers`, `getServerAuthenticated`, `getServerMembers`, and `getServerMembersWithRole`. Note: `trpcQuery` throws rather than resolving `undefined` (see implementation in `@/lib/trpc-client.ts`), so `undefined` is not a valid mock return value.
+- **`trpcMutate`** — resolve to test `updateServer`, `deleteServer`, `joinServer`, `createServer`, `changeMemberRole`, and `removeMember` happy paths; reject with an `Error` carrying a `401`, `403`, or `404` status code to test error propagation in each.
+- **`publicGet`** — resolves with `T | null` only (never `undefined`); resolve with a public server record to test the `getServer` happy path; resolve with `null` to test the 404 early-return path; reject with an `Error` to test the `catch` branch.
+- **`console.warn` / `console.error`** — use `jest.spyOn(console, 'warn')` and `jest.spyOn(console, 'error')` in tests that exercise validation warnings or error logging; restore spies in `afterEach` or use `mockImplementation(() => {})` to suppress test output noise.
+
+### Fixture Shapes
+
+Use distinct fixtures for the two server response shapes, as the public REST endpoint omits fields only returned by the authenticated tRPC endpoint.
+
+**Public REST fixture** (for `publicGet` in `getServer` tests — omits `ownerId`, `isPublic`, `updatedAt`):
+
+```
+{
+  id: "server-1",
+  name: "Test Server",
+  slug: "test-server",
+  iconUrl: undefined,
+  description: undefined,
+  bannerUrl: undefined,
+  memberCount: 5,
+  createdAt: "2026-01-01T00:00:00.000Z",
+}
+```
+
+**Authenticated tRPC fixture** (for `trpcQuery` / `trpcMutate` in all other server tests — includes `ownerId`, `isPublic`, `updatedAt`):
+
+```
+{
+  id: "server-1",
+  name: "Test Server",
+  slug: "test-server",
+  ownerId: "user-1",
+  iconUrl: undefined,
+  icon: undefined,
+  description: undefined,
+  bannerUrl: undefined,
+  memberCount: 5,
+  isPublic: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+}
+```
+
+**Member fixture** (for `trpcQuery` in `getServerMembers` and `getServerMembersWithRole` tests):
+
+```
+{
+  userId: "user-1",
+  serverId: "server-1",
+  role: "MEMBER",
+  joinedAt: "2026-01-01T00:00:00.000Z",
+  user: {
+    id: "user-1",
+    username: "alice",
+    displayName: "Alice",
+    avatarUrl: null,
+    status: "ONLINE",
+  },
+}
+```
+
+## 7. Coverage Expectation
+
+The cases above are intended to cover:
+
+- all eleven exported functions,
+- every explicit null-guard and early-return branch,
+- successful transport call paths and their return value adaptation,
+- all transport rejection paths (network failures, 401 unauthorized, 403 forbidden, 404 not found) and their propagation or suppression behavior per function,
+- the `publicGet`-based REST path in `getServer` and its error swallowing,
+- both adapter functions (`toFrontendServer` and `toFrontendMember`) with valid and invalid input shapes,
+- all field-level validation warnings in `toFrontendServer` (`id`, `slug`, `createdAt`),
+- role and status mapping fallbacks in `toFrontendMember` and `getServerMembersWithRole`,
+- all three `changeMemberRole` role values (`ADMIN`, `MODERATOR`, `MEMBER`),
+- `updateServer` selective key forwarding (all four keys individually and combined), and
+- the `isPublic` default (`false`) in `createServer`.
+
+Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures (e.g., React `cache` internals) outside the service's direct branching logic.
+````
+
+#### Tool: exec_command
+
+```sh
+rtk read docs/test-specs/auth-service-spec.md
+```
+
+Output:
+
+````text
+Total output lines: 253
+
+# Auth Service Test Specification
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-backend/src/services/auth.service.ts`.
+
+It covers all exported service functions:
+
+- `authService.register`
+- `authService.login`
+- `authService.logout`
+- `authService.refreshTokens`
+- `authService.verifyAccessToken`
+
+The internal token helpers (`signAccessToken`, `signRefreshToken`, `hashToken`, `storeRefreshToken`, `ensureAdminUser`) are exercised indirectly through the main service functions.
+
+The goal is to cover the main success cases, all explicit error branches, and the auth-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+### Database Isolation
+- Use a single test database with transaction rollback per test, or use unique email/username per test (e.g., `user_${Date.now()}@test.com`) to prevent collisions across parallel test runs.
+- Seed `harmony-hq` server as a one-time fixture before all tests (not per-test).
+- Example cleanup: `await db.user.deleteMany({ where: { email: { contains: 'test' } } })`
+
+### Environment Variables & Module Initialization
+- **CRITICAL**: JWT-related env vars (secrets and expiry settings) are read at module import time (lines 14–28 of `auth.service.ts`), NOT at function call time. This includes `JWT_ACCESS_SECRET`, `JWT_REFRESH_SECRET`, `JWT_ACCESS_EXPIRES_IN`, and `JWT_REFRESH_EXPIRES_DAYS`.
+- **DO NOT** mock `process.env` after importing the service; env var changes will have no effect on any of these values.
+- **MUST** use one of these patterns whenever a test needs different values for any of the above env vars:
+  - `jest.resetModules()` before each test, then re-import `auth.service` with new env vars set
+  - OR test with the default env vars and mock `jwt.sign()` / `jwt.verify()` at the function level
+  - OR use `jest.isolateModulesAsync()` to isolate imports with different env vars
+- Example (note that both secrets and expiry env vars are set *before* importing the service module):
+  ```javascript
+  beforeEach(() => {
+    delete require.cache[require.resolve('../services/auth.service')];
+    process.env.JWT_ACCESS_SECRET = 'test-access-secret';
+    process.env.JWT_REFRESH_SECRET = 'test-refresh-secret';
+    process.env.JWT_ACCESS_EXPIRES_IN = '15m';
+    process.env.JWT_REFRESH_EXPIRES_DAYS = '7';
+    authService = require('../services/auth.service').authService;
+  });
+  ```
+
+### Mocking Strategy
+- Use `jest.fn()` with `.mockResolvedValue()` / `.mockRejectedValue()` for async dependencies.
+- Mock `serverMemberService.joinServer` as `jest.fn().mockResolvedValue(undefined)` by default; set `.mockRejectedValue(error)` for failure scenarios.
+- For JWT verification tests, use actual JWT signing with real secrets (after env var setup) to catch signature mismatches.
+- Spy on `bcrypt.compare()` to verify it is called even for non-existent users (timing-attack prevention).
+
+### Token Expiry & Time Mocking
+- When testing JWT expiry:
+  - Use Jest fake timers (e.g., `jest.useFakeTimers()` and `jest.setSystemTime()` as in `tests/rate-limit.middleware.test.ts`) to control JS Date/time
+  - Restore timers in `afterEach()` with `jest.useRealTimers()` to prevent test pollution
+  - Be aware: JWT `exp` is in seconds, Prisma `expiresAt` is in milliseconds; test both boundaries
+- Example boundary test:
+  - Token with JWT `exp = now_seconds` should be REJECTED/EXPIRED (`jsonwebtoken` treats tokens as expired when `now_seconds >= exp`, i.e., `exp <= now_seconds`)
+  - Token with DB `expiresAt = now_ms` should be REVOKED (Prisma uses `expiresAt > now`, so `==` fails)
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `register`
+
+Purpose: create a new user account, hash the password with bcrypt, auto-join the default `harmony-hq` server, and return authentication tokens.
+
+Program paths:
+
+- Email already in use: pre-checked with `findUnique`, throws `TRPCError` with code `CONFLICT`.
+- Username already taken: pre-checked with `findUnique`, throws `TRPCError` with code `CONFLICT`.
+- User creation succeeds: password is hashed with bcrypt (12 rounds), user is persisted, `displayName` defaults to `username`.
+- Race condition on email or username uniqueness: Prisma `P2002` error is caught and mapped to `TRPCError` with code `CONFLICT`.
+- Auto-join default server `harmony-hq`: `serverMemberService.joinServer` is called; if it fails, the error is caught and registration continues (soft fail).
+- Tokens are generated and stored: `signAccessToken` and `signRefreshToken` are called; refresh token is stored in DB with hash and expiry.
+- Return value is `{ accessToken, refreshToken }`.
+
+### 3.2 `login`
+
+Purpose: authenticate a user by email and password, returning authentication tokens.
+
+Program paths:
+
+- Dev admin override: if `NODE_ENV !== 'production'`, `email === ADMIN_EMAIL`, and `password === 'admin'`, the admin user is upserted and tokens are issued (bypasses all password checks).
+- User does not exist: timing-safe check using a dummy bcrypt hash comparison, throws `TRPCError` with code `UNAUTHORIZED` with message "Invalid credentials".
+- Password does not match: bcrypt comparison fails, throws `TRPCError` with code `UNAUTHORIZED` with message "Invalid credentials".
+- Login succeeds: user is found, password is valid, new tokens are generated and refresh token is stored.
+- Tokens are issued and refresh token is persisted in DB.
+- Return value is `{ accessToken, refreshToken }`.
+
+### 3.3 `logout`
+
+Purpose: revoke a refresh token by marking it as revoked in the database.
+
+Program paths:
+
+- Token hash is computed from the raw token using SHA256.
+- All refresh token records matching the hash and with `revokedAt === null` are marked as revoked (set `revokedAt` to current timestamp).
+- No error is thrown if the token hash does not exist in the database (idempotent).
+- Return value is `undefined` (void).
+
+### 3.4 `refreshTokens`
+
+Purpose: validate a refresh token, verify it has not been revoked or expired, issue new tokens, and revoke the old token atomically.
+
+Program paths:
+
+- Token signature is invalid: JWT verification fails, throws `TRPCError` with code `UNAUTHORIZED` with message "Invalid refresh token".
+- Token signature is valid but expired: JWT `exp` claim is before `now`, JWT verification fails, throws same error.
+- Token hash exists but is already revoked: atomic `updateMany` returns `count === 0`, throws `TRPCError` with code `UNAUTHORIZED` with message "Refresh token revoked or expired".
+- Token hash exists but is expired in DB: atomic `updateMany` with `expiresAt > now` returns `count === 0`, throws same error.
+- Token is valid, not revoked, and not expired: atomic `updateMany` succeeds with `count === 1`, new tokens are generated, new refresh token is stored, old token is marked as revoked.
+- Concurrent requests with the same token: the atomic `updateMany` ensures exactly one request succeeds (`count === 1`) and others fail (`count === 0`); no duplicate tokens are issued.
+- Return value is `{ accessToken, refreshToken }`.
+
+### 3.5 `verifyAccessToken`
+
+Purpose: validate an access token and extract the JWT payload.
+
+Program paths:
+
+- Token signature is invalid: JWT verification fails, throws `TRPCError` with code `UNAUTHORIZED` with message "Invalid or expired access token".
+- Token is expired: JWT `exp` claim is before `now`, verification fails, throws same error.
+- Token is valid: JWT is verified, payload is extracted and returned as `JwtPayload { sub: userId, jti?: string }`.
+- Return value is the decoded JWT payload (no database interaction).
+
+## 4. Detailed Test Cases
+
+### 4.1 `register`
+
+Description: creates a new user, persists the account, auto-joins default server, and returns tokens.
+
+| Test Purpose | Inputs | Expected Output |
+|---|---|---|
+| Register with valid email, username, password | email: `"user@example.com"`, username: `"newuser"`, password: `"SecurePass123!"` | Returns `{ accessToken, refreshToken }` where both are non-empty strings; user is created in DB with hashed password; refresh token is stored with hash and expiry |
+| Reject duplicate email | email: `"existing@example.com"` (already in DB), username: `"newname"`, password: `"pass"` | Throws `TRPCError` with code `CONFLICT` and message `"Email already in use"` |
+| Reject duplicate username | email: `"newemail@example.com"`, username: `"existingname"` (already in DB), password: `"pass"` | Throws `TRPCError` with code `CONFLICT` and message `"Username already taken"` |
+| Catch Prisma P2002 race on email/username | Mock `prisma.user.create` to throw P2002 on first call | Throws `TRPCError` with code `CONFLICT` and message `"Email or username already in use"` |
+| Auto-join default server succeeds | Valid inputs; default server `harmony-hq` exists | `serverMemberService.joinServer` is called with correct userId and server id; registration completes successfully |
+| Auto-join when default server does not exist | Valid inputs; no server with slug=`"harmony-hq"` in DB | Registration succeeds, tokens returned, no error; `joinServer` is never called |
+| Continue on joinServer failure | Valid inputs; `serverMemberService.joinServer` throws an error | Registration succeeds and tokens are returned; error is caught and not propagated |
+| Hash password with 12 bcrypt rounds | Valid inputs | Stored password hash is a bcrypt hash; plaintext password is never stored |
+| displayName defaults to username | Valid inputs; no explicit `displayName` parameter | User record has `displayName === username` |
+| Empty email input (router-level validation) | email: `""`, username: `"user"`, password: `"pass"` | `authService.register` does not perform this validation; this case is validated by Zod in `auth.router.ts` and should be covered in auth-router tests |
+| Malformed email input (router-level validation) | email: `"notanemail"`, username: `"user"`, password: `"pass"` | `authService.register` does not enforce email format; malformed emails a…475 tokens truncated… `"anypass"` | Throws `TRPCError` with code `UNAUTHORIZED` and message `"Invalid credentials"`; timing-safe dummy hash check is performed |
+| Timing-safe bcrypt comparison on non-existent email | Non-existent email + any password | Spy on `bcrypt.compare()` verifies it is called with (password, TIMING_DUMMY_HASH) even though user lookup failed (prevents timing-based user enumeration) |
+| Admin override in non-production | `NODE_ENV = 'development'`, email: `"admin@harmony.dev"`, password: `"admin"` | Returns valid tokens; admin user is created or updated in DB; admin is added as OWNER to all servers |
+| Disable admin override in production | `NODE_ENV = 'production'`, email: `"admin@harmony.dev"`, password: `"admin"` | Throws `TRPCError` with code `UNAUTHORIZED` (normal credential check applies, admin user likely does not exist) |
+| Admin override creates user if not exists | `NODE_ENV = 'development'`, admin email provided | User is created with `email = ADMIN_EMAIL`, `username = 'admin'`, `displayName = 'System Admin'` |
+| Admin override makes admin OWNER of all servers | `NODE_ENV = 'development'`, admin login, 3+ servers exist | For each server in the database, a serverMember record is created or updated with role `OWNER` |
+| Admin user creation fails on DB error | `NODE_ENV = 'development'`, `admin@harmony.dev`/`admin`, but `prisma.user.upsert()` throws error | Throws error (does not silently fail); login fails |
+| Admin serverMember creation fails on loop | `NODE_ENV = 'development'`, admin login succeeds, but `prisma.serverMember.upsert()` fails on 3rd iteration | Error is propagated to the login caller; login fails (no soft-fail/partial success) |
+
+### 4.3 `logout`
+
+Description: revokes a refresh token, making it unusable for future refreshes.
+
+| Test Purpose | Inputs | Expected Output |
+|---|---|---|
+| Revoke a valid token | rawRefreshToken: a valid token previously stored in DB | Token hash is computed; DB record with matching hash and `revokedAt === null` is updated to `revokedAt = now`; no error thrown |
+| Logout is idempotent | Token already revoked (call logout twice with same token) | Second call succeeds without error; `updateMany` returns `count === 0` but no error is thrown |
+| Logout with invalid token | rawRefreshToken: a token that was never stored | `updateMany` returns `count === 0`; no error is thrown (idempotent) |
+| Logout does not affect other tokens | Multiple refresh tokens in DB for same user | Only the token matching the provided hash is revoked; other tokens are unaffected |
+
+### 4.4 `refreshTokens`
+
+Description: validates a refresh token, revokes the old one, and issues new access and refresh tokens (atomic).
+
+| Test Purpose | Inputs | Expected Output |
+|---|---|---|
+| Refresh with valid, non-revoked, non-expired token | rawRefreshToken: a valid token stored in DB with `revokedAt === null` and `expiresAt > now` | Returns `{ accessToken, refreshToken }`; old token is marked as revoked; new tokens are issued and new refresh token is stored in DB |
+| Reject token with invalid signature | rawRefreshToken: a token with tampered payload or signature | Throws `TRPCError` with code `UNAUTHORIZED` and message `"Invalid refresh token"` |
+| Reject token signed with wrong key/secret | rawRefreshToken: a token signed with a different secret than the one used by `auth.service` | Throws `TRPCError` with code `UNAUTHORIZED` and message `"Invalid refresh token"` |
+| Reject expired token | rawRefreshToken: a valid token whose JWT `exp` claim is in the past | Throws `TRPCError` with code `UNAUTHORIZED` and message `"Invalid refresh token"` |
+| Reject revoked token | rawRefreshToken: a token with `revokedAt !== null` in DB | Throws `TRPCError` with code `UNAUTHORIZED` and message `"Refresh token revoked or expired"` |
+| Reject token past database expiry | rawRefreshToken: a valid JWT but DB record has `expiresAt < now` | Atomic `updateMany` returns `count === 0`; throws `TRPCError` with code `UNAUTHORIZED` and message `"Refresh token revoked or expired"` |
+| Reject token at exact expiry boundary | JWT `exp = now_seconds`, DB `expiresAt = now_ms`, both equal | JWT verification fails (`jsonwebtoken` rejects when `now_seconds >= exp`); throws `TRPCError` with code `UNAUTHORIZED` and message `"Invalid refresh token"` |
+| Atomic revocation prevents replay | Two concurrent refresh requests with the same token | Exactly one request succeeds and revokes the token; the other sees `count === 0` and fails with `UNAUTHORIZED`; no duplicate tokens are issued |
+| Token cannot be reused after refresh | 1. Refresh with tokenA → get tokenB; 2. Try to refresh again with tokenA | First refresh succeeds; second refresh fails with "Refresh token revoked or expired" |
+| New tokens are properly signed | Valid refresh | Returned `accessToken` and `refreshToken` are valid JWTs; `accessToken` has `sub` claim; `refreshToken` has `sub` and `jti` claims |
+| New refresh token has correct expiry | Valid refresh; `JWT_REFRESH_EXPIRES_DAYS = 7` | Stored refresh token has `expiresAt = now + 7 days` |
+
+### 4.5 `verifyAccessToken`
+
+Description: validates an access token and returns the decoded payload (pure verification, no DB mutation).
+
+| Test Purpose | Inputs | Expected Output |
+|---|---|---|
+| Verify valid access token | accessToken: a valid JWT signed with `ACCESS_SECRET` | Returns `JwtPayload { sub: userId }` |
+| Reject token with invalid signature | accessToken: a JWT signed with wrong secret | Throws `TRPCError` with code `UNAUTHORIZED` and message `"Invalid or expired access token"` |
+| Reject token signed with wrong secret | accessToken: a JWT signed with a different secret than `ACCESS_SECRET` | Throws `TRPCError` with code `UNAUTHORIZED` and message `"Invalid or expired access token"` |
+| Reject expired access token | accessToken: a valid JWT with `exp` claim in the past | Throws `TRPCError` with code `UNAUTHORIZED` and message `"Invalid or expired access token"` |
+| Extract userId from valid token | accessToken: signed JWT | Decoded payload contains `sub` field equal to the original userId |
+| No database interaction | Any token | Function does not call any database methods; verification is pure |
+| Reject malformed token | accessToken: `"not.a.jwt"`, `"invalid"`, or `""` | Throws `TRPCError` with code `UNAUTHORIZED` |
+
+## 5. Edge Cases to Explicitly Validate
+
+### Security & Timing
+- **Timing attacks on login**: ensure `bcrypt.compare()` is ALWAYS called for non-existent emails, even though the user lookup fails early. Spy on bcrypt to verify this.
+- **No user enumeration**: both "user not found" and "wrong password" return identical error message and timing.
+- **JWT secret enforcement**: tokens signed with a different secret are rejected. Note: `jsonwebtoken` does not enforce an algorithm allowlist by default, so algorithm mismatch tests (e.g., HS512 vs HS256) may not fail with a shared HMAC secret.
+- **No plaintext password storage**: verify password is never logged, returned, or stored unencrypted.
+
+### Concurrency & Atomicity
+- **Race conditions on refresh**: atomic `updateMany` with both `revokedAt === null` and `expiresAt > now` ensures exactly one of two concurrent requests succeeds.
+- **Token reuse prevention**: old token becomes unusable immediately after first successful refresh.
+- **No duplicate token issuance**: concurrent refresh requests cannot both succeed with the same token.
+
+### Token Expiry & Boundaries
+- **JWT expiry precision**: JWT `exp` is in seconds; `jsonwebtoken` treats tokens as expired when `now_seconds >= exp` (i.e., `exp <= now_seconds` is rejected).
+- **DB expiry precision**: Prisma `expiresAt` is in milliseconds; test that tokens with `expiresAt <= now_ms` are rejected.
+- **Expiry boundary alignment**: Both JWT verification (`exp <= now_seconds` → rejected) and Prisma (`expiresAt > now` → `expiresAt <= now` fails) reject at the exact boundary. Test both sides of this boundary.
+
+### Admin & Configuration
+- **Admin override isolation**: ensure admin override is disabled in production and only active in dev/test.
+- **Admin user auto-join**: admin must be added as OWNER to all servers on override login.
+- **Admin failure handling**: if `ensureAdminUser()` fails (DB error, server loop failure), the error is propagated (not silently caught).
+
+### Default Behavior
+- **Soft fail on auto-join in register**: registration must succeed even if `serverMemberService.joinServer` fails; error is caught and not propagated.
+- **Graceful missing default server**: if `harmony-hq` does not exist, registration succeeds without attempting join.
+- **Idempotent logout**: calling logout multiple times with the same token should not error.
+
+### Bcrypt & Hashing
+- **Bcrypt cost**: confirm password hashes use exactly 12 rounds as per `BCRYPT_ROUNDS = 12`.
+- **Token hashing for storage**: refresh tokens are hashed with SHA256 before storage in DB; raw tokens are never stored.
+
+### JWT Payload Structure
+- **Access token structure**: custom payload includes `sub` claim (userId); the JWT library may also add standard claims (e.g., `iat`, `exp` via `expiresIn`).
+- **Refresh token structure**: custom payload includes both `sub` and `jti` claims (jti is a random UUID for uniqueness); the JWT library may also add standard claims (e.g., `iat`, `exp` via `expiresIn`).
+
+### Rate Limiting (Responsibility: API Layer)
+- **The auth service does NOT implement rate limiting**.
+- **API layer MUST enforce** rate limiting (e.g., max 5 failed login attempts per IP per 15 minutes).
+- **This spec does NOT test rate limiting**; that responsibility belongs to the API layer and is out of scope for auth.service.ts unit tests.
+
+### Coverage Metric
+- **Target: 80% branch coverage (C1 coverage)** as measured by nyc/istanbul.
+- **All explicit error branches** (every `throw` statement) must have at least one corresponding test case.
+- This ensures "execution paths" are interpreted as control-flow branches, not combinatorial path complexity.
+````
+
+#### Tool: exec_command
+
+```sh
+rtk read docs/test-specs/server-member-service-spec.md
+```
+
+Output:
+
+```text
+# Server Member Service Test Specification
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-backend/src/services/serverMember.service.ts`.
+It covers all six exported service functions:
+
+- `addOwner`
+- `joinServer`
+- `leaveServer`
+- `getServerMembers`
+- `changeRole`
+- `removeMember`
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Use a test database with isolated server, user, and membership fixtures per test.
+- Use distinct users for owner, admin, moderator, member, guest, and outsider scenarios.
+- Seed role hierarchy fixtures to match the implementation order: `OWNER`, `ADMIN`, `MODERATOR`, `MEMBER`, `GUEST`.
+- Mock or spy on `eventBus.publish` so tests can verify event emission without requiring the full event system.
+- When transaction failures or unexpected Prisma failures are simulated, assert that the original error is surfaced unless the code explicitly maps it to a `TRPCError`.
+- Validate both the direct return value and the side effects on `server.memberCount` where applicable.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `addOwner`
+
+Purpose: add the creator of a new server as an `OWNER` membership and increment the server member count.
+
+Program paths:
+
+- Owner membership is created successfully and `memberCount` is incremented.
+- Database or transaction failure bubbles to the caller.
+
+### 3.2 `joinServer`
+
+Purpose: allow a user to join a public server as a `MEMBER`.
+
+Program paths:
+
+- Target server does not exist.
+- Target server exists but is private.
+- Membership is created successfully, `memberCount` is incremented, and `MEMBER_JOINED` is published.
+- Unique membership constraint fails because the user is already a member.
+- Unexpected transaction or Prisma failure bubbles to the caller.
+
+### 3.3 `leaveServer`
+
+Purpose: remove the current user's membership, unless that user is the server owner.
+
+Program paths:
+
+- Membership does not exist.
+- Membership exists but role is `OWNER`.
+- Membership is deleted successfully, `memberCount` is decremented, and `MEMBER_LEFT` is published with reason `LEFT`.
+- Database or transaction failure bubbles to the caller.
+
+### 3.4 `getServerMembers`
+
+Purpose: return all members for a server, enriched with user profile data and ordered by role hierarchy.
+
+Program paths:
+
+- Target server does not exist.
+- Target server exists and has no members.
+- Target server exists and members are returned in role-priority order, with same-role members retaining ascending `joinedAt` order from the database query.
+
+### 3.5 `changeRole`
+
+Purpose: let an actor with sufficient privilege update another member's role, while preventing owner reassignment and privilege escalation.
+
+Program paths:
+
+- Requested role is `OWNER`.
+- Actor is not a member of the server.
+- Target user is not a member of the server.
+- Target user is the `OWNER`.
+- Actor tries to change a member with equal or higher privilege.
+- Actor tries to assign a role equal to or higher than the actor's own role.
+- Role update succeeds.
+
+### 3.6 `removeMember`
+
+Purpose: let an actor remove a lower-privileged member from the server while protecting the owner and enforcing hierarchy.
+
+Program paths:
+
+- Actor is not a member of the server.
+- Target user is not a member of the server.
+- Target user is the `OWNER`.
+- Actor tries to remove a member with equal or higher privilege.
+- Removal succeeds, `memberCount` is decremented, and `MEMBER_LEFT` is published with reason `KICKED`.
+- Database or transaction failure bubbles to the caller.
+
+## 4. Detailed Test Cases
+
+### 4.1 `addOwner`
+
+Description: creates the initial owner membership for a newly created server.
+
+| Test Purpose                                     | Inputs                                                                                                | Expected Output                                                                                               |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Create owner membership for a new server         | Valid `userId` and `serverId` for an existing server with `memberCount = 0`                           | Returns created `ServerMember` with role `OWNER`; persists membership; increments `server.memberCount` to `1` |
+| Bubble transaction failure during owner creation | Valid `userId` and `serverId`; mocked transaction failure on `serverMember.create` or `server.update` | Throws the underlying database error; no false success is returned                                            |
+
+### 4.2 `joinServer`
+
+Description: joins a public server with the default `MEMBER` role.
+
+| Test Purpose                                 | Inputs                                                                                                  | Expected Output                                                                                                                                                         |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Join a public server successfully            | Non-member `userId`; existing public `serverId`                                                         | Returns created `ServerMember` with role `MEMBER`; increments `memberCount`; publishes `MEMBER_JOINED` with `userId`, `serverId`, role `MEMBER`, and an ISO `timestamp` |
+| Reject join when server does not exist       | Any `userId`; unknown `serverId`                                                                        | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                                                                                                 |
+| Reject join when server is private           | Non-member `userId`; existing private `serverId`                                                        | Throws `TRPCError` with code `FORBIDDEN` and message `This server is private`                                                                                           |
+| Reject duplicate join for existing member    | `userId` already present in `serverMember`; existing public `serverId`; mocked Prisma `P2002` on create | Throws `TRPCError` with code `CONFLICT` and message `Already a member of this server`; does not double-increment `memberCount`; does not publish join event             |
+| Bubble unexpected Prisma failure during join | Valid public server; mocked non-`P2002` Prisma error or transaction error                               | Throws the original error so operational failures are not masked                                                                                                        |
+
+### 4.3 `leaveServer`
+
+Description: removes a non-owner member from a server.
+
+| Test Purpose                                | Inputs                                                                                                  | Expected Output                                                                                                                                        |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Leave server successfully as non-owner      | Existing membership for `userId` with role `MEMBER`, `MODERATOR`, `ADMIN`, or `GUEST`; valid `serverId` | Returns `void`; deletes membership; decrements `memberCount`; publishes `MEMBER_LEFT` with `userId`, `serverId`, reason `LEFT`, and an ISO `timestamp` |
+| Reject leave when membership does not exist | Non-member `userId`; valid `serverId`                                                                   | Throws `TRPCError` with code `NOT_FOUND` and message `Not a member of this server`                                                                     |
+| Reject leave when caller is owner           | Existing membership for `userId` with role `OWNER`; valid `serverId`                                    | Throws `TRPCError` with code `BAD_REQUEST` and message `Server owner cannot leave. Transfer ownership or delete the server.`                           |
+| Bubble transaction failure during leave     | Existing non-owner membership; mocked transaction failure on delete or server update                    | Throws the underlying database error; membership state is not reported as successful if the transaction fails                                          |
+
+### 4.4 `getServerMembers`
+
+Description: loads all members for a server with user profile fields and role-priority sorting.
+
+| Test Purpose                                       | Inputs                                                                                  | Expected Output                                                                                                                          |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Return sorted member list for an existing server   | Existing `serverId` with seeded owner/admin/member fixtures and valid joined timestamps | Returns an array of `ServerMemberWithUser`; members are ordered `OWNER` before `ADMIN` before `MODERATOR` before `MEMBER` before `GUEST` |
+| Preserve ascending join order within the same role | Existing `serverId` with multiple `MEMBER` rows having different `joinedAt` values      | Returns same-role members in ascending `joinedAt` order after sorting                                                                    |
+| Return empty list when server has no members       | Existing `serverId` with no related `serverMember` records                              | Returns `[]`                                                                                                                             |
+| Reject lookup when server does not exist           | Unknown `serverId`                                                                      | Throws `TRPCError` with code `NOT_FOUND` and message `Server not found`                                                                  |
+
+### 4.5 `changeRole`
+
+Description: updates a target member's role when the actor outranks both the target's current role and the requested new role.
+
+| Test Purpose                                                                 | Inputs                                                                                                                                         | Expected Output                                                                                                      |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Change a lower-privileged member's role successfully                         | `actorId` with role `OWNER` or `ADMIN`; `targetUserId` with lower privilege; `newRole` lower than actor role and not `OWNER`; valid `serverId` | Returns updated `ServerMember`; persists the new role                                                                |
+| Reject assigning `OWNER` directly                                            | Valid memberships; `newRole = OWNER`                                                                                                           | Throws `TRPCError` with code `BAD_REQUEST` and message `Cannot assign OWNER role. Use ownership transfer.`           |
+| Reject change when actor is not a server member                              | Outsider `actorId`; valid target membership; valid `newRole`; valid `serverId`                                                                 | Throws `TRPCError` with code `FORBIDDEN` and message `You are not a member of this server`                           |
+| Reject change when target is not a server member                             | Valid actor membership; unknown `targetUserId`; valid `newRole`; valid `serverId`                                                              | Throws `TRPCError` with code `NOT_FOUND` and message `Target user is not a member of this server`                    |
+| Reject change when target is owner                                           | Valid actor membership below owner; target membership role `OWNER`; valid `newRole`                                                            | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot change the role of the server owner`                    |
+| Reject change when actor does not outrank target                             | `actorId` and `targetUserId` with equal roles, or actor lower than target                                                                      | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot change role of a member with equal or higher privilege` |
+| Reject change when actor tries to assign equal or higher role than their own | Valid actor membership; lower-ranked target; `newRole` equal to actor role or higher                                                           | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot assign a role equal to or higher than your own`         |
+| Reject self-role-change through hierarchy rule                               | `actorId === targetUserId`; any non-owner role; valid `newRole`                                                                                | Throws `TRPCError` with code `FORBIDDEN` because the actor does not outrank the target when both are the same member |
+
+### 4.6 `removeMember`
+
+Description: removes a lower-privileged target member from the server.
+
+| Test Purpose                                          | Inputs                                                                                        | Expected Output                                                                                                                                                                       |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Remove a lower-privileged member successfully         | `actorId` with higher role than `targetUserId`; valid `serverId`                              | Returns `void`; deletes target membership; decrements `memberCount`; publishes `MEMBER_LEFT` with `userId` set to `targetUserId`, `serverId`, reason `KICKED`, and an ISO `timestamp` |
+| Reject removal when actor is not a server member      | Outsider `actorId`; existing target membership; valid `serverId`                              | Throws `TRPCError` with code `FORBIDDEN` and message `You are not a member of this server`                                                                                            |
+| Reject removal when target is not a server member     | Valid actor membership; unknown `targetUserId`; valid `serverId`                              | Throws `TRPCError` with code `NOT_FOUND` and message `Target user is not a member of this server`                                                                                     |
+| Reject removal of owner                               | Valid actor membership; target membership role `OWNER`; valid `serverId`                      | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot remove the server owner`                                                                                                 |
+| Reject removal when actor does not outrank target     | Actor and target have equal roles, or actor has lower privilege than target                   | Throws `TRPCError` with code `FORBIDDEN` and message `Cannot remove a member with equal or higher privilege`                                                                          |
+| Reject self-removal through moderator/admin kick path | `actorId === targetUserId` for a non-owner actor; valid `serverId`                            | Throws `TRPCError` with code `FORBIDDEN` because the actor does not outrank the target                                                                                                |
+| Bubble transaction failure during removal             | Valid actor and target memberships with mocked transaction failure on delete or server update | Throws the underlying database error; no success event should be asserted                                                                                                             |
+
+## 5. Edge Cases to Explicitly Validate
+
+- Duplicate membership attempts must map Prisma unique constraint `P2002` to a `CONFLICT` error in `joinServer`.
+- Owners cannot leave the server through `leaveServer`.
+- Owners cannot be targeted by `changeRole` or `removeMember`.
+- Role hierarchy rules must block equal-rank operations, not only lower-rank operations.
+- A caller cannot promote another member to the caller's own role or any higher role.
+- Self-targeted moderation actions (`changeRole` or `removeMember` where `actorId === targetUserId`) should be rejected by the same hierarchy guard.
+- Event publication should only happen after successful membership changes.
+- `getServerMembers` should still behave correctly when the member list is empty.
+
+## 6. Coverage Expectation
+
+The cases above are intended to cover:
+
+- all six exported functions,
+- every explicit `TRPCError` branch,
+- successful transaction paths,
+- event publication side effects,
+- role hierarchy edge cases, and
+- representative unexpected database failure paths.
+
+Executing this specification should yield at least 80% coverage of the service's reachable execution paths, with the remaining uncovered paths limited to low-level infrastructure failures outside the service's direct branching logic.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read README.md
+```
+
+Output:
+
+```text
+# Harmony
+A search engine indexible chat application
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:10:31.248Z
+
+I’ve confirmed the main P5 documentation exists, but the README is still essentially empty, which is already one deliverable gap. I’m checking the Jest configs and then I’ll run the frontend/backend suites, including coverage where the setup allows it, so the progress report is based on the current branch rather than file presence alone.
+
+#### Tool: exec_command
+
+```sh
+rg --files harmony-backend harmony-frontend | rg 'jest(\.|-)config|jest\.setup|setupTests|tsconfig\.test'
+```
+
+Output:
+
+```text
+harmony-frontend/jest.config.js
+harmony-backend/tsconfig.test.json
+harmony-backend/jest.config.js
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/jest.config.js
+```
+
+Output:
+
+```text
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  setupFiles: ['dotenv/config'],
+  roots: ['<rootDir>/tests'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
+  },
+};
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/jest.config.js
+```
+
+Output:
+
+```text
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jest-environment-jsdom',
+  roots: ['<rootDir>/src'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          jsx: 'react-jsx',
+          esModuleInterop: true,
+          module: 'commonjs',
+          moduleResolution: 'node',
+        },
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+};
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read planning/SPRINT_3_PLAN.md
+```
+
+Output:
+
+````text
+# Testing Sprint Plan — March 29 – April 5, 2026
+
+## Context
+Harmony is a search-engine-indexable chat app (Discord-like). Sprints 1–2 built out requirements, dev specs, frontend, and backend. This sprint adds comprehensive unit testing for 4 core untested files (2 frontend, 2 backend), CI workflow automation, and documentation updates.
+
+**Assignment:** P5: Testing
+**Due:** Sunday, April 5, 2026, 11:59 PM AOE
+
+## Team
+5 developers: acabrera04, Aiden-Barrera, AvanishKulkarni, declanblanc, FardeenI
+
+## Tech Stack (Testing)
+- Jest 29.7 (backend) / Jest 30.3 (frontend)
+- Supertest 7.0 (backend HTTP testing)
+- @testing-library/react 16.3 (frontend)
+- ts-jest (TypeScript transpilation)
+- GitHub Actions (CI/CD)
+
+---
+
+## Files Under Test
+
+| # | Side | File | Functions | Why |
+|---|------|------|-----------|-----|
+| 1 | Backend | `harmony-backend/src/services/auth.service.ts` | 5 (`register`, `login`, `logout`, `refreshTokens`, `verifyAccessToken`) | Core auth — every user story depends on it, security-critical, untested |
+| 2 | Backend | `harmony-backend/src/services/server.service.ts` | 10 (`getPublicServers`, `getAllServers`, `getMemberServers`, `getServer`, `createServer`, `updateServer`, `deleteServer`, `incrementMemberCount`, `decrementMemberCount`, `getMembers`) | Primary domain object — server CRUD + membership counts, untested |
+| 3 | Frontend | `harmony-frontend/src/services/serverService.ts` | 11 (`getServers`, `getServer`, `getServerAuthenticated`, `getServerMembers`, `updateServer`, `deleteServer`, `joinServer`, `createServer`, `getServerMembersWithRole`, `changeMemberRole`, `removeMember`) | Frontend API layer for server management, untested |
+| 4 | Frontend | `harmony-frontend/src/services/channelService.ts` | 8 (`getChannels`, `getChannel`, `updateVisibility`, `updateChannel`, `createChannel`, `getAuditLog`, `deleteChannel`) | Frontend API layer for channels + SEO visibility toggle, untested |
+
+---
+
+## Issues (10 total)
+
+### Phase 1: TEST SPECIFICATIONS + CI SETUP — Days 1–2 (March 29–30)
+
+**1. Test Specification — `auth.service.ts`**
+- Write English-language test spec document for all 5 functions
+- List every function, its purpose, and all program paths
+- Create table: test purpose, inputs, expected output
+- Cover happy paths, error paths (invalid credentials, expired tokens, duplicate email), and edge cases
+- Target 80%+ code coverage of all execution paths
+- Output: `docs/test-specs/auth-service-spec.md`
+- Assignee: **Aiden-Barrera**
+- Due: March 30
+
+**2. Test Specification — `server.service.ts`**
+- Write English-language test spec document for all 10 functions
+- List every function, its purpose, and all program paths
+- Create table: test purpose, inputs, expected output
+- Cover happy paths, error paths (not found, duplicate slugs, unauthorized), and edge cases
+- Target 80%+ code coverage of all execution paths
+- Output: `docs/test-specs/server-service-spec.md`
+- Assignee: **declanblanc**
+- Due: March 30
+
+**3. Test Specification — `serverService.ts` (frontend)**
+- Write English-language test spec document for all 11 functions
+- List every function, its purpose, and all program paths
+- Create table: test purpose, inputs, expected output
+- Cover happy paths, API error handling (network failures, 401/403/404), and edge cases
+- Describe mock strategy for `apiClient` / `ApiClient`
+- Target 80%+ code coverage of all execution paths
+- Output: `docs/test-specs/frontend-server-service-spec.md`
+- Assignee: **FardeenI**
+- Due: March 30
+
+**4. Test Specification — `channelService.ts` (frontend)**
+- Write English-language test spec document for all 8 functions
+- List every function, its purpose, and all program paths
+- Create table: test purpose, inputs, expected output
+- Cover happy paths, API error handling, visibility enum edge cases
+- Describe mock strategy for `apiClient` / `ApiClient`
+- Target 80%+ code coverage of all execution paths
+- Output: `docs/test-specs/frontend-channel-service-spec.md`
+- Assignee: **AvanishKulkarni**
+- Due: March 30
+
+**5. GitHub Actions — CI Workflows**
+- Create `.github/workflows/run-frontend-tests.yml`
+  - Trigger on every push and PR
+  - Checkout code, setup Node.js 20, install deps, run frontend tests
+- Create `.github/workflows/run-backend-tests.yml`
+  - Trigger on every push and PR
+  - Checkout code, setup Node.js 20, install deps
+  - Start PostgreSQL + Redis services
+  - Run Prisma generate + migrate, then run backend tests
+- Reference existing `ci.yml` for service configuration patterns
+- Test by pushing a small change and verifying green checkmarks in Actions tab
+- No dependencies — can start immediately using existing tests in the repo
+- Assignee: **acabrera04**
+- Due: March 30
+
+### Phase 2: UNIT TEST IMPLEMENTATION — Days 2–4 (March 30 – April 1)
+
+**6. Unit Tests — `auth.service.ts`**
+- Implement Jest tests from spec in `harmony-backend/tests/auth.service.test.ts`
+- Mock Prisma client and bcrypt/JWT dependencies
+- Generate one test at a time via LLM to prevent hallucination
+- Verify no duplicate or overlapping test cases
+- Run tests locally, fix any failures (use LLM for 3 alternative fixes)
+- **Acceptance criteria:** 80%+ code coverage (run Jest with `--coverage`), capture coverage report for submission
+- Assignee: **Aiden-Barrera**
+- Due: April 1
+- Depends on: #1
+
+**7. Unit Tests — `server.service.ts`**
+- Implement Jest tests from spec in `harmony-backend/tests/server.service.test.ts`
+- Mock Prisma client
+- Generate one test at a time via LLM to prevent hallucination
+- Verify no duplicate or overlapping test cases
+- Run tests locally, fix any failures
+- **Acceptance criteria:** 80%+ code coverage (run Jest with `--coverage`), capture coverage report for submission
+- Assignee: **declanblanc**
+- Due: April 1
+- Depends on: #2
+
+**8. Unit Tests — `serverService.ts` (frontend)**
+- Implement Jest tests from spec in `harmony-frontend/src/__tests__/serverService.test.ts`
+- Mock `apiClient` and `ApiClient` imports from `@/lib/api-client`
+- Generate one test at a time via LLM to prevent hallucination
+- Verify no duplicate or overlapping test cases
+- Run tests locally, fix any failures
+- **Acceptance criteria:** 80%+ code coverage (run Jest with `--coverage`), capture coverage report for submission
+- Assignee: **FardeenI**
+- Due: April 1
+- Depends on: #3
+
+**9. Unit Tests — `channelService.ts` (frontend)**
+- Implement Jest tests from spec in `harmony-frontend/src/__tests__/channelService.test.ts`
+- Mock `apiClient` and `ApiClient` imports from `@/lib/api-client`
+- Generate one test at a time via LLM to prevent hallucination
+- Verify no duplicate or overlapping test cases
+- Run tests locally, fix any failures
+- **Acceptance criteria:** 80%+ code coverage (run Jest with `--coverage`), capture coverage report for submission
+- Assignee: **AvanishKulkarni**
+- Due: April 1
+- Depends on: #4
+
+### Phase 3: DOCUMENTATION & SUBMISSION — Days 5–7 (April 3–5)
+
+**10. README Update & Final Submission**
+- Update `README.md` with:
+  - Instructions to manually run frontend tests (frameworks, libraries, commands)
+  - Instructions to manually run backend tests (frameworks, libraries, commands)
+- Compile final submission document with all 17 deliverables
+- Collect and include all LLM interaction logs with model name/version
+- Note: 500-word reflection is written collaboratively as a group
+- Assignee: **acabrera04**
+- Due: April 5
+- Depends on: #6, #7, #8, #9
+
+---
+
+## Assignment Summary
+
+| Developer | Issues | Focus Area |
+|-----------|--------|------------|
+| acabrera04 | #5, #10 | CI workflows (both YAML files), README update/submission |
+| Aiden-Barrera | #1, #6 | Auth service test spec + unit tests |
+| AvanishKulkarni | #4, #9 | Channel service (FE) test spec + unit tests |
+| declanblanc | #2, #7 | Server service (BE) test spec + unit tests |
+| FardeenI | #3, #8 | Server service (FE) test spec + unit tests |
+
+## Dependency Graph
+
+```
+Phase 1 (Specs + CI)              Phase 2 (Tests + Coverage)       Phase 3 (Docs)
+
+#1 Auth Spec ───────────────────► #6 Auth Tests (80%+) ────────┐
+#2 Server Spec ─────────────────► #7 Server Tests (80%+) ──────┤
+#3 FE Server Spec ──────────────► #8 FE Server Tests (80%+) ───┼──► #10 README + Reflection
+#4 FE Channel Spec ─────────────► #9 FE Channel Tests (80%+) ──┘        + Submission
+#5 CI YAML (no dependencies) ──────────────────────────────────┘
+
+Note: 500-word reflection is a group effort, not tracked as an individual issue.
+```
+
+## Timeline
+
+| Date | Milestone |
+|------|-----------|
+| March 29 (Sat) | Sprint kickoff, begin test specs + CI workflows |
+| March 30 (Sun) | All 4 test specs complete, CI workflows verified, begin unit test implementation |
+| April 1 (Tue) | All 4 test files complete, tests passing locally, 80%+ coverage verified |
+| April 3 (Thu) | README updated, reflection draft |
+| April 5 (Sat) | Final submission compiled and turned in |
+
+## Notes
+- Use LLM to generate test specs and unit tests (course requirement)
+- Generate **one unit test at a time** to prevent LLM hallucination
+- All tests must be isolated — no cross-network calls between frontend and backend
+- Frontend tests must mock the API client; backend tests must mock Prisma
+- Save all LLM interaction logs for submission deliverable #17
+- Existing `ci.yml` already runs tests on push/PR — new workflow files are separate as required by the assignment
+````
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:10:43.078Z
+
+There’s a substantive mismatch emerging between the sprint plan and the repo: the plan expects `serverService.test.ts`, but that file is not present, and the backend choices may have shifted from `server.service.ts` to `serverMember.service.ts`. I’m verifying that against the current test files while the local test runs start.
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "describe\(|from '../src/services/server.service|from '../src/services/serverMember.service|from '@/services/serverService|from '@/services/channelService|auth.service|serverMember.service" harmony-backend/tests harmony-frontend/src/__tests__
+```
+
+Output:
+
+```text
+🔍 208 in 46F:
+
+📄 harmony-backend/tests/app.test.ts (4):
+    11: describe('GET /health', () => {
+    20: describe('GET /trpc/health', () => {
+    29: describe('404 handler', () => {
+    37: describe('CORS', () => {
+
+📄 harmony-backend/tests/attachment.router.test.ts (2):
+    17: jest.mock('../src/services/auth.service', () => ({
+    56: describe('POST /api/attachments/upload', () => {
+
+📄 harmony-backend/tests/attachment.service.test.ts (2):
+   103: describe('attachmentService.validateUpload', () => {
+   133: describe('attachmentService.listByMessage', () => {
+
+📄 harmony-backend/tests/auditLog.service.test.ts (2):
+    99: describe('auditLogService.logVisibilityChange', () => {
+   155: describe('auditLogService.getVisibilityAuditLog', () => {
+
+📄 harmony-backend/tests/auth.service.init.test.ts (5):
+    35: describe('auth.service module initialization', () => {
+    43: jest.doMock('../src/services/serverMember.service', serverMemberMockFactory);
+    46: expect(() => require('../src/services/auth.service')).toThrow(
+    59: jest.doMock('../src/services/serverMember.service', serverMemberMockFactory);
+    62: expect(() => require('../src/services/auth.service')).toThrow(
+
+📄 harmony-backend/tests/auth.service.test.ts (9):
+    43: jest.mock('../src/services/serverMember.service', () => ({
+    54: import { serverMemberService } from '../src/services/serverMember.service';
+    55: import { authService } from '../src/services/auth.service';
+   146: describe('authService.register', () => {
+   296: describe('authService.login', () => {
+   451: describe('authService.logout', () => {
+   506: describe('authService.refreshTokens', () => {
+   689: describe('authService.verifyAccessToken', () => {
+   750: // defaults) live in a dedicated file: tests/auth.service.init.test.ts
+
+📄 harmony-backend/tests/auth.test.ts (5):
+    86: describe('POST /api/auth/register', () => {
+   127: describe('POST /api/auth/login', () => {
+   177: describe('POST /api/auth/logout', () => {
+   213: describe('POST /api/auth/refresh', () => {
+   243: describe('tRPC health check with Bearer token', () => {
+
+📄 harmony-backend/tests/cache.middleware.test.ts (1):
+    52: describe('cacheMiddleware', () => {
+
+📄 harmony-backend/tests/cache.service.test.ts (8):
+    28: describe('CacheKeys', () => {
+    44: describe('sanitizeKeySegment', () => {
+    64: describe('CacheTTL', () => {
+    74: describe('cacheService.set / get', () => {
+   109: describe('cacheService.invalidate', () => {
+   121: describe('cacheService.invalidatePattern', () => {
+   140: describe('cacheService.isStale', () => {
+   154: describe('cacheService.getOrRevalidate', () => {
+
+📄 harmony-backend/tests/channel.getAuditLog.test.ts (4):
+   144: describe('channel.getAuditLog — permission gate', () => {
+   160: describe('channel.getAuditLog — cross-server probe blocked', () => {
+   172: describe('channel.getAuditLog — response shape', () => {
+   211: describe('channel.getAuditLog — pagination', () => {
+
+📄 harmony-backend/tests/channel.service.events.test.ts (3):
+    94: describe('channelService.createChannel — event publishing', () => {
+   167: describe('channelService.updateChannel — event publishing', () => {
+   209: describe('channelService.deleteChannel — event publishing', () => {
+
+📄 harmony-backend/tests/channel.service.test.ts (6):
+    53: describe('channelService.createChannel', () => {
+   109: describe('channelService.getChannels', () => {
+   120: describe('channelService.getChannelBySlug', () => {
+   149: describe('channelService.updateChannel', () => {
+   183: describe('channelService.createDefaultChannel', () => {
+
+... +158
+```
+
+#### Tool: exec_command
+
+```sh
+npm --prefix harmony-frontend test -- --runInBand
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 test
+> jest --forceExit --runInBand
+```
+
+#### Tool: exec_command
+
+```sh
+npm --prefix harmony-backend test -- --runInBand
+```
+
+Output:
+
+```text
+
+> harmony-backend@0.1.0 test
+> jest --runInBand
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 39671,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'npm --prefix harmony-frontend test -- --runInBand'
+Chunk ID: a84ca5
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 72
+Output:
+
+Test Suites: 9 passed, 9 total
+Tests:       158 passed, 158 total
+Snapshots:   0 total
+Time:        1.374 s, estimated 13 s
+Ran all test suites.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 46488,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'npm --prefix harmony-backend test -- --runInBand'
+Chunk ID: 2a451c
+Wall time: 5.0024 seconds
+Process running with session ID 46488
+Original token count: 38
+Output:
+PASS tests/auth.service.test.ts (5.501 s)
+PASS tests/auth.service.init.test.ts
+PASS tests/events.router.member.test.ts
+PASS tests/events.router.test.ts
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:10:57.923Z
+
+The frontend suite is green: 9 suites, 158 tests, all passing. Backend is still running; once that finishes I’ll have enough to separate “implemented and passing” from “present on disk but still incomplete for the assignment.”
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 46488,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'npm --prefix harmony-backend test -- --runInBand'
+Chunk ID: 815401
+Wall time: 5.0023 seconds
+Process running with session ID 46488
+Original token count: 108
+Output:
+PASS tests/events.router.server.test.ts
+PASS tests/events.router.visibility.test.ts
+PASS tests/events.router.status.test.ts
+PASS tests/events.router.sse-server-updated.test.ts
+PASS tests/rate-limit.middleware.test.ts
+PASS tests/server.test.ts
+PASS tests/auth.test.ts
+PASS tests/message.service.test.ts
+PASS tests/message.replies.test.ts
+PASS tests/eventBus.test.ts
+PASS tests/reaction.test.ts
+PASS tests/channel.getAuditLog.test.ts
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 46488,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'npm --prefix harmony-backend test -- --runInBand'
+Chunk ID: 3b7b42
+Wall time: 5.0008 seconds
+Process running with session ID 46488
+Original token count: 276
+Output:
+PASS tests/permission.service.test.ts
+PASS tests/cache.middleware.test.ts
+PASS tests/visibility.service.test.ts
+PASS tests/cache.service.test.ts
+PASS tests/channel.service.test.ts
+PASS tests/serverMember.test.ts
+PASS tests/indexing.service.test.ts
+PASS tests/user.service.test.ts
+PASS tests/trpc.permission.middleware.test.ts
+PASS tests/mock-seed.test.ts
+PASS tests/auditLog.service.test.ts
+PASS tests/public.router.test.ts
+PASS tests/attachment.service.test.ts
+PASS tests/schema.test.ts
+PASS tests/attachment.router.test.ts
+PASS tests/voice.service.test.ts
+PASS tests/app.test.ts
+PASS tests/trpc.error-formatter.test.ts
+PASS tests/channel.service.events.test.ts
+PASS tests/message.service.events.test.ts
+PASS tests/demo-seed.test.ts
+
+Test Suites: 37 passed, 37 total
+Tests:       490 passed, 490 total
+Snapshots:   0 total
+Time:        21.871 s
+Ran all test suites.
+Jest did not exit one second after the test run has completed.
+
+'This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "from '@/services/serverService'|describe\('getServers|serverService" harmony-frontend/src/__tests__
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "serverMemberService|describe\('serverMemberService|describe\(\"serverMemberService" harmony-backend/tests
+```
+
+Output:
+
+```text
+harmony-backend/tests/auth.service.init.test.ts:24:  serverMemberService: { joinServer: jest.fn() },
+harmony-backend/tests/serverMember.test.ts:3:import { serverMemberService } from '../src/services/serverMember.service';
+harmony-backend/tests/serverMember.test.ts:5:describe('serverMemberService (integration)', () => {
+harmony-backend/tests/serverMember.test.ts:71:    await serverMemberService.addOwner(ownerUserId, serverId);
+harmony-backend/tests/serverMember.test.ts:89:      const membership = await serverMemberService.joinServer(memberUserId, serverId);
+harmony-backend/tests/serverMember.test.ts:102:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:110:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:118:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:130:      const members = await serverMemberService.getServerMembers(serverId);
+harmony-backend/tests/serverMember.test.ts:144:      const members = await serverMemberService.getServerMembers(serverId);
+harmony-backend/tests/serverMember.test.ts:151:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:163:      const updated = await serverMemberService.changeRole(
+harmony-backend/tests/serverMember.test.ts:173:      const updated = await serverMemberService.changeRole(
+harmony-backend/tests/serverMember.test.ts:183:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:191:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:201:      await serverMemberService.joinServer(otherUserId, serverId);
+harmony-backend/tests/serverMember.test.ts:203:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:220:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:235:      await serverMemberService.joinServer(otherUserId, serverId);
+harmony-backend/tests/serverMember.test.ts:240:      await serverMemberService.removeMember(kickTargetId, serverId, ownerUserId);
+harmony-backend/tests/serverMember.test.ts:255:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:263:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:275:      await serverMemberService.leaveServer(memberUserId, serverId);
+harmony-backend/tests/serverMember.test.ts:289:      const err = await serverMemberService
+harmony-backend/tests/serverMember.test.ts:297:      const err = await serverMemberService
+harmony-backend/tests/auth.service.test.ts:5: * Prisma and serverMemberService are fully mocked — no real DB required.
+harmony-backend/tests/auth.service.test.ts:44:  serverMemberService: { joinServer: jest.fn() },
+harmony-backend/tests/auth.service.test.ts:54:import { serverMemberService } from '../src/services/serverMember.service';
+harmony-backend/tests/auth.service.test.ts:78:const mockJoinServer = serverMemberService.joinServer as jest.Mock;
+```
+
+#### Tool: exec_command
+
+```sh
+ls harmony-backend/src/services && ls harmony-frontend/src/services
+```
+
+Output:
+
+```text
+attachment.service.ts
+auditLog.service.ts
+auth.service.ts
+cache.service.ts
+cacheInvalidator.service.ts
+channel.service.ts
+indexing.service.ts
+message.service.ts
+permission.service.ts
+reaction.service.ts
+server.service.ts
+serverMember.service.ts
+user.service.ts
+visibility.service.ts
+voice.service.ts
+authService.ts
+channelService.ts
+index.ts
+messageService.ts
+publicApiService.ts
+serverService.ts
+```
+
+#### Tool: exec_command
+
+```sh
+npm --prefix harmony-frontend test -- --coverage --runInBand --collectCoverageFrom=src/services/channelService.ts --collectCoverageFrom=src/services/serverService.ts
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 test
+> jest --forceExit --coverage --runInBand --collectCoverageFrom=src/services/channelService.ts --collectCoverageFrom=src/services/serverService.ts
+```
+
+#### Tool: exec_command
+
+```sh
+npm --prefix harmony-backend test -- --coverage --runInBand --collectCoverageFrom=src/services/auth.service.ts --collectCoverageFrom=src/services/serverMember.service.ts
+```
+
+Output:
+
+```text
+
+> harmony-backend@0.1.0 test
+> jest --coverage --runInBand --collectCoverageFrom=src/services/auth.service.ts --collectCoverageFrom=src/services/serverMember.service.ts
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:11:30.143Z
+
+The file mapping is confirmed: backend has direct coverage-bearing tests for `auth.service.ts` and `serverMember.service.ts`, but frontend still has no `serverService`-focused test file at all. I’m waiting on the coverage runs now to turn that into a precise gap statement instead of a guess.
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 10058,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'npm --prefix harmony-frontend test -- --coverage --runInBand --collectCoverageFrom=src/services/channelService.ts --collectCoverageFrom=src/services/serverService.ts'
+Chunk ID: 83a2d8
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 209
+Output:
+-------------------|---------|----------|---------|---------|-------------------
+File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+-------------------|---------|----------|---------|---------|-------------------
+All files          |    52.1 |    43.08 |   46.15 |   52.77 |                   
+ channelService.ts |     100 |      100 |     100 |     100 |                   
+ serverService.ts  |       0 |        0 |       0 |       0 | 7-225             
+-------------------|---------|----------|---------|---------|-------------------
+
+Test Suites: 9 passed, 9 total
+Tests:       158 passed, 158 total
+Snapshots:   0 total
+Time:        1.14 s
+Ran all test suites.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 16470,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'npm --prefix harmony-backend test -- --coverage --runInBand --collectCoverageFrom=src/services/auth.service.ts --collectCoverageFrom=src/services/serverMember.service.ts'
+Chunk ID: c67633
+Wall time: 5.0017 seconds
+Process running with session ID 16470
+Original token count: 21
+Output:
+PASS tests/auth.service.test.ts (5.122 s)
+PASS tests/events.router.server.test.ts
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 16470,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'npm --prefix harmony-backend test -- --coverage --runInBand --collectCoverageFrom=src/services/auth.service.ts --collectCoverageFrom=src/services/serverMember.service.ts'
+Chunk ID: 83bbb9
+Wall time: 5.0013 seconds
+Process running with session ID 16470
+Original token count: 138
+Output:
+PASS tests/events.router.test.ts
+PASS tests/events.router.member.test.ts
+PASS tests/events.router.visibility.test.ts
+PASS tests/events.router.status.test.ts
+PASS tests/events.router.sse-server-updated.test.ts
+PASS tests/server.test.ts
+PASS tests/auth.test.ts
+PASS tests/channel.getAuditLog.test.ts
+PASS tests/message.service.test.ts
+PASS tests/reaction.test.ts
+PASS tests/eventBus.test.ts
+PASS tests/message.replies.test.ts
+PASS tests/trpc.permission.middleware.test.ts
+PASS tests/permission.service.test.ts
+PASS tests/rate-limit.middleware.test.ts
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 16470,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'npm --prefix harmony-backend test -- --coverage --runInBand --collectCoverageFrom=src/services/auth.service.ts --collectCoverageFrom=src/services/serverMember.service.ts'
+Chunk ID: 350a39
+Wall time: 5.0017 seconds
+Process running with session ID 16470
+Original token count: 417
+Output:
+PASS tests/cache.middleware.test.ts
+PASS tests/schema.test.ts
+PASS tests/cache.service.test.ts
+PASS tests/serverMember.test.ts
+PASS tests/visibility.service.test.ts
+PASS tests/channel.service.test.ts
+PASS tests/indexing.service.test.ts
+PASS tests/user.service.test.ts
+PASS tests/attachment.router.test.ts
+PASS tests/auditLog.service.test.ts
+PASS tests/auth.service.init.test.ts
+PASS tests/attachment.service.test.ts
+PASS tests/voice.service.test.ts
+PASS tests/app.test.ts
+PASS tests/public.router.test.ts
+PASS tests/trpc.error-formatter.test.ts
+PASS tests/mock-seed.test.ts
+PASS tests/demo-seed.test.ts
+PASS tests/channel.service.events.test.ts
+PASS tests/message.service.events.test.ts
+-------------------------|---------|----------|---------|---------|-------------------
+File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+-------------------------|---------|----------|---------|---------|-------------------
+All files                |   96.85 |    85.36 |     100 |      98 |                   
+ auth.service.ts         |     100 |     91.3 |     100 |     100 | 20-29             
+ serverMember.service.ts |   92.64 |    77.77 |     100 |      95 | 78,164,189        
+-------------------------|---------|----------|---------|---------|-------------------
+
+Test Suites: 37 passed, 37 total
+Tests:       490 passed, 490 total
+Snapshots:   0 total
+Time:        22.794 s
+Ran all test suites.
+Jest did not exit one second after the test run has completed.
+
+'This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:12:18.182Z
+
+The coverage picture is clear now: `channelService.ts` is at 100%, `auth.service.ts` is at 100/91.3 branch, and `serverMember.service.ts` is strong but still short of the 80% branch target. The major frontend gap is confirmed: `serverService.ts` is at 0% because there is no targeted test file yet.
+
+#### Tool: exec_command
+
+```sh
+git remote -v
+```
+
+Output:
+
+```text
+origin	git@github.com:acabrera04/Harmony.git (fetch)
+origin	git@github.com:acabrera04/Harmony.git (push)
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "500-word|reflection|README|frontend tests|backend tests|LLM" docs planning llm-logs tasks README.md
+```
+
+Output:
+
+````text
+Total output lines: 632
+
+planning/Create_Sprint_Plan.md:24:Using your LLM, generate the front end code from your user stories, Figma mockups (with their design rationale and developer implementation guides), and development specifications.
+planning/P1_ Requirements Engineering.md:3:1. What is the big idea of the startup you have chosen? What problem is it solving? What is its solution? What makes their solution special and distinguishes it from the competition? Do not use an LLM for this part. (1-2 paragraphs)
+planning/P1_ Requirements Engineering.md:9:2. What is/are the value proposition(s) for your product? Do not use an LLM for this part. (1-2 sentences)
+planning/P1_ Requirements Engineering.md:13:3. Ask an LLM to describe the value proposition(s) for your product (1-2 sentences). 
+planning/P1_ Requirements Engineering.md:19:4. What is the difference between the human and LLM-generated value propositions? Which one is more compelling? (3-4 sentences)
+planning/P1_ Requirements Engineering.md:21:The major difference between the human and LLM-generated value propositions is that the human version uses less flattery but is direct and to the point with understanding exactly what the value in our product holds. This compared to the LLM-generated value proposition is more attention grabbing with the sentence and verbiage usage such as it including “dark social” which wasn’t mentioned in the the prompting. The LLM-generated rendition is more compelling with the verbiage used but I believe this is intentional with the model to be engaging with the material it trained upon to get the attention of people better.
+planning/P1_ Requirements Engineering.md:64:2. Many users nowadays turn to ChatGPT or other LLMs as opposed to joining online communities.  
+planning/P1_ Requirements Engineering.md:71:When conducting user experience research for this assignment, my groupmates and I all decided to interview fellow college students. As a result, the collection of interview results and feedback we received is representative of the average college student persona. The questions we asked our peers were centered around the user experience of searching for answers to questions and managing useful information exchanged through chat applications. We found that the average college student of today’s day and age has a high ease of access to solutions to their questions through the benefit of the internet. We found that the average college student’s first solution to searching for answers to a question is utilizing the popular search engine Google. The average college student finds success in their Google searches a majority of the time, and experiences difficulty finding direct answers to their questions almost exclusively when their questions are niche or highly nuanced. Oftentimes, the average college student’s failover mechanism when dissatisfied with the answers their search results provide is to plug the same question into an LLM-integrated application like ChatGPT or Gemini. Interviewees also note that, as of lately, sometimes, their first route of action when searching for the solution to a problem they have is by consulting their favorite LLM-integrated application. Interviewees note that when searching the answer to a question, if the platform hosting the answer they’re searching for requires account registration and authentication, they feel inconvenienced and will search elsewhere for their answer. 
+planning/P1_ Requirements Engineering.md:73:With regards to chat applications, every interviewee noted that they use Discord. Many interviewees mentioned that their behavior in large Discord servers is passive, reading through updates and mentions, rather than actively participating in conversation. Interviewees note that the search functionality in Discord is “usually good enough” when they wish to refer back to some information exchanged in a previous conversation, so long as they remember key phrases, and doing so is easier in public forums / servers than in private conversations. Furthermore, the average college student does not usually bookmark / explicitly save conversation points for later, noting that server mods typically pin important information, saving them the need to do so. The key takeaways from the interviewees for our focus area is that the average college student does not frequently turn to online forums as their first source when searching for solutions to problems and that the most disqualifying factor for a college student’s search tool of choice is inconvenience of use. This could mean that the value of the solution our product aims to introduce may not be great enough for the average college student to utilize our product over something like an LLM-integrated application as a first option for their search experience.
+docs/dev-spec-channel-visibility-toggle.md:246:After having an LLM review this spec, the canonical owner of the sitemap generation should be the IndexingService. There was a discrepancy between this spec and the seo-meta-tag-generation spec on what would consume server updates and generate new sitemaps for external services. 
+docs/dev-spec-channel-visibility-toggle.md:315:Like the previous section, I had to reprompt to fix inconsistencies. The LLM also noticed that the ChannelRepository interface/class has discrepancies across each spec, so it consolidated each of them together. The class diagrams correctly display the interactions between each class, so no update was needed there. 
+docs/dev-spec-channel-visibility-toggle.md:373:The first diagram correctly tracks the state changes for all possible channel states. No changes or reprompting the LLM was necessary for this section. The channel will be public, public & indexable, or private. A simplification of the roles-based access control in Discord, but covers the general idea. 
+docs/dev-spec-channel-visibility-toggle.md:497:The LLM had to be reprompted here to clarify which protocols (RPC vs REST) would be used for communications. This was an issue across the this whole dev spec. It was determined REST protocols would be used for public APIs and RPC for internal communications. 
+docs/dev-spec-channel-visibility-toggle.md:499:The LLM also had to be reprompted to finalize what the event bus would be. It chose Redis Pub/Sub to allow for visibility change updates to propagate. The cache keying also needed to be updated to match earlier updates. 
+docs/dev-spec-channel-visibility-toggle.md:614:Significant reprompting was necessary here because of conflicting tech stacks across each spec. This spec was missing DOMPurify, which would be needed to sanitize and generate sitemaps with other public content. The communication APIs being a mix of RPC and REST was also detected by the LLM here, requiring prompting to fix it. The LLM then determined to use RPC for authenticated internal APIs, while public endpoints would be REST for compatibility with web indexers.
+docs/dev-spec-channel-visibility-toggle.md:616:Finally, the LLM made a shared tech-stack document that would be used across each spec. 
+docs/dev-spec-channel-visibility-toggle.md:750:The LLM had generated mismatched class methods and variables from before and now. It had to be reprompted to recouncile the differences and create missing functions both here and in previous sections. Like mentioned before, it also had to be reprompted to standardize a ratelimiting policy here instead of arbitrary values elsewhere.
+docs/dev-spec-channel-visibility-toggle.md:752:The separation of public APIs, business logic, and data access layers is good practice in large systems, so I agree with the LLM's decisions here.
+docs/dev-spec-channel-visibility-toggle.md:877:The LLM correctly generated the public API specification. It did not need to be reprompted for any fixes here. The generated API specification is correct and exposes the endpoints necessary for this specific user story. 
+docs/dev-spec-channel-visibility-toggle.md:1064:The LLM did not have issues with generating security and privacy requirements. This architecture is justified because it creates an audit trail for any actions. All actions are tagged by the user doing the action. IP addresses are also stored for audits. 
+docs/dev-spec-channel-visibility-toggle.md:1133:Component risks make sense, primarily external API changes and growing storage/bandwidth costs. These are common issues which the LLM caught and documented well. 
+docs/dev-spec-channel-visibility-toggle.md:1135:The LLM is justified in determining the cost of operation as well, figuring out what finanical risks are present in creating this software. 
+docs/dev-spec-channel-visibility-toggle.md:1137:Contingency plans and thresholds to activate them match industry standards for API, database, and caching failures. Therefore the LLM is justified in making these decisions.
+llm-logs/planning/03-29-sprint-3-planning.md:139:- Less total new code to write since backend tests exist
+llm-logs/planning/03-29-sprint-3-planning.md:142:- The backend tests already exist — grading may expect you to write them yourself via LLM prompting (the assignment says "have your LLM generate the required unit tests")
+llm-logs/planning/03-29-sprint-3-planning.md:153:| **BE:** `auth.service.ts` | 5 | Untested, security-critical, must be written fresh via LLM |
+llm-logs/planning/03-29-sprint-3-planning.md:158:This gives you fresh tests for all 4 files (satisfying the "LLM-generated" requirement), a mix of simple and complex testing scenarios, and the strongest deliverable for grading.
+llm-logs/planning/03-29-sprint-3-planning.md:193:| 4. Docs & Submit | Apr 3–5 | README update, 500-word reflection, final submission |
+llm-logs/planning/03-29-sprint-3-planning.md:198:- **FardeenI** — `serverService.ts` frontend (spec + tests) + README/reflection/submission
+llm-logs/planning/03-29-sprint-3-planning.md:252:2. **Redistributed acabrera04's load** — now owns CI workflows (#5) + README/reflection/submission (#10), giving everyone 2 issues each.
+llm-logs/planning/03-29-sprint-3-planning.md:266:remove the reflection portion of issue 10 since that happens as a group and it doesn't really make sense for me to write it if I didn't make any tests
+llm-logs/planning/03-29-sprint-3-planning.md:278:Done. Removed the reflection from #10 — it's now just README update + submission compilation. Added a note that the reflection is a group effort.
+llm-logs/planning/03-29-sprint-3-planning.md:333:| [#267](https://github.com/acabrera04/Harmony/issues/267) | README Update & Final Submission | acabrera04 |
+planning/SPRINT_3_PLAN.md:81:  - Checkout code, setup Node.js 20, install deps, run frontend tests
+planning/SPRINT_3_PLAN.md:86:  - Run Prisma generate + migrate, then run backend tests
+planning/SPRINT_3_PLAN.md:98:- Generate one test at a time via LLM to prevent hallucination
+planning/SPRINT_3_PLAN.md:100:- Run tests locally, fix any failures (use LLM for 3 alternative fixes)
+planning/SPRINT_3_PLAN.md:109:- Generate one test at a time via LLM to prevent hallucination
+planning/SPRINT_3_PLAN.md:120:- Generate one test at a time via LLM to prevent hallucination
+planning/SPRINT_3_PLAN.md:131:- Generate one test at a time via LLM to prevent hallucination
+planning/SPRINT_3_PLAN.md:141:**10. README Update & Final Submission**
+planning/SPRINT_3_PLAN.md:142:- Update `README.md` with:
+planning/SPRINT_3_PLAN.md:143:  - Instructions to manually run frontend tests (frameworks, libraries, commands)
+planning/SPRINT_3_PLAN.md:144:  - Instructions to manually run backend tests (frameworks, libraries, commands)
+planning/SPRINT_3_PLAN.md:146:- Collect and include all LLM interaction logs with model name/version
+planning/SPRINT_3_PLAN.md:147:- Note: 500-word reflection is written collaboratively as a group
+planning/SPRINT_3_PLAN.md:158:| acabrera04 | #5, #10 | CI workflows (both YAML files), README update/submission |
+planning/SPRINT_3_PLAN.md:171:#3 FE Server Spec ──────────────► #8 FE Server Tests (80%+) ───┼──► #10 README + Reflection
+planning/SPRINT_3_PLAN.md:175:Note: 500-word reflection is a group effort, not tracked as an individual issue.
+planning/SPRINT_3_PLAN.md:185:| April 3 (Thu) | README updated, reflection draft |
+planning/SPRINT_3_PLAN.md:189:- Use LLM to generate test specs and unit tests (course requirement)
+planning/SPRINT_3_PLAN.md:190:- Generate **one unit test at a time** to prevent LLM hallucination
+planning/SPRINT_3_PLAN.md:192:- Frontend tests must mock the API client; backend tests must mock Prisma
+planning/SPRINT_3_PLAN.md:193:- Save all LLM interaction logs for submission deliverable #17
+llm-logs/docs_agentsMD/claude-conversation-2026-02-24-08dd58c0.md:40:- LLM-generated context files **decrease** success by ~3%; human-written only gain ~4%
+llm-logs/docs_agentsMD/claude-conversation-2026-02-24-08dd58c0.md:73:| LLM-generated context files | -3% task success rate |
+llm-logs/planning/02-16_spring-1-plan.md:67:24. Using your LLM, generate the front end code from your user stories, Figma mockups (with their design rationale and developer implementation guides), and development specifications.
+llm-logs/planning/02-16_spring-1-plan.md:99:3. 1. What is the big idea of the startup you have chosen? What problem is it solving? What is its solution? What makes their solution special and distinguishes it from the competition? Do not use an LLM for this part. (1-2 paragraphs)
+llm-logs/planning/02-16_spring-1-plan.md:105:9. 2. What is/are the value proposition(s) for your product? Do not use an LLM for this part. (1-2 sentences)
+llm-logs/planning/02-16_spring-1-plan.md:109:13. 3. Ask an LLM to describe the value proposition(s) for your product (1-2 sentences). 
+llm-logs/planning/02-16_spring-1-plan.md:115:19. 4. What is the difference between the human and LLM-generated value propositions? Which one is more compelling? (3-4 sentences)
+llm-logs/planning/02-16_spring-1-plan.md:117:21. The major difference between the human and LLM-generated value propositions is that the human version uses less flattery but is direct and to the point with understanding exactly what the value in our product holds. This compared to the LLM-generated value proposition is more attention grabbing with the sentence and verbiage usage such as it including “dark social” which wasn’t mentioned in the the prompting. The LLM-generated rendition is more compelling with the verbiage used but I believe this is intentional with the model to be engaging with the material it trained upon to get the attention of people better.
+llm-logs/planning/02-16_spring-1-plan.md:160:64. 2. Many users nowadays turn to ChatGPT or other LLMs as opposed to joining online communities.  
+llm-logs/planning/02-16_spring-1-plan.md:167:71. When conducting user experience research for this assignment, my groupmates and I all decided to interview fellow college students. As a result, the collection of interview results and feedback we received is representative of the average college student persona. The questions we asked our peers were centered around the user experience of searching for answers to questions and managing useful information exchanged through chat applications. We found that the average college student of today’s day and age has a high ease of access to solutions to their questions through the benefit of the internet. We found that the average college student’s first solution to searching for answers to a question is utilizing the popular search engine Google. The average college student finds success in their Google searches a majority of the time, and experiences difficulty finding direct answers to their questions almost exclusively when their questions are niche or highly nuanced. Oftentimes, the average college student’s failover mechanism when dissatisfied with the answers their search results provide is to plug the same question into an LLM-integrated application like ChatGPT or Gemini. Interviewees also note that, as …74723 tokens truncated…"docs/unified-backend-architecture.md","line":959,"author":"FardeenI","created_at":"2026-03-05T03:09:22Z","updated_at":"2026-03-05T03:09:22Z","html_url":"https://github.com/acabrera04/Harmony/pull/125#discussion_r2887324160"}],"total_count":1},{"is_resolved":true,"is_outdated":false,"is_collapsed":true,"comments":[{"body":"**These two DB writes should be a single transaction.** If the `INSERT INTO visibility_audit_log` fails after `UPDATE channels` succeeds, you'll have an unaudited visibility change — a silent correctness bug that could matter for debugging or compliance. Wrap both in a Prisma transaction:\n\n```typescript\nawait prisma.$transaction([\n  prisma.channel.update({ where: { id: channelId }, data: { visibility } }),\n  prisma.visibilityAuditLog.create({ data: { channelId, actorId, ... } }),\n]);\n```\n\nThe `ChannelVisibilityService.setVisibility()` description in §6.3 should explicitly require this atomicity.","path":"docs/unified-backend-architecture.md","line":1327,"author":"FardeenI","created_at":"2026-03-05T03:09:22Z","updated_at":"2026-03-05T03:09:22Z","html_url":"https://github.com/acabrera04/Harmony/pull/125#discussion_r2887324161"}],"total_count":1},{"is_resolved":true,"is_outdated":true,"is_collapsed":true,"comments":[{"body":"**DOMPurify is browser-only and won't work in Node.js without a shim.** A bare `import DOMPurify from 'dompurify'` in the Express backend (`ContentFilter`, M-B2) will throw at startup because DOMPurify requires a browser DOM. For server-side use, you need:\n\n- `isomorphic-dompurify` — wraps `jsdom`, drop-in compatible with DOMPurify's API\n- `sanitize-html` — Node-native, no DOM required, simpler config for stripping tags/attributes\n\nThe tech stack entry should name the Node.js-compatible variant. `sanitize-html` is likely the lighter choice since `jsdom` adds significant startup overhead.","path":"docs/unified-backend-architecture.md","author":"FardeenI","created_at":"2026-03-05T03:09:22Z","updated_at":"2026-03-05T03:09:22Z","html_url":"https://github.com/acabrera04/Harmony/pull/125#discussion_r2887324163"}],"total_count":1},{"is_resolved":true,"is_outdated":false,"is_collapsed":true,"comments":[{"body":"**`.env.example` is referenced here but not included in this PR.** Any developer who clones and runs `npm install && npm run dev` will immediately get a database connection error. Please add `harmony-backend/.env.example` alongside `docker-compose.yml` — the compose file already has all the right defaults:\n\n```\nDATABASE_URL=postgresql://harmony:harmony@localhost:5432/harmony_dev\nREDIS_URL=redis://:devsecret@localhost:6379\nFRONTEND_URL=http://localhost:3000\nPORT=4000\n```","path":"harmony-backend/README.md","line":33,"author":"FardeenI","created_at":"2026-03-05T03:09:22Z","updated_at":"2026-03-05T03:09:22Z","html_url":"https://github.com/acabrera04/Harmony/pull/125#discussion_r2887324166"},{"body":".env.example is already committed to main","path":"harmony-backend/README.md","line":33,"author":"acabrera04","created_at":"2026-03-05T03:14:36Z","updated_at":"2026-03-05T03:14:37Z","html_url":"https://github.com/acabrera04/Harmony/pull/125#discussion_r2887337808"}],"total_count":2},{"is_resolved":false,"is_outdated":false,"is_collapsed":false,"comments":[{"body":"**The slug→UUID resolution here is still circular.** The note says the settings page should call `channel.getSettings` to get the `channelId` UUID — but `channel.getSettings` takes `{ channelId: UUID }` as input (line 958). The settings page only has `serverSlug` + `channelSlug` from the URL. There's no procedure to look up a channel by slug.\n\nNeeds one of:\n- A new procedure like `channel.getBySlug({ serverSlug, channelSlug })` that returns `ChannelSettingsResponse` (including `channelId`)\n- Or change `channel.getSettings` input to accept `{ serverSlug: string, channelSlug: string }` instead of `{ channelId: UUID }`\n\nAs written, the settings page has no way to get a UUID without already having a UUID.","path":"docs/unified-backend-architecture.md","line":965,"author":"FardeenI","created_at":"2026-03-05T03:38:25Z","updated_at":"2026-03-05T03:38:25Z","html_url":"https://github.com/acabrera04/Harmony/pull/125#discussion_r2887394728"}],"total_count":1},{"is_resolved":false,"is_outdated":false,"is_collapsed":false,"comments":[{"body":"**Sequence diagram still shows two separate DB writes.** §6.3 correctly requires a Prisma transaction, but this diagram still shows `UPDATE channels` and `INSERT INTO visibility_audit_log` as sequential independent arrows — which looks exactly like the two-separate-writes pattern the prose forbids. A reader going straight to the diagram will miss the transactional requirement. Add a `rect` block around both lines:\n\n```\nrect rgb(200, 230, 200)\n    note over VisService,DB: Prisma $transaction — atomic\n    VisService->>DB: UPDATE channels SET visibility ...\n    VisService->>DB: INSERT INTO visibility_audit_log\nend\n```","path":"docs/unified-backend-architecture.md","line":1328,"author":"FardeenI","created_at":"2026-03-05T03:38:25Z","updated_at":"2026-03-05T03:38:25Z","html_url":"https://github.com/acabrera04/Harmony/pull/125#discussion_r2887394735"}],"total_count":1},{"is_resolved":false,"is_outdated":false,"is_collapsed":false,"comments":[{"body":"**`channel_type` should be a database enum, not `VARCHAR_20`.** `ChannelType` has exactly three valid values (TEXT, VOICE, ANNOUNCEMENT). Storing it as unrestricted `VARCHAR_20` means the database won't reject invalid values. Add a `CREATE TYPE` alongside the existing `visibility_enum` in §4.2:\n\n```sql\nCREATE TYPE channel_type_enum AS ENUM ('TEXT', 'VOICE', 'ANNOUNCEMENT');\n```\n\nAnd update the column to `channel_type_enum channel_type`. This mirrors the same pattern used for `visibility`.","path":"docs/unified-backend-architecture.md","line":734,"author":"FardeenI","created_at":"2026-03-05T03:38:25Z","updated_at":"2026-03-05T03:38:25Z","html_url":"https://github.com/acabrera04/Harmony/pull/125#discussion_r2887394739"}],"total_count":1}],"total_count":20,"page_info":{"has_next_page":false,"has_previous_page":false,"start_cursor":"Y3Vyc29yOnYyOpK0MjAyNi0wMy0wNVQwMToxNzo1NlrOcjQhdA==","end_cursor":"Y3Vyc29yOnYyOpK0MjAyNi0wMy0wNVQwMzozODoyNVrOcjhYXA=="}}
+llm-logs/acabrera04-logs/acabrera04-backend/03-07-pr-136-reviews-addressed.md:10406:The latest change caused the backend tests to fail in the CI. Specifically this happened
+llm-logs/acabrera04-logs/acabrera04-backend/03-07-pr-136-reviews-addressed.md:10414:*The user says the latest change caused backend tests to fail in CI. Let me check the CI run to see what failed.*
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:307:I need to recall relevant files from the session_store once I know what they are. I should survey the codebase with at least two searches—maybe using a subagent to explore for mock data and context? It could help to also utilize GitHub issue tools since the last fetch failed due to a wrong owner. I might want to read the README/docs, especially the architecture doc for the backend. Additionally, I should take note of the user’s requirement about removable mock data, as this may influence the scope. I need to inspect the issue further.**Fetching issue details**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:946:README.md
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:1038:README.md
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:1071:README.md
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:2883:**Check README for context**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:2885:$ cat /Users/allen/repos/Harmony/README.md | head -100
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:4305:  # 3. Run backend tests (should verify schema + seeded data integrity)
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:4344:    - name: Run backend tests
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:4756:# 3. Run backend tests
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:4785:- name: Run backend tests
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:6827:I need to create a plan document that outlines the problem and approach, focusing on deterministic UUID mapping due to schema conflict and isolating development seed data. I should reflect the to-dos in SQL and then ask the user to confirm the plan, especially since it's a large task. Including options like "Preserve slugs + derive stable UUIDs from mock IDs" as default seems best. It might also be beneficial to get more context from backend tests before finalizing the plan.**Planning for implementation**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:6922:I'm tackling the issue that asks for test users with different roles. Since we don't have a role field, it limits how we can store that information. I think about using `publicProfile`, but that might not fit either. It might be worth adding a comment or README to note that true role persistence is blocked by the current schema. 
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:8515:**Run full backend tests**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:12724:**Rerun full backend tests after fixes**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:14730:AGENTS.md                dogfood-output/          llm-logs/                README.md
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:17230:**Final full backend tests**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:17628:**Full backend tests after final comment**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:18713:I need to update the plan.md with progress and next steps, specifically using SQL todos. It's important to capture the current baseline, which may involve building, linting, and running tests. Since this is a medium task, I'll check if the "anvil_checks" table already exists, and I might create it with a new task ID like "add-demo-seed-path." Additionally, I’ll need to insert the baseline results and look into session_store recall for relevant files like .github/workflows, package.json, README, or docs. Time to search!**Exploring deployment workflows**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:18773:  "glob": "{.github/workflows/**,README.md,WORKFLOW.md,harmony-backend/package.json,harmony-backend/src/**/*.ts,docs/**/*.md}",
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:18858:README.md
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:18992:/Users/allen/repos/Harmony-issue-104/harmony-backend/README.md
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:19048:/Users/allen/repos/Harmony-issue-104/harmony-frontend/README.md
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:19077:README.md
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:19783:$ grep -r "staging\|STAGING\|demo\|DEMO\|deployment" /Users/allen/repos/Harmony-issue-104/WORKFLOW.md /Users/allen/repos/Harmony-issue-104/README.md 2>/dev/null | head -20
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:20475:I’m adding a manual workflow in the `.github/workflows/demo-seed.yml` file that will run on a manual trigger and uses `workflow_dispatch` inputs like `environment`, set to default to demo. It configures `DATABASE_URL` from the `DEMO_DATABASE_URL` secret and sets `HARMONY_DEMO_MODE` to true. The workflow will execute certain commands to ensure a demo seed path for deployment without affecting the normal backend. I’m considering updates to the `.env.example` file and possibly the README to reflect changes. I might also want to post progress comments on issues related to this workflow.**Updating plan document**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:20483:I’m thinking that if the workflow is absent, it will likely fail, so I should document that well. I wonder if I could use `workflow_dispatch` with an input for the `database-url-secret-name`. However, GitHub Actions can't dynamically select secret names easily. It might be simpler to just use an environment variable like `DATABASE_URL: ${{ secrets.DEMO_DATABASE_URL }}` and then note in the workflow name or README that it must be configured as a secret. Since this is for a class project, that should be okay.**Evaluating demo seed design**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:20489:Updating the README might be beneficial too, especially since the user mentioned a class project and demos. I should consider if minimal documentation in `.env.example` or the README would help users find the local demo seeding command. Maybe I can also comment within the workflow file.**Evaluating workflow inputs**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:21157:I see the script uses explicit demo mode while setting up HARMONY_ALLOW_MOCK_SEED. To replicate a production environment, I should set `NODE_ENV: production`. I’m considering adding `concurrency` to the workflow—though it's not strictly necessary. Maybe I should name the manual workflow "Seed demo database" and include `inputs.apply_migrations`. If there’s no deploy path, then focusing on the manual workflow is key. It might also be helpful to update the README, particularly in relation to the demo. **Considering backend command updates**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:21159:I think I could update the backend command list to include `npm run db:seed:mock` and `npm run db:seed:demo`. However, the user might already see the package, which may not be sufficient. Since this is a new workflow, adding documentation could be helpful, but the root README might end up too lengthy. I'll check the initial lines or the commands section to see if an update is truly necessary. I might search for backend commands to get a better idea.*
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:21167:**/Users/allen/repos/Harmony-issue-104/README.md**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:21175:  "path": "/Users/allen/repos/Harmony-issue-104/README.md",
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:21205:  "glob": "README.md|docs/**/*.md|harmony-backend/.env.example|harmony-backend/package.json",
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:21226:I’m considering that a README file might not require commands, but maybe the .env.example file will be enough. I could focus on updating the workflow only. It makes sense to patch multiple files at once if needed. Also, I should think about adding an issue comment later to keep track of everything. Crafting a careful patch sounds like the right approach to ensure accuracy. It's all about taking the time to get it right!*
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:21548:I’m considering running `HARMONY_DEMO_MODE=true npm exec tsx` to invoke the demo seed while ensuring it doesn’t access the actual database. I think this setup could effectively exercise the helper path. After making changes, I’ll need to build, lint, and run tests in parallel. It might be good to run full backend tests, including both mock and demo seed tests. I’ll also look at targeted demo tests and see if `npm test -- --runInBand tests/demo-seed.test.ts` works for parallel execution.*
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:21653:**Run full backend tests after demo seed changes**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:23085:**Rerun full backend tests**
+llm-logs/acabrera04-logs/acabrera04-backend/03-06-issue-104-logs.md:24229:README.md
+````
+
+#### Tool: exec_command
+
+```sh
+find llm-logs -maxdepth 2 -type f | head -n 20
+```
+
+Output:
+
+```text
+llm-logs/fardeeni-backend/claude-conversation-2026-03-15-agent-ae.md
+llm-logs/fardeeni-backend/claude-conversation-2026-03-05-40a3132e.md
+llm-logs/fardeeni-backend/claude-conversation-2026-03-06-5352a452.md
+llm-logs/fardeeni-backend/claude-conversation-2026-03-06-agent-a0.md
+llm-logs/fardeeni-backend/claude-conversation-2026-03-08-8a026b19.md
+llm-logs/fardeeni-backend/claude-conversation-2026-03-15-edd2e22e.md
+llm-logs/fardeeni-backend/claude-conversation-2026-03-16-bb11eabb.md
+llm-logs/fardeeni-backend/claude-conversation-2026-03-09-89745d67.md
+llm-logs/fardeeni-backend/claude-conversation-2026-03-09-agent-a1.md
+llm-logs/declanblanc-backend/planning.md
+llm-logs/declanblanc-backend/session-ses_3407.md
+llm-logs/declanblanc-backend/session-ses_33f8.md
+llm-logs/declanblanc-backend/address-pr-comment.txt
+llm-logs/declanblanc-backend/session-ses_3415.md
+llm-logs/declanblanc-backend/2026-03-05-190925-local-command-caveatcaveat-the-messages-below-w.txt
+llm-logs/declanblanc-backend/session-ses_33fc.md
+llm-logs/acabrera04-logs/.DS_Store
+llm-logs/.DS_Store
+llm-logs/2026-03-06-215839-review-pr-132.txt
+llm-logs/frontend/02-23-pr-fix-plan-app-router.md
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short --branch
+```
+
+Output:
+
+```text
+## main...origin/main
+?? "P4: Backend Development | CS 485 AI-Assisted Software Engineering (Sp26).html"
+?? "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf"
+?? harmony-backend/coverage/
+?? load-test.js
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:12:29.566Z
+
+I’ve checked the repo-local deliverables. The last piece worth verifying is whether the two required GitHub Actions have actually run successfully on GitHub yet, because that’s a separate assignment requirement from just having the YAML files in the repo.
+
+#### Tool: exec_command
+
+```sh
+which gh && gh run list -R acabrera04/Harmony --limit 20
+```
+
+Output:
+
+```text
+/opt/homebrew/bin/gh
+completed	success	Merge pull request #283 from acabrera04/test/issue-263-auth-service-t…	CI	main	push	23957265540	1m8s	2026-04-03T18:26:24Z
+completed	success	Merge pull request #283 from acabrera04/test/issue-263-auth-service-t…	CI	main	push	23957265539	35s	2026-04-03T18:26:24Z
+completed	success	Merge pull request #283 from acabrera04/test/issue-263-auth-service-t…	CI	main	push	23957265535	41s	2026-04-03T18:26:24Z
+completed	success	test: auth.service.ts unit tests (issue #263)	CI	test/issue-263-auth-service-tests	pull_request	23955620809	1m19s	2026-04-03T17:34:44Z
+completed	success	test: auth.service.ts unit tests (issue #263)	CI	test/issue-263-auth-service-tests	pull_request	23955620783	41s	2026-04-03T17:34:44Z
+completed	success	test: auth.service.ts unit tests (issue #263)	CI	test/issue-263-auth-service-tests	pull_request	23955620782	31s	2026-04-03T17:34:44Z
+completed	success	Merge pull request #284 from acabrera04/test/channelService-unit-test…	CI	main	push	23952411680	40s	2026-04-03T15:53:29Z
+completed	success	Merge pull request #284 from acabrera04/test/channelService-unit-test…	CI	main	push	23952411677	1m7s	2026-04-03T15:53:29Z
+completed	success	Merge pull request #284 from acabrera04/test/channelService-unit-test…	CI	main	push	23952411674	31s	2026-04-03T15:53:29Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952359061	1m14s	2026-04-03T15:51:45Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952359051	30s	2026-04-03T15:51:45Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952359040	46s	2026-04-03T15:51:45Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952332680	1m13s	2026-04-03T15:50:55Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952332621	29s	2026-04-03T15:50:55Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952332617	40s	2026-04-03T15:50:55Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952168848	1m6s	2026-04-03T15:45:32Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952168810	30s	2026-04-03T15:45:31Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952168788	46s	2026-04-03T15:45:31Z
+completed	success	Copilot code review	Copilot code review	refs/pull/284/head	dynamic	23951850414	4m25s	2026-04-03T15:35:54Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23951847836	39s	2026-04-03T15:35:50Z
+```
+
+#### Tool: exec_command
+
+```sh
+gh workflow list -R acabrera04/Harmony
+```
+
+Output:
+
+```text
+CI	active	238273485
+Claude Code Review	active	243035817
+Seed Demo Database	active	242973158
+Discord Forum PR Thread	active	242220624
+CI	active	253888784
+Frontend E2E	active	254660473
+CI	active	253888785
+Copilot code review	active	234042605
+Copilot coding agent	active	235276471
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:12:43.413Z
+
+GitHub confirms the required workflows do run remotely, but all three test-related workflows are named `CI`, which makes the Actions tab harder to interpret. I’m mapping those workflow IDs back to their files so I can tell you whether the assignment’s “successful run” evidence is already satisfied or just nominally present.
+
+#### Tool: exec_command
+
+```sh
+gh workflow view 238273485 -R acabrera04/Harmony --yaml
+```
+
+Output:
+
+```text
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  # The core CI workflow handles static validation for each package.
+  # Test execution lives in dedicated workflows so failures are easier to spot.
+  frontend-lint-build:
+    name: Frontend Lint and Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: harmony-frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: harmony-frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+  backend-lint-build:
+    name: Backend Lint and Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: harmony-backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: harmony-backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Build
+        run: npm run build
+```
+
+#### Tool: exec_command
+
+```sh
+gh workflow view 253888784 -R acabrera04/Harmony --yaml
+```
+
+Output:
+
+```text
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  backend-tests:
+    name: Run Backend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: harmony-backend
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: harmony
+          POSTGRES_PASSWORD: harmony
+          POSTGRES_DB: harmony_dev
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://harmony:harmony@localhost:5432/harmony_dev
+      REDIS_URL: redis://localhost:6379
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: harmony-backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Run migrations
+        run: npx prisma migrate deploy
+
+      - name: Run backend tests
+        run: npm test
+```
+
+#### Tool: exec_command
+
+```sh
+gh workflow view 253888785 -R acabrera04/Harmony --yaml
+```
+
+Output:
+
+```text
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  frontend-tests:
+    name: Run Frontend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: harmony-frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: harmony-frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        run: npm test
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:12:53.182Z
+
+The mapping is confirmed: the repo has three separate workflows, but all display as `CI` in GitHub. I’m fetching the latest successful run URLs for the frontend-test and backend-test workflows specifically, since those links are part of the assignment turn-in.
+
+#### Tool: exec_command
+
+```sh
+gh run list -R acabrera04/Harmony --workflow 253888784 --limit 5
+```
+
+Output:
+
+```text
+completed	success	Merge pull request #283 from acabrera04/test/issue-263-auth-service-t…	CI	main	push	23957265540	1m8s	2026-04-03T18:26:24Z
+completed	success	test: auth.service.ts unit tests (issue #263)	CI	test/issue-263-auth-service-tests	pull_request	23955620809	1m19s	2026-04-03T17:34:44Z
+completed	success	Merge pull request #284 from acabrera04/test/channelService-unit-test…	CI	main	push	23952411677	1m7s	2026-04-03T15:53:29Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952359061	1m14s	2026-04-03T15:51:45Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952332680	1m13s	2026-04-03T15:50:55Z
+```
+
+#### Tool: exec_command
+
+```sh
+gh run list -R acabrera04/Harmony --workflow 253888785 --limit 5
+```
+
+Output:
+
+```text
+completed	success	Merge pull request #283 from acabrera04/test/issue-263-auth-service-t…	CI	main	push	23957265539	35s	2026-04-03T18:26:24Z
+completed	success	test: auth.service.ts unit tests (issue #263)	CI	test/issue-263-auth-service-tests	pull_request	23955620782	31s	2026-04-03T17:34:44Z
+completed	success	Merge pull request #284 from acabrera04/test/channelService-unit-test…	CI	main	push	23952411674	31s	2026-04-03T15:53:29Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952359051	30s	2026-04-03T15:51:45Z
+completed	success	test: add channelService.ts unit tests (#266)	CI	test/channelService-unit-tests-266	pull_request	23952332621	29s	2026-04-03T15:50:55Z
+```
+
+#### Tool: exec_command
+
+```sh
+gh run view 23957265540 -R acabrera04/Harmony --json url
+```
+
+Output:
+
+```text
+{"url":"https://github.com/acabrera04/Harmony/actions/runs/23957265540"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh run view 23957265539 -R acabrera04/Harmony --json url
+```
+
+Output:
+
+```text
+{"url":"https://github.com/acabrera04/Harmony/actions/runs/23957265539"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:13:06.967Z
+
+I’ve got the exact Actions run URLs now. I’m doing one last pass over README/doc locations so the final status is split cleanly into complete, partial, and missing deliverables.
+
+#### Tool: exec_command
+
+```sh
+find . -maxdepth 2 -iname 'README.md' | sort
+```
+
+Output:
+
+```text
+./README.md
+./harmony-backend/README.md
+./harmony-frontend/README.md
+```
+
+#### Tool: exec_command
+
+```sh
+ls docs/test-specs
+```
+
+Output:
+
+```text
+auth-service-spec.md
+frontend-channel-service-spec.md
+frontend-server-service-spec.md
+server-member-service-spec.md
+server-service-spec.md
+```
+
+#### Tool: exec_command
+
+```sh
+wc -l harmony-backend/tests/serverMember.test.ts harmony-backend/tests/auth.service.test.ts harmony-frontend/src/__tests__/channelService.test.ts
+```
+
+Output:
+
+```text
+     304 harmony-backend/tests/serverMember.test.ts
+     752 harmony-backend/tests/auth.service.test.ts
+     648 harmony-frontend/src/__tests__/channelService.test.ts
+    1704 total
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "serverService\.test|channelService\.test|auth\.service\.test|serverMember\.test|run-frontend-tests\.yml|run-backend-tests\.yml" -g '*'
+```
+
+Output:
+
+````text
+Total output lines: 184
+
+.entire/metadata/5bb6bb0d-e773-4c66-8a0e-604c69ca03d8/full.jsonl:104:{"parentUuid":"8f67efaf-d83a-49ef-aecf-aa609fc395db","isSidechain":false,"type":"progress","data":{"message":{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01SdaWZ8haT7E4YXLhTQmKUa","type":"tool_result","content":"/Users/allen/repos/Harmony/harmony-backend/tests/app.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/schema.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/auth.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/rate-limit.middleware.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/mock-seed.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/auditLog.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/eventBus.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/channel.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/message.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/trpc.permission.middleware.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/user.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/cache.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/demo-seed.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/cache.middleware.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/permission.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/serverMember.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/trpc.error-formatter.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/server.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/visibility.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/public.router.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/indexing.service.test.ts","is_error":false}]},"uuid":"4b426391-35a3-40ad-8e35-58dbd76e5745","timestamp":"2026-03-13T04:07:54.499Z"},"type":"agent_progress","prompt":"","agentId":"a1eac9e89f63a8f7d"},"toolUseID":"agent_msg_01FuVrtGCsXKhjZrs25ntiwg","parentToolUseID":"toolu_01LUBaQJtjznsGrMW7wuDZQC","uuid":"2366c698-572e-4fca-89f7-0d2e3df5d1ad","timestamp":"2026-03-13T04:07:54.601Z","userType":"external","cwd":"/Users/allen/repos/Harmony","sessionId":"5bb6bb0d-e773-4c66-8a0e-604c69ca03d8","version":"2.1.74","gitBranch":"main","slug":"fancy-doodling-quill"}
+.entire/metadata/a8e8ee61-ef16-454a-baed-ff44cb6083e3/full.jsonl:110:{"parentUuid":"582a8a0a-20ca-40c7-b5aa-aa42e0be1227","isSidechain":false,"userType":"external","cwd":"/Users/allen/repos/Harmony","sessionId":"a8e8ee61-ef16-454a-baed-ff44cb6083e3","version":"2.1.72","gitBranch":"main","slug":"goofy-noodling-wombat","type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_019YYq4A91bnfv5qfBqK1ven","type":"tool_result","content":"/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/app.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/auditLog.service.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/auth.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/cache.middleware.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/cache.service.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/channel.service.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/demo-seed.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/eventBus.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/indexing.service.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/message.service.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/mock-seed.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/permission.service.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/public.router.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/rate-limit.middleware.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/schema.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/server.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/serverMember.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/trpc.error-formatter.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/trpc.permission.middleware.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/user.service.test.ts\n/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/visibility.service.test.ts"}]},"uuid":"45d6189f-a40c-4eed-9200-02e077ef47a7","timestamp":"2026-03-10T22:11:34.264Z","toolUseResult":{"filenames":["/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/app.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/auditLog.service.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/auth.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/cache.middleware.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/cache.service.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/channel.service.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/demo-seed.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/eventBus.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/indexing.service.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/message.service.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/mock-seed.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/permission.service.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/public.router.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/rate-limit.middleware.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/schema.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/server.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/serverMember.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/trpc.error-formatter.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/trpc.permission.middleware.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/user.service.test.ts","/Users/allen/repos/Harmony-issue-169/harmony-backend/tests/visibility.service.test.ts"],"durationMs":15,"numFiles":21,"truncated":false},"sourceToolAssistantUUID":"582a8a0a-20ca-40c7-b5aa-aa42e0be1227"}
+.entire/metadata/5856b47f-b181-4fab-9c1c-47c8fb53c0b2/full.jsonl:20:{"parentUuid":"64752ce0-902e-46de-b34f-3370782bad8a","isSidechain":false,"type":"progress","data":{"message":{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_011yBSScqQv9RWEfhs7jZUJe","type":"tool_result","content":"/Users/allen/repos/Harmony/harmony-backend/tests/app.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/attachment.router.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/schema.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/auth.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/events.router.server.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/rate-limit.middleware.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/mock-seed.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/voice.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/auditLog.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/eventBus.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/channel.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/message.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/channel.service.events.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/events.router.sse-server-updated.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/message.service.events.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/trpc.permission.middleware.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/user.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/cache.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/demo-seed.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/events.router.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/cache.middleware.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/permission.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/serverMember.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/trpc.error-formatter.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/server.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/visibility.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/public.router.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/indexing.service.test.ts\n/Users/allen/repos/Harmony/harmony-backend/tests/attachment.service.test.ts","is_error":false}]},"uuid":"bb1239be-e12b-4c93-a35a-6cf3699e603a","timestamp":"2026-03-20T19:30:11.668Z"},"type":"agent_progress","prompt":"","agentId":"ac81b8106911e8e3a"},"toolUseID":"agent_msg_01UkdbxfMAAuN7FRMiooREG8","parentToolUseID":"toolu_01S96ZAbYNXdcbCXRfTt87yS","uuid":"3fe58e55-40dd-4404-b860-c33e8a098248","timestamp":"2026-03-20T19:30:11.779Z","userType":"external","entrypoint":"cli","cwd":"/Users/allen/repos/Harmony","sessionId":"5856b47f-b181-4fab-9c1c-47c8fb53c0b2","version":"2.1.80","gitBranch":"main"}
+.entire/metadata/5856b47f-b181-4fab-9c1c-47c8fb53c0b2/full.jsonl:73:{"parentUuid":"a2f13507-06fd-4897-b16c-e519e635fc95","isSidechain":false,"promptId":"ae51519d-52bf-40af-87b1-ac7e91bd851d","type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01S96ZAbYNXdcbCXRfTt87yS","type":"tool_result","content":[{"type":"text","text":"Perfect! Now I have a comprehensive picture. Let me compile the findings:\n\n## Comprehensive Backend Overview: Harmony Repository\n\n### 1. **Backend Code Structure**\n\n**Location:** `/Users/allen/repos/Harmony/harmony-backend/`\n\n**Core Directory Organization:**\n- `/src/` - TypeScript source code\n  - `/trpc/` - tRPC routers and initialization (7 routers)\n  - `/routes/` - Express REST endpoints (5 routers)\n  - `/services/` - Business logic services (14 services)\n  - `/middleware/` - Express middleware (4 files)\n  - `/db/` - Database and Redis connections\n  - `/lib/` - Utilities and storage providers\n  - `/events/` - Event bus and pub/sub system\n  - `/dev/` - Development seed scripts\n- `/dist/` - Compiled JavaScript output\n- `/tests/` - Test suite (29 test files, 6436 lines total)\n- `/prisma/` - Database schema and migrations\n- `/node_modules/` - Dependencies\n\n---\n\n### 2. **Documentation & Specifications**\n\n**Location:** `/Users/allen/repos/Harmony/docs/`\n\n**Key Documents:**\n- `/docs/unified-backend-architecture.md` - **Authoritative reference** for:\n  - Module boundaries (M-B1 through M-B7 backend modules)\n  - Class hierarchy and entity relationships\n  - Data model and ER diagrams\n  - tRPC vs REST API split design\n  - Event bus architecture\n  - Cache strategy and TTLs\n  - Security model (rate limiting, visibility guards)\n\n**Feature Dev Specs:**\n1. `/docs/dev-spec-channel-visibility-toggle.md` - Channel visibility control feature\n   - User story: Community admins toggle channels Public/Private\n   - Modules: M-B3 (Visibility Management), M-B6 (SEO & Indexing)\n   - Contains: Architecture diagram, class diagrams, API specs\n\n2. `/docs/dev-spec-guest-public-channel-view.md` - Anonymous public access\n   - User story: Guest users view public channels without login\n   - Modules: M-B2 (Access Control), M-B4 (Content Delivery)\n   - Contains: System diagrams, permission models, cache strategies\n\n3. `/docs/dev-spec-seo-meta-tag-generation.md` - SEO meta tags\n   - User story: Auto-generate meta tags for search engine indexing\n   - Modules: M-B5 (Meta Tag Engine), M-B6 (SEO & Indexing)\n   - Contains: Meta tag generation logic, structured data specs\n\n**Backend README:**\n- `/harmony-backend/README.md` - Setup, development, and architecture reference\n\n---\n\n### 3. **Test Files (29 test files)**\n\n**Location:** `/Users/allen/repos/Harmony/harmony-backend/tests/`\n\n**Coverage Areas:**\n- **Service Tests:** \n  - `channel.service.test.ts`\n  - `message.service.test.ts`\n  - `user.service.test.ts`\n  - `voice.service.test.ts`\n  - `auditLog.service.test.ts`\n  - `visibility.service.test.ts`\n  - `cache.service.test.ts`\n  - `permission.service.test.ts`\n  - `indexing.service.test.ts`\n  - `attachment.service.test.ts`\n\n- **Event Tests:**\n  - `eventBus.test.ts`\n  - `channel.service.events.test.ts`\n  - `message.service.events.test.ts`\n\n- **Router Tests:**\n  - `attachment.router.test.ts`\n  - `auth.test.ts`\n  - `public.router.test.ts`\n  - `events.router.test.ts`\n  - `events.router.sse-server-updated.test.ts`\n  - `events.router.server-updated.test.ts`\n\n- **Middleware Tests:**\n  - `rate-limit.middleware.test.ts`\n  - `cache.middleware.test.ts`\n  - `trpc.permission.middleware.test.ts`\n  - `trpc.error-formatter.test.ts`\n\n- **Data Tests:**\n  - `schema.test.ts`\n  - `mock-seed.test.ts`\n  - `demo-seed.test.ts`\n\n- **Integration Tests:**\n  - `app.test.ts`\n  - `server.test.ts`\n  - `serverMember.test.ts`\n\n**Test Configuration:**\n- Jest with ts-jest preset\n- Node test environment\n- dotenv setup for env vars\n- ~6,436 lines of test code\n\n---\n\n### 4. **tRPC Router Architecture**\n\n**Main Router:** `/src/trpc/router.ts`\n```typescript\nappRouter {\n  ├─ health: publicProcedure.query()\n  ├─ channel: channelRouter\n  ├─ server: serverRouter\n  ├─ serverMember: serverMemberRouter\n  ├─ message: messageRouter\n  ├─ user: userRouter\n  ├─ attachment: attachmentRouter\n  └─ voice: voiceRouter\n}\n```\n\n**7 tRPC Routers:**\n1. `/src/trpc/routers/channel.router.ts` (3.1K) - Channel operations\n2. `/src/trpc/routers/server.router.ts` (2.1K) - Server management\n3. `/src/trpc/routers/serverMember.router.ts` (1.9K) - Member operations\n4. `/src/trpc/routers/message.router.ts` (3.7K) - Message CRUD + SSE\n5. `/src/trpc/routers/user.router.ts` (919B) - User profile\n6. `/src/trpc/routers/attachment.router.ts` (947B) - File uploads\n7. `/src/trpc/routers/voice.router.ts` (4.8K) - Voice channel handling\n\n**Initialization:** `/src/trpc/init.ts`\n- TRPCContext interface with userId, ip, userAgent\n- Context factory from Express Request\n- Error formatter (hides stack in production)\n- **Procedure types:**\n  - `publicProcedure` - Unauthenticated\n  - `authedProcedure` - Requires authentication\n  - `withPermission(action)` - RBAC middleware (requires serverId in input)\n\n---\n\n### 5. **REST Routes (Express)**\n\n**5 REST Routers:** `/src/routes/`\n1. `/src/routes/auth.router.ts` (4.5K) - Login, register, refresh, logout\n2. `/src/routes/public.router.ts` (9.3K) - Public channel/server access\n3. `/src/routes/attachment.router.ts` (4.8K) - File uploads/downloads\n4. `/src/routes/events.router.ts` (12.2K) - Server-Sent Events (SSE) for real-time updates\n5. `/src/routes/seo.router.ts` (1.7K) - SEO endpoints (robots.txt, sitemap)\n\n---\n\n### 6. **Business Logic Services (14 services)**\n\n**Location:** `/src/services/`\n\n**Core Services:**\n1. **`channel.service.ts`** (5.5K)\n   - `getChannels(serverId)`\n   - `getChannelBySlug(serverSlug, channelSlug)`\n   - `createChannel(input)` - Validates visibility rules\n   - Channel queries and updates\n\n2. **`message.service.ts`** (11K)\n   - `getMessages(serverId, channelId, cursor, limit)` - Paginated retrieval\n   - `sendMessage(input)` - Author anonymity rules for public channels\n   - `editMessage(input)`, `deleteMessage(input)`\n   - Attachment projection\n   - Event emission (MESSAGE_CREATED, MESSAGE_EDITED, MESSAGE_DELETED)\n\n3. **`visibility.service.ts`** (4.5K) - **M-B3 Visibility Management**\n   - `getVisibility(channelId, s…39231 tokens truncated…anonymous> (tests/serverMember.test.ts:18:19)
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:2891:    /Users/allen/.codex/worktrees/e457/Harmony/harmony-backend/tests/serverMember.test.ts:18:37
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:2918:      at Object.<anonymous> (tests/serverMember.test.ts:18:19)
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:2924:    /Users/allen/.codex/worktrees/e457/Harmony/harmony-backend/tests/serverMember.test.ts:18:37
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:3646:  "comment": "**[AI Agent — Complete]**\n\nImplemented the CI workflow split for issue `#262`.\n\nChanges made:\n- Added `.github/workflows/run-frontend-tests.yml` to run frontend tests on every `push`, `pull_request`, and `workflow_dispatch`\n- Added `.github/workflows/run-backend-tests.yml` to run backend tests on every `push`, `pull_request`, and `workflow_dispatch`, including PostgreSQL + Redis services plus Prisma generate/migrate\n- Updated `.github/workflows/ci.yml` so the main CI lane keeps frontend/backend lint + build coverage without duplicating the dedicated test jobs\n- Widened the existing CI triggers to all pushes and PRs so the pipeline now runs on every commit path instead of only `main`/`master`\n\nVerification completed locally:\n- Workflow YAML parses successfully\n- Frontend: `npm run lint` passed, `npm test` passed\n- Backend: `npm run lint` completed with existing warnings only, `npx prisma generate` succeeded, `npm run build` passed\n\nLocal environment limitations:\n- `harmony-frontend` build is blocked in this sandbox because Next.js tries to fetch Google Fonts during build\n- Full backend Jest execution needs the database/service environment and unrestricted socket binding that the GitHub Actions workflow provisions\n\nNext step to fully satisfy the final acceptance criterion is to push the branch and confirm the new workflow runs show green in the Actions tab."
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:3682:?? .github/workflows/run-backend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:3683:?? .github/workflows/run-frontend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:3703:Issue `#262` is implemented. I added dedicated test workflows at [run-frontend-tests.yml](/Users/allen/.codex/worktrees/e457/Harmony/.github/workflows/run-frontend-tests.yml) and [run-backend-tests.yml](/Users/allen/.codex/worktrees/e457/Harmony/.github/workflows/run-backend-tests.yml), and updated [ci.yml](/Users/allen/.codex/worktrees/e457/Harmony/.github/workflows/ci.yml) so the main CI lane keeps lint/build checks without re-running the same test suites. I also widened the CI triggers so the workflows run on all pushes and pull requests, which matches the “every commit” requirement.
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4124:?? .github/workflows/run-backend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4125:?? .github/workflows/run-frontend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4335:git add .github/workflows/ci.yml .github/workflows/run-frontend-tests.yml .github/workflows/run-backend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4354: .github/workflows/run-backend-tests.yml  | 60 ++++++++++++++++++++++++++++++++
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4355: .github/workflows/run-frontend-tests.yml | 28 +++++++++++++++
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4372: create mode 100644 .github/workflows/run-backend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4373: create mode 100644 .github/workflows/run-frontend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4418:  "body": "## Summary\n- split automated test execution into dedicated frontend and backend GitHub Actions workflows\n- keep the main `ci.yml` focused on lint/build validation with clearer job names in the Actions UI\n- trigger the workflows on all pushes and pull requests\n\n## Why\nIssue #262 asked for separate frontend and backend test workflows that run on every commit. Splitting the jobs makes failures easier to isolate while keeping the existing CI lane focused on static validation.\n\n## Impact\n- frontend tests now run in `run-frontend-tests.yml`\n- backend tests now run in `run-backend-tests.yml` with PostgreSQL, Redis, Prisma generate, and Prisma migrate setup\n- `ci.yml` now shows `frontend-lint-build` and `backend-lint-build` for clearer status checks\n\n## Validation\n- workflow YAML parsed successfully\n- `harmony-frontend`: `npm run lint` passed, `npm test` passed\n- `harmony-backend`: `npm run lint` completed with existing warnings, `npx prisma generate` passed, `npm run build` passed\n- local frontend build is blocked in the sandbox by Google Fonts fetching\n- full local backend Jest execution depends on database/service setup and unrestricted socket binding, which the GitHub Actions workflow provides\n\nCloses #262",
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4429:{"url":"https://github.com/acabrera04/Harmony/pull/270","number":270,"state":"open","merged":false,"mergeable":false,"draft":true,"body":"## Summary\n- split automated test execution into dedicated frontend and backend GitHub Actions workflows\n- keep the main `ci.yml` focused on lint/build validation with clearer job names in the Actions UI\n- trigger the workflows on all pushes and pull requests\n\n## Why\nIssue #262 asked for separate frontend and backend test workflows that run on every commit. Splitting the jobs makes failures easier to isolate while keeping the existing CI lane focused on static validation.\n\n## Impact\n- frontend tests now run in `run-frontend-tests.yml`\n- backend tests now run in `run-backend-tests.yml` with PostgreSQL, Redis, Prisma generate, and Prisma migrate setup\n- `ci.yml` now shows `frontend-lint-build` and `backend-lint-build` for clearer status checks\n\n## Validation\n- workflow YAML parsed successfully\n- `harmony-frontend`: `npm run lint` passed, `npm test` passed\n- `harmony-backend`: `npm run lint` completed with existing warnings, `npx prisma generate` passed, `npm run build` passed\n- local frontend build is blocked in the sandbox by Google Fonts fetching\n- full local backend Jest execution depends on database/service setup and unrestricted socket binding, which the GitHub Actions workflow provides\n\nCloses #262","title":"[codex] Split CI test workflows and clarify job names","base":"main","base_sha":"07dd3a213ee70ad60dad44556d43b38953105888","head":"codex/issue-262-ci-workflows","head_sha":"ae3946a311b071fe2992a77cf8c43e7229cb2386","merge_commit_sha":null,"user":{"login":"acabrera04","name":"acabrera04","email":null,"avatar_url":"https://avatars.githubusercontent.com/u/145043651?v=4","id":145043651},"requested_reviewers":null,"diff":null,"comments":null,"created_at":"2026-03-30T15:42:55Z","updated_at":"2026-03-30T15:42:55Z","closed_at":null,"merged_at":null,"commits":1,"changed_files":null,"additions":null,"deletions":null,"display_url":"https://github.com/acabrera04/Harmony/pull/270","display_title":"[codex] Split CI test workflows and clarify job names"}
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4509:ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/run-frontend-tests.yml .github/workflows/run-backend-tests.yml].each { |f| YAML.load_file(f); puts "OK #{f}" }'
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4516:OK .github/workflows/run-frontend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4517:OK .github/workflows/run-backend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4531: M .github/workflows/run-backend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4532: M .github/workflows/run-frontend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4545: .github/workflows/run-backend-tests.yml  | 2 ++
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4546: .github/workflows/run-frontend-tests.yml | 2 ++
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4553:git add .github/workflows/ci.yml .github/workflows/run-frontend-tests.yml .github/workflows/run-backend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4668: .github/workflows/run-backend-tests.yml  | 2 ++
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4669: .github/workflows/run-frontend-tests.yml | 2 ++
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4770:ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/run-frontend-tests.yml .github/workflows/run-backend-tests.yml].each { |f| YAML.load_file(f); puts "OK #{f}" }'
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4777:OK .github/workflows/run-frontend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4778:OK .github/workflows/run-backend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4790: .github/workflows/run-backend-tests.yml  | 2 +-
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4791: .github/workflows/run-frontend-tests.yml | 2 +-
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4805: M .github/workflows/run-backend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4806: M .github/workflows/run-frontend-tests.yml
+llm-logs/acabrera04-logs/acabrera04-tests/2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md:4818:git add .github/workflows/run-frontend-tests.yml .github/workflows/run-backend-tests.yml
+llm-logs/fardeeni-backend/claude-conversation-2026-03-09-agent-a1.md:357:├── serverMember.test.ts
+.claude/worktrees/issue-188/.entire/metadata/98492d38-3df4-49d7-b89d-0f946b92bf19/full.jsonl:168:{"parentUuid":"75d7794d-ba1b-400b-9269-dbb7391df8b7","isSidechain":false,"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01YGq2hx4EjgTzGGEe32293P","type":"tool_result","content":"Found 4 files\nharmony-backend/tests/serverMember.test.ts\nharmony-backend/src/trpc/routers/serverMember.router.ts\nharmony-backend/src/services/serverMember.service.ts\nharmony-backend/src/services/auth.service.ts"}]},"uuid":"68bf1366-2393-49cf-8bd6-0d55edd45d9a","timestamp":"2026-03-16T01:28:06.267Z","toolUseResult":{"mode":"files_with_matches","filenames":["harmony-backend/tests/serverMember.test.ts","harmony-backend/src/trpc/routers/serverMember.router.ts","harmony-backend/src/services/serverMember.service.ts","harmony-backend/src/services/auth.service.ts"],"numFiles":4},"sourceToolAssistantUUID":"75d7794d-ba1b-400b-9269-dbb7391df8b7","userType":"external","cwd":"/Users/allen/repos/Harmony/.claude/worktrees/issue-188","sessionId":"98492d38-3df4-49d7-b89d-0f946b92bf19","version":"2.1.76","gitBranch":"worktree-issue-188","slug":"bubbly-growing-peacock"}
+.claude/worktrees/issue-188/.entire/metadata/98492d38-3df4-49d7-b89d-0f946b92bf19/full.jsonl:260:{"parentUuid":"ec4b9391-7e73-4dc1-8b30-66eaa4182b9d","isSidechain":false,"type":"progress","data":{"message":{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01Y25jLJgpg64EUz5NU66kTt","type":"tool_result","content":"app.test.ts\nauditLog.service.test.ts\nauth.test.ts\ncache.middleware.test.ts\ncache.service.test.ts\nchannel.service.test.ts\ndemo-seed.test.ts\neventBus.test.ts\nevents.router.test.ts\nindexing.service.test.ts\nmessage.service.events.test.ts\nmessage.service.test.ts\nmock-seed.test.ts\npermission.service.test.ts\npublic.router.test.ts\nrate-limit.middleware.test.ts\nschema.test.ts\nserver.test.ts\nserverMember.test.ts\ntrpc.error-formatter.test.ts\ntrpc.permission.middleware.test.ts\nuser.service.test.ts\nvisibility.service.test.ts\nvoice.service.test.ts","is_error":false}]},"uuid":"88039a72-608b-41d2-a5d9-dba6cffc1eb5","timestamp":"2026-03-16T01:30:36.630Z"},"type":"agent_progress","prompt":"","agentId":"a629e07bf5d1ea979"},"toolUseID":"agent_msg_014pp5nErfeHxAznKpjBoNp6","parentToolUseID":"toolu_01NVALtbMTtzBcwGZj9HBPhN","uuid":"9f1bbaec-7fa5-4bd5-92c0-51fb2f1364cc","timestamp":"2026-03-16T01:30:36.737Z","userType":"external","cwd":"/Users/allen/repos/Harmony/.claude/worktrees/issue-188","sessionId":"98492d38-3df4-49d7-b89d-0f946b92bf19","version":"2.1.76","gitBranch":"worktree-issue-188","slug":"bubbly-growing-peacock"}
+.claude/worktrees/issue-188/llm-logs/backend/03-09-pr149-add-server-membership.md:200:⏺ Write(tests/serverMember.test.ts)
+.claude/worktrees/issue-188/llm-logs/backend/03-09-pr149-add-server-membership.md:201:  ⎿  Wrote 292 lines to tests/serverMember.test.ts
+.claude/worktrees/issue-188/llm-logs/backend/03-09-pr149-add-server-membership.md:245:⏺ Bash(npx jest tests/serverMember.test.ts --no-cache 2>&1)
+.claude/worktrees/issue-188/llm-logs/backend/03-09-pr149-add-server-membership.md:247:     FAIL tests/serverMember.test.ts
+.claude/worktrees/issue-188/llm-logs/backend/03-09-pr149-add-server-membership.md:328:      src/trpc/routers/serverMember.router.ts tests/serverMember.test.ts
+.claude/worktrees/issue-188/llm-logs/backend/03-09-pr149-add-server-membership.md:366:                                  (new)\n- `tests/serverMember.test.ts` (new)\n-
+.claude/worktrees/issue-188/llm-logs/backend/03-09-pr149-add-server-membership.md:389:  - serverMember.test.ts — 21 integration tests covering all operations and
+.claude/worktrees/issue-188/llm-logs/backend/03-09-pr149-add-server-membership.md:739:⏺ Write(tests/serverMember.test.ts)
+.claude/worktrees/issue-188/llm-logs/backend/03-09-pr149-add-server-membership.md:858:      tests/serverMember.test.ts 2>&1)
+.claude/worktrees/issue-188/llm-logs/backend/03-09-pr149-add-server-membership.md:864:      tests/serverMember.test.ts && git commit -m "$(cat <<'EOF'
+````
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,160p' harmony-backend/README.md
+```
+
+Output:
+
+````text
+# Harmony Backend
+
+Express + tRPC server for the Harmony chat application.
+
+## Architecture
+
+> **Before making changes to this backend, read the unified backend architecture document:**
+> [`docs/unified-backend-architecture.md`](../docs/unified-backend-architecture.md)
+
+The architecture doc covers:
+- **Module map** — what each module (M-B1–M-B7, M-D1–M-D3) owns and its boundaries
+- **Class diagrams** — all services, repositories, controllers, entities, and DTOs
+- **Data model** — ER diagram for all shared database tables
+- **API surface** — tRPC procedures and public REST endpoints
+- **Event bus** — Redis Pub/Sub event flow between modules
+- **Cache strategy** — Redis key layout and TTLs
+- **Security model** — rate limiting, visibility guards, content filtering
+
+---
+
+## Dependencies
+
+### Frameworks & Runtime
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| **Node.js** | ≥ 20 | JavaScript runtime (required) |
+| **Express** | ^4.21 | HTTP server and middleware layer |
+| **tRPC** (`@trpc/server`) | ^11.0 | Type-safe RPC API layer over Express |
+| **TypeScript** | ^5.8 | Compile-time type safety; compiled to `dist/` via `tsc` |
+
+### Database & Caching
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| **Prisma** (`prisma` + `@prisma/client`) | ^5.22 | ORM for PostgreSQL — schema migrations, queries, and type generation |
+| **ioredis** | ^5.10 | Redis client for visibility caching and the Pub/Sub event bus |
+
+### Authentication & Security
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| **jsonwebtoken** | ^9.0 | Issues and verifies JWT access and refresh tokens |
+| **bcryptjs** | ^3.0 | Password hashing (bcrypt) |
+| **helmet** | ^8.1 | Sets security-related HTTP headers |
+| **express-rate-limit** | ^8.3 | Per-IP rate limiting on auth and mutation endpoints |
+| **cors** | ^2.8 | CORS policy enforcement; restricted to `FRONTEND_URL` |
+| **zod** | ^3.24 | Runtime input validation for all API boundaries |
+
+### File Handling
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| **multer** | ^2.1 | Multipart form-data parsing for file uploads |
+| **file-type** | ^21.3 | MIME-type detection from file bytes (not filename extension) |
+
+### External Services
+
+| Dependency | Version | Purpose | Required? |
+|---|---|---|---|
+| **Twilio** (`twilio`) | ^5.13 | Programmable Video — issues Access Tokens for voice channels | Optional — falls back to mock mode when credentials are absent or `TWILIO_MOCK=true` |
+
+### Deployment
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| **serverless-http** | ^3.2 | Wraps the Express app for AWS Lambda deployment |
+
+### Development & Testing
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| **Jest** + **ts-jest** | ^29 | Unit and integration test runner |
+| **supertest** | ^7.0 | HTTP integration testing against the Express app |
+| **tsx** | ^4.19 | TypeScript execution for dev server (`tsx watch`) and seed scripts |
+| **eslint** + **prettier** | ^9 / ^3 | Linting and formatting |
+| **dotenv** | ^17 | Loads `.env` during local development |
+
+---
+
+## Databases
+
+### PostgreSQL (`harmony_dev`)
+
+The primary relational database. All persistent application state lives here.
+
+**Tables created by Prisma migrations:**
+
+| Table | Reads | Writes | Notes |
+|---|---|---|---|
+| `users` | Auth, profile lookups | Registration, profile updates | Stores hashed passwords; never raw |
+| `refresh_tokens` | Token rotation and revocation | Login (issue), logout (revoke) | Stores SHA-256 hash of token, not the raw token |
+| `servers` | Server listing, membership checks | Create/delete server | `is_public` flag controls search indexability |
+| `server_members` | Role checks, member lists | Join/leave, role changes | Composite PK `(user_id, server_id)` |
+| `channels` | Message routing, visibility checks | Create/update/delete channel | `visibility` enum: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE` |
+| `messages` | Channel history, thread reads | Send, edit, soft-delete | Soft delete via `is_deleted`; reply count denormalised on parent |
+| `attachments` | Message attachment display | File upload completion | References S3-hosted URLs |
+| `visibility_audit_log` | Compliance queries | Any visibility change | 7-year retention requirement — do **not** purge within window |
+| `generated_meta_tags` | SEO meta tag serving | LLM-generated tag writes | `needs_regeneration` flag triggers regeneration job |
+
+### Redis
+
+Used for two independent concerns — both must be running for full functionality:
+
+| Use | Key pattern | Reads | Writes |
+|---|---|---|---|
+| **Visibility cache** | `channel:vis:<channelId>` | Every channel visibility check | On visibility change, on cache miss |
+| **Pub/Sub event bus** | Channels: `member:statusChanged`, etc. | WebSocket gateway (subscriber) | Any service publishing a domain event |
+
+> Losing Redis connectivity degrades — but does not crash — the server. Visibility lookups fall through to PostgreSQL; real-time events stop propagating.
+
+---
+
+## Environment Variables
+
+Copy `.env.example` to `.env` before running locally. All variables with no default listed are **required**.
+
+| Variable | Default | Description |
+|---|---|---|
+| `NODE_ENV` | `development` | `development` \| `production` \| `test` |
+| `PORT` | `4000` | HTTP listen port |
+| `DATABASE_URL` | *(see example)* | PostgreSQL connection string |
+| `REDIS_URL` | *(see example)* | Redis connection string (include password) |
+| `FRONTEND_URL` | `http://localhost:3000` | Allowed CORS origin |
+| `JWT_ACCESS_SECRET` | — | **Required.** Sign/verify access tokens. Must be 32+ random chars in production. |
+| `JWT_REFRESH_SECRET` | — | **Required.** Sign/verify refresh tokens. Must be 32+ random chars in production. |
+| `JWT_ACCESS_EXPIRES_IN` | `15m` | Access token TTL (`jsonwebtoken` duration string) |
+| `JWT_REFRESH_EXPIRES_DAYS` | `7` | Refresh token TTL in days |
+| `TWILIO_ACCOUNT_SID` | — | Optional. Twilio Account SID for voice channels. |
+| `TWILIO_API_KEY` | — | Optional. Twilio API Key SID. |
+| `TWILIO_API_SECRET` | — | Optional. Twilio API Key Secret. |
+| `TWILIO_MOCK` | `false` | Set `true` to stub Twilio locally without real credentials. Auto-enabled when credentials are missing. |
+| `HARMONY_DEMO_MODE` | `false` | Set `true` only when running `npm run db:seed:demo`. |
+
+---
+
+## Install, Start, Stop, and Reset
+
+### Prerequisites
+
+- **Docker** and **Docker Compose** — for Postgres and Redis
+- **Node.js ≥ 20** — `node --version` to verify
+- **npm** — bundled with Node.js
+
+### Install
+
+```bash
+# From harmony-backend/
+npm install
+```
+
+### First-Time Setup
+
+```bash
+# 1. Start Postgres and Redis
+docker compose up -d
+
+# 2. Create your local env file
+cp .env.example .env
+# Open .env and set strong secrets for JWT_ACCESS_SECRET and JWT_REFRESH_SECRET
+````
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,160p' harmony-frontend/README.md
+```
+
+Output:
+
+````text
+# Harmony Frontend
+
+Next.js 14+ application for the Harmony search-engine-indexable chat platform.
+
+## Tech Stack
+
+This project uses the canonical tech stack from the Harmony dev specs (Section 8):
+
+- **T1**: TypeScript 5.3+ - Primary language with strict mode
+- **T2**: React 18.2+ - UI framework
+- **T3**: Next.js 14.0+ - SSR/SSG framework (SEO-critical for public pages)
+- **T4**: Node.js 20 LTS - Server runtime
+- **Tailwind CSS** - Styling framework
+- **ESLint** - Code linting
+- **Prettier** - Code formatting
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20 LTS or later
+- npm (comes with Node.js)
+
+### Installation
+
+```bash
+npm install
+```
+
+### Development
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+You can start editing the page by modifying `src/app/page.tsx`.
+
+### Build
+
+Build for production:
+
+```bash
+npm run build
+npm start
+```
+
+## Project Structure
+
+```
+harmony-frontend/
+├── src/
+│   ├── app/                    # Next.js App Router
+│   │   ├── (public)/          # Route group for public pages (future)
+│   │   ├── (authenticated)/   # Route group for authenticated pages (future)
+│   │   ├── api/               # API routes (future)
+│   │   ├── layout.tsx         # Root layout
+│   │   ├── page.tsx           # Home page
+│   │   └── globals.css        # Global styles
+│   ├── components/            # React components
+│   │   ├── ui/               # Basic UI components (Button, Card, etc.)
+│   │   ├── channel/          # Channel-specific components
+│   │   ├── server/           # Server-specific components
+│   │   └── shared/           # Shared components across domains
+│   ├── lib/                   # Core utilities and configurations
+│   │   ├── utils.ts          # Helper functions (cn, formatDate, etc.)
+│   │   ├── constants.ts      # App constants and enums
+│   │   └── api-client.ts     # Configured Axios client
+│   ├── services/              # Business logic & API calls
+│   ├── hooks/                 # Custom React hooks
+│   ├── types/                 # TypeScript type definitions
+│   │   ├── channel.ts        # Channel types
+│   │   ├── message.ts        # Message types
+│   │   └── server.ts         # Server types
+│   ├── context/               # React Context providers
+│   ├── layouts/               # Layout components
+│   ├── mocks/                 # Mock data for development/testing
+│   └── assets/                # Static assets (images, fonts, etc.)
+├── public/                    # Public static files
+└── .env.example               # Environment variables template
+```
+
+### Directory Purpose
+
+- **`app/`** - Next.js 14 App Router with pages, layouts, and routing
+- **`components/`** - Reusable UI components organized by domain (see
+  [components/README.md](src/components/README.md))
+- **`lib/`** - Shared utilities, constants, and configurations
+- **`services/`** - API service layer and business logic
+- **`types/`** - TypeScript type definitions aligned with dev spec data schemas
+- **`hooks/`** - Custom React hooks for shared logic
+- **`context/`** - React Context providers for global state
+- **`layouts/`** - Shared layout components
+- **`mocks/`** - Mock data for development and testing
+
+## Path Aliases
+
+TypeScript is configured with path aliases for cleaner imports:
+
+```typescript
+// Instead of: import { Button } from '../../../components/ui/Button'
+import { Button } from '@/components/ui/Button';
+import { formatDate } from '@/lib/utils';
+import { apiClient } from '@/lib/api-client';
+```
+
+The `@/` alias maps to `src/`.
+
+## Example Components
+
+The project includes example components demonstrating the architecture:
+
+- **UI Components**: `Button`, `Card` - Basic reusable components
+- **Channel Components**: `MessageCard`, `MessageList`, `GuestPromoBanner` - From dev spec M1
+- **Server Components**: `ServerSidebar` - Server navigation component
+
+These components align with the dev spec class diagrams (C1.3, C1.4, C1.5, C1.6).
+
+## Environment Variables
+
+Copy `.env.example` to `.env.local` and fill in your values:
+
+```bash
+cp .env.example .env.local
+```
+
+## Code Quality
+
+- **Linting**: `npm run lint`
+- **TypeScript**: Strict mode enabled in `tsconfig.json`
+
+## Development Specifications
+
+This frontend implementation is based on the following dev specs in the repository root:
+
+- `docs/dev-spec-channel-visibility-toggle.md`
+- `docs/dev-spec-guest-public-channel-view.md`
+- `docs/dev-spec-seo-meta-tag-generation.md`
+
+All specs specify **Next.js 14.0+ (T3)** for SSR/SSG capabilities required for SEO optimization.
+
+## Learn More
+
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API
+- [Harmony Project](https://github.com/acabrera04/Harmony) - main repository
+````
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:14:06.458Z
+
+Pulled `origin/main` into local `main`; it was 15 commits behind and fast-forwarded cleanly. I checked progress against the April 5, 2026 P5 requirements on the [course page](https://kelloggm.github.io/martinjkellogg.com/teaching/cs485-sp26/projects/p5.html).
+
+**Status**
+- Complete: all local tests pass right now. Frontend is 9/9 suites, 158/158 tests. Backend is 37/37 suites, 490/490 tests.
+- Complete: the required CI workflow files exist at [run-frontend-tests.yml](/Users/allen/repos/Harmony/.github/workflows/run-frontend-tests.yml) and [run-backend-tests.yml](/Users/allen/repos/Harmony/.github/workflows/run-backend-tests.yml), and both have successful GitHub runs: [frontend](https://github.com/acabrera04/Harmony/actions/runs/23957265539) and [backend](https://github.com/acabrera04/Harmony/actions/runs/23957265540).
+- Complete: English-language test specs exist for the intended targets at [frontend-channel-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/frontend-channel-service-spec.md), [frontend-server-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/frontend-server-service-spec.md), [auth-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/auth-service-spec.md), and [server-member-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/server-member-service-spec.md).
+- Strong: `channelService.ts` is fully covered by current tests: 100% statements, branch, functions, and lines.
+- Strong: `auth.service.ts` is also in good shape: 100% statements/functions/lines, 91.3% branch.
+- Risk: `serverMember.service.ts` is 92.64% statements and 95% lines, but only 77.77% branch. Inference: if your grader interprets “execution paths” as branch coverage, this is still below the 80% target.
+- Missing: `serverService.ts` currently has 0% coverage. There is no `harmony-frontend/src/__tests__/serverService.test.ts`, despite the spec at [frontend-server-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/frontend-server-service-spec.md). That means you effectively have 3 of the 4 required target test implementations, not 4.
+- Missing: the project README deliverable is not done. The root [README.md](/Users/allen/repos/Harmony/README.md) is still just a short placeholder, even though P5 asks for frontend/backend test instructions in the project README.
+- Partial: the repo has LLM logs under [llm-logs](/Users/allen/repos/Harmony/llm-logs), which helps deliverable 17, but I did not find a committed final P5 reflection/turn-in document.
+
+The biggest blockers are `serverService.ts` tests and the root README. After that, I’d raise `serverMember.service.ts` branch coverage above 80% to remove grading risk. If you want, I can take those three gaps next.
+
+### Turn 2: Do the tests cover the 2 user stories that we implemented?
+
+#### 👤 User Prompt
+
+- Time: 2026-04-03T19:15:15.607Z
+
+```text
+Do the tests cover the 2 user stories that we implemented? [dev-spec-channel-visibility-toggle.md](docs/dev-spec-channel-visibility-toggle.md) and [dev-spec-guest-public-channel-view.md](docs/dev-spec-guest-public-channel-view.md) ?
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:15:31.791Z
+
+I’m mapping the two dev specs to the current test suite now. First I’ll pull the user-story requirements and acceptance criteria from the spec docs, then I’ll match them against the relevant frontend/backend tests and call out anything missing.
+
+#### Tool: exec_command
+
+```sh
+rg -n "User Story|Acceptance Criteria|visibility|guest|public channel|anonymous|SEO|index|audit|PUBLIC_INDEXABLE|PUBLIC_NO_INDEX|PRIVATE" docs/dev-spec-channel-visibility-toggle.md
+```
+
+Output:
+
+```text
+5:**User Story:** As a Community Administrator, I want to toggle specific channels as "Public/Indexable" or "Private," so that I can control which parts of my community are exposed to the open web while keeping sensitive social conversations private.
+7:> **Unified Backend Reference:** This feature's backend classes are part of the shared Harmony backend defined in [`unified-backend-architecture.md`](./unified-backend-architecture.md). The mapping from this spec's class labels to the unified module labels is in §10 of that document. Key modules contributed by this feature: **M-B3** (Visibility Management), **M-B6** (SEO & Indexing, shared), **M-D1** (Data Access, shared).
+61:        subgraph MB6["M-B6: SEO & Indexing"]
+74:            AuditLogTable[("visibility_audit_log")]
+77:            VisCache["channel:{channelId}:visibility\nTTL: 3600s"]
+107:> **Note:** All cache keys use UUID-based identifiers (e.g., `channel:{channelId}:visibility`) for consistency across all Harmony specs.
+123:This follows a clear model-view-controller architecture, where the client can view channels and control their visibility state with the M1 Admin Dashboard controller. The underlying model is represented by the server layer, which handles get/set operations and any necessary side-effects for search engine indexing. 
+144:        -auditLogger
+185:        +visibility Enum
+188:        +indexedAt DateTime
+242:> **Sitemap Ownership:** `IndexingService` (CL6.1 / C5.2) is the canonical owner of sitemap generation and search engine notification across all Harmony specs. Other features (e.g., SEO Meta Tag Generation) emit events that this service consumes to trigger sitemap updates.
+258:| CL-C1.1 | ChannelSettingsView | View Component | Channel settings page with visibility management |
+260:| CL-C2.1 | PublicChannelView | View Component | Public channel content for anonymous users and crawlers |
+261:| CL-C2.2 | MessageListComponent | UI Component | Paginated message list with SEO-optimized markup |
+262:| CL-C3.1 | ChannelService | Service | Client-side channel API calls including visibility updates |
+279:| CL-C5.4 | AuditLogService | Service | Audit trail for visibility changes |
+292:| CL-D1 | Channel | Entity | Domain entity representing a channel with visibility state |
+293:| CL-D2 | AuditLogEntry | Entity | Single audit log record |
+294:| CL-D3 | VisibilityChangeEvent | Event | Event emitted on visibility changes |
+295:| CL-D4 | ChannelVisibility | Enumeration | Possible visibility states |
+296:| CL-D5 | VisibilityUpdateRequest | DTO | Request payload for visibility update |
+297:| CL-D6 | VisibilityUpdateResponse | DTO | Response payload for visibility update |
+325:| channel.visibility | ChannelVisibility | Current visibility state |
+326:| channel.indexedAt | DateTime | Last sitemap inclusion timestamp |
+328:| auditLog.entries | AuditLogEntry[] | Audit records |
+334:    [*] --> PRIVATE : Channel created (default)
+336:    state "PRIVATE (indexedAt=null, robots=noindex nofollow)" as PRIVATE
+337:    state "PUBLIC_NO_INDEX (indexedAt=null, robots=noindex)" as PUBLIC_NO_INDEX
+338:    state "PUBLIC_INDEXABLE (indexedAt=now, robots=index follow)" as PUBLIC_INDEXABLE
+340:    PRIVATE --> PUBLIC_NO_INDEX : setVisibility(PUBLIC_NO_INDEX)
+341:    PRIVATE --> PUBLIC_INDEXABLE : setVisibility(PUBLIC_INDEXABLE) - add to sitemap, notify search engines
+343:    PUBLIC_NO_INDEX --> PRIVATE : setVisibility(PRIVATE)
+344:    PUBLIC_NO_INDEX --> PUBLIC_INDEXABLE : setVisibility(PUBLIC_INDEXABLE) - add to sitemap, notify search engines
+346:    PUBLIC_INDEXABLE --> PRIVATE : setVisibility(PRIVATE) - remove from sitemap, request de-index
+347:    PUBLIC_INDEXABLE --> PUBLIC_NO_INDEX : setVisibility(PUBLIC_NO_INDEX) - remove from sitemap, set noindex
+360:    A5 : A5: Success State\nvisibility=updated
+373:The first diagram correctly tracks the state changes for all possible channel states. No changes or reprompting the LLM was necessary for this section. The channel will be public, public & indexable, or private. A simplification of the roles-based access control in Discord, but covers the general idea. 
+375:The second diagram correctly tracks the state transitions for the channel visibility permission. It is quite simple so the model did not need to the reprompted for any changes.
+383:Admin navigates to channel settings and toggles a private channel to publicly indexable. System validates permissions, updates DB, regenerates sitemap, and notifies search engines.
+389:    F12["F1.2 Display current visibility toggle"]
+393:    F16["F1.6 Send API request:\nupdateVisibility(channelId, PUBLIC_INDEXABLE)"]
+400:    F113["F1.13 Update visibility in DB"]
+401:    F114["F1.14 Create audit log entry"]
+423:#### 6.1.1 Cross-Spec Integration: Visibility → PUBLIC_INDEXABLE
+425:When visibility changes to `PUBLIC_INDEXABLE`:
+427:2. **SEO Meta Tag Generation spec** consumes event → generates meta tags for the channel
+428:3. **Guest Public Channel View spec** consumes event → warms guest view cache
+432:An anonymous user or crawler requests a public channel page. System verifies visibility and serves content with appropriate SEO headers.
+438:    F22["F2.2 Check cache:\nchannel:{channelId}:visibility"]
+448:    F212["F2.12 Set X-Robots-Tag header\nPUBLIC_INDEXABLE → index,follow\nPUBLIC_NO_INDEX → noindex"]
+450:    F214["F2.14 Return HTML with SEO metadata"]
+462:### 6.3 Scenario: Admin Sets Channel to Private (De-indexing)
+464:Administrator changes a public/indexable channel back to private. System removes from sitemap and requests de-indexing.
+472:    F34["F3.4 API: updateVisibility(PRIVATE)\n(Permission checks same as F1.7-F1.12)"]
+473:    F35["F3.5 Update DB:\nvisibility=PRIVATE, indexedAt=null"]
+474:    F36["F3.6 Create audit log"]
+478:    F310["F3.10 Return success with de-indexing notice"]
+486:#### 6.3.1 Cross-Spec Integration: Visibility → PRIVATE
+488:When visibility changes to `PRIVATE`:
+490:2. **SEO Meta Tag Generation spec** consumes event → deletes meta tags for the channel
+491:3. **Guest Public Channel View spec** consumes event → invalidates guest view cache
+499:The LLM also had to be reprompted to finalize what the event bus would be. It chose Redis Pub/Sub to allow for visibility change updates to propagate. The cache keying also needed to be updated to match earlier updates. 
+508:| RF-2 | Lost runtime state | Stale visibility displayed | Cache invalidation on recovery | Low | Low |
+509:| RF-3 | Database corruption | Incorrect visibility; privacy breach | Restore from backup; audit reconciliation | Very Low | Critical |
+514:| RF-8 | Database out of space | Write operations fail | Storage alerts; archive old audit logs | Low | High |
+580:| T3 | Next.js | 14.0+ | SSR/SSG framework (SEO-critical for public pages) | https://nextjs.org/ |
+590:| T13 | Google Search Console API | v1 | Programmatic indexing/de-indexing | https://developers.google.com/webmaster-tools |
+596:> **Convention:** tRPC is used for authenticated internal APIs between client and server. Public-facing endpoints (sitemaps, public channel pages, robots.txt) use REST for maximum compatibility with crawlers and third-party consumers.
+606:| `VISIBILITY_CHANGED` | Channel Visibility Toggle (this spec) | Emitted when channel visibility state changes |
+607:| `MESSAGE_CREATED` | SEO Meta Tag Generation | New message in a public channel |
+608:| `MESSAGE_EDITED` | SEO Meta Tag Generation | Message edited in a public channel |
+609:| `MESSAGE_DELETED` | SEO Meta Tag Generation | Message deleted from a public channel |
+610:| `META_TAGS_UPDATED` | SEO Meta Tag Generation | Meta tags regenerated for a channel |
+614:Significant reprompting was necessary here because of conflicting tech stacks across each spec. This spec was missing DOMPurify, which would be needed to sanitize and generate sitemaps with other public content. The communication APIs being a mix of RPC and REST was also detected by the LLM here, requiring prompting to fix it. The LLM then determined to use RPC for authenticated internal APIs, while public endpoints would be REST for compatibility with web indexers.
+629:// Get channel settings including visibility
+635:// Update channel visibility
+638:  body: VisibilityUpdateRequest,  // { visibility: ChannelVisibility }
+642:// Get visibility change audit history
+682:// Set channel visibility with validation
+704:getRobotsDirectives(visibility: ChannelVisibility): RobotsDirectives
+767:| getPublicChannel() | PublicAccessController | Viewing public channel |
+774:| setVisibility() | ChannelVisibilityService | Processing visibility updates |
+775:| getVisibility() | ChannelVisibilityService | Reading current visibility |
+778:| generateCanonicalUrl() | IndexingService | SEO headers |
+779:| getRobotsDirectives() | IndexingService | SEO headers |
+788:| update() | ChannelRepository | Persisting visibility changes |
+790:| getVisibility() | ChannelRepository | Fast visibility check |
+792:| create() | AuditLogRepository | Writing audit entries |
+793:| findByChannelId() | AuditLogRepository | Reading audit history |
+804:  /api/channels/{channelId}/visibility:
+806:      summary: Update channel visibility
+842:      enum: [PUBLIC_INDEXABLE, PUBLIC_NO_INDEX, PRIVATE]
+846:      required: [visibility]
+848:        visibility:
+860:        indexingStatus:
+869:| New Visibility | Downstream Action (SEO Spec) | Downstream Action (Guest View Spec) |
+871:| `PUBLIC_INDEXABLE` | Generate meta tags for channel | Warm guest view cache |
+872:| `PUBLIC_NO_INDEX` | Update meta tags (add noindex) | Keep guest view cache (public content) |
+873:| `PRIVATE` | Delete meta tags for channel | Invalidate guest view cache |
+897:| visibility | visibility_enum | NOT NULL, DEFAULT 'PRIVATE' | Current visibility state |
+900:| indexed_at | TIMESTAMP WITH TIME ZONE | NULL | When channel was added to sitemap |
+906:CREATE TYPE visibility_enum AS ENUM ('PUBLIC_INDEXABLE', 'PUBLIC_NO_INDEX', 'PRIVATE');
+911:-- Composite index for server-scoped visibility queries
+912:CREATE INDEX idx_channels_server_visibility ON channels(server_id, visibility);
+917:-- Partial index for indexable channels (sitemap generation)
+918:CREATE INDEX idx_channels_visibility_indexed ON channels(visibility, indexed_at)
+919:  WHERE visibility = 'PUBLIC_INDEXABLE';
+921:-- Partial index for all public channels (guest view queries)
+922:CREATE INDEX idx_channels_visibility ON channels(visibility)
+923:  WHERE visibility IN ('PUBLIC_INDEXABLE', 'PUBLIC_NO_INDEX');
+926:#### D7.2 visibility_audit_log
+944:CREATE INDEX idx_audit_channel_time ON visibility_audit_log(channel_id, timestamp DESC);
+945:CREATE INDEX idx_audit_actor ON visibility_audit_log(actor_id, timestamp DESC);
+969:- **Key Pattern:** `channel:{channelId}:visibility` (UUID-based)
+970:- **Value:** String (visibility enum value)
+984:| ChannelVisibility (enum) | visibility_enum | PostgreSQL enum |
+986:| object (audit values) | JSONB | Flexible schema |
+991:This section needed significant reprompting due to database schema and index mismatches across all specs. Beyond that, the architecture is justified because it provides unique mappings for all (server, channel) pairs, allowing for indexers to access them consistently for updates. 
+1003:| IP Address | Audit trail | Logged with visibility changes | Retained in audit log | TLS in transit; encrypted at rest |
+1004:| User Agent | Identifying suspicious activity | Logged with visibility changes | Retained in audit log | TLS in transit; encrypted at rest |
+1011:| Actor ID (→ User) | Accountability for admin actions | D7.2 visibility_audit_log.actor_id | AuditLogRepository → AuditLogService → ChannelController |
+1012:| IP Address | Security investigation, abuse prevention | D7.2 visibility_audit_log.ip_address | Only via audit log export by authorized personnel |
+1024:- Messages in public channels may appear in search results
+1025:- Administrators can change channel visibility at any time
+1026:- Previously indexed content may remain in search engine caches after being made private
+1028:**Policy Presentation:** Warning on channel creation; confirmation dialog on public toggle; de-indexing notice on private toggle.
+1060:All public-facing content (public channel pages, sitemap entries, PublicChannelDTO fields) is sanitized using sanitize-html (T17) before rendering to prevent XSS attacks from user-generated content.
+1064:The LLM did not have issues with generating security and privacy requirements. This architecture is justified because it creates an audit trail for any actions. All actions are tagged by the user doing the action. IP addresses are also stored for audits. 
+1066:Visibility rules and search indexing is also handled with the appropriate care needed for making channels publically indexable. 
+1108:2. SSR performance for public pages — critical for SEO
+1125:| DB performance degradation | p99 > 500ms | Read replicas; query plan review; add indexes |
+1149:| X-Robots-Tag | HTTP header providing indexing instructions to crawlers |
+1150:| De-indexing | Requesting search engines remove content from their index |
+1160:- User Story: Channel Visibility Toggle (this document)
+1161:- Dev Spec: SEO Meta Tag Generation (cross-referenced for event integration)
+1165:- SEO Best Practices Guide (separate document)
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "User Story|Acceptance Criteria|visibility|guest|public channel|anonymous|SEO|index|audit|PUBLIC_INDEXABLE|PUBLIC_NO_INDEX|PRIVATE" docs/dev-spec-guest-public-channel-view.md
+```
+
+Output:
+
+```text
+5:**User Story:** As a Guest User (Searcher), I want to view the full contents of a public channel via a direct URL without being prompted to log in, so that I can get the answer to my specific question immediately without the friction of creating an account I might only use once.
+48:        SEOMetadata["SEOMetadataComponent\ngenerateMetaTags()\ngenerateStructuredData()"]
+78:        SEOService["SEOService\ngeneratePageTitle()\ngenerateDescription()\ngenerateStructuredData()"]
+97:        VisCache["channel:{channelId}:visibility\nTTL: 3600s (M-B3 owner)"]
+100:        GuestSession["guest:session:{sessionId}\nTTL: 86400s (M-B2 owner)"]
+107:    PublicChannelPage --> SEOMetadata
+119:    PublicChannelCtrl --> SEOService
+138:> **Note:** All cache keys use UUID-based identifiers (e.g., `channel:{channelId}:visibility`) for consistency across all Harmony specs.
+151:| F8 | C5.4 SEOService | C1.2 SEOMetadataComponent | SEO Data | Internal |
+167:    NextJS_SSR->>Database: Check visibility
+168:    Database-->>NextJS_SSR: visibility=PUBLIC
+171:    NextJS_SSR-->>NextJS_SSR: Render HTML with SEO tags
+180:The archtecture diagram is justified because client server split abstracts from the guest the authorization logic the server handles and caching requests significantly helps with performance for storing the same content that will be served to many users. Furthermore, the importance of authorization lies in the fact whether a channel is public or not, to make sure guests can't see private channels. 
+197:        -visibilityGuard
+244:    class SEOMetadataComponent {
+290:        +visibility Enum
+361:    PublicChannelPage *-- SEOMetadataComponent
+378:The class diagram clearly separates the entities that will be needed for displaying the public channel to the guest user, specifically with only grabbing public entities such as the server, messages and owner of the message to avoid exposing private channel information. 
+395:| CL-C1.1 | PublicChannelPage | Page Component | Main Next.js page component for rendering public channel content with SSR |
+396:| CL-C1.2 | SEOMetadataComponent | UI Component | Generates and renders SEO meta tags, Open Graph tags, and structured data |
+398:| CL-C1.4 | GuestPromoBanner | UI Component | Non-intrusive banner encouraging guests to join the community |
+400:| CL-C1.6 | ServerSidebar | UI Component | Displays server info and list of other public channels for navigation |
+415:| CL-C3.1 | PublicChannelController | Controller | Handles API requests for public channel data without authentication |
+422:| CL-C4.1 | VisibilityGuard | Service | Checks channel/server visibility before serving content to guests |
+424:| CL-C4.3 | RateLimiter | Middleware | Prevents abuse by limiting request rate for anonymous users |
+425:| CL-C4.4 | AnonymousSessionManager | Service | Manages lightweight sessions for guests to store preferences |
+434:| CL-C5.4 | SEOService | Service | Generates SEO metadata, structured data, and canonical URLs |
+440:| CL-C6.1 | ChannelRepository | Repository | Data access for channel entities with visibility filtering |
+454:| CL-D6 | SEODataDTO | DTO | SEO metadata for page head |
+473:  PUBLIC_INDEXABLE = 'PUBLIC_INDEXABLE',   // Visible to guests and indexed by search engines
+474:  PUBLIC_NO_INDEX = 'PUBLIC_NO_INDEX',     // Visible to guests but not indexed
+475:  PRIVATE = 'PRIVATE'                      // Only visible to authenticated members
+483:| CL-D7 | Channel | Entity | Channel domain entity with visibility state |
+491:The list of classes clearly states the moving parts for ensuring guest user can access public channels and their messages, with handling caching. The classes cover all the responsibilities needed for this feature to function from route handling to retrieving the public data to formatting the response to the guest. The inclusion of caching and bot detection justified since retrieval of the same content from multiple guest is unnecessary more work on the server. 
+502:| channel.visibility | ChannelVisibility | Visibility state of requested channel |
+504:| guest.sessionId | string | Anonymous session identifier |
+508:> **Convention:** `is_public` (boolean) applies to **servers** — whether the server appears in discovery. `visibility` (enum: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) applies to **channels** — whether channel content is accessible to guests and/or indexed by search engines.
+519:    S4 : S4: Visibility Check\nchannel.visibility=?
+529:    S4 --> S5 : visibility != PUBLIC_*\n[return 403 or redirect]
+530:    S4 --> S6 : visibility = PUBLIC_*\n[query messages]
+562:    [*] --> D1 : Private channel requested\n(visibility=PRIVATE)
+566:    D3 : D3: Show Server Landing\nRedirect to /s/{server}\nShow public channels list
+576:These states were chosen to show the phases a guest can be for viewing a public channel, the states handle critical edge cases a guest can experience since the endpoints are publicily accessible such as trying to visit a private channel or channel that isn't cached. The state also has no login redirect due to the fact that this feature is supposed allow anonymous users to access public channels. Importantly each state has a clear end to each phase so the guest ins't stuck in a loop state that they can't get out off.
+584:**Scenario Description:** A guest user clicks a search result link that leads to a public channel. The system serves the full content without any login prompts, allowing the user to immediately access the information they were searching for.
+597:    F19["F1.9 Check visibility\nVisibilityGuard.isChannelPublic(channelId)"]
+598:    IsPublic{"F1.10: Is PUBLIC_INDEXABLE\nor PUBLIC_NO_INDEX?"}
+601:    F113["F1.13 Fetch public channels for sidebar\nChannelRepository.findPublicByServerId()"]
+606:    F117["F1.17 Generate SEO data\nSEOService.generatePageTitle()\ngenerateDescription()\ngenerateStructuredData()"]
+607:    F118["F1.18 Render HTML with Next.js SSR\n- SEO meta tags\n- Server sidebar\n- Message list\n- Guest promo banner\n- Structured data JSON-LD"]
+608:    F119["F1.19 Set cache headers\nCache-Control: public, max-age=60, s-maxage=60\nstale-while-revalidate=300\nX-Robots-Tag: index, follow"]
+609:    F120["F1.20 Response delivered to guest browser"]
+615:    End(["END: Guest viewing public channel\n- Full content visible\n- No login prompt shown\n- Search terms highlighted\n- Can navigate to other public channels"])
+622:    IsPublic -->|No PRIVATE| F111 --> F120
+632:**Scenario Description:** A guest user requests a channel URL that points to a private channel. The system provides a helpful response without revealing sensitive information about the server's structure.
+637:    F21["F2.1 Visibility check returns PRIVATE\nVisibilityGuard.getVisibilityStatus()"]
+644:    F28["F2.8 Redirect to server landing page\n302 Redirect to /s/company\nShow list of public channels"]
+656:**Scenario Description:** A guest user scrolls to the bottom of the message list, triggering the infinite scroll mechanism to load older messages without a full page reload.
+666:    F36["F3.6 Server validates channel is still public\n(visibility could change)"]
+685:**Scenario Description:** A search engine bot (Googlebot, Bingbot, etc.) crawls a public channel page. The system serves optimized content with appropriate SEO signals.
+689:    Start(["START: Bot requests public channel\nUser-Agent: Googlebot/2.1\nURL: /c/opensource/announcements"])
+692:    F43SameFlow["Same visibility and content flow as F1.4-F1.18"]
+694:    F44["F4.4 Set SEO headers\nX-Robots-Tag: index, follow\nLink: canonical; rel=canon\nCache-Control: public, s-maxage=3600"]
+696:    End(["END: Bot crawl complete\n- Content indexed\n- Structured data parsed\n- Links discovered"])
+707:| `PUBLIC_INDEXABLE` | Warm guest view cache for channel; begin serving public content |
+708:| `PUBLIC_NO_INDEX` | Keep guest view cache (content still public); update `X-Robots-Tag` to `noindex` |
+709:| `PRIVATE` | Invalidate all guest view caches for channel; return 403/404 on subsequent requests |
+722:**Cache Keys Invalidated on PRIVATE:**
+723:- `channel:{channelId}:visibility`
+729:The flow charts depict the major flow cases a guest will experience for Harmony. The first flow covers the primary case that the guest visits the public channel from search engine result, which is the primary aim for Harmony, to be able to provide public channel information to guests without the need of logging in. The second flow covers the edge case a guests tries to visit a private channel, safely redirecting them without revealing any sensitive information about the server. The third flow covers the guest loading more messages of the channel, allowing the guest to infinitely scroll older messages. The fourth flow covers the public channels to be crawlable by search engine bots, so guests searching for information related to public channels can see it. 
+744:| RF-6 | SEO data generation fails | Missing meta tags | Empty title/description | Default fallback values; monitoring | Low | Medium |
+755:| CF-5 | Slow network to guest | Long load times | Time to first byte high | CDN edge caching; image optimization | Medium | Medium |
+780:| DF-1 | Private content exposed | Privacy breach | Visibility check bypassed | Audit; immediate visibility fix; notification | Very Low | Critical |
+815:The development risks and failures categories were chosen to represent the primary threat this feature can face. The runtime and connectivity failures are catagorized due to the feature being a publicly accessible endpoint that any guest can use, leading to unpredictable traffic volumes. Intruder risks face the highest priorty due to the endpoint having no authentication since guests aren't required to log in. 
+825:| T3 | Next.js | 14.0+ | React framework with SSR | Critical for SEO; server components | https://nextjs.org/ |
+835:| T13 | Google Search Console API | v1 | Programmatic indexing | Sitemap ping; URL submission | https://developers.google.com/webmaster-tools |
+838:| T16 | Playwright | 1.40+ | E2E testing | SEO verification; crawl simulation | https://playwright.dev/ |
+845:> **Convention:** tRPC is used for authenticated internal APIs between client and server. Public-facing endpoints (public channel pages, sitemaps, robots.txt) use REST for maximum compatibility with crawlers and third-party consumers.
+855:| `VISIBILITY_CHANGED` | Channel Visibility Toggle | Channel visibility state changed; invalidate/warm caches |
+856:| `MESSAGE_CREATED` | SEO Meta Tag Generation | New message in public channel; invalidate message cache |
+857:| `MESSAGE_EDITED` | SEO Meta Tag Generation | Message edited; invalidate affected cache pages |
+858:| `MESSAGE_DELETED` | SEO Meta Tag Generation | Message deleted; invalidate affected cache pages |
+875:// Get public channel with initial messages (SSR)
+886:// Get public channel messages (API for infinite scroll)
+891:    page: number,               // Page number (1-indexed)
+934:// Get list of public channels in server
+959:// Check if server has any public channels
+964:// Get detailed visibility status
+968:// Returns: { isPublic, visibility, indexable, reason }
+1027:// Get or create anonymous session
+1032:// Store preference for guest
+1039:// Get guest preferences
+1128:#### 9.3.4 CL-C5.4 SEOService
+1191:// Find all public channels for server
+1196:// Get visibility directly
+1240:| Human (anonymous) | 100 requests | 1 minute | Token bucket per IP |
+1254:The APIs for Guest Public Channel View, clearly handle the usage of the feature for being able to publicily access channels that are from the original search message. The first section APIs' purpose is for handling showing the information for the channel in which was derived from the search query and being able to load further messages in the channel. Next section APIs' purpose is for handling the server information once there, such as showing the server information and other public channels inside that server.
+1278:| getVisibilityStatus() | VisibilityGuard | Detailed visibility info |
+1282:| sanitizeAttachments() | ContentFilter | Attachment visibility filtering |
+1286:| storePreference() | AnonymousSessionManager | Storing guest preferences |
+1287:| getPreferences() | AnonymousSessionManager | Retrieving guest preferences |
+1298:| generatePageTitle() | SEOService | SEO metadata |
+1299:| generateDescription() | SEOService | Meta description generation |
+1300:| generateStructuredData() | SEOService | JSON-LD |
+1301:| generateBreadcrumbs() | SEOService | Breadcrumb schema data |
+1302:| getCanonicalUrl() | SEOService | Canonical URL generation |
+1305:| isAttachmentPublic() | AttachmentService | Attachment visibility check |
+1313:| getVisibility() | ChannelRepository | Channel visibility check |
+1327:  description: Unauthenticated API for accessing public channel content
+1435:      summary: Get list of public channels in server
+1457:      description: Renders server landing page with list of public channels
+1591:| `PUBLIC_INDEXABLE` | Warm guest view cache for channel |
+1592:| `PUBLIC_NO_INDEX` | Keep guest view cache (public content, but update X-Robots-Tag) |
+1593:| `PRIVATE` | Invalidate guest view cache; return 403/404 |
+1597:The public interfaces categories appropriately define the public method this featur needs for other modules to intercat with. For the public api, the public method serve its purpose for providing the necessary entry points other modules need to allow guests to view public channels without logging in. The access controls purpose is to protect private channels from being accessed by guests, verifying that the channel is public. Content delivery and data access purpose is guest receiving the public information the channel has. 
+1638:| visibility | visibility_enum | NOT NULL, DEFAULT 'PRIVATE' | Visibility state | 1 byte |
+1641:| indexed_at | TIMESTAMP WITH TIME ZONE | NULL | When channel was added to sitemap | 8 bytes |
+1645:> **Note:** `messageCount` (shown in `PublicChannelDTO`) is computed via `COUNT(*)` query on the messages table, not stored as a column. The `visibility` column uses the `visibility_enum` type (not a boolean); see toggle spec for the `is_public` boolean on the `servers` table.
+1649:-- Composite index for server-scoped visibility queries (from toggle spec)
+1650:CREATE INDEX idx_channels_server_visibility ON channels(server_id, visibility);
+1655:-- Partial index for all public channels (guest view queries)
+1656:CREATE INDEX idx_channels_visibility ON channels(visibility)
+1657:  WHERE visibility IN ('PUBLIC_INDEXABLE', 'PUBLIC_NO_INDEX');
+1659:-- Partial index for indexable channels (sitemap generation, from toggle spec)
+1660:CREATE INDEX idx_channels_visibility_indexed ON channels(visibility, indexed_at)
+1661:  WHERE visibility = 'PUBLIC_INDEXABLE';
+1699:| public_profile | BOOLEAN | NOT NULL, DEFAULT TRUE | Show in public channels | 1 byte |
+1723:**Key Pattern:** `channel:{channelId}:visibility`
+1724:**Value Type:** String (enum value: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`)
+1726:**Invalidation:** On visibility change via admin toggle
+1744:**Key Pattern:** `guest:session:{sessionId}`
+1747:**Purpose:** Store guest preferences (dismissed banners, etc.)
+1761:The data schemas covers the data required for rendering the feature of public channel view. The three important tables needed being server, channels, and messages, all handle the public information that guests will be given, however the schemas clearly denote the information that will be given to guests only, meaning guests that haven't logged in. 
+1783:| Message Content | D7.3 Messages.content | Exposed (in public channels) | Content filter applied |
+1844:- Messages in public channels are visible to anyone, including search engines
+1845:- Your display name and avatar appear with your messages in public channels
+1847:- We do not track or store identifying information about anonymous viewers
+1854:| View public channel messages | Yes | Core feature |
+1855:| View public channel attachments | Yes | If attachment is in a public channel |
+1856:| Navigate between public channels | Yes | Via server sidebar |
+1864:| Download message history | No | Not exposed to guests |
+1865:| Use search within channel | No | Not available for guests (future feature) |
+1869:The security and privacy answers obvious concerns for handling messages that are publicily accessible to anyone. The restriction on guest users are enforced for security purposes such as not being able to interact with the channel without verifying who you are, meaning public channels are read only. Privacy purposes users who send messages in public channels can opt out of revealing their profile information and instead have it be anonymous. 
+1890:| SSR Performance | Slow TTFB affects SEO | Edge caching; ISR; streaming |
+1892:| Infinite Scroll | SEO crawlers can't follow | Pagination fallback links; sitemap |
+1896:### 13.3 SEO-Specific Risks
+1903:| Thin content pages | Not indexed | Minimum message threshold for indexing |
+1922:| SEO ranking drop | > 20% traffic decrease | Audit with Search Console; fix issues |
+1930:## Appendix A: SEO Optimization Checklist
+1941:### Technical SEO
+1946:- [ ] XML sitemap including all public channels
+1975:| Visibility Enum | `ChannelVisibility` enum with values: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE` |
+1982:- Dev Spec: SEO Meta Tag Generation (cross-referenced for event integration and MetaTagService)
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "visibility|audit log|PUBLIC_INDEXABLE|PUBLIC_NO_INDEX|PRIVATE|getChannel|publicGet|getAuditLog|channel settings|guest|public channel|anonymous|indexable|no-index|robots|sitemap|seo|serverSlug|channelSlug" harmony-frontend/src/__tests__ harmony-backend/tests
+```
+
+Output:
+
+```text
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:6: * visibility changes on a server.
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:99:  visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:198:    expect(addedTypes).toContain('channel:visibility-changed');
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:491:describe('useServerEvents — channel:visibility-changed events', () => {
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:492:  it('registers a listener for channel:visibility-changed', () => {
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:507:    expect(addedTypes).toContain('channel:visibility-changed');
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:512:    const updatedChannel: Channel = { ...MOCK_CHANNEL, visibility: ChannelVisibility.PRIVATE };
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:525:      mockEventSourceInstance!.simulateEvent('channel:visibility-changed', {
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:527:        oldVisibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:535:      ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:552:        mockEventSourceInstance!.simulateEvent('channel:visibility-changed', {
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:554:          visibility: ChannelVisibility.PRIVATE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:555:          oldVisibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:561:  it('removes channel:visibility-changed listener on unmount', () => {
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:578:    expect(removedTypes).toContain('channel:visibility-changed');
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:596:        const badEvent = new MessageEvent('channel:visibility-changed', { data: 'not-json{{{' });
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:598:          .filter(([type]) => type === 'channel:visibility-changed')
+harmony-backend/tests/mock-seed.test.ts:36:  it('preserves server slugs and derives public visibility from channel data', () => {
+harmony-backend/tests/schema.test.ts:50:    'visibility_audit_log',
+harmony-backend/tests/schema.test.ts:74:    const values = await enumValues('channel_visibility');
+harmony-backend/tests/schema.test.ts:75:    expect(values).toEqual(['PUBLIC_INDEXABLE', 'PUBLIC_NO_INDEX', 'PRIVATE']);
+harmony-backend/tests/schema.test.ts:100:    'idx_channels_server_visibility',
+harmony-backend/tests/schema.test.ts:102:    'idx_channels_visibility_indexed',
+harmony-backend/tests/schema.test.ts:103:    'idx_channels_visibility',
+harmony-backend/tests/schema.test.ts:107:    // visibility_audit_log
+harmony-backend/tests/schema.test.ts:134:  it('idx_channels_visibility_indexed is partial WHERE visibility = PUBLIC_INDEXABLE', async () => {
+harmony-backend/tests/schema.test.ts:135:    const def = await indexDef('idx_channels_visibility_indexed');
+harmony-backend/tests/schema.test.ts:137:    expect(def).toContain("PUBLIC_INDEXABLE");
+harmony-backend/tests/schema.test.ts:140:  it('idx_channels_visibility is partial WHERE visibility IN (PUBLIC_INDEXABLE, PUBLIC_NO_INDEX)', async () => {
+harmony-backend/tests/schema.test.ts:141:    const def = await indexDef('idx_channels_visibility');
+harmony-backend/tests/schema.test.ts:143:    expect(def.toUpperCase()).toContain('PUBLIC_INDEXABLE');
+harmony-backend/tests/schema.test.ts:144:    expect(def.toUpperCase()).toContain('PUBLIC_NO_INDEX');
+harmony-backend/tests/schema.test.ts:211:        visibility: 'PRIVATE',
+harmony-backend/tests/schema.test.ts:216:    expect(channel.visibility).toBe('PRIVATE');
+harmony-backend/tests/schema.test.ts:228:          visibility: 'PRIVATE',
+harmony-backend/tests/auditLog.service.test.ts:54:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/auditLog.service.test.ts:66:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/auditLog.service.test.ts:90:  oldValue: { visibility: 'PRIVATE' },
+harmony-backend/tests/auditLog.service.test.ts:91:  newValue: { visibility: 'PUBLIC_NO_INDEX' },
+harmony-backend/tests/auditLog.service.test.ts:103:    await prisma.visibilityAuditLog.deleteMany({ where: { actorId: userId, channelId } });
+harmony-backend/tests/auditLog.service.test.ts:112:    expect(entry.oldValue).toEqual({ visibility: 'PRIVATE' });
+harmony-backend/tests/auditLog.service.test.ts:113:    expect(entry.newValue).toEqual({ visibility: 'PUBLIC_NO_INDEX' });
+harmony-backend/tests/auditLog.service.test.ts:138:        makeLogInput({ newValue: { visibility: 'PUBLIC_INDEXABLE' } }),
+harmony-backend/tests/auditLog.service.test.ts:145:    const persisted = await prisma.visibilityAuditLog.findUnique({
+harmony-backend/tests/auditLog.service.test.ts:149:    expect(persisted!.newValue).toEqual({ visibility: 'PUBLIC_INDEXABLE' });
+harmony-backend/tests/auditLog.service.test.ts:156:  // Seed several audit log entries for the pagination tests
+harmony-backend/tests/auditLog.service.test.ts:164:      const entry = await prisma.visibilityAuditLog.create({
+harmony-backend/tests/auditLog.service.test.ts:169:          oldValue: { visibility: 'PRIVATE' },
+harmony-backend/tests/auditLog.service.test.ts:170:          newValue: { visibility: 'PUBLIC_NO_INDEX' },
+harmony-backend/tests/auditLog.service.test.ts:183:      await prisma.visibilityAuditLog.deleteMany({
+harmony-backend/tests/reaction.test.ts:60:      visibility: 'PRIVATE',
+harmony-backend/tests/indexing.service.test.ts:4: * Covers sitemap generation for PUBLIC_INDEXABLE channels,
+harmony-backend/tests/indexing.service.test.ts:5: * robots.txt endpoint, and sitemap updates on visibility changes.
+harmony-backend/tests/indexing.service.test.ts:19:let serverSlug: string;
+harmony-backend/tests/indexing.service.test.ts:21:let indexableChannelId: string;
+harmony-backend/tests/indexing.service.test.ts:30:      email: `sitemap-test-${Date.now()}@test.com`,
+harmony-backend/tests/indexing.service.test.ts:31:      username: `sitemap-test-${Date.now()}`,
+harmony-backend/tests/indexing.service.test.ts:38:  serverSlug = `sitemap-test-${Date.now()}`;
+harmony-backend/tests/indexing.service.test.ts:42:      slug: serverSlug,
+harmony-backend/tests/indexing.service.test.ts:49:  const indexableChannel = await prisma.channel.create({
+harmony-backend/tests/indexing.service.test.ts:55:      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-backend/tests/indexing.service.test.ts:59:  indexableChannelId = indexableChannel.id;
+harmony-backend/tests/indexing.service.test.ts:67:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/indexing.service.test.ts:87:  it('generates valid XML sitemap with PUBLIC_INDEXABLE channels only', async () => {
+harmony-backend/tests/indexing.service.test.ts:88:    const xml = await indexingService.generateSitemap(serverSlug);
+harmony-backend/tests/indexing.service.test.ts:92:    expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+harmony-backend/tests/indexing.service.test.ts:93:    expect(xml).toContain(`/c/${serverSlug}/public-channel`);
+harmony-backend/tests/indexing.service.test.ts:100:  it('returns empty urlset when server has no PUBLIC_INDEXABLE channels', async () => {
+harmony-backend/tests/indexing.service.test.ts:101:    // Create a server with no indexable channels
+harmony-backend/tests/indexing.service.test.ts:102:    const emptySlug = `empty-sitemap-${Date.now()}`;
+harmony-backend/tests/indexing.service.test.ts:132:  it('invalidates sitemap cache when channel becomes PUBLIC_INDEXABLE', async () => {
+harmony-backend/tests/indexing.service.test.ts:133:    await indexingService.generateSitemap(serverSlug);
+harmony-backend/tests/indexing.service.test.ts:137:      oldVisibility: 'PRIVATE',
+harmony-backend/tests/indexing.service.test.ts:138:      newVisibility: 'PUBLIC_INDEXABLE',
+harmony-backend/tests/indexing.service.test.ts:142:      expect.stringContaining('sitemap:'),
+harmony-backend/tests/indexing.service.test.ts:146:  it('invalidates sitemap cache when channel leaves PUBLIC_INDEXABLE', async () => {
+harmony-backend/tests/indexing.service.test.ts:147:    await indexingService.generateSitemap(serverSlug);
+harmony-backend/tests/indexing.service.test.ts:150:      channelId: indexableChannelId,
+harmony-backend/tests/indexing.service.test.ts:151:      oldVisibility: 'PUBLIC_INDEXABLE',
+harmony-backend/tests/indexing.service.test.ts:152:      newVisibility: 'PRIVATE',
+harmony-backend/tests/indexing.service.test.ts:156:      expect.stringContaining('sitemap:'),
+harmony-backend/tests/indexing.service.test.ts:160:  it('does not invalidate cache when visibility change does not involve PUBLIC_INDEXABLE', async () => {
+harmony-backend/tests/indexing.service.test.ts:163:      oldVisibility: 'PRIVATE',
+harmony-backend/tests/indexing.service.test.ts:164:      newVisibility: 'PUBLIC_NO_INDEX',
+harmony-backend/tests/indexing.service.test.ts:171:describe('GET /robots.txt', () => {
+harmony-backend/tests/indexing.service.test.ts:172:  it('returns robots.txt with correct directives', async () => {
+harmony-backend/tests/indexing.service.test.ts:173:    const res = await request(app).get('/robots.txt');
+harmony-backend/tests/indexing.service.test.ts:184:describe('GET /sitemap/:serverSlug.xml', () => {
+harmony-backend/tests/indexing.service.test.ts:185:  it('returns XML sitemap for valid server', async () => {
+harmony-backend/tests/indexing.service.test.ts:186:    const res = await request(app).get(`/sitemap/${serverSlug}.xml`);
+harmony-backend/tests/indexing.service.test.ts:191:    expect(res.text).toContain(`/c/${serverSlug}/public-channel`);
+harmony-backend/tests/indexing.service.test.ts:196:    const res = await request(app).get('/sitemap/non-existent-server.xml');
+harmony-backend/tests/message.service.test.ts:47:      visibility: 'PRIVATE',
+harmony-backend/tests/message.service.test.ts:132:        visibility: 'PRIVATE',
+harmony-backend/tests/message.service.test.ts:162:        visibility: 'PRIVATE',
+harmony-backend/tests/events.router.visibility.test.ts:2: * events.router.visibility.test.ts — Issue #187
+harmony-backend/tests/events.router.visibility.test.ts:4: * Integration tests for channel:visibility-changed SSE events on
+harmony-backend/tests/events.router.visibility.test.ts:126:  visibility: 'PRIVATE',
+harmony-backend/tests/events.router.visibility.test.ts:156:describe('GET /api/events/server/:serverId — visibility subscription', () => {
+harmony-backend/tests/events.router.visibility.test.ts:176:// ─── channel:visibility-changed event delivery ────────────────────────────────
+harmony-backend/tests/events.router.visibility.test.ts:178:describe('GET /api/events/server/:serverId — channel:visibility-changed event', () => {
+harmony-backend/tests/events.router.visibility.test.ts:179:  it('pushes channel:visibility-changed SSE frame when visibility changes', async () => {
+harmony-backend/tests/events.router.visibility.test.ts:180:    let visibilityChangedHandler: ((payload: unknown) => Promise<void>) | null = null;
+harmony-backend/tests/events.router.visibility.test.ts:185:          visibilityChangedHandler = handler;
+harmony-backend/tests/events.router.visibility.test.ts:207:            if (visibilityChangedHandler) {
+harmony-backend/tests/events.router.visibility.test.ts:208:              await visibilityChangedHandler({
+harmony-backend/tests/events.router.visibility.test.ts:211:                oldVisibility: 'PUBLIC_INDEXABLE',
+harmony-backend/tests/events.router.visibility.test.ts:212:                newVisibility: 'PRIVATE',
+harmony-backend/tests/events.router.visibility.test.ts:231:    expect(body).toContain('event: channel:visibility-changed');
+harmony-backend/tests/events.router.visibility.test.ts:234:    expect(body).toContain('PUBLIC_INDEXABLE');
+harmony-backend/tests/events.router.visibility.test.ts:235:    // newVisibility (PRIVATE) must be present in the channel payload
+harmony-backend/tests/events.router.visibility.test.ts:236:    expect(body).toContain('PRIVATE');
+harmony-backend/tests/events.router.visibility.test.ts:239:  it('does not emit channel:visibility-changed when channel no longer exists (race condition)', async () => {
+harmony-backend/tests/events.router.visibility.test.ts:243:    let visibilityChangedHandler: ((payload: unknown) => Promise<void>) | null = null;
+harmony-backend/tests/events.router.visibility.test.ts:248:          visibilityChangedHandler = handler;
+harmony-backend/tests/events.router.visibility.test.ts:273:            if (visibilityChangedHandler) {
+harmony-backend/tests/events.router.visibility.test.ts:274:              await visibilityChangedHandler({
+harmony-backend/tests/events.router.visibility.test.ts:277:                oldVisibility: 'PUBLIC_INDEXABLE',
+harmony-backend/tests/events.router.visibility.test.ts:278:                newVisibility: 'PRIVATE',
+harmony-backend/tests/events.router.visibility.test.ts:297:    expect(body).not.toContain('event: channel:visibility-changed');
+harmony-backend/tests/events.router.visibility.test.ts:300:  it('does not emit channel:visibility-changed for a different server', async () => {
+harmony-backend/tests/events.router.visibility.test.ts:301:    let visibilityChangedHandler: ((payload: unknown) => Promise<void>) | null = null;
+harmony-backend/tests/events.router.visibility.test.ts:306:          visibilityChangedHandler = handler;
+harmony-backend/tests/events.router.visibility.test.ts:328:            if (visibilityChangedHandler) {
+harmony-backend/tests/events.router.visibility.test.ts:330:              await visibilityChangedHandler({
+harmony-backend/tests/events.router.visibility.test.ts:333:                oldVisibility: 'PUBLIC_INDEXABLE',
+harmony-backend/tests/events.router.visibility.test.ts:334:                newVisibility: 'PRIVATE',
+harmony-backend/tests/events.router.visibility.test.ts:353:    expect(body).not.toContain('event: channel:visibility-changed');
+harmony-frontend/src/__tests__/trpc-client.test.ts:6:import { publicGet, TrpcHttpError, trpcMutate, trpcQuery } from '../lib/trpc-client';
+harmony-frontend/src/__tests__/trpc-client.test.ts:35:  describe('publicGet', () => {
+harmony-frontend/src/__tests__/trpc-client.test.ts:39:      await expect(publicGet<{ id: string }>('/servers/server-1')).resolves.toEqual({
+harmony-frontend/src/__tests__/trpc-client.test.ts:55:      await expect(publicGet('/servers/missing')).resolves.toBeNull();
+harmony-frontend/src/__tests__/trpc-client.test.ts:61:      await expect(publicGet('/servers/failing')).rejects.toThrow('Public API error: 500');
+harmony-frontend/src/__tests__/trpc-client.test.ts:73:        trpcQuery<{ ok: boolean }>('channel.getChannels', { serverId: 'server-1' }),
+harmony-frontend/src/__tests__/trpc-client.test.ts:77:        'http://localhost:4000/trpc/channel.getChannels?input=%7B%22serverId%22%3A%22server-1%22%7D',
+harmony-frontend/src/__tests__/trpc-client.test.ts:122:      await expect(trpcQuery('channel.getChannels')).rejects.toEqual(
+harmony-frontend/src/__tests__/trpc-client.test.ts:125:          procedure: 'channel.getChannels',
+harmony-frontend/src/__tests__/trpc-client.test.ts:137:      await expect(trpcQuery('channel.getChannels')).rejects.toThrow(
+harmony-frontend/src/__tests__/trpc-client.test.ts:138:        'tRPC query [channel.getChannels]: response missing result.data',
+harmony-backend/tests/channel.service.test.ts:4: * Covers happy-path CRUD operations and the VOICE ≠ PUBLIC_INDEXABLE guard.
+harmony-backend/tests/channel.service.test.ts:54:  it('creates a TEXT PRIVATE channel', async () => {
+harmony-backend/tests/channel.service.test.ts:60:      visibility: 'PRIVATE',
+harmony-backend/tests/channel.service.test.ts:67:    expect(channel.visibility).toBe('PRIVATE');
+harmony-backend/tests/channel.service.test.ts:70:  it('rejects VOICE + PUBLIC_INDEXABLE', async () => {
+harmony-backend/tests/channel.service.test.ts:77:        visibility: 'PUBLIC_INDEXABLE',
+harmony-backend/tests/channel.service.test.ts:89:        visibility: 'PRIVATE',
+harmony-backend/tests/channel.service.test.ts:101:        visibility: 'PRIVATE',
+harmony-backend/tests/channel.service.test.ts:107:// ─── getChannels ──────────────────────────────────────────────────────────────
+harmony-backend/tests/channel.service.test.ts:109:describe('channelService.getChannels', () => {
+harmony-backend/tests/channel.service.test.ts:111:    const channels = await channelService.getChannels(serverId);
+harmony-backend/tests/channel.service.test.ts:118:// ─── getChannelBySlug ─────────────────────────────────────────────────────────
+harmony-backend/tests/channel.service.test.ts:120:describe('channelService.getChannelBySlug', () => {
+harmony-backend/tests/channel.service.test.ts:121:  let serverSlug: string;
+harmony-backend/tests/channel.service.test.ts:125:    serverSlug = server!.slug;
+harmony-backend/tests/channel.service.test.ts:129:    const channel = await channelService.getChannelBySlug(serverSlug, 'general');
+harmony-backend/tests/channel.service.test.ts:136:      channelService.getChannelBySlug('no-such-server', 'general'),
+harmony-backend/tests/channel.service.test.ts:142:      channelService.getChannelBySlug(serverSlug, 'no-such-channel'),
+harmony-backend/tests/channel.service.test.ts:204:  it('creates a "general" TEXT PRIVATE channel at position 0', async () => {
+harmony-backend/tests/channel.service.test.ts:209:    expect(channel.visibility).toBe('PRIVATE');
+harmony-backend/tests/channel.service.test.ts:223:      visibility: 'PRIVATE',
+harmony-backend/tests/channel.service.test.ts:242:      visibility: 'PRIVATE',
+harmony-backend/tests/eventBus.test.ts:77:      oldVisibility: 'PRIVATE',
+harmony-backend/tests/eventBus.test.ts:78:      newVisibility: 'PUBLIC_INDEXABLE',
+harmony-backend/tests/eventBus.test.ts:170:      oldVisibility: 'PRIVATE' as const,
+harmony-backend/tests/eventBus.test.ts:171:      newVisibility: 'PUBLIC_NO_INDEX' as const,
+harmony-backend/tests/eventBus.test.ts:210:      oldVisibility: 'PRIVATE' as const,
+harmony-backend/tests/eventBus.test.ts:211:      newVisibility: 'PUBLIC_INDEXABLE' as const,
+harmony-backend/tests/eventBus.test.ts:218:    expect(invalidateSpy).toHaveBeenCalledWith(`channel:${TEST_CHANNEL_ID}:visibility`);
+harmony-backend/tests/channel.service.events.test.ts:55:  CacheKeys: { channelVisibility: (id: string) => `channel:${id}:visibility` },
+harmony-backend/tests/channel.service.events.test.ts:76:  visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/channel.service.events.test.ts:105:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/channel.service.events.test.ts:125:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/channel.service.events.test.ts:141:        visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/channel.service.events.test.ts:157:        visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/cache.service.test.ts:29:  it('generates correct channel visibility key', () => {
+harmony-backend/tests/cache.service.test.ts:30:    expect(CacheKeys.channelVisibility('abc-123')).toBe('channel:abc-123:visibility');
+harmony-backend/tests/cache.service.test.ts:57:    expect(CacheKeys.channelVisibility('*')).toBe('channel::visibility');
+harmony-backend/tests/cache.service.test.ts:81:    const data = { visibility: 'PUBLIC_INDEXABLE' };
+harmony-backend/tests/public.router.test.ts:5: *   GET /api/public/servers/:serverSlug
+harmony-backend/tests/public.router.test.ts:6: *   GET /api/public/servers/:serverSlug/channels
+harmony-backend/tests/public.router.test.ts:86:  visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-backend/tests/public.router.test.ts:111:// ─── GET /api/public/servers/:serverSlug ─────────────────────────────────────
+harmony-backend/tests/public.router.test.ts:113:describe('GET /api/public/servers/:serverSlug', () => {
+harmony-backend/tests/public.router.test.ts:138:// ─── GET /api/public/servers/:serverSlug/channels ────────────────────────────
+harmony-backend/tests/public.router.test.ts:140:describe('GET /api/public/servers/:serverSlug/channels', () => {
+harmony-backend/tests/public.router.test.ts:141:  it('returns 200 with PUBLIC_INDEXABLE channels when the server exists', async () => {
+harmony-backend/tests/public.router.test.ts:161:        where: expect.objectContaining({ visibility: ChannelVisibility.PUBLIC_INDEXABLE }),
+harmony-backend/tests/public.router.test.ts:166:  it('returns 200 with an empty array when the server has no public channels', async () => {
+harmony-backend/tests/public.router.test.ts:189:  it('returns 200 with paginated messages for a PUBLIC_INDEXABLE channel', async () => {
+harmony-backend/tests/public.router.test.ts:192:      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-backend/tests/public.router.test.ts:209:      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-backend/tests/public.router.test.ts:222:      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-backend/tests/public.router.test.ts:246:  it('returns 404 when the channel is PRIVATE', async () => {
+harmony-backend/tests/public.router.test.ts:249:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/public.router.test.ts:258:  it('returns 404 when the channel is PUBLIC_NO_INDEX', async () => {
+harmony-backend/tests/public.router.test.ts:261:      visibility: ChannelVisibility.PUBLIC_NO_INDEX,
+harmony-backend/tests/public.router.test.ts:274:  it('returns 200 with the message when it exists in a PUBLIC_INDEXABLE channel', async () => {
+harmony-backend/tests/public.router.test.ts:277:      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-backend/tests/public.router.test.ts:288:  it('returns 404 when the channel is PRIVATE', async () => {
+harmony-backend/tests/public.router.test.ts:291:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/public.router.test.ts:300:  it('returns 404 when the channel is PUBLIC_NO_INDEX', async () => {
+harmony-backend/tests/public.router.test.ts:303:      visibility: ChannelVisibility.PUBLIC_NO_INDEX,
+harmony-backend/tests/public.router.test.ts:326:      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:19:jest.mock('../app/settings/[serverSlug]/[channelSlug]/updateVisibility', () => ({
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:42:      serverSlug={SERVER_SLUG}
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:43:      channelSlug={CHANNEL_SLUG}
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:68:    renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:74:  it('marks the initial visibility as checked', () => {
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:75:    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:82:    renderToggle(ChannelVisibility.PRIVATE, true);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:89:    renderToggle(ChannelVisibility.PRIVATE, true);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:104:    renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:116:  it('calls onVisibilityChanged with the new visibility on success', async () => {
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:119:    const { onVisibilityChanged } = renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:125:    expect(onVisibilityChanged).toHaveBeenCalledWith(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:131:    renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:149:    renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:155:    // Should have rolled back to PRIVATE
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:163:    renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:177:    const { onVisibilityChanged } = renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:187:// ─── Confirmation modal (PRIVATE transition) ─────────────────────────────────
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:190:  it('shows a confirmation dialog when selecting PRIVATE', () => {
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:192:    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:202:    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:213:      ChannelVisibility.PRIVATE,
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:219:    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-backend/tests/permission.service.test.ts:104:    'channel:read', 'channel:create', 'channel:update', 'channel:delete', 'channel:manage_visibility',
+harmony-backend/tests/permission.service.test.ts:124:    for (const action of ['channel:create', 'channel:update', 'channel:delete', 'channel:manage_visibility'] as Action[]) {
+harmony-backend/tests/permission.service.test.ts:153:  it('moderator cannot change channel visibility', async () => {
+harmony-backend/tests/permission.service.test.ts:154:    await expect(can('MODERATOR', 'channel:manage_visibility')).resolves.toBe(false);
+harmony-backend/tests/permission.service.test.ts:200:  it('guest can read server, channels, and messages', async () => {
+harmony-backend/tests/permission.service.test.ts:206:  it('guest cannot create messages', async () => {
+harmony-backend/tests/permission.service.test.ts:210:  it('guest cannot create channels', async () => {
+harmony-backend/tests/permission.service.test.ts:214:  it('guest cannot update settings', async () => {
+harmony-backend/tests/user.service.test.ts:68:    expect(user.username).toBe('anonymous');
+harmony-backend/tests/user.service.test.ts:99:    expect(user.username).not.toBe('anonymous');
+harmony-backend/tests/channel.getAuditLog.test.ts:2: * channel.getAuditLog tRPC procedure tests — Issue #117
+harmony-backend/tests/channel.getAuditLog.test.ts:6: *   - FORBIDDEN when caller lacks channel:manage_visibility (non-admin member)
+harmony-backend/tests/channel.getAuditLog.test.ts:82:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/channel.getAuditLog.test.ts:109:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/channel.getAuditLog.test.ts:115:  // Seed a few audit log entries for pagination tests
+harmony-backend/tests/channel.getAuditLog.test.ts:117:    await prisma.visibilityAuditLog.create({
+harmony-backend/tests/channel.getAuditLog.test.ts:122:        oldValue: { visibility: 'PRIVATE' },
+harmony-backend/tests/channel.getAuditLog.test.ts:123:        newValue: { visibility: 'PUBLIC_NO_INDEX' },
+harmony-backend/tests/channel.getAuditLog.test.ts:133:  await prisma.visibilityAuditLog.deleteMany({ where: { channelId } });
+harmony-backend/tests/channel.getAuditLog.test.ts:144:describe('channel.getAuditLog — permission gate', () => {
+harmony-backend/tests/channel.getAuditLog.test.ts:146:    await expect(callerAs(null).getAuditLog({ serverId, channelId })).rejects.toMatchObject({
+harmony-backend/tests/channel.getAuditLog.test.ts:152:    await expect(callerAs(memberId).getAuditLog({ serverId, channelId })).rejects.toMatchObject({
+harmony-backend/tests/channel.getAuditLog.test.ts:160:describe('channel.getAuditLog — cross-server probe blocked', () => {
+harmony-backend/tests/channel.getAuditLog.test.ts:162:    // Admin of serverId attempts to read audit log for a channel in otherServerId.
+harmony-backend/tests/channel.getAuditLog.test.ts:165:      callerAs(adminId).getAuditLog({ serverId, channelId: otherChannelId }),
+harmony-backend/tests/channel.getAuditLog.test.ts:172:describe('channel.getAuditLog — response shape', () => {
+harmony-backend/tests/channel.getAuditLog.test.ts:174:    const result = await callerAs(adminId).getAuditLog({ serverId, channelId });
+harmony-backend/tests/channel.getAuditLog.test.ts:184:    const result = await callerAs(adminId).getAuditLog({ serverId, channelId, limit: 1 });
+harmony-backend/tests/channel.getAuditLog.test.ts:200:    const result = await callerAs(adminId).getAuditLog({ serverId, channelId });
+harmony-backend/tests/channel.getAuditLog.test.ts:211:describe('channel.getAuditLog — pagination', () => {
+harmony-backend/tests/channel.getAuditLog.test.ts:213:    const result = await callerAs(adminId).getAuditLog({ serverId, channelId, limit: 1 });
+harmony-backend/tests/channel.getAuditLog.test.ts:218:    const first = await callerAs(adminId).getAuditLog({ serverId, channelId, limit: 2, offset: 0 });
+harmony-backend/tests/channel.getAuditLog.test.ts:219:    const second = await callerAs(adminId).getAuditLog({
+harmony-backend/tests/message.replies.test.ts:47:      visibility: 'PRIVATE',
+harmony-frontend/src/__tests__/utils.test.ts:8:  getChannelUrl,
+harmony-frontend/src/__tests__/utils.test.ts:161:  describe('getChannelUrl', () => {
+harmony-frontend/src/__tests__/utils.test.ts:171:      expect(getChannelUrl('server', 'general')).toBe('https://harmony.example/c/server/general');
+harmony-frontend/src/__tests__/utils.test.ts:177:      expect(getChannelUrl('server', 'general')).toBe('http://localhost:3000/c/server/general');
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:158:    const err = new TrpcHttpError('server.getChannels', 403, '{"error":"FORBIDDEN"}');
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:160:    expect(err.procedure).toBe('server.getChannels');
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:167:    const err = new TrpcHttpError('server.getChannels', 403, '{"error":"FORBIDDEN"}');
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:172:    const err = new TrpcHttpError('server.getChannels', 401, '{"error":"UNAUTHORIZED"}');
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:177:    const err = new TrpcHttpError('server.getChannels', 500, 'Internal Server Error');
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:190:    const err = new TrpcHttpError('server.getChannels', 403, '{"error":"FORBIDDEN"}');
+harmony-backend/tests/visibility.service.test.ts:4: * Covers all visibility state transitions per §5.2 of
+harmony-backend/tests/visibility.service.test.ts:5: * dev-spec-channel-visibility-toggle.md, the VOICE guard,
+harmony-backend/tests/visibility.service.test.ts:14:import { visibilityService, SetVisibilityInput } from '../src/services/visibility.service';
+harmony-backend/tests/visibility.service.test.ts:26:  visibility: ChannelVisibility,
+harmony-backend/tests/visibility.service.test.ts:30:  visibility,
+harmony-backend/tests/visibility.service.test.ts:37:  // Create a test user for audit log foreign key
+harmony-backend/tests/visibility.service.test.ts:64:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/visibility.service.test.ts:76:      visibility: ChannelVisibility.PRIVATE,
+harmony-backend/tests/visibility.service.test.ts:105:describe('visibilityService.getVisibility', () => {
+harmony-backend/tests/visibility.service.test.ts:106:  it('returns the current visibility of a channel', async () => {
+harmony-backend/tests/visibility.service.test.ts:107:    const visibility = await visibilityService.getVisibility(textChannelId, serverId);
+harmony-backend/tests/visibility.service.test.ts:108:    expect(visibility).toBe(ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:113:      visibilityService.getVisibility('00000000-0000-0000-0000-000000000000', serverId),
+harmony-backend/tests/visibility.service.test.ts:119:      visibilityService.getVisibility(textChannelId, '00000000-0000-0000-0000-000000000000'),
+harmony-backend/tests/visibility.service.test.ts:126:describe('visibilityService.setVisibility — state transitions', () => {
+harmony-backend/tests/visibility.service.test.ts:131:      data: { visibility: vis, indexedAt: null },
+harmony-backend/tests/visibility.service.test.ts:135:  // S1 → S3: PRIVATE → PUBLIC_INDEXABLE
+harmony-backend/tests/visibility.service.test.ts:136:  it('PRIVATE → PUBLIC_INDEXABLE: sets indexedAt', async () => {
+harmony-backend/tests/visibility.service.test.ts:137:    await resetChannel(textChannelId, ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:139:    const result = await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:140:      makeInput(textChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
+harmony-backend/tests/visibility.service.test.ts:144:    expect(result.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:145:    expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+harmony-backend/tests/visibility.service.test.ts:148:    expect(channel!.visibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+harmony-backend/tests/visibility.service.test.ts:152:  // S1 → S2: PRIVATE → PUBLIC_NO_INDEX
+harmony-backend/tests/visibility.service.test.ts:153:  it('PRIVATE → PUBLIC_NO_INDEX: indexedAt remains null', async () => {
+harmony-backend/tests/visibility.service.test.ts:154:    await resetChannel(textChannelId, ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:156:    const result = await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:157:      makeInput(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX),
+harmony-backend/tests/visibility.service.test.ts:161:    expect(result.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:162:    expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-backend/tests/visibility.service.test.ts:168:  // S2 → S3: PUBLIC_NO_INDEX → PUBLIC_INDEXABLE
+harmony-backend/tests/visibility.service.test.ts:169:  it('PUBLIC_NO_INDEX → PUBLIC_INDEXABLE: sets indexedAt', async () => {
+harmony-backend/tests/visibility.service.test.ts:170:    await resetChannel(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-backend/tests/visibility.service.test.ts:172:    const result = await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:173:      makeInput(textChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
+harmony-backend/tests/visibility.service.test.ts:177:    expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-backend/tests/visibility.service.test.ts:178:    expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+harmony-backend/tests/visibility.service.test.ts:184:  // S3 → S2: PUBLIC_INDEXABLE → PUBLIC_NO_INDEX
+harmony-backend/tests/visibility.service.test.ts:185:  it('PUBLIC_INDEXABLE → PUBLIC_NO_INDEX: indexedAt unchanged', async () => {
+harmony-backend/tests/visibility.service.test.ts:186:    // Start with PUBLIC_INDEXABLE + a known indexedAt
+harmony-backend/tests/visibility.service.test.ts:190:      data: { visibility: ChannelVisibility.PUBLIC_INDEXABLE, indexedAt: knownDate },
+harmony-backend/tests/visibility.service.test.ts:193:    const result = await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:194:      makeInput(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX),
+harmony-backend/tests/visibility.service.test.ts:198:    expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+harmony-backend/tests/visibility.service.test.ts:199:    expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-backend/tests/visibility.service.test.ts:202:    expect(channel!.visibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-backend/tests/visibility.service.test.ts:206:  // S3 → S1: PUBLIC_INDEXABLE → PRIVATE (clears indexedAt)
+harmony-backend/tests/visibility.service.test.ts:207:  it('PUBLIC_INDEXABLE → PRIVATE: clears indexedAt', async () => {
+harmony-backend/tests/visibility.service.test.ts:211:        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-backend/tests/visibility.service.test.ts:216:    const result = await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:217:      makeInput(textChannelId, ChannelVisibility.PRIVATE),
+harmony-backend/tests/visibility.service.test.ts:221:    expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+harmony-backend/tests/visibility.service.test.ts:222:    expect(result.newVisibility).toBe(ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:225:    expect(channel!.visibility).toBe(ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:229:  // S2 → S1: PUBLIC_NO_INDEX → PRIVATE
+harmony-backend/tests/visibility.service.test.ts:230:  it('PUBLIC_NO_INDEX → PRIVATE: clears indexedAt', async () => {
+harmony-backend/tests/visibility.service.test.ts:234:      data: { visibility: ChannelVisibility.PUBLIC_NO_INDEX, indexedAt: new Date('2026-01-01T00:00:00Z') },
+harmony-backend/tests/visibility.service.test.ts:237:    const result = await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:238:      makeInput(textChannelId, ChannelVisibility.PRIVATE),
+harmony-backend/tests/visibility.service.test.ts:242:    expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-backend/tests/visibility.service.test.ts:243:    expect(result.newVisibility).toBe(ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:249:  // No-op: same visibility
+harmony-backend/tests/visibility.service.test.ts:250:  it('same visibility (no-op): succeeds without changing indexedAt', async () => {
+harmony-backend/tests/visibility.service.test.ts:251:    await resetChannel(textChannelId, ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:253:    const result = await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:254:      makeInput(textChannelId, ChannelVisibility.PRIVATE),
+harmony-backend/tests/visibility.service.test.ts:258:    expect(result.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:259:    expect(result.newVisibility).toBe(ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:265:describe('visibilityService.setVisibility — VOICE guard', () => {
+harmony-backend/tests/visibility.service.test.ts:266:  it('rejects VOICE channel → PUBLIC_INDEXABLE', async () => {
+harmony-backend/tests/visibility.service.test.ts:268:      visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:269:        makeInput(voiceChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
+harmony-backend/tests/visibility.service.test.ts:274:  it('allows VOICE channel → PUBLIC_NO_INDEX', async () => {
+harmony-backend/tests/visibility.service.test.ts:275:    const result = await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:276:      makeInput(voiceChannelId, ChannelVisibility.PUBLIC_NO_INDEX),
+harmony-backend/tests/visibility.service.test.ts:281:  it('allows VOICE channel → PRIVATE', async () => {
+harmony-backend/tests/visibility.service.test.ts:282:    const result = await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:283:      makeInput(voiceChannelId, ChannelVisibility.PRIVATE),
+harmony-backend/tests/visibility.service.test.ts:291:describe('visibilityService.setVisibility — error cases', () => {
+harmony-backend/tests/visibility.service.test.ts:294:      visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:295:        makeInput('00000000-0000-0000-0000-000000000000', ChannelVisibility.PUBLIC_INDEXABLE),
+harmony-backend/tests/visibility.service.test.ts:315:      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-backend/tests/visibility.service.test.ts:320:    await expect(visibilityService.setVisibility(input)).rejects.toThrow(TRPCError);
+harmony-backend/tests/visibility.service.test.ts:326:describe('visibilityService.setVisibility — audit logging', () => {
+harmony-backend/tests/visibility.service.test.ts:327:  it('creates an audit log entry on visibility change', async () => {
+harmony-backend/tests/visibility.service.test.ts:331:      data: { visibility: ChannelVisibility.PRIVATE, indexedAt: null },
+harmony-backend/tests/visibility.service.test.ts:334:    const result = await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:335:      makeInput(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX),
+harmony-backend/tests/visibility.service.test.ts:340:    const auditEntry = await prisma.visibilityAuditLog.findUnique({
+harmony-backend/tests/visibility.service.test.ts:352:describe('visibilityService.setVisibility — VISIBILITY_CHANGED event', () => {
+harmony-backend/tests/visibility.service.test.ts:357:      data: { visibility: ChannelVisibility.PRIVATE, indexedAt: null },
+harmony-backend/tests/visibility.service.test.ts:381:    await visibilityService.setVisibility(
+harmony-backend/tests/visibility.service.test.ts:382:      makeInput(textChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
+harmony-backend/tests/visibility.service.test.ts:411:    expect(payload.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+harmony-backend/tests/visibility.service.test.ts:412:    expect(payload.newVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+harmony-frontend/src/__tests__/channelService.test.ts:13:  publicGet: jest.fn(),
+harmony-frontend/src/__tests__/channelService.test.ts:33:import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+harmony-frontend/src/__tests__/channelService.test.ts:36:  getChannels,
+harmony-frontend/src/__tests__/channelService.test.ts:37:  getChannel,
+harmony-frontend/src/__tests__/channelService.test.ts:41:  getAuditLog,
+harmony-frontend/src/__tests__/channelService.test.ts:46:const mockedPublicGet = jest.mocked(publicGet);
+harmony-frontend/src/__tests__/channelService.test.ts:59:    visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:75:    oldValue: { visibility: 'PRIVATE' },
+harmony-frontend/src/__tests__/channelService.test.ts:76:    newValue: { visibility: 'PUBLIC_INDEXABLE' },
+harmony-frontend/src/__tests__/channelService.test.ts:97:  // ── getChannels ──────────────────────────────────────────────────────────
+harmony-frontend/src/__tests__/channelService.test.ts:99:  describe('getChannels', () => {
+harmony-frontend/src/__tests__/channelService.test.ts:104:      const result = await getChannels('srv-1');
+harmony-frontend/src/__tests__/channelService.test.ts:106:      expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getChannels', { serverId: 'srv-1' });
+harmony-frontend/src/__tests__/channelService.test.ts:115:      const result = await getChannels('srv-1');
+harmony-frontend/src/__tests__/channelService.test.ts:123:      await expect(getChannels('srv-1')).rejects.toThrow('Network error');
+harmony-frontend/src/__tests__/channelService.test.ts:127:  // ── getChannel ───────────────────────────────────────────────────────────
+harmony-frontend/src/__tests__/channelService.test.ts:129:  describe('getChannel', () => {
+harmony-frontend/src/__tests__/channelService.test.ts:134:          channels: [makeRawChannel({ serverId: undefined, visibility: undefined })],
+harmony-frontend/src/__tests__/channelService.test.ts:135:        } as never); // public channels
+harmony-frontend/src/__tests__/channelService.test.ts:137:      const result = await getChannel('my-server', 'general');
+harmony-frontend/src/__tests__/channelService.test.ts:143:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:150:      const result = await getChannel('missing-server', 'general');
+harmony-frontend/src/__tests__/channelService.test.ts:160:      mockedTrpcQuery.mockResolvedValue(makeRawChannel({ visibility: 'PRIVATE' }));
+harmony-frontend/src/__tests__/channelService.test.ts:162:      const result = await getChannel('my-server', 'general');
+harmony-frontend/src/__tests__/channelService.test.ts:164:      expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getChannel', {
+harmony-frontend/src/__tests__/channelService.test.ts:166:        serverSlug: 'my-server',
+harmony-frontend/src/__tests__/channelService.test.ts:167:        channelSlug: 'general',
+harmony-frontend/src/__tests__/channelService.test.ts:169:      expect(result).toMatchObject({ id: 'ch-1', visibility: 'PRIVATE' });
+harmony-frontend/src/__tests__/channelService.test.ts:178:      const result = await getChannel('my-server', 'general');
+harmony-frontend/src/__tests__/channelService.test.ts:190:      const result = await getChannel('my-server', 'general');
+harmony-frontend/src/__tests__/channelService.test.ts:202:      const result = await getChannel('my-server', 'general');
+harmony-frontend/src/__tests__/channelService.test.ts:213:      const result = await getChannel('my-server', 'general');
+harmony-frontend/src/__tests__/channelService.test.ts:225:      await expect(getChannel('my-server', 'general')).rejects.toThrow('DNS failure');
+harmony-frontend/src/__tests__/channelService.test.ts:244:      const result = await getChannel('my-server', 'public-chan');
+harmony-frontend/src/__tests__/channelService.test.ts:249:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:258:      await getChannel('my server', 'general');
+harmony-frontend/src/__tests__/channelService.test.ts:268:      ['PRIVATE', ChannelVisibility.PRIVATE],
+harmony-frontend/src/__tests__/channelService.test.ts:269:      ['PUBLIC_INDEXABLE', ChannelVisibility.PUBLIC_INDEXABLE],
+harmony-frontend/src/__tests__/channelService.test.ts:270:      ['PUBLIC_NO_INDEX', ChannelVisibility.PUBLIC_NO_INDEX],
+harmony-frontend/src/__tests__/channelService.test.ts:279:        visibility: value,
+harmony-frontend/src/__tests__/channelService.test.ts:287:        updateVisibility('ch-1', ChannelVisibility.PUBLIC_INDEXABLE, 'srv-1'),
+harmony-frontend/src/__tests__/channelService.test.ts:354:        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/channelService.test.ts:367:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:380:        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/channelService.test.ts:392:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:404:        visibility: ChannelVisibility.PRIVATE,
+harmony-frontend/src/__tests__/channelService.test.ts:417:      ['PUBLIC_NO_INDEX', ChannelVisibility.PUBLIC_NO_INDEX],
+harmony-frontend/src/__tests__/channelService.test.ts:418:      ['PRIVATE', ChannelVisibility.PRIVATE],
+harmony-frontend/src/__tests__/channelService.test.ts:419:    ] as const)('forwards %s visibility through the mutation payload', async (_label, vis) => {
+harmony-frontend/src/__tests__/channelService.test.ts:425:        visibility: vis,
+harmony-frontend/src/__tests__/channelService.test.ts:434:        expect.objectContaining({ visibility: vis }),
+harmony-frontend/src/__tests__/channelService.test.ts:447:          visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/channelService.test.ts:454:  // ── getAuditLog ──────────────────────────────────────────────────────────
+harmony-frontend/src/__tests__/channelService.test.ts:456:  describe('getAuditLog', () => {
+harmony-frontend/src/__tests__/channelService.test.ts:457:    it('returns mapped audit log entries with total', async () => {
+harmony-frontend/src/__tests__/channelService.test.ts:463:      const result = await getAuditLog('srv-1', 'ch-1');
+harmony-frontend/src/__tests__/channelService.test.ts:465:      expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getAuditLog', {
+harmony-frontend/src/__tests__/channelService.test.ts:481:      await getAuditLog('srv-1', 'ch-1', { limit: 10, offset: 20, startDate: '2025-01-01' });
+harmony-frontend/src/__tests__/channelService.test.ts:483:      expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getAuditLog', {
+harmony-frontend/src/__tests__/channelService.test.ts:495:      await expect(getAuditLog('srv-1', 'ch-1')).rejects.toThrow('Unauthorized');
+harmony-frontend/src/__tests__/channelService.test.ts:523:  describe('toFrontendChannel (via getChannels)', () => {
+harmony-frontend/src/__tests__/channelService.test.ts:527:      const [channel] = await getChannels('srv-1');
+harmony-frontend/src/__tests__/channelService.test.ts:535:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:547:      const [channel] = await getChannels('srv-1');
+harmony-frontend/src/__tests__/channelService.test.ts:555:      const [channel] = await getChannels('srv-1');
+harmony-frontend/src/__tests__/channelService.test.ts:565:      await getChannels('srv-1');
+harmony-frontend/src/__tests__/channelService.test.ts:576:  describe('toAuditLogEntry (via getAuditLog)', () => {
+harmony-frontend/src/__tests__/channelService.test.ts:583:      const { entries } = await getAuditLog('srv-1', 'ch-1');
+harmony-frontend/src/__tests__/channelService.test.ts:590:        oldValue: { visibility: 'PRIVATE' },
+harmony-frontend/src/__tests__/channelService.test.ts:591:        newValue: { visibility: 'PUBLIC_INDEXABLE' },
+harmony-frontend/src/__tests__/channelService.test.ts:604:      await getAuditLog('srv-1', 'ch-1');
+harmony-frontend/src/__tests__/channelService.test.ts:618:      const { entries } = await getAuditLog('srv-1', 'ch-1');
+harmony-frontend/src/__tests__/channelService.test.ts:633:      const { entries } = await getAuditLog('srv-1', 'ch-1');
+harmony-frontend/src/__tests__/channelService.test.ts:642:    it('exposes all visibility enum values', () => {
+harmony-frontend/src/__tests__/channelService.test.ts:643:      expect(ChannelVisibility.PUBLIC_INDEXABLE).toBe('PUBLIC_INDEXABLE');
+harmony-frontend/src/__tests__/channelService.test.ts:644:      expect(ChannelVisibility.PUBLIC_NO_INDEX).toBe('PUBLIC_NO_INDEX');
+harmony-frontend/src/__tests__/channelService.test.ts:645:      expect(ChannelVisibility.PRIVATE).toBe('PRIVATE');
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:15:47.015Z
+
+I’ve got the broad mapping. I’m reading the handful of tests that matter most for these two stories now so I can answer at the level of actual behaviors covered, not just keyword matches.
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,240p' harmony-frontend/src/__tests__/VisibilityToggle.test.tsx
+```
+
+Output:
+
+```text
+/**
+ * VisibilityToggle.test.tsx — Issue #117
+ *
+ * Tests the optimistic update and rollback behavior of the VisibilityToggle component.
+ *
+ * updateChannelVisibility (server action) is mocked to avoid real API calls.
+ * useToast is mocked to avoid needing ToastProvider in the test tree.
+ */
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { VisibilityToggle } from '../components/channel/VisibilityToggle';
+import { ChannelVisibility } from '../types';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockUpdateChannelVisibility = jest.fn();
+
+jest.mock('../app/settings/[serverSlug]/[channelSlug]/updateVisibility', () => ({
+  updateChannelVisibility: (...args: unknown[]) => mockUpdateChannelVisibility(...args),
+}));
+
+const mockShowToast = jest.fn();
+
+jest.mock('../hooks/useToast', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+    dismissToast: jest.fn(),
+    cancelAutoDismiss: jest.fn(),
+  }),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SERVER_SLUG = 'test-server';
+const CHANNEL_SLUG = 'test-channel';
+
+function renderToggle(initialVisibility: ChannelVisibility, disabled = false) {
+  const onVisibilityChanged = jest.fn();
+  const utils = render(
+    <VisibilityToggle
+      serverSlug={SERVER_SLUG}
+      channelSlug={CHANNEL_SLUG}
+      initialVisibility={initialVisibility}
+      disabled={disabled}
+      onVisibilityChanged={onVisibilityChanged}
+    />,
+  );
+  return { ...utils, onVisibilityChanged };
+}
+
+function getOptionButton(label: string) {
+  return screen.getByRole('radio', { name: (accessibleName) =>
+    accessibleName.toLowerCase().includes(label.toLowerCase()),
+  });
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+
+describe('VisibilityToggle — rendering', () => {
+  it('renders all three options', () => {
+    renderToggle(ChannelVisibility.PRIVATE);
+    expect(getOptionButton('Public (Search Indexed)')).toBeInTheDocument();
+    expect(getOptionButton('Public (Not Indexed)')).toBeInTheDocument();
+    expect(getOptionButton('Private')).toBeInTheDocument();
+  });
+
+  it('marks the initial visibility as checked', () => {
+    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+    expect(getOptionButton('Public (Not Indexed)')).toHaveAttribute('aria-checked', 'true');
+    expect(getOptionButton('Public (Search Indexed)')).toHaveAttribute('aria-checked', 'false');
+    expect(getOptionButton('Private')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('disables all options when disabled=true', () => {
+    renderToggle(ChannelVisibility.PRIVATE, true);
+    expect(getOptionButton('Public (Search Indexed)')).toBeDisabled();
+    expect(getOptionButton('Public (Not Indexed)')).toBeDisabled();
+    expect(getOptionButton('Private')).toBeDisabled();
+  });
+
+  it('shows admin-only hint when disabled', () => {
+    renderToggle(ChannelVisibility.PRIVATE, true);
+    expect(screen.getByText(/only administrators can change/i)).toBeInTheDocument();
+  });
+});
+
+// ─── Optimistic update ────────────────────────────────────────────────────────
+
+describe('VisibilityToggle — optimistic update', () => {
+  it('immediately marks the clicked option as checked before the API resolves', async () => {
+    // Defer resolution so we can observe the intermediate state
+    let resolveUpdate!: () => void;
+    mockUpdateChannelVisibility.mockReturnValue(
+      new Promise<void>((resolve) => { resolveUpdate = resolve; }),
+    );
+
+    renderToggle(ChannelVisibility.PRIVATE);
+
+    fireEvent.click(getOptionButton('Public (Search Indexed)'));
+
+    // Optimistic update should be visible before the promise resolves
+    expect(getOptionButton('Public (Search Indexed)')).toHaveAttribute('aria-checked', 'true');
+    expect(getOptionButton('Private')).toHaveAttribute('aria-checked', 'false');
+
+    // Clean up: resolve the pending promise
+    await act(async () => { resolveUpdate(); });
+  });
+
+  it('calls onVisibilityChanged with the new visibility on success', async () => {
+    mockUpdateChannelVisibility.mockResolvedValue(undefined);
+
+    const { onVisibilityChanged } = renderToggle(ChannelVisibility.PRIVATE);
+
+    await act(async () => {
+      fireEvent.click(getOptionButton('Public (Not Indexed)'));
+    });
+
+    expect(onVisibilityChanged).toHaveBeenCalledWith(ChannelVisibility.PUBLIC_NO_INDEX);
+  });
+
+  it('shows a success toast on successful save', async () => {
+    mockUpdateChannelVisibility.mockResolvedValue(undefined);
+
+    renderToggle(ChannelVisibility.PRIVATE);
+
+    await act(async () => {
+      fireEvent.click(getOptionButton('Public (Not Indexed)'));
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success' }),
+    );
+  });
+});
+
+// ─── Rollback on error ────────────────────────────────────────────────────────
+
+describe('VisibilityToggle — rollback on error', () => {
+  it('reverts to the previous selection when the API call fails', async () => {
+    mockUpdateChannelVisibility.mockRejectedValue(new Error('Network error'));
+
+    renderToggle(ChannelVisibility.PRIVATE);
+
+    await act(async () => {
+      fireEvent.click(getOptionButton('Public (Search Indexed)'));
+    });
+
+    // Should have rolled back to PRIVATE
+    expect(getOptionButton('Private')).toHaveAttribute('aria-checked', 'true');
+    expect(getOptionButton('Public (Search Indexed)')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('shows an error toast when the API call fails', async () => {
+    mockUpdateChannelVisibility.mockRejectedValue(new Error('Network error'));
+
+    renderToggle(ChannelVisibility.PRIVATE);
+
+    await act(async () => {
+      fireEvent.click(getOptionButton('Public (Search Indexed)'));
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' }),
+    );
+  });
+
+  it('does NOT call onVisibilityChanged when the API call fails', async () => {
+    mockUpdateChannelVisibility.mockRejectedValue(new Error('Network error'));
+
+    const { onVisibilityChanged } = renderToggle(ChannelVisibility.PRIVATE);
+
+    await act(async () => {
+      fireEvent.click(getOptionButton('Public (Search Indexed)'));
+    });
+
+    expect(onVisibilityChanged).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Confirmation modal (PRIVATE transition) ─────────────────────────────────
+
+describe('VisibilityToggle — confirmation modal', () => {
+  it('shows a confirmation dialog when selecting PRIVATE', () => {
+    mockUpdateChannelVisibility.mockResolvedValue(undefined);
+    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+
+    fireEvent.click(getOptionButton('Private'));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/make channel private/i)).toBeInTheDocument();
+  });
+
+  it('applies the change after confirmation', async () => {
+    mockUpdateChannelVisibility.mockResolvedValue(undefined);
+    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+
+    fireEvent.click(getOptionButton('Private'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /make private/i }));
+    });
+
+    expect(mockUpdateChannelVisibility).toHaveBeenCalledWith(
+      SERVER_SLUG,
+      CHANNEL_SLUG,
+      ChannelVisibility.PRIVATE,
+    );
+  });
+
+  it('cancels without changing selection', async () => {
+    mockUpdateChannelVisibility.mockResolvedValue(undefined);
+    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+
+    fireEvent.click(getOptionButton('Private'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    });
+
+    expect(mockUpdateChannelVisibility).not.toHaveBeenCalled();
+    expect(getOptionButton('Public (Not Indexed)')).toHaveAttribute('aria-checked', 'true');
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,260p' harmony-backend/tests/visibility.service.test.ts
+```
+
+Output:
+
+```text
+/**
+ * Visibility service tests — Issue #105
+ *
+ * Covers all visibility state transitions per §5.2 of
+ * dev-spec-channel-visibility-toggle.md, the VOICE guard,
+ * indexedAt timestamp management, and event emission.
+ *
+ * Requires DATABASE_URL pointing at a running Postgres instance
+ * and REDIS_URL for event bus tests.
+ */
+
+import { ChannelVisibility, ChannelType } from '@prisma/client';
+import { TRPCError } from '@trpc/server';
+import { visibilityService, SetVisibilityInput } from '../src/services/visibility.service';
+import { eventBus, EventChannels, VisibilityChangedPayload } from '../src/events/eventBus';
+import { prisma } from '../src/db/prisma';
+
+let serverId: string;
+let userId: string;
+let textChannelId: string;
+let voiceChannelId: string;
+let otherServerId: string | null = null;
+
+const makeInput = (
+  channelId: string,
+  visibility: ChannelVisibility,
+): SetVisibilityInput => ({
+  channelId,
+  serverId,
+  visibility,
+  actorId: userId,
+  ip: '127.0.0.1',
+  userAgent: 'test-agent',
+});
+
+beforeAll(async () => {
+  // Create a test user for audit log foreign key
+  const user = await prisma.user.create({
+    data: {
+      email: `vis-test-${Date.now()}@test.com`,
+      username: `vis-test-${Date.now()}`,
+      passwordHash: '$2a$10$placeholder',
+      displayName: 'Vis Test User',
+    },
+  });
+  userId = user.id;
+
+  const server = await prisma.server.create({
+    data: {
+      name: 'Visibility Test Server',
+      slug: `vis-test-${Date.now()}`,
+      isPublic: false,
+      ownerId: userId,
+    },
+  });
+  serverId = server.id;
+
+  const textChannel = await prisma.channel.create({
+    data: {
+      serverId,
+      name: 'vis-text',
+      slug: 'vis-text',
+      type: ChannelType.TEXT,
+      visibility: ChannelVisibility.PRIVATE,
+      position: 0,
+    },
+  });
+  textChannelId = textChannel.id;
+
+  const voiceChannel = await prisma.channel.create({
+    data: {
+      serverId,
+      name: 'vis-voice',
+      slug: 'vis-voice',
+      type: ChannelType.VOICE,
+      visibility: ChannelVisibility.PRIVATE,
+      position: 1,
+    },
+  });
+  voiceChannelId = voiceChannel.id;
+});
+
+afterAll(async () => {
+  if (otherServerId) {
+    await prisma.server.delete({ where: { id: otherServerId } }).catch((err) => {
+      console.error('Cleanup: failed to delete other test server:', err);
+    });
+  }
+  if (serverId) {
+    await prisma.server.delete({ where: { id: serverId } }).catch((err) => {
+      console.error('Cleanup: failed to delete test server:', err);
+    });
+  }
+  if (userId) {
+    await prisma.user.delete({ where: { id: userId } }).catch((err) => {
+      console.error('Cleanup: failed to delete test user:', err);
+    });
+  }
+  await eventBus.disconnect();
+  await prisma.$disconnect();
+});
+
+// ─── getVisibility ───────────────────────────────────────────────────────────
+
+describe('visibilityService.getVisibility', () => {
+  it('returns the current visibility of a channel', async () => {
+    const visibility = await visibilityService.getVisibility(textChannelId, serverId);
+    expect(visibility).toBe(ChannelVisibility.PRIVATE);
+  });
+
+  it('throws NOT_FOUND for unknown channelId', async () => {
+    await expect(
+      visibilityService.getVisibility('00000000-0000-0000-0000-000000000000', serverId),
+    ).rejects.toThrow(TRPCError);
+  });
+
+  it('throws NOT_FOUND when channelId does not belong to serverId', async () => {
+    await expect(
+      visibilityService.getVisibility(textChannelId, '00000000-0000-0000-0000-000000000000'),
+    ).rejects.toThrow(TRPCError);
+  });
+});
+
+// ─── State transitions (§5.2) ────────────────────────────────────────────────
+
+describe('visibilityService.setVisibility — state transitions', () => {
+  // Helper to reset channel to a known state before each transition test
+  async function resetChannel(channelId: string, vis: ChannelVisibility) {
+    await prisma.channel.update({
+      where: { id: channelId },
+      data: { visibility: vis, indexedAt: null },
+    });
+  }
+
+  // S1 → S3: PRIVATE → PUBLIC_INDEXABLE
+  it('PRIVATE → PUBLIC_INDEXABLE: sets indexedAt', async () => {
+    await resetChannel(textChannelId, ChannelVisibility.PRIVATE);
+
+    const result = await visibilityService.setVisibility(
+      makeInput(textChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+    expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+
+    const channel = await prisma.channel.findUnique({ where: { id: textChannelId } });
+    expect(channel!.visibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+    expect(channel!.indexedAt).not.toBeNull();
+  });
+
+  // S1 → S2: PRIVATE → PUBLIC_NO_INDEX
+  it('PRIVATE → PUBLIC_NO_INDEX: indexedAt remains null', async () => {
+    await resetChannel(textChannelId, ChannelVisibility.PRIVATE);
+
+    const result = await visibilityService.setVisibility(
+      makeInput(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+    expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+
+    const channel = await prisma.channel.findUnique({ where: { id: textChannelId } });
+    expect(channel!.indexedAt).toBeNull();
+  });
+
+  // S2 → S3: PUBLIC_NO_INDEX → PUBLIC_INDEXABLE
+  it('PUBLIC_NO_INDEX → PUBLIC_INDEXABLE: sets indexedAt', async () => {
+    await resetChannel(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX);
+
+    const result = await visibilityService.setVisibility(
+      makeInput(textChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+    expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+
+    const channel = await prisma.channel.findUnique({ where: { id: textChannelId } });
+    expect(channel!.indexedAt).not.toBeNull();
+  });
+
+  // S3 → S2: PUBLIC_INDEXABLE → PUBLIC_NO_INDEX
+  it('PUBLIC_INDEXABLE → PUBLIC_NO_INDEX: indexedAt unchanged', async () => {
+    // Start with PUBLIC_INDEXABLE + a known indexedAt
+    const knownDate = new Date('2026-01-01T00:00:00Z');
+    await prisma.channel.update({
+      where: { id: textChannelId },
+      data: { visibility: ChannelVisibility.PUBLIC_INDEXABLE, indexedAt: knownDate },
+    });
+
+    const result = await visibilityService.setVisibility(
+      makeInput(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+    expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+
+    const channel = await prisma.channel.findUnique({ where: { id: textChannelId } });
+    expect(channel!.visibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+    expect(channel!.indexedAt).toEqual(knownDate);
+  });
+
+  // S3 → S1: PUBLIC_INDEXABLE → PRIVATE (clears indexedAt)
+  it('PUBLIC_INDEXABLE → PRIVATE: clears indexedAt', async () => {
+    await prisma.channel.update({
+      where: { id: textChannelId },
+      data: {
+        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+        indexedAt: new Date(),
+      },
+    });
+
+    const result = await visibilityService.setVisibility(
+      makeInput(textChannelId, ChannelVisibility.PRIVATE),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+    expect(result.newVisibility).toBe(ChannelVisibility.PRIVATE);
+
+    const channel = await prisma.channel.findUnique({ where: { id: textChannelId } });
+    expect(channel!.visibility).toBe(ChannelVisibility.PRIVATE);
+    expect(channel!.indexedAt).toBeNull();
+  });
+
+  // S2 → S1: PUBLIC_NO_INDEX → PRIVATE
+  it('PUBLIC_NO_INDEX → PRIVATE: clears indexedAt', async () => {
+    // Set indexedAt to a non-null value so we can verify it gets cleared
+    await prisma.channel.update({
+      where: { id: textChannelId },
+      data: { visibility: ChannelVisibility.PUBLIC_NO_INDEX, indexedAt: new Date('2026-01-01T00:00:00Z') },
+    });
+
+    const result = await visibilityService.setVisibility(
+      makeInput(textChannelId, ChannelVisibility.PRIVATE),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+    expect(result.newVisibility).toBe(ChannelVisibility.PRIVATE);
+
+    const channel = await prisma.channel.findUnique({ where: { id: textChannelId } });
+    expect(channel!.indexedAt).toBeNull();
+  });
+
+  // No-op: same visibility
+  it('same visibility (no-op): succeeds without changing indexedAt', async () => {
+    await resetChannel(textChannelId, ChannelVisibility.PRIVATE);
+
+    const result = await visibilityService.setVisibility(
+      makeInput(textChannelId, ChannelVisibility.PRIVATE),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+    expect(result.newVisibility).toBe(ChannelVisibility.PRIVATE);
+  });
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,260p' harmony-backend/tests/public.router.test.ts
+```
+
+Output:
+
+```text
+/**
+ * Public REST API route tests — Issue #108
+ *
+ * Coverage for unauthenticated endpoints:
+ *   GET /api/public/servers/:serverSlug
+ *   GET /api/public/servers/:serverSlug/channels
+ *   GET /api/public/channels/:channelId/messages
+ *   GET /api/public/channels/:channelId/messages/:messageId
+ *
+ * Prisma and cacheService are mocked so no running database or Redis is required.
+ */
+
+import request from 'supertest';
+import { createApp } from '../src/app';
+import { ChannelVisibility, ChannelType } from '@prisma/client';
+import { _clearBucketsForTesting } from '../src/middleware/rate-limit.middleware';
+
+// ─── Mock Prisma ──────────────────────────────────────────────────────────────
+
+jest.mock('../src/db/prisma', () => ({
+  prisma: {
+    server: { findUnique: jest.fn() },
+    channel: { findUnique: jest.fn(), findMany: jest.fn() },
+    message: { findMany: jest.fn(), findFirst: jest.fn() },
+  },
+}));
+
+import { prisma } from '../src/db/prisma';
+
+const mockPrisma = prisma as unknown as {
+  server: { findUnique: jest.Mock };
+  channel: { findUnique: jest.Mock; findMany: jest.Mock };
+  message: { findMany: jest.Mock; findFirst: jest.Mock };
+};
+
+// ─── Mock cacheService (bypass Redis) ────────────────────────────────────────
+//
+// Always returning null from get() means every request is a cache miss,
+// so the route handler runs in full on every test.
+
+jest.mock('../src/services/cache.service', () => {
+  const { ChannelVisibility } = jest.requireActual('@prisma/client');
+
+  return {
+    cacheService: {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      isStale: jest.fn().mockReturnValue(false),
+      getOrRevalidate: jest
+        .fn()
+        .mockImplementation(async (_key: string, fetcher: () => Promise<unknown>) => fetcher()),
+    },
+    // Re-export constants that the router imports
+    CacheKeys: {
+      channelMessages: (id: string, page: number) => `channel:msgs:${id}:page:${page}`,
+      serverInfo: (id: string) => `server:${id}:info`,
+    },
+    CacheTTL: {
+      channelMessages: 60,
+      serverInfo: 300,
+    },
+    sanitizeKeySegment: (s: string) => s.replace(/[*?[\]]/g, ''),
+    ChannelVisibility, // keep the real enum available if needed elsewhere
+  };
+});
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const SERVER = {
+  id: 'srv-0000-0000-0000-000000000001',
+  name: 'Test Server',
+  slug: 'test-server',
+  iconUrl: null,
+  description: 'A test server',
+  memberCount: 42,
+  createdAt: new Date('2025-01-01T00:00:00Z'),
+};
+
+const CHANNEL = {
+  id: 'chn-0000-0000-0000-000000000001',
+  serverId: SERVER.id,
+  name: 'general',
+  slug: 'general',
+  type: ChannelType.TEXT,
+  topic: 'General discussion',
+  visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+  position: 0,
+};
+
+const MESSAGE = {
+  id: 'msg-0000-0000-0000-000000000001',
+  content: 'Hello, world!',
+  createdAt: new Date('2025-06-01T12:00:00Z'),
+  editedAt: null,
+  author: { id: 'usr-0000-0000-0000-000000000001', username: 'alice' },
+};
+
+// ─── Test setup ───────────────────────────────────────────────────────────────
+
+let app: ReturnType<typeof createApp>;
+
+beforeAll(() => {
+  app = createApp();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _clearBucketsForTesting();
+});
+
+// ─── GET /api/public/servers/:serverSlug ─────────────────────────────────────
+
+describe('GET /api/public/servers/:serverSlug', () => {
+  it('returns 200 with server info when the server exists', async () => {
+    mockPrisma.server.findUnique.mockResolvedValue(SERVER);
+
+    const res = await request(app).get(`/api/public/servers/${SERVER.slug}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      id: SERVER.id,
+      name: SERVER.name,
+      slug: SERVER.slug,
+      memberCount: SERVER.memberCount,
+    });
+  });
+
+  it('returns 404 when the server slug does not exist', async () => {
+    mockPrisma.server.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/public/servers/does-not-exist');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+});
+
+// ─── GET /api/public/servers/:serverSlug/channels ────────────────────────────
+
+describe('GET /api/public/servers/:serverSlug/channels', () => {
+  it('returns 200 with PUBLIC_INDEXABLE channels when the server exists', async () => {
+    mockPrisma.server.findUnique.mockResolvedValue({ id: SERVER.id });
+    mockPrisma.channel.findMany.mockResolvedValue([
+      {
+        id: CHANNEL.id,
+        name: CHANNEL.name,
+        slug: CHANNEL.slug,
+        type: CHANNEL.type,
+        topic: CHANNEL.topic,
+      },
+    ]);
+
+    const res = await request(app).get(`/api/public/servers/${SERVER.slug}/channels`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('channels');
+    expect(res.body.channels).toHaveLength(1);
+    expect(res.body.channels[0]).toMatchObject({ id: CHANNEL.id, name: CHANNEL.name });
+    expect(mockPrisma.channel.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ visibility: ChannelVisibility.PUBLIC_INDEXABLE }),
+      }),
+    );
+  });
+
+  it('returns 200 with an empty array when the server has no public channels', async () => {
+    mockPrisma.server.findUnique.mockResolvedValue({ id: SERVER.id });
+    mockPrisma.channel.findMany.mockResolvedValue([]);
+
+    const res = await request(app).get(`/api/public/servers/${SERVER.slug}/channels`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.channels).toHaveLength(0);
+  });
+
+  it('returns 404 when the server slug does not exist', async () => {
+    mockPrisma.server.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/public/servers/does-not-exist/channels');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+});
+
+// ─── GET /api/public/channels/:channelId/messages ────────────────────────────
+
+describe('GET /api/public/channels/:channelId/messages', () => {
+  it('returns 200 with paginated messages for a PUBLIC_INDEXABLE channel', async () => {
+    mockPrisma.channel.findUnique.mockResolvedValue({
+      id: CHANNEL.id,
+      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+    });
+    mockPrisma.message.findMany.mockResolvedValue([MESSAGE]);
+
+    const res = await request(app).get(`/api/public/channels/${CHANNEL.id}/messages`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('messages');
+    expect(res.body.messages).toHaveLength(1);
+    expect(res.body.messages[0]).toMatchObject({ id: MESSAGE.id, content: MESSAGE.content });
+    expect(res.body).toHaveProperty('page', 1);
+    expect(res.body).toHaveProperty('pageSize', 50);
+  });
+
+  it('returns 200 respecting the ?page query parameter', async () => {
+    mockPrisma.channel.findUnique.mockResolvedValue({
+      id: CHANNEL.id,
+      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+    });
+    mockPrisma.message.findMany.mockResolvedValue([]);
+
+    const res = await request(app).get(`/api/public/channels/${CHANNEL.id}/messages?page=3`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('page', 3);
+  });
+
+  it('clamps invalid ?page values to 1', async () => {
+    mockPrisma.channel.findUnique.mockResolvedValue({
+      id: CHANNEL.id,
+      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+    });
+    mockPrisma.message.findMany.mockResolvedValue([]);
+
+    const zeroPage = await request(app).get(`/api/public/channels/${CHANNEL.id}/messages?page=0`);
+    expect(zeroPage.status).toBe(200);
+    expect(zeroPage.body).toHaveProperty('page', 1);
+
+    _clearBucketsForTesting();
+
+    const negPage = await request(app).get(`/api/public/channels/${CHANNEL.id}/messages?page=-5`);
+    expect(negPage.status).toBe(200);
+    expect(negPage.body).toHaveProperty('page', 1);
+  });
+
+  it('returns 404 when the channel does not exist', async () => {
+    mockPrisma.channel.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/public/channels/no-such-channel/messages');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 404 when the channel is PRIVATE', async () => {
+    mockPrisma.channel.findUnique.mockResolvedValue({
+      id: CHANNEL.id,
+      visibility: ChannelVisibility.PRIVATE,
+    });
+
+    const res = await request(app).get(`/api/public/channels/${CHANNEL.id}/messages`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 404 when the channel is PUBLIC_NO_INDEX', async () => {
+    mockPrisma.channel.findUnique.mockResolvedValue({
+      id: CHANNEL.id,
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,320p' harmony-frontend/src/__tests__/channelService.test.ts
+```
+
+Output:
+
+```text
+/**
+ * Unit tests for channelService.ts
+ * Issue #266 — Sprint 3 (P5 Testing)
+ */
+
+// Mock next/headers before any imports (required by trpc-client)
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+// Mock the trpc-client module used by channelService
+jest.mock('@/lib/trpc-client', () => ({
+  publicGet: jest.fn(),
+  trpcQuery: jest.fn(),
+  trpcMutate: jest.fn(),
+  TrpcHttpError: class TrpcHttpError extends Error {
+    procedure: string;
+    status: number;
+    constructor(procedure: string, status: number, body: string) {
+      super(body);
+      this.name = 'TrpcHttpError';
+      this.procedure = procedure;
+      this.status = status;
+    }
+  },
+}));
+
+// Mock react cache to pass through
+jest.mock('react', () => ({
+  cache: <T extends (...args: never[]) => unknown>(fn: T): T => fn,
+}));
+
+import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+import { ChannelType } from '@/types';
+import {
+  getChannels,
+  getChannel,
+  updateVisibility,
+  updateChannel,
+  createChannel,
+  getAuditLog,
+  deleteChannel,
+  ChannelVisibility,
+} from '@/services/channelService';
+
+const mockedPublicGet = jest.mocked(publicGet);
+const mockedTrpcQuery = jest.mocked(trpcQuery);
+const mockedTrpcMutate = jest.mocked(trpcMutate);
+
+// ─── Test fixtures ───────────────────────────────────────────────────────────
+
+function makeRawChannel(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'ch-1',
+    serverId: 'srv-1',
+    name: 'general',
+    slug: 'general',
+    type: 'TEXT',
+    visibility: 'PUBLIC_INDEXABLE',
+    topic: 'Welcome',
+    position: 0,
+    description: 'The general channel',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeRawAuditEntry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'audit-1',
+    channelId: 'ch-1',
+    actorId: 'user-1',
+    action: 'VISIBILITY_CHANGE',
+    oldValue: { visibility: 'PRIVATE' },
+    newValue: { visibility: 'PUBLIC_INDEXABLE' },
+    timestamp: '2025-06-01T12:00:00.000Z',
+    ipAddress: '127.0.0.1',
+    userAgent: 'test-agent',
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('channelService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ── getChannels ──────────────────────────────────────────────────────────
+
+  describe('getChannels', () => {
+    it('returns mapped channels from tRPC query', async () => {
+      const raw = [makeRawChannel(), makeRawChannel({ id: 'ch-2', name: 'random', slug: 'random' })];
+      mockedTrpcQuery.mockResolvedValue(raw);
+
+      const result = await getChannels('srv-1');
+
+      expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getChannels', { serverId: 'srv-1' });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ id: 'ch-1', name: 'general' });
+      expect(result[1]).toMatchObject({ id: 'ch-2', name: 'random' });
+    });
+
+    it('returns empty array when API returns null/undefined', async () => {
+      mockedTrpcQuery.mockResolvedValue(null);
+
+      const result = await getChannels('srv-1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('propagates errors to the caller', async () => {
+      mockedTrpcQuery.mockRejectedValue(new Error('Network error'));
+
+      await expect(getChannels('srv-1')).rejects.toThrow('Network error');
+    });
+  });
+
+  // ── getChannel ───────────────────────────────────────────────────────────
+
+  describe('getChannel', () => {
+    it('returns channel from public endpoint when found', async () => {
+      mockedPublicGet
+        .mockResolvedValueOnce({ id: 'srv-1' } as never) // server lookup
+        .mockResolvedValueOnce({
+          channels: [makeRawChannel({ serverId: undefined, visibility: undefined })],
+        } as never); // public channels
+
+      const result = await getChannel('my-server', 'general');
+
+      expect(result).toMatchObject({
+        id: 'ch-1',
+        serverId: 'srv-1',
+        slug: 'general',
+        visibility: 'PUBLIC_INDEXABLE',
+      });
+    });
+
+    it('returns null when server is not found', async () => {
+      mockedPublicGet.mockResolvedValueOnce(null);
+
+      const result = await getChannel('missing-server', 'general');
+
+      expect(result).toBeNull();
+      expect(mockedTrpcQuery).not.toHaveBeenCalled();
+    });
+
+    it('falls back to tRPC when public endpoint has no matching channel', async () => {
+      mockedPublicGet
+        .mockResolvedValueOnce({ id: 'srv-1' } as never) // server lookup
+        .mockResolvedValueOnce({ channels: [] } as never); // no public match
+      mockedTrpcQuery.mockResolvedValue(makeRawChannel({ visibility: 'PRIVATE' }));
+
+      const result = await getChannel('my-server', 'general');
+
+      expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getChannel', {
+        serverId: 'srv-1',
+        serverSlug: 'my-server',
+        channelSlug: 'general',
+      });
+      expect(result).toMatchObject({ id: 'ch-1', visibility: 'PRIVATE' });
+    });
+
+    it('falls back to tRPC when public endpoint throws', async () => {
+      mockedPublicGet
+        .mockResolvedValueOnce({ id: 'srv-1' } as never) // server lookup
+        .mockRejectedValueOnce(new Error('Public API error: 500')); // public fails
+      mockedTrpcQuery.mockResolvedValue(makeRawChannel());
+
+      const result = await getChannel('my-server', 'general');
+
+      expect(mockedTrpcQuery).toHaveBeenCalled();
+      expect(result).toMatchObject({ id: 'ch-1' });
+    });
+
+    it('falls back to tRPC when public endpoint returns null', async () => {
+      mockedPublicGet
+        .mockResolvedValueOnce({ id: 'srv-1' } as never) // server lookup
+        .mockResolvedValueOnce(null); // public returns null
+      mockedTrpcQuery.mockResolvedValue(makeRawChannel());
+
+      const result = await getChannel('my-server', 'general');
+
+      expect(mockedTrpcQuery).toHaveBeenCalled();
+      expect(result).toMatchObject({ id: 'ch-1' });
+    });
+
+    it('returns null when tRPC fallback returns null', async () => {
+      mockedPublicGet
+        .mockResolvedValueOnce({ id: 'srv-1' } as never)
+        .mockResolvedValueOnce({ channels: [] } as never);
+      mockedTrpcQuery.mockResolvedValue(null);
+
+      const result = await getChannel('my-server', 'general');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null and logs error when tRPC fallback throws', async () => {
+      mockedPublicGet
+        .mockResolvedValueOnce({ id: 'srv-1' } as never)
+        .mockResolvedValueOnce({ channels: [] } as never);
+      mockedTrpcQuery.mockRejectedValue(new Error('Auth failed'));
+
+      const result = await getChannel('my-server', 'general');
+
+      expect(result).toBeNull();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('my-server/general'),
+        expect.any(Error),
+      );
+    });
+
+    it('propagates server-lookup rejection (uncaught path)', async () => {
+      mockedPublicGet.mockRejectedValueOnce(new Error('DNS failure'));
+
+      await expect(getChannel('my-server', 'general')).rejects.toThrow('DNS failure');
+      expect(mockedTrpcQuery).not.toHaveBeenCalled();
+    });
+
+    it('fills default position=0 and createdAt=epoch for public hit missing those fields', async () => {
+      mockedPublicGet
+        .mockResolvedValueOnce({ id: 'srv-1' } as never)
+        .mockResolvedValueOnce({
+          channels: [
+            {
+              id: 'ch-pub',
+              name: 'public-chan',
+              slug: 'public-chan',
+              type: 'TEXT',
+              // position and createdAt intentionally omitted
+            },
+          ],
+        } as never);
+
+      const result = await getChannel('my-server', 'public-chan');
+
+      expect(result).toMatchObject({
+        id: 'ch-pub',
+        serverId: 'srv-1',
+        visibility: 'PUBLIC_INDEXABLE',
+        position: 0,
+        createdAt: new Date(0).toISOString(),
+      });
+    });
+
+    it('encodes server slug in URL', async () => {
+      mockedPublicGet.mockResolvedValueOnce(null);
+
+      await getChannel('my server', 'general');
+
+      expect(mockedPublicGet).toHaveBeenCalledWith('/servers/my%20server');
+    });
+  });
+
+  // ── updateVisibility ─────────────────────────────────────────────────────
+
+  describe('updateVisibility', () => {
+    it.each([
+      ['PRIVATE', ChannelVisibility.PRIVATE],
+      ['PUBLIC_INDEXABLE', ChannelVisibility.PUBLIC_INDEXABLE],
+      ['PUBLIC_NO_INDEX', ChannelVisibility.PUBLIC_NO_INDEX],
+    ] as const)('forwards %s through the mutation payload', async (_label, value) => {
+      mockedTrpcMutate.mockResolvedValue(undefined);
+
+      await updateVisibility('ch-1', value, 'srv-1');
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('channel.setVisibility', {
+        serverId: 'srv-1',
+        channelId: 'ch-1',
+        visibility: value,
+      });
+    });
+
+    it('propagates mutation errors', async () => {
+      mockedTrpcMutate.mockRejectedValue(new Error('Forbidden'));
+
+      await expect(
+        updateVisibility('ch-1', ChannelVisibility.PUBLIC_INDEXABLE, 'srv-1'),
+      ).rejects.toThrow('Forbidden');
+    });
+  });
+
+  // ── updateChannel ────────────────────────────────────────────────────────
+
+  describe('updateChannel', () => {
+    it('sends name and topic when both provided', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawChannel({ name: 'updated', topic: 'new topic' }));
+
+      const result = await updateChannel('ch-1', 'srv-1', { name: 'updated', topic: 'new topic' });
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('channel.updateChannel', {
+        serverId: 'srv-1',
+        channelId: 'ch-1',
+        name: 'updated',
+        topic: 'new topic',
+      });
+      expect(result).toMatchObject({ name: 'updated', topic: 'new topic' });
+    });
+
+    it('sends only name when topic is not provided', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawChannel({ name: 'renamed' }));
+
+      await updateChannel('ch-1', 'srv-1', { name: 'renamed' });
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('channel.updateChannel', {
+        serverId: 'srv-1',
+        channelId: 'ch-1',
+        name: 'renamed',
+      });
+    });
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "PublicChannelPage|GuestPromoBanner|ServerSidebar|SEOService|generateStructuredData|metadata|robots|login prompt|infinite scroll|load more" harmony-frontend/src harmony-frontend/src/__tests__ harmony-backend/tests
+```
+
+Output:
+
+```text
+harmony-backend/tests/message.service.test.ts:90:  it('creates a message with attachment metadata', async () => {
+harmony-backend/tests/attachment.router.test.ts:105:  it('returns 201 with attachment metadata for a valid image upload', async () => {
+harmony-frontend/src/services/channelService.ts:133: * Updates editable metadata (name, topic) of a channel via tRPC.
+harmony-frontend/src/services/serverService.ts:134: * Updates editable metadata of a server via the tRPC API.
+harmony-backend/tests/indexing.service.test.ts:5: * robots.txt endpoint, and sitemap updates on visibility changes.
+harmony-backend/tests/indexing.service.test.ts:171:describe('GET /robots.txt', () => {
+harmony-backend/tests/indexing.service.test.ts:172:  it('returns robots.txt with correct directives', async () => {
+harmony-backend/tests/indexing.service.test.ts:173:    const res = await request(app).get('/robots.txt');
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:28:    robots: { index: isIndexable, follow: true },
+harmony-frontend/src/app/layout.tsx:11:export const metadata: Metadata = {
+harmony-frontend/src/components/channel/GuestPromoBanner.tsx:2: * Channel Component: GuestPromoBanner
+harmony-frontend/src/components/channel/GuestPromoBanner.tsx:5: * Based on dev spec C1.4 GuestPromoBanner
+harmony-frontend/src/components/channel/GuestPromoBanner.tsx:25:interface GuestPromoBannerProps {
+harmony-frontend/src/components/channel/GuestPromoBanner.tsx:30:export function GuestPromoBanner({ serverName, memberCount }: GuestPromoBannerProps) {
+harmony-frontend/src/components/channel/GuestChannelView.tsx:5: * Ref: dev-spec-guest-public-channel-view.md — M1, C1.1 PublicChannelPage
+harmony-frontend/src/components/channel/GuestChannelView.tsx:19:import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+harmony-frontend/src/components/channel/GuestChannelView.tsx:149:            <GuestPromoBanner serverName={server.name} memberCount={memberCount} />
+harmony-frontend/src/components/layout/HarmonyShell.tsx:19:import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+harmony-frontend/src/components/layout/HarmonyShell.tsx:448:                <GuestPromoBanner
+harmony-frontend/src/components/README.md:31:- `GuestPromoBanner.tsx` - Guest user promo banner (C1.4)
+harmony-frontend/src/components/README.md:37:- `ServerSidebar.tsx` - Server navigation sidebar (C1.6)
+harmony-frontend/src/components/server/ServerSidebar.tsx:2: * Server Component: ServerSidebar
+harmony-frontend/src/components/server/ServerSidebar.tsx:4: * Based on dev spec C1.6 ServerSidebar
+harmony-frontend/src/components/server/ServerSidebar.tsx:16:interface ServerSidebarProps {
+harmony-frontend/src/components/server/ServerSidebar.tsx:27:export function ServerSidebar({
+harmony-frontend/src/components/server/ServerSidebar.tsx:31:}: ServerSidebarProps) {
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:15:58.366Z
+
+I have enough to judge the backend/public API coverage. I’m checking the guest-facing page/components one time so I can distinguish “story logic is covered” from “the actual user-facing flow is covered.”
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,260p' harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+Output:
+
+```text
+zsh:1: no matches found: harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,260p' harmony-frontend/src/components/channel/GuestChannelView.tsx
+```
+
+Output:
+
+```text
+/**
+ * GuestChannelView — simplified layout for anonymous public channel access.
+ * No ServerRail, no ChannelSidebar, no MessageInput.
+ * Wraps content in VisibilityGuard so PRIVATE channels show AccessDeniedPage.
+ * Ref: dev-spec-guest-public-channel-view.md — M1, C1.1 PublicChannelPage
+ */
+
+import { notFound } from 'next/navigation';
+import {
+  fetchPublicServer,
+  fetchPublicChannel,
+  fetchPublicMessages,
+} from '@/services/publicApiService';
+import { getChannels } from '@/services/channelService';
+import { TrpcHttpError } from '@/lib/trpc-errors';
+import { AuthRedirect } from '@/components/channel/AuthRedirect';
+import { VisibilityGuard } from '@/components/channel/VisibilityGuard';
+import { MessageList } from '@/components/channel/MessageList';
+import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+import { ChannelVisibility } from '@/types';
+import type { Server, Channel } from '@/types';
+
+type PublicServer = Omit<Server, 'ownerId'>;
+
+// ─── Guest Header ─────────────────────────────────────────────────────────────
+
+function GuestHeader({ server, memberCount }: { server: PublicServer; memberCount: number }) {
+  return (
+    <header className='flex h-14 shrink-0 items-center gap-3 border-b border-black/20 bg-[#2f3136] px-4'>
+      {/* Harmony logo wordmark */}
+      <span className='text-lg font-bold text-[#5865f2]'>Harmony</span>
+
+      {/* Divider */}
+      <span className='text-gray-600' aria-hidden='true'>
+        /
+      </span>
+
+      {/* Server name */}
+      <span className='text-sm font-semibold text-white'>{server.name}</span>
+
+      {/* Member count */}
+      <span className='ml-auto flex items-center gap-1.5 text-xs text-gray-400'>
+        <svg
+          className='h-3.5 w-3.5'
+          viewBox='0 0 24 24'
+          fill='currentColor'
+          aria-hidden='true'
+          focusable='false'
+        >
+          <path d='M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z' />
+        </svg>
+        {memberCount.toLocaleString()} members
+      </span>
+    </header>
+  );
+}
+
+// ─── Channel Header ───────────────────────────────────────────────────────────
+
+function ChannelHeader({ channel }: { channel: Channel }) {
+  return (
+    <div className='flex shrink-0 items-center gap-2 border-b border-black/20 bg-[#36393f] px-4 py-3'>
+      <svg
+        className='h-5 w-5 shrink-0 text-gray-400'
+        viewBox='0 0 24 24'
+        fill='currentColor'
+        aria-hidden='true'
+        focusable='false'
+      >
+        <path d='M5.88657 21C5.57547 21 5.3399 20.7189 5.39427 20.4126L6.00001 17H2.59511C2.28449 17 2.04905 16.7198 2.10259 16.4138L2.27759 15.4138C2.31946 15.1746 2.52722 15 2.77011 15H6.35001L7.41001 9H4.00511C3.69449 9 3.45905 8.71977 3.51259 8.41381L3.68759 7.41381C3.72946 7.17456 3.93722 7 4.18011 7H7.76001L8.39677 3.41262C8.43914 3.17391 8.64664 3 8.88907 3H9.87344C10.1845 3 10.4201 3.28107 10.3657 3.58738L9.76001 7H15.76L16.3968 3.41262C16.4391 3.17391 16.6466 3 16.8891 3H17.8734C18.1845 3 18.4201 3.28107 18.3657 3.58738L17.76 7H21.1649C21.4755 7 21.711 7.28023 21.6574 7.58619L21.4824 8.58619C21.4406 8.82544 21.2328 9 20.9899 9H17.41L16.35 15H19.7549C20.0655 15 20.301 15.2802 20.2474 15.5862L20.0724 16.5862C20.0306 16.8254 19.8228 17 19.5799 17H16L15.3632 20.5874C15.3209 20.8261 15.1134 21 14.871 21H13.8866C13.5755 21 13.3399 20.7189 13.3943 20.4126L14 17H8.00001L7.36325 20.5874C7.32088 20.8261 7.11337 21 6.87094 21H5.88657ZM9.41001 9L8.35001 15H14.35L15.41 9H9.41001Z' />
+      </svg>
+      <h1 className='text-sm font-semibold text-white'>{channel.name}</h1>
+      {channel.topic && (
+        <>
+          <span className='text-gray-600' aria-hidden='true'>
+            |
+          </span>
+          <p className='truncate text-sm text-gray-400'>{channel.topic}</p>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface GuestChannelViewProps {
+  serverSlug: string;
+  channelSlug: string;
+}
+
+export async function GuestChannelView({ serverSlug, channelSlug }: GuestChannelViewProps) {
+  const [server, channelResult] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+  ]);
+
+  if (!server || !channelResult) notFound();
+
+  // Check if the authenticated user is a member of this server.
+  // Only redirect members to the full /channels/ view; non-members stay here
+  // so we don't create a redirect loop (ChannelPageContent → /c/ → /channels/ → loop).
+  //
+  // Error handling:
+  //   - Success  → confirmed member; redirect to /channels/
+  //   - 403      → confirmed non-member (valid token, no ServerMember row); stay on guest view
+  //   - 401/other → expired/invalid token; membership unknown — still render AuthRedirect so
+  //                 the client can redirect after the token is refreshed client-side.
+  //                 If the user turns out not to be a member, ChannelPageContent will redirect
+  //                 back here with a valid token and we'll get a 403, stopping any loop.
+  let isMember = false;
+  try {
+    await getChannels(server.id);
+    isMember = true;
+  } catch (err: unknown) {
+    // trpcQuery throws TrpcHttpError — check status directly rather than parsing
+    // the message string, which would couple us to the error format in trpc-client.
+    isMember = !(err instanceof TrpcHttpError && err.status === 403);
+  }
+
+  if (channelResult.isPrivate) {
+    return (
+      <div className='flex h-screen flex-col overflow-hidden bg-[#36393f] font-sans'>
+        {isMember && <AuthRedirect to={`/channels/${serverSlug}/${channelSlug}`} />}
+        <GuestHeader server={server} memberCount={server.memberCount ?? 0} />
+        <VisibilityGuard visibility={ChannelVisibility.PRIVATE} isLoading={false}>
+          {null}
+        </VisibilityGuard>
+      </div>
+    );
+  }
+
+  const { channel } = channelResult;
+  const { messages } = await fetchPublicMessages(channel.id);
+  const sortedMessages = [...messages].reverse();
+  const memberCount = server.memberCount ?? 0;
+
+  return (
+    <div className='flex h-screen flex-col overflow-hidden bg-[#36393f] font-sans'>
+      {isMember && <AuthRedirect to={`/channels/${serverSlug}/${channelSlug}`} />}
+      <GuestHeader server={server} memberCount={memberCount} />
+
+      <VisibilityGuard visibility={channel.visibility} isLoading={false}>
+        <div className='flex flex-1 flex-col overflow-hidden'>
+          <ChannelHeader channel={channel} />
+
+          <div className='flex flex-1 flex-col overflow-hidden'>
+            <MessageList key={channel.id} channel={channel} messages={sortedMessages} />
+            <GuestPromoBanner serverName={server.name} memberCount={memberCount} />
+          </div>
+        </div>
+      </VisibilityGuard>
+    </div>
+  );
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "GuestChannelView|GuestPromoBanner|ServerSidebar|app/c/\[serverSlug\]/\[channelSlug\]/page|generateMetadata" harmony-frontend/src/__tests__
+```
+
+Output:
+
+```text
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:8: * Fix 2 — GuestChannelView: isMember check must handle plain Error objects from trpcQuery,
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:144:// ─── Fix 2: GuestChannelView isMember check ───────────────────────────────────
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:147:// GuestChannelView checks `err instanceof TrpcHttpError && err.status === 403`,
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:150:describe('Fix 2 — GuestChannelView: isMember check uses TrpcHttpError.status', () => {
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts:151:  // Mirror the exact expression from GuestChannelView.tsx so these tests FAIL if
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:16:13.233Z
+
+I found one extra guest-flow test file, but it’s narrowly scoped to a regression in the member-check redirect logic, not the full guest story. I’m reading that and then I can give you a precise yes/no with the gaps.
+
+#### Tool: exec_command
+
+```sh
+sed -n '130,240p' harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts
+```
+
+Output:
+
+```text
+
+    const mock401Error = {
+      config: { _retry: false, headers: { Authorization: 'Bearer old-token' } },
+      response: { status: 401 },
+    };
+
+    // The interceptor wraps setSessionCookie in try/catch — the retry must still succeed
+    await expect(mockCapturedResponseErrorHandler!(mock401Error)).resolves.toBeDefined();
+
+    // setSessionCookie was still attempted despite the failure (best-effort)
+    expect(setSessionCookie).toHaveBeenCalledWith('refreshed-access-token');
+  });
+});
+
+// ─── Fix 2: GuestChannelView isMember check ───────────────────────────────────
+//
+// trpcQuery now throws TrpcHttpError (a typed subclass with a .status field).
+// GuestChannelView checks `err instanceof TrpcHttpError && err.status === 403`,
+// which is immune to message-format drift in trpc-client.ts.
+
+describe('Fix 2 — GuestChannelView: isMember check uses TrpcHttpError.status', () => {
+  // Mirror the exact expression from GuestChannelView.tsx so these tests FAIL if
+  // the production code reverts to a string-match or other fragile pattern.
+  function isMemberAfterError(err: unknown): boolean {
+    return !(err instanceof TrpcHttpError && err.status === 403);
+  }
+
+  it('TrpcHttpError carries procedure and status as typed fields', () => {
+    const err = new TrpcHttpError('server.getChannels', 403, '{"error":"FORBIDDEN"}');
+    expect(err.status).toBe(403);
+    expect(err.procedure).toBe('server.getChannels');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(TrpcHttpError);
+    expect(err.name).toBe('TrpcHttpError');
+  });
+
+  it('returns false for TrpcHttpError status 403 — confirmed non-member', () => {
+    const err = new TrpcHttpError('server.getChannels', 403, '{"error":"FORBIDDEN"}');
+    expect(isMemberAfterError(err)).toBe(false);
+  });
+
+  it('returns true for TrpcHttpError status 401 — expired token, membership unknown', () => {
+    const err = new TrpcHttpError('server.getChannels', 401, '{"error":"UNAUTHORIZED"}');
+    expect(isMemberAfterError(err)).toBe(true);
+  });
+
+  it('returns true for TrpcHttpError status 500 — server error, membership unknown', () => {
+    const err = new TrpcHttpError('server.getChannels', 500, 'Internal Server Error');
+    expect(isMemberAfterError(err)).toBe(true);
+  });
+
+  it('returns true for non-TrpcHttpError thrown values', () => {
+    expect(isMemberAfterError(new Error('plain error'))).toBe(true);
+    expect(isMemberAfterError('string error')).toBe(true);
+    expect(isMemberAfterError({ status: 403 })).toBe(true);
+    expect(isMemberAfterError(null)).toBe(true);
+  });
+
+  it('demonstrates the regression: OLD isAxiosError check was always false for TrpcHttpError', () => {
+    const { isAxiosError } = jest.requireActual<typeof import('axios')>('axios');
+    const err = new TrpcHttpError('server.getChannels', 403, '{"error":"FORBIDDEN"}');
+
+    // BUG (pre-fix): isAxiosError(err) is always false for TrpcHttpError → isMember=true (wrong)
+    const oldIsMember = !(
+      isAxiosError(err) && (err as { response?: { status: number } }).response?.status === 403
+    );
+    expect(oldIsMember).toBe(true); // wrong — treated non-member as member
+
+    // FIX: instanceof + status check correctly identifies 403
+    expect(isMemberAfterError(err)).toBe(false); // correctly identifies non-member
+  });
+});
+
+// ─── Fix 3: BrowseServersModal onJoined callback ──────────────────────────────
+//
+// After a successful joinServerAction, handleJoin calls onJoined?.(server.id).
+// This allows HarmonyShell to broadcast to other tabs via notifyServerJoined.
+
+describe('Fix 3 — BrowseServersModal: onJoined prop is called on successful join', () => {
+  it('onJoined is called with the server ID before onClose and router.push', () => {
+    const callOrder: string[] = [];
+    const serverId = 'srv-abc';
+
+    const onJoined = jest.fn(() => callOrder.push('onJoined'));
+    const onClose = jest.fn(() => callOrder.push('onClose'));
+    const routerPush = jest.fn(() => callOrder.push('routerPush'));
+
+    // Replicate the success path of handleJoin in BrowseServersModal
+    onJoined(serverId);
+    onClose();
+    routerPush('/channels/server-slug/general');
+
+    expect(callOrder).toEqual(['onJoined', 'onClose', 'routerPush']);
+    expect(onJoined).toHaveBeenCalledWith(serverId);
+  });
+
+  it('onJoined is optional — omitting it does not throw', () => {
+    const onJoined: ((id: string) => void) | undefined = undefined;
+    expect(() => onJoined?.('srv-xyz')).not.toThrow();
+  });
+
+  it('onJoined is called exactly once per successful join', () => {
+    const onJoined = jest.fn();
+    onJoined('srv-123');
+    expect(onJoined).toHaveBeenCalledTimes(1);
+    expect(onJoined).toHaveBeenCalledWith('srv-123');
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+python3 - <<'PY'
+from pathlib import Path
+files = [
+'/Users/allen/repos/Harmony/harmony-backend/tests/visibility.service.test.ts',
+'/Users/allen/repos/Harmony/harmony-frontend/src/__tests__/VisibilityToggle.test.tsx',
+'/Users/allen/repos/Harmony/harmony-frontend/src/__tests__/channelService.test.ts',
+'/Users/allen/repos/Harmony/harmony-backend/tests/public.router.test.ts',
+'/Users/allen/repos/Harmony/harmony-backend/tests/indexing.service.test.ts',
+'/Users/allen/repos/Harmony/harmony-backend/tests/channel.getAuditLog.test.ts',
+'/Users/allen/repos/Harmony/harmony-backend/tests/events.router.visibility.test.ts',
+'/Users/allen/repos/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx',
+'/Users/allen/repos/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx',
+]
+for fp in files:
+    p = Path(fp)
+    if not p.exists():
+        print(f'MISSING {fp}')
+        continue
+    print(f'FILE {fp}')
+    with p.open() as f:
+        for i, line in enumerate(f, 1):
+            if any(k in line for k in [
+                'describe(', 'it(', 'PUBLIC_INDEXABLE', 'PUBLIC_NO_INDEX', 'PRIVATE',
+                'getAuditLog', 'generateSitemap', 'robots.txt', 'channel:visibility-changed',
+                'GuestChannelView', 'AuthRedirect', 'robots:', 'generateMetadata',
+                'updateVisibility', 'VisibilityGuard', 'GuestPromoBanner'
+            ]):
+                print(f'{i}: {line.rstrip()}')
+    print()
+PY
+```
+
+Output:
+
+```text
+FILE /Users/allen/repos/Harmony/harmony-backend/tests/visibility.service.test.ts
+64:       visibility: ChannelVisibility.PRIVATE,
+76:       visibility: ChannelVisibility.PRIVATE,
+105: describe('visibilityService.getVisibility', () => {
+106:   it('returns the current visibility of a channel', async () => {
+108:     expect(visibility).toBe(ChannelVisibility.PRIVATE);
+111:   it('throws NOT_FOUND for unknown channelId', async () => {
+117:   it('throws NOT_FOUND when channelId does not belong to serverId', async () => {
+126: describe('visibilityService.setVisibility — state transitions', () => {
+135:   // S1 → S3: PRIVATE → PUBLIC_INDEXABLE
+136:   it('PRIVATE → PUBLIC_INDEXABLE: sets indexedAt', async () => {
+137:     await resetChannel(textChannelId, ChannelVisibility.PRIVATE);
+140:       makeInput(textChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
+144:     expect(result.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+145:     expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+148:     expect(channel!.visibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+152:   // S1 → S2: PRIVATE → PUBLIC_NO_INDEX
+153:   it('PRIVATE → PUBLIC_NO_INDEX: indexedAt remains null', async () => {
+154:     await resetChannel(textChannelId, ChannelVisibility.PRIVATE);
+157:       makeInput(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX),
+161:     expect(result.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+162:     expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+168:   // S2 → S3: PUBLIC_NO_INDEX → PUBLIC_INDEXABLE
+169:   it('PUBLIC_NO_INDEX → PUBLIC_INDEXABLE: sets indexedAt', async () => {
+170:     await resetChannel(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX);
+173:       makeInput(textChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
+177:     expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+178:     expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+184:   // S3 → S2: PUBLIC_INDEXABLE → PUBLIC_NO_INDEX
+185:   it('PUBLIC_INDEXABLE → PUBLIC_NO_INDEX: indexedAt unchanged', async () => {
+186:     // Start with PUBLIC_INDEXABLE + a known indexedAt
+190:       data: { visibility: ChannelVisibility.PUBLIC_INDEXABLE, indexedAt: knownDate },
+194:       makeInput(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX),
+198:     expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+199:     expect(result.newVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+202:     expect(channel!.visibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+206:   // S3 → S1: PUBLIC_INDEXABLE → PRIVATE (clears indexedAt)
+207:   it('PUBLIC_INDEXABLE → PRIVATE: clears indexedAt', async () => {
+211:         visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+217:       makeInput(textChannelId, ChannelVisibility.PRIVATE),
+221:     expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+222:     expect(result.newVisibility).toBe(ChannelVisibility.PRIVATE);
+225:     expect(channel!.visibility).toBe(ChannelVisibility.PRIVATE);
+229:   // S2 → S1: PUBLIC_NO_INDEX → PRIVATE
+230:   it('PUBLIC_NO_INDEX → PRIVATE: clears indexedAt', async () => {
+234:       data: { visibility: ChannelVisibility.PUBLIC_NO_INDEX, indexedAt: new Date('2026-01-01T00:00:00Z') },
+238:       makeInput(textChannelId, ChannelVisibility.PRIVATE),
+242:     expect(result.oldVisibility).toBe(ChannelVisibility.PUBLIC_NO_INDEX);
+243:     expect(result.newVisibility).toBe(ChannelVisibility.PRIVATE);
+250:   it('same visibility (no-op): succeeds without changing indexedAt', async () => {
+251:     await resetChannel(textChannelId, ChannelVisibility.PRIVATE);
+254:       makeInput(textChannelId, ChannelVisibility.PRIVATE),
+258:     expect(result.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+259:     expect(result.newVisibility).toBe(ChannelVisibility.PRIVATE);
+265: describe('visibilityService.setVisibility — VOICE guard', () => {
+266:   it('rejects VOICE channel → PUBLIC_INDEXABLE', async () => {
+269:         makeInput(voiceChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
+274:   it('allows VOICE channel → PUBLIC_NO_INDEX', async () => {
+276:       makeInput(voiceChannelId, ChannelVisibility.PUBLIC_NO_INDEX),
+281:   it('allows VOICE channel → PRIVATE', async () => {
+283:       makeInput(voiceChannelId, ChannelVisibility.PRIVATE),
+291: describe('visibilityService.setVisibility — error cases', () => {
+292:   it('throws NOT_FOUND for unknown channelId', async () => {
+295:         makeInput('00000000-0000-0000-0000-000000000000', ChannelVisibility.PUBLIC_INDEXABLE),
+300:   it('throws NOT_FOUND when channelId does not belong to serverId', async () => {
+315:       visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+326: describe('visibilityService.setVisibility — audit logging', () => {
+327:   it('creates an audit log entry on visibility change', async () => {
+331:       data: { visibility: ChannelVisibility.PRIVATE, indexedAt: null },
+335:       makeInput(textChannelId, ChannelVisibility.PUBLIC_NO_INDEX),
+352: describe('visibilityService.setVisibility — VISIBILITY_CHANGED event', () => {
+353:   it('emits a VISIBILITY_CHANGED event after successful change', async () => {
+357:       data: { visibility: ChannelVisibility.PRIVATE, indexedAt: null },
+382:       makeInput(textChannelId, ChannelVisibility.PUBLIC_INDEXABLE),
+411:     expect(payload.oldVisibility).toBe(ChannelVisibility.PRIVATE);
+412:     expect(payload.newVisibility).toBe(ChannelVisibility.PUBLIC_INDEXABLE);
+
+FILE /Users/allen/repos/Harmony/harmony-frontend/src/__tests__/VisibilityToggle.test.tsx
+19: jest.mock('../app/settings/[serverSlug]/[channelSlug]/updateVisibility', () => ({
+66: describe('VisibilityToggle — rendering', () => {
+67:   it('renders all three options', () => {
+68:     renderToggle(ChannelVisibility.PRIVATE);
+74:   it('marks the initial visibility as checked', () => {
+75:     renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+81:   it('disables all options when disabled=true', () => {
+82:     renderToggle(ChannelVisibility.PRIVATE, true);
+88:   it('shows admin-only hint when disabled', () => {
+89:     renderToggle(ChannelVisibility.PRIVATE, true);
+96: describe('VisibilityToggle — optimistic update', () => {
+97:   it('immediately marks the clicked option as checked before the API resolves', async () => {
+104:     renderToggle(ChannelVisibility.PRIVATE);
+116:   it('calls onVisibilityChanged with the new visibility on success', async () => {
+119:     const { onVisibilityChanged } = renderToggle(ChannelVisibility.PRIVATE);
+125:     expect(onVisibilityChanged).toHaveBeenCalledWith(ChannelVisibility.PUBLIC_NO_INDEX);
+128:   it('shows a success toast on successful save', async () => {
+131:     renderToggle(ChannelVisibility.PRIVATE);
+145: describe('VisibilityToggle — rollback on error', () => {
+146:   it('reverts to the previous selection when the API call fails', async () => {
+149:     renderToggle(ChannelVisibility.PRIVATE);
+155:     // Should have rolled back to PRIVATE
+160:   it('shows an error toast when the API call fails', async () => {
+163:     renderToggle(ChannelVisibility.PRIVATE);
+174:   it('does NOT call onVisibilityChanged when the API call fails', async () => {
+177:     const { onVisibilityChanged } = renderToggle(ChannelVisibility.PRIVATE);
+187: // ─── Confirmation modal (PRIVATE transition) ─────────────────────────────────
+189: describe('VisibilityToggle — confirmation modal', () => {
+190:   it('shows a confirmation dialog when selecting PRIVATE', () => {
+192:     renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+200:   it('applies the change after confirmation', async () => {
+202:     renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+213:       ChannelVisibility.PRIVATE,
+217:   it('cancels without changing selection', async () => {
+219:     renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+
+FILE /Users/allen/repos/Harmony/harmony-frontend/src/__tests__/channelService.test.ts
+38:   updateVisibility,
+41:   getAuditLog,
+59:     visibility: 'PUBLIC_INDEXABLE',
+75:     oldValue: { visibility: 'PRIVATE' },
+76:     newValue: { visibility: 'PUBLIC_INDEXABLE' },
+86: describe('channelService', () => {
+99:   describe('getChannels', () => {
+100:     it('returns mapped channels from tRPC query', async () => {
+112:     it('returns empty array when API returns null/undefined', async () => {
+120:     it('propagates errors to the caller', async () => {
+129:   describe('getChannel', () => {
+130:     it('returns channel from public endpoint when found', async () => {
+143:         visibility: 'PUBLIC_INDEXABLE',
+147:     it('returns null when server is not found', async () => {
+156:     it('falls back to tRPC when public endpoint has no matching channel', async () => {
+160:       mockedTrpcQuery.mockResolvedValue(makeRawChannel({ visibility: 'PRIVATE' }));
+169:       expect(result).toMatchObject({ id: 'ch-1', visibility: 'PRIVATE' });
+172:     it('falls back to tRPC when public endpoint throws', async () => {
+184:     it('falls back to tRPC when public endpoint returns null', async () => {
+196:     it('returns null when tRPC fallback returns null', async () => {
+207:     it('returns null and logs error when tRPC fallback throws', async () => {
+222:     it('propagates server-lookup rejection (uncaught path)', async () => {
+229:     it('fills default position=0 and createdAt=epoch for public hit missing those fields', async () => {
+249:         visibility: 'PUBLIC_INDEXABLE',
+255:     it('encodes server slug in URL', async () => {
+264:   // ── updateVisibility ─────────────────────────────────────────────────────
+266:   describe('updateVisibility', () => {
+268:       ['PRIVATE', ChannelVisibility.PRIVATE],
+269:       ['PUBLIC_INDEXABLE', ChannelVisibility.PUBLIC_INDEXABLE],
+270:       ['PUBLIC_NO_INDEX', ChannelVisibility.PUBLIC_NO_INDEX],
+274:       await updateVisibility('ch-1', value, 'srv-1');
+283:     it('propagates mutation errors', async () => {
+287:         updateVisibility('ch-1', ChannelVisibility.PUBLIC_INDEXABLE, 'srv-1'),
+294:   describe('updateChannel', () => {
+295:     it('sends name and topic when both provided', async () => {
+309:     it('sends only name when topic is not provided', async () => {
+321:     it('sends only topic when name is not provided', async () => {
+333:     it('sends neither name nor topic when patch is empty', async () => {
+347:   describe('createChannel', () => {
+348:     it('sends all channel fields and returns mapped channel', async () => {
+354:         visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+367:         visibility: 'PUBLIC_INDEXABLE',
+374:     it('sends topic as undefined when omitted from input', async () => {
+380:         visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+392:         visibility: 'PUBLIC_INDEXABLE',
+398:     it('does not forward description to the mutation payload', async () => {
+404:         visibility: ChannelVisibility.PRIVATE,
+417:       ['PUBLIC_NO_INDEX', ChannelVisibility.PUBLIC_NO_INDEX],
+418:       ['PRIVATE', ChannelVisibility.PRIVATE],
+438:     it('propagates creation errors', async () => {
+447:           visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+454:   // ── getAuditLog ──────────────────────────────────────────────────────────
+456:   describe('getAuditLog', () => {
+457:     it('returns mapped audit log entries with total', async () => {
+463:       const result = await getAuditLog('srv-1', 'ch-1');
+465:       expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getAuditLog', {
+478:     it('passes pagination options to the query', async () => {
+481:       await getAuditLog('srv-1', 'ch-1', { limit: 10, offset: 20, startDate: '2025-01-01' });
+483:       expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getAuditLog', {
+492:     it('propagates query errors', async () => {
+495:       await expect(getAuditLog('srv-1', 'ch-1')).rejects.toThrow('Unauthorized');
+501:   describe('deleteChannel', () => {
+502:     it('calls tRPC mutate and returns true', async () => {
+514:     it('propagates deletion errors', async () => {
+523:   describe('toFrontendChannel (via getChannels)', () => {
+524:     it('maps all fields correctly from raw backend shape', async () => {
+535:         visibility: 'PUBLIC_INDEXABLE',
+544:     it('defaults position to 0 when missing', async () => {
+552:     it('sets topic to undefined when missing', async () => {
+560:     it('warns on missing required fields', async () => {
+576:   describe('toAuditLogEntry (via getAuditLog)', () => {
+577:     it('maps all fields correctly from raw backend shape', async () => {
+583:       const { entries } = await getAuditLog('srv-1', 'ch-1');
+590:         oldValue: { visibility: 'PRIVATE' },
+591:         newValue: { visibility: 'PUBLIC_INDEXABLE' },
+598:     it('warns on missing required string fields', async () => {
+604:       await getAuditLog('srv-1', 'ch-1');
+612:     it('defaults to epoch timestamp when timestamp is invalid', async () => {
+618:       const { entries } = await getAuditLog('srv-1', 'ch-1');
+627:     it('defaults to epoch timestamp when timestamp is missing', async () => {
+633:       const { entries } = await getAuditLog('srv-1', 'ch-1');
+641:   describe('ChannelVisibility re-export', () => {
+642:     it('exposes all visibility enum values', () => {
+643:       expect(ChannelVisibility.PUBLIC_INDEXABLE).toBe('PUBLIC_INDEXABLE');
+644:       expect(ChannelVisibility.PUBLIC_NO_INDEX).toBe('PUBLIC_NO_INDEX');
+645:       expect(ChannelVisibility.PRIVATE).toBe('PRIVATE');
+
+FILE /Users/allen/repos/Harmony/harmony-backend/tests/public.router.test.ts
+86:   visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+113: describe('GET /api/public/servers/:serverSlug', () => {
+114:   it('returns 200 with server info when the server exists', async () => {
+128:   it('returns 404 when the server slug does not exist', async () => {
+140: describe('GET /api/public/servers/:serverSlug/channels', () => {
+141:   it('returns 200 with PUBLIC_INDEXABLE channels when the server exists', async () => {
+161:         where: expect.objectContaining({ visibility: ChannelVisibility.PUBLIC_INDEXABLE }),
+166:   it('returns 200 with an empty array when the server has no public channels', async () => {
+176:   it('returns 404 when the server slug does not exist', async () => {
+188: describe('GET /api/public/channels/:channelId/messages', () => {
+189:   it('returns 200 with paginated messages for a PUBLIC_INDEXABLE channel', async () => {
+192:       visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+206:   it('returns 200 respecting the ?page query parameter', async () => {
+209:       visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+219:   it('clamps invalid ?page values to 1', async () => {
+222:       visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+237:   it('returns 404 when the channel does not exist', async () => {
+246:   it('returns 404 when the channel is PRIVATE', async () => {
+249:       visibility: ChannelVisibility.PRIVATE,
+258:   it('returns 404 when the channel is PUBLIC_NO_INDEX', async () => {
+261:       visibility: ChannelVisibility.PUBLIC_NO_INDEX,
+273: describe('GET /api/public/channels/:channelId/messages/:messageId', () => {
+274:   it('returns 200 with the message when it exists in a PUBLIC_INDEXABLE channel', async () => {
+277:       visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+288:   it('returns 404 when the channel is PRIVATE', async () => {
+291:       visibility: ChannelVisibility.PRIVATE,
+300:   it('returns 404 when the channel is PUBLIC_NO_INDEX', async () => {
+303:       visibility: ChannelVisibility.PUBLIC_NO_INDEX,
+312:   it('returns 404 when the channel does not exist', async () => {
+323:   it('returns 404 when the message does not exist in the channel', async () => {
+326:       visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+
+FILE /Users/allen/repos/Harmony/harmony-backend/tests/indexing.service.test.ts
+4:  * Covers sitemap generation for PUBLIC_INDEXABLE channels,
+5:  * robots.txt endpoint, and sitemap updates on visibility changes.
+55:       visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+67:       visibility: ChannelVisibility.PRIVATE,
+81: describe('indexingService.generateSitemap', () => {
+82:   it('returns null for non-existent server', async () => {
+83:     const result = await indexingService.generateSitemap('non-existent-server-slug');
+87:   it('generates valid XML sitemap with PUBLIC_INDEXABLE channels only', async () => {
+88:     const xml = await indexingService.generateSitemap(serverSlug);
+100:   it('returns empty urlset when server has no PUBLIC_INDEXABLE channels', async () => {
+112:     const xml = await indexingService.generateSitemap(emptySlug);
+121: describe('indexingService.onVisibilityChanged', () => {
+132:   it('invalidates sitemap cache when channel becomes PUBLIC_INDEXABLE', async () => {
+133:     await indexingService.generateSitemap(serverSlug);
+137:       oldVisibility: 'PRIVATE',
+138:       newVisibility: 'PUBLIC_INDEXABLE',
+146:   it('invalidates sitemap cache when channel leaves PUBLIC_INDEXABLE', async () => {
+147:     await indexingService.generateSitemap(serverSlug);
+151:       oldVisibility: 'PUBLIC_INDEXABLE',
+152:       newVisibility: 'PRIVATE',
+160:   it('does not invalidate cache when visibility change does not involve PUBLIC_INDEXABLE', async () => {
+163:       oldVisibility: 'PRIVATE',
+164:       newVisibility: 'PUBLIC_NO_INDEX',
+171: describe('GET /robots.txt', () => {
+172:   it('returns robots.txt with correct directives', async () => {
+173:     const res = await request(app).get('/robots.txt');
+184: describe('GET /sitemap/:serverSlug.xml', () => {
+185:   it('returns XML sitemap for valid server', async () => {
+195:   it('returns 404 for non-existent server', async () => {
+
+FILE /Users/allen/repos/Harmony/harmony-backend/tests/channel.getAuditLog.test.ts
+2:  * channel.getAuditLog tRPC procedure tests — Issue #117
+82:       visibility: ChannelVisibility.PRIVATE,
+109:       visibility: ChannelVisibility.PRIVATE,
+122:         oldValue: { visibility: 'PRIVATE' },
+123:         newValue: { visibility: 'PUBLIC_NO_INDEX' },
+144: describe('channel.getAuditLog — permission gate', () => {
+145:   it('throws UNAUTHORIZED when caller is unauthenticated', async () => {
+146:     await expect(callerAs(null).getAuditLog({ serverId, channelId })).rejects.toMatchObject({
+151:   it('throws FORBIDDEN when caller is a non-admin member', async () => {
+152:     await expect(callerAs(memberId).getAuditLog({ serverId, channelId })).rejects.toMatchObject({
+160: describe('channel.getAuditLog — cross-server probe blocked', () => {
+161:   it('throws NOT_FOUND when channelId belongs to a different server', async () => {
+165:       callerAs(adminId).getAuditLog({ serverId, channelId: otherChannelId }),
+172: describe('channel.getAuditLog — response shape', () => {
+173:   it('returns entries array and total count for an admin caller', async () => {
+174:     const result = await callerAs(adminId).getAuditLog({ serverId, channelId });
+183:   it('entry has expected fields', async () => {
+184:     const result = await callerAs(adminId).getAuditLog({ serverId, channelId, limit: 1 });
+199:   it('results are ordered newest-first', async () => {
+200:     const result = await callerAs(adminId).getAuditLog({ serverId, channelId });
+211: describe('channel.getAuditLog — pagination', () => {
+212:   it('respects limit', async () => {
+213:     const result = await callerAs(adminId).getAuditLog({ serverId, channelId, limit: 1 });
+217:   it('respects offset (no overlap between pages)', async () => {
+218:     const first = await callerAs(adminId).getAuditLog({ serverId, channelId, limit: 2, offset: 0 });
+219:     const second = await callerAs(adminId).getAuditLog({
+
+FILE /Users/allen/repos/Harmony/harmony-backend/tests/events.router.visibility.test.ts
+4:  * Integration tests for channel:visibility-changed SSE events on
+126:   visibility: 'PRIVATE',
+156: describe('GET /api/events/server/:serverId — visibility subscription', () => {
+159:   it('subscribes to VISIBILITY_CHANGED event channel', async () => {
+166:   it('subscribes to VISIBILITY_CHANGED alongside channel and member events', async () => {
+176: // ─── channel:visibility-changed event delivery ────────────────────────────────
+178: describe('GET /api/events/server/:serverId — channel:visibility-changed event', () => {
+179:   it('pushes channel:visibility-changed SSE frame when visibility changes', async () => {
+211:                 oldVisibility: 'PUBLIC_INDEXABLE',
+212:                 newVisibility: 'PRIVATE',
+231:     expect(body).toContain('event: channel:visibility-changed');
+234:     expect(body).toContain('PUBLIC_INDEXABLE');
+235:     // newVisibility (PRIVATE) must be present in the channel payload
+236:     expect(body).toContain('PRIVATE');
+239:   it('does not emit channel:visibility-changed when channel no longer exists (race condition)', async () => {
+277:                 oldVisibility: 'PUBLIC_INDEXABLE',
+278:                 newVisibility: 'PRIVATE',
+297:     expect(body).not.toContain('event: channel:visibility-changed');
+300:   it('does not emit channel:visibility-changed for a different server', async () => {
+333:                 oldVisibility: 'PUBLIC_INDEXABLE',
+334:                 newVisibility: 'PRIVATE',
+353:     expect(body).not.toContain('event: channel:visibility-changed');
+
+FILE /Users/allen/repos/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx
+2:  * GuestChannelView — simplified layout for anonymous public channel access.
+4:  * Wraps content in VisibilityGuard so PRIVATE channels show AccessDeniedPage.
+16: import { AuthRedirect } from '@/components/channel/AuthRedirect';
+17: import { VisibilityGuard } from '@/components/channel/VisibilityGuard';
+19: import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+87: interface GuestChannelViewProps {
+92: export async function GuestChannelView({ serverSlug, channelSlug }: GuestChannelViewProps) {
+107:   //   - 401/other → expired/invalid token; membership unknown — still render AuthRedirect so
+124:         {isMember && <AuthRedirect to={`/channels/${serverSlug}/${channelSlug}`} />}
+126:         <VisibilityGuard visibility={ChannelVisibility.PRIVATE} isLoading={false}>
+128:         </VisibilityGuard>
+140:       {isMember && <AuthRedirect to={`/channels/${serverSlug}/${channelSlug}`} />}
+143:       <VisibilityGuard visibility={channel.visibility} isLoading={false}>
+149:             <GuestPromoBanner serverName={server.name} memberCount={memberCount} />
+152:       </VisibilityGuard>
+
+FILE /Users/allen/repos/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+2: import { GuestChannelView } from '@/components/channel/GuestChannelView';
+10: export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+20:   const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+28:     robots: { index: isIndexable, follow: true },
+41:   return <GuestChannelView serverSlug={serverSlug} channelSlug={channelSlug} />;
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:16:27.585Z
+
+There’s one important spec mismatch I want to verify before I answer: the guest-view spec says `PUBLIC_NO_INDEX` should still be guest-visible, but some public-route tests are asserting 404 for that state. I’m checking the actual frontend public API usage so I don’t overstate coverage.
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,260p' harmony-frontend/src/services/publicApiService.ts
+```
+
+Output:
+
+```text
+/**
+ * publicApiService — server-side service for the backend public REST API.
+ * Uses fetch (not the axios api-client) so it can be called from React Server
+ * Components, generateMetadata, and other server-only contexts.
+ * React `cache` is used for request deduplication within a single render pass.
+ */
+
+import { cache } from 'react';
+import type { Server, Channel, Message } from '@/types';
+import { ChannelType, ChannelVisibility } from '@/types';
+import { API_CONFIG, CACHE_DURATION } from '@/lib/constants';
+
+type PublicServer = Omit<Server, 'ownerId'>;
+
+// ─── Response shapes from the backend ─────────────────────────────────────────
+
+interface PublicServerResponse {
+  id: string;
+  name: string;
+  slug: string;
+  iconUrl?: string;
+  description?: string;
+  memberCount: number;
+  createdAt: string;
+}
+
+interface PublicChannelResponse {
+  id: string;
+  name: string;
+  slug: string;
+  serverId: string;
+  type: string;
+  visibility: string;
+  topic?: string | null;
+  position: number;
+  createdAt: string;
+}
+
+interface PublicMessageResponse {
+  id: string;
+  content: string;
+  createdAt: string;
+  editedAt?: string | null;
+  author: { id: string; username: string };
+}
+
+interface PublicMessagesApiResponse {
+  messages: PublicMessageResponse[];
+  page: number;
+  pageSize: number;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function mapChannelType(type: string): ChannelType {
+  switch (type) {
+    case 'VOICE':
+      return ChannelType.VOICE;
+    case 'ANNOUNCEMENT':
+      return ChannelType.ANNOUNCEMENT;
+    default:
+      return ChannelType.TEXT;
+  }
+}
+
+function mapChannelVisibility(visibility: string): ChannelVisibility {
+  switch (visibility) {
+    case 'PUBLIC_NO_INDEX':
+      return ChannelVisibility.PUBLIC_NO_INDEX;
+    case 'PRIVATE':
+      return ChannelVisibility.PRIVATE;
+    default:
+      return ChannelVisibility.PUBLIC_INDEXABLE;
+  }
+}
+
+// ─── Public API functions ──────────────────────────────────────────────────────
+
+/**
+ * Fetch public server info by slug.
+ * Returns null on any error or if the server is not found (404).
+ * Deduplicated within a single render pass via React `cache`.
+ */
+export const fetchPublicServer = cache(async (serverSlug: string): Promise<PublicServer | null> => {
+  try {
+    const res = await fetch(
+      `${API_CONFIG.BASE_URL}/api/public/servers/${encodeURIComponent(serverSlug)}`,
+      { next: { revalidate: CACHE_DURATION.PUBLIC_API_REVALIDATE } },
+    );
+    if (!res.ok) return null;
+
+    const data: PublicServerResponse = await res.json();
+    const server: PublicServer = {
+      id: data.id,
+      name: data.name,
+      slug: data.slug,
+      icon: data.iconUrl,
+      description: data.description,
+      memberCount: data.memberCount,
+      createdAt: data.createdAt,
+    };
+    return server;
+  } catch {
+    return null;
+  }
+});
+
+/**
+ * Fetch a single public channel by server slug + channel slug.
+ * - Returns null if the server or channel does not exist (404).
+ * - Returns `{ isPrivate: true }` if the channel is PRIVATE (403).
+ * - Returns `{ channel, isPrivate: false }` on success (200).
+ * Deduplicated within a single render pass via React `cache`.
+ */
+export const fetchPublicChannel = cache(
+  async (
+    serverSlug: string,
+    channelSlug: string,
+  ): Promise<{ channel: Channel; isPrivate: false } | { isPrivate: true } | null> => {
+    try {
+      const res = await fetch(
+        `${API_CONFIG.BASE_URL}/api/public/servers/${encodeURIComponent(serverSlug)}/channels/${encodeURIComponent(channelSlug)}`,
+        { next: { revalidate: CACHE_DURATION.PUBLIC_API_REVALIDATE } },
+      );
+
+      if (res.status === 404) return null;
+      if (res.status === 403) return { isPrivate: true };
+      if (!res.ok) return null;
+
+      const data: PublicChannelResponse = await res.json();
+      const channel: Channel = {
+        id: data.id,
+        name: data.name,
+        slug: data.slug,
+        serverId: data.serverId,
+        type: mapChannelType(data.type),
+        visibility: mapChannelVisibility(data.visibility),
+        topic: data.topic ?? undefined,
+        position: data.position,
+        createdAt: data.createdAt,
+      };
+      return { channel, isPrivate: false };
+    } catch {
+      return null;
+    }
+  },
+);
+
+/**
+ * Fetch paginated public messages for a channel.
+ * Returns an empty list on error.
+ */
+export async function fetchPublicMessages(
+  channelId: string,
+  page = 1,
+): Promise<{ messages: Message[]; hasMore: boolean }> {
+  try {
+    const res = await fetch(
+      `${API_CONFIG.BASE_URL}/api/public/channels/${encodeURIComponent(channelId)}/messages?page=${page}`,
+    );
+    if (!res.ok) return { messages: [], hasMore: false };
+
+    const data: PublicMessagesApiResponse = await res.json();
+    const messages: Message[] = data.messages.map(m => ({
+      id: m.id,
+      channelId,
+      authorId: m.author.id,
+      author: { id: m.author.id, username: m.author.username },
+      content: m.content,
+      timestamp: m.createdAt,
+      editedAt: m.editedAt ?? undefined,
+    }));
+    return { messages, hasMore: messages.length >= data.pageSize };
+  } catch {
+    return { messages: [], hasMore: false };
+  }
+}
+
+/**
+ * Returns true if the channel is publicly accessible (not PRIVATE and not missing).
+ */
+export async function isChannelGuestAccessible(
+  serverSlug: string,
+  channelSlug: string,
+): Promise<boolean> {
+  const result = await fetchPublicChannel(serverSlug, channelSlug);
+  return result !== null && !result.isPrivate;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "PUBLIC_NO_INDEX|PUBLIC_INDEXABLE|PRIVATE|getPublicChannel|fetchPublicChannel|findPublicByServerId|getVisibilityStatus|VisibilityGuard|/api/public/channels" harmony-backend/src harmony-frontend/src
+```
+
+Output:
+
+```text
+harmony-frontend/src/services/channelService.ts:42: * Uses tRPC authed endpoint for full channel list (including PRIVATE channels).
+harmony-frontend/src/services/channelService.ts:56: * for PUBLIC_INDEXABLE channels without requiring an auth cookie. If the channel
+harmony-frontend/src/services/channelService.ts:60: * Note: the public endpoint returns only PUBLIC_INDEXABLE channels and omits
+harmony-frontend/src/services/channelService.ts:63: * to PUBLIC_INDEXABLE).
+harmony-frontend/src/services/channelService.ts:75:    // Try the public REST endpoint. It returns only PUBLIC_INDEXABLE channels, so
+harmony-frontend/src/services/channelService.ts:87:            visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/services/channelService.ts:97:    // Fall back to the authenticated tRPC procedure (for PRIVATE / PUBLIC_NO_INDEX channels).
+harmony-frontend/src/services/publicApiService.ts:68:    case 'PUBLIC_NO_INDEX':
+harmony-frontend/src/services/publicApiService.ts:69:      return ChannelVisibility.PUBLIC_NO_INDEX;
+harmony-frontend/src/services/publicApiService.ts:70:    case 'PRIVATE':
+harmony-frontend/src/services/publicApiService.ts:71:      return ChannelVisibility.PRIVATE;
+harmony-frontend/src/services/publicApiService.ts:73:      return ChannelVisibility.PUBLIC_INDEXABLE;
+harmony-frontend/src/services/publicApiService.ts:111: * - Returns `{ isPrivate: true }` if the channel is PRIVATE (403).
+harmony-frontend/src/services/publicApiService.ts:115:export const fetchPublicChannel = cache(
+harmony-frontend/src/services/publicApiService.ts:159:      `${API_CONFIG.BASE_URL}/api/public/channels/${encodeURIComponent(channelId)}/messages?page=${page}`,
+harmony-frontend/src/services/publicApiService.ts:180: * Returns true if the channel is publicly accessible (not PRIVATE and not missing).
+harmony-frontend/src/services/publicApiService.ts:186:  const result = await fetchPublicChannel(serverSlug, channelSlug);
+harmony-frontend/src/services/messageService.ts:38: * Uses the public REST endpoint for PUBLIC_INDEXABLE channels.
+harmony-frontend/src/services/messageService.ts:49:  // Try public endpoint first (works for PUBLIC_INDEXABLE channels).
+harmony-frontend/src/services/messageService.ts:69:    // Public endpoint unavailable or channel is not PUBLIC_INDEXABLE — try tRPC.
+harmony-backend/src/services/visibility.service.ts:81:      // VOICE channels cannot be made PUBLIC_INDEXABLE
+harmony-backend/src/services/visibility.service.ts:82:      if (current.type === ChannelType.VOICE && visibility === ChannelVisibility.PUBLIC_INDEXABLE) {
+harmony-backend/src/services/visibility.service.ts:85:          message: 'VOICE channels cannot have PUBLIC_INDEXABLE visibility',
+harmony-backend/src/services/visibility.service.ts:93:          // §6.3: set indexedAt only when transitioning TO PUBLIC_INDEXABLE (not on no-op updates)
+harmony-backend/src/services/visibility.service.ts:94:          ...(visibility === ChannelVisibility.PUBLIC_INDEXABLE &&
+harmony-backend/src/services/visibility.service.ts:95:            current.visibility !== ChannelVisibility.PUBLIC_INDEXABLE && { indexedAt: new Date() }),
+harmony-backend/src/services/visibility.service.ts:96:          // §5.2: clear indexedAt when transitioning TO PRIVATE
+harmony-backend/src/services/visibility.service.ts:97:          ...(visibility === ChannelVisibility.PRIVATE &&
+harmony-backend/src/services/visibility.service.ts:98:            current.visibility !== ChannelVisibility.PRIVATE && { indexedAt: null }),
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:99:  visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:512:    const updatedChannel: Channel = { ...MOCK_CHANNEL, visibility: ChannelVisibility.PRIVATE };
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:527:        oldVisibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:535:      ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:554:          visibility: ChannelVisibility.PRIVATE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:555:          oldVisibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/lib/constants.ts:55:  PUBLIC_INDEXABLE = 'PUBLIC_INDEXABLE',
+harmony-frontend/src/lib/constants.ts:56:  PUBLIC_NO_INDEX = 'PUBLIC_NO_INDEX',
+harmony-frontend/src/lib/constants.ts:57:  PRIVATE = 'PRIVATE',
+harmony-backend/src/dev/mockSeed.ts:149:      .filter((channel) => parseChannelVisibility(channel.visibility) !== ChannelVisibility.PRIVATE)
+harmony-backend/src/dev/mockSeed.ts:189:    if (type === ChannelType.VOICE && visibility === ChannelVisibility.PUBLIC_INDEXABLE) {
+harmony-backend/src/dev/mockSeed.ts:190:      throw new Error(`VOICE channel ${channel.id} cannot be PUBLIC_INDEXABLE`);
+harmony-backend/src/dev/mockSeed.ts:206:      indexedAt: visibility === ChannelVisibility.PUBLIC_INDEXABLE ? createdAt : null,
+harmony-backend/src/services/indexing.service.ts:2: * IndexingService — manages sitemap data for PUBLIC_INDEXABLE channels.
+harmony-backend/src/services/indexing.service.ts:59:   * Generate a sitemap XML string for all PUBLIC_INDEXABLE channels in a server.
+harmony-backend/src/services/indexing.service.ts:78:            visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-backend/src/services/indexing.service.ts:98:    if (payload.newVisibility === 'PUBLIC_INDEXABLE') {
+harmony-backend/src/services/indexing.service.ts:100:    } else if (payload.oldVisibility === 'PUBLIC_INDEXABLE') {
+harmony-backend/src/routes/public.router.ts:14: * GET /api/public/channels/:channelId/messages
+harmony-backend/src/routes/public.router.ts:15: * Returns paginated messages for a PUBLIC_INDEXABLE channel.
+harmony-backend/src/routes/public.router.ts:37:      if (!channel || channel.visibility !== ChannelVisibility.PUBLIC_INDEXABLE) {
+harmony-backend/src/routes/public.router.ts:68: * GET /api/public/channels/:channelId/messages/:messageId
+harmony-backend/src/routes/public.router.ts:69: * Returns a single message from a PUBLIC_INDEXABLE channel.
+harmony-backend/src/routes/public.router.ts:89:      if (!channel || channel.visibility !== ChannelVisibility.PUBLIC_INDEXABLE) {
+harmony-backend/src/routes/public.router.ts:227:        where: { serverId: server.id, visibility: ChannelVisibility.PUBLIC_INDEXABLE },
+harmony-backend/src/routes/public.router.ts:259: * Returns channel info by slug. Returns 403 for PRIVATE channels, 404 if not found.
+harmony-backend/src/routes/public.router.ts:260: * Supports PUBLIC_INDEXABLE and PUBLIC_NO_INDEX channels for guest access.
+harmony-backend/src/routes/public.router.ts:296:      if (channel.visibility === ChannelVisibility.PRIVATE) {
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:68:    renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:75:    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:82:    renderToggle(ChannelVisibility.PRIVATE, true);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:89:    renderToggle(ChannelVisibility.PRIVATE, true);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:104:    renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:119:    const { onVisibilityChanged } = renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:125:    expect(onVisibilityChanged).toHaveBeenCalledWith(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:131:    renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:149:    renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:155:    // Should have rolled back to PRIVATE
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:163:    renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:177:    const { onVisibilityChanged } = renderToggle(ChannelVisibility.PRIVATE);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:187:// ─── Confirmation modal (PRIVATE transition) ─────────────────────────────────
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:190:  it('shows a confirmation dialog when selecting PRIVATE', () => {
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:192:    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:202:    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:213:      ChannelVisibility.PRIVATE,
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx:219:    renderToggle(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-backend/src/services/channel.service.ts:50:    // VOICE channels cannot be PUBLIC_INDEXABLE
+harmony-backend/src/services/channel.service.ts:51:    if (type === ChannelType.VOICE && visibility === ChannelVisibility.PUBLIC_INDEXABLE) {
+harmony-backend/src/services/channel.service.ts:54:        message: 'VOICE channels cannot have PUBLIC_INDEXABLE visibility',
+harmony-backend/src/services/channel.service.ts:169:      visibility: ChannelVisibility.PRIVATE,
+harmony-frontend/src/hooks/useServerEvents.ts:47:   * revocation (e.g. a PUBLIC channel became PRIVATE). Optional.
+harmony-backend/src/routes/seo.router.ts:4: * - GET /sitemap/:serverSlug.xml — dynamic sitemap of PUBLIC_INDEXABLE channels
+harmony-backend/src/routes/seo.router.ts:36: * Returns a dynamic XML sitemap containing all PUBLIC_INDEXABLE channels
+harmony-frontend/src/__tests__/channelService.test.ts:59:    visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:75:    oldValue: { visibility: 'PRIVATE' },
+harmony-frontend/src/__tests__/channelService.test.ts:76:    newValue: { visibility: 'PUBLIC_INDEXABLE' },
+harmony-frontend/src/__tests__/channelService.test.ts:143:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:160:      mockedTrpcQuery.mockResolvedValue(makeRawChannel({ visibility: 'PRIVATE' }));
+harmony-frontend/src/__tests__/channelService.test.ts:169:      expect(result).toMatchObject({ id: 'ch-1', visibility: 'PRIVATE' });
+harmony-frontend/src/__tests__/channelService.test.ts:249:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:268:      ['PRIVATE', ChannelVisibility.PRIVATE],
+harmony-frontend/src/__tests__/channelService.test.ts:269:      ['PUBLIC_INDEXABLE', ChannelVisibility.PUBLIC_INDEXABLE],
+harmony-frontend/src/__tests__/channelService.test.ts:270:      ['PUBLIC_NO_INDEX', ChannelVisibility.PUBLIC_NO_INDEX],
+harmony-frontend/src/__tests__/channelService.test.ts:287:        updateVisibility('ch-1', ChannelVisibility.PUBLIC_INDEXABLE, 'srv-1'),
+harmony-frontend/src/__tests__/channelService.test.ts:354:        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/channelService.test.ts:367:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:380:        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/channelService.test.ts:392:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:404:        visibility: ChannelVisibility.PRIVATE,
+harmony-frontend/src/__tests__/channelService.test.ts:417:      ['PUBLIC_NO_INDEX', ChannelVisibility.PUBLIC_NO_INDEX],
+harmony-frontend/src/__tests__/channelService.test.ts:418:      ['PRIVATE', ChannelVisibility.PRIVATE],
+harmony-frontend/src/__tests__/channelService.test.ts:447:          visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/channelService.test.ts:535:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:590:        oldValue: { visibility: 'PRIVATE' },
+harmony-frontend/src/__tests__/channelService.test.ts:591:        newValue: { visibility: 'PUBLIC_INDEXABLE' },
+harmony-frontend/src/__tests__/channelService.test.ts:643:      expect(ChannelVisibility.PUBLIC_INDEXABLE).toBe('PUBLIC_INDEXABLE');
+harmony-frontend/src/__tests__/channelService.test.ts:644:      expect(ChannelVisibility.PUBLIC_NO_INDEX).toBe('PUBLIC_NO_INDEX');
+harmony-frontend/src/__tests__/channelService.test.ts:645:      expect(ChannelVisibility.PRIVATE).toBe('PRIVATE');
+harmony-backend/src/services/auditLog.service.ts:28:  /** JSON snapshot of the old visibility state, e.g. `{ visibility: 'PRIVATE' }` */
+harmony-backend/src/services/auditLog.service.ts:30:  /** JSON snapshot of the new visibility state, e.g. `{ visibility: 'PUBLIC_INDEXABLE' }` */
+harmony-backend/src/trpc/routers/channel.router.ts:8:const ChannelVisibilitySchema = z.enum(['PUBLIC_INDEXABLE', 'PUBLIC_NO_INDEX', 'PRIVATE']);
+harmony-backend/src/trpc/routers/channel.router.ts:16:  /** Requires channel:read — prevents leaking PRIVATE channel metadata to non-members. */
+harmony-backend/src/trpc/routers/channel.router.ts:28:        visibility: ChannelVisibilitySchema.default('PRIVATE'),
+harmony-backend/src/routes/events.router.ts:14: * owns the requested channel, preventing access to PRIVATE channels by non-members.
+harmony-backend/src/routes/events.router.ts:402:  // (PRIVATE channels become inaccessible to non-members) without a page reload.
+harmony-backend/src/routes/events.router.ts:419:          // (e.g. current user is viewing a channel that just became PRIVATE).
+harmony-backend/src/events/eventTypes.ts:4:export type ChannelVisibilityValue = 'PUBLIC_INDEXABLE' | 'PUBLIC_NO_INDEX' | 'PRIVATE';
+harmony-backend/src/dev/mock-seed-data.json:129:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:140:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:151:      "visibility": "PUBLIC_NO_INDEX",
+harmony-backend/src/dev/mock-seed-data.json:162:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:173:      "visibility": "PRIVATE",
+harmony-backend/src/dev/mock-seed-data.json:184:      "visibility": "PUBLIC_NO_INDEX",
+harmony-backend/src/dev/mock-seed-data.json:195:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:206:      "visibility": "PRIVATE",
+harmony-backend/src/dev/mock-seed-data.json:217:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:228:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:239:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:250:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:261:      "visibility": "PUBLIC_NO_INDEX",
+harmony-backend/src/dev/mock-seed-data.json:272:      "visibility": "PRIVATE",
+harmony-backend/src/dev/mock-seed-data.json:283:      "visibility": "PUBLIC_NO_INDEX",
+harmony-backend/src/dev/mock-seed-data.json:294:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:305:      "visibility": "PRIVATE",
+harmony-backend/src/dev/mock-seed-data.json:316:      "visibility": "PRIVATE",
+harmony-backend/src/dev/mock-seed-data.json:327:      "visibility": "PRIVATE",
+harmony-backend/src/dev/mock-seed-data.json:338:      "visibility": "PUBLIC_NO_INDEX",
+harmony-backend/src/dev/mock-seed-data.json:349:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:360:      "visibility": "PRIVATE",
+harmony-backend/src/dev/mock-seed-data.json:371:      "visibility": "PRIVATE",
+harmony-backend/src/dev/mock-seed-data.json:382:      "visibility": "PUBLIC_INDEXABLE",
+harmony-backend/src/dev/mock-seed-data.json:393:      "visibility": "PRIVATE",
+harmony-backend/src/dev/mock-seed-data.json:1875:      "content": "📦 **PR #7 merged** — TypeScript types for Server, Channel, Message, User. Visibility enum values locked in: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.",
+harmony-backend/src/dev/mock-seed-data.json:1979:      "content": "📦 **VisibilityGuard + SearchModal** added in #56 — gate content by visibility state, Ctrl+K search.",
+harmony-backend/src/dev/mock-seed-data.json:3588:      "content": "Sharing my QA demo recording. Shows the VisibilityGuard switching between PUBLIC and PRIVATE states. Works perfectly!",
+harmony-backend/src/dev/mock-seed-data.json:3601:      "content": "That VisibilityGuard demo is exactly what the professor will want to see. The lock icon + CTA buttons look polished.",
+harmony-backend/src/dev/mock-seed-data.json:7365:      "content": "**Wireframe v1 — VisibilityGuard/AccessDenied:** Lock icon centred, two CTA buttons. Simple and clear.",
+harmony-frontend/src/types/channel.ts:27:  PUBLIC_INDEXABLE = 'PUBLIC_INDEXABLE',
+harmony-frontend/src/types/channel.ts:28:  PUBLIC_NO_INDEX = 'PUBLIC_NO_INDEX',
+harmony-frontend/src/types/channel.ts:29:  PRIVATE = 'PRIVATE',
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:3:import { fetchPublicServer, fetchPublicChannel } from '@/services/publicApiService';
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:14:    fetchPublicChannel(serverSlug, channelSlug),
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:20:  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+harmony-frontend/src/app/settings/actions.ts:7: * unauthenticated users (PUBLIC_INDEXABLE or PUBLIC_NO_INDEX). Returns false
+harmony-frontend/src/app/settings/actions.ts:8: * for PRIVATE channels and channels that don't exist.
+harmony-frontend/src/app/settings/actions.ts:22:    // 200 = accessible (PUBLIC_INDEXABLE or PUBLIC_NO_INDEX)
+harmony-frontend/src/app/settings/actions.ts:23:    // 403 = PRIVATE (not guest accessible)
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:2: * Channel Component: VisibilityGuard
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:6: *   PUBLIC_INDEXABLE  → render children
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:7: *   PUBLIC_NO_INDEX   → render children (same guest experience)
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:8: *   PRIVATE           → render AccessDeniedPage
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:10: * Ref: dev-spec-guest-public-channel-view.md — VisibilityGuard (C1.2)
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:80:// ─── Access denied page (PRIVATE channel) ────────────────────────────────────
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:140:export interface VisibilityGuardProps {
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:149:   * VisibilityGuard uses it to check whether the authenticated user is an
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:150:   * admin/owner and therefore allowed to view PRIVATE channels. Authenticated
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:151:   * non-admin members are shown AccessDeniedPage for PRIVATE channels, covering
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:160:   * except system admins). Passing this prop lets VisibilityGuard correctly allow
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:161:   * access for server admins when viewing PRIVATE channels directly by URL.
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:168:export function VisibilityGuard({
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:175:}: VisibilityGuardProps) {
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:193:  if (visibility === ChannelVisibility.PRIVATE && isAuthLoading) {
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:197:  if (visibility === ChannelVisibility.PRIVATE) {
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:198:    // Unauthenticated users never have access to PRIVATE channels.
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:203:    // Authenticated non-admin members also cannot access PRIVATE channels.
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:205:    // path: a non-admin member who navigates to a PRIVATE channel URL after
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:217:  // PUBLIC_INDEXABLE or PUBLIC_NO_INDEX, or PRIVATE + admin/owner — show content
+harmony-frontend/src/components/layout/HarmonyShell.tsx:300:      // If the current user is viewing this channel and it just became PRIVATE,
+harmony-frontend/src/components/layout/HarmonyShell.tsx:301:      // redirect non-admin members to the server root so VisibilityGuard can
+harmony-frontend/src/components/layout/HarmonyShell.tsx:303:      // because they retain access to PRIVATE channels.
+harmony-frontend/src/components/layout/HarmonyShell.tsx:319:        oldVisibility !== ChannelVisibility.PRIVATE &&
+harmony-frontend/src/components/layout/HarmonyShell.tsx:320:        channel.visibility === ChannelVisibility.PRIVATE &&
+harmony-frontend/src/components/channel/MessageList.tsx:134:          {channel.visibility === ChannelVisibility.PUBLIC_INDEXABLE &&
+harmony-frontend/src/components/channel/MessageList.tsx:136:          {channel.visibility === ChannelVisibility.PUBLIC_NO_INDEX && '👁 Public · Not indexed'}
+harmony-frontend/src/components/channel/MessageList.tsx:137:          {channel.visibility === ChannelVisibility.PRIVATE && '🔒 Private channel'}
+harmony-frontend/src/components/channel/ChannelSidebar.tsx:72:  [ChannelVisibility.PRIVATE]: '🔒',
+harmony-frontend/src/components/channel/ChannelSidebar.tsx:73:  [ChannelVisibility.PUBLIC_NO_INDEX]: '👁',
+harmony-frontend/src/components/channel/ChannelSidebar.tsx:74:  [ChannelVisibility.PUBLIC_INDEXABLE]: null,
+harmony-frontend/src/components/channel/ChannelSidebar.tsx:78:  [ChannelVisibility.PRIVATE]: 'Private channel',
+harmony-frontend/src/components/channel/ChannelSidebar.tsx:79:  [ChannelVisibility.PUBLIC_NO_INDEX]: 'Public channel, not indexed',
+harmony-frontend/src/components/channel/ChannelSidebar.tsx:80:  [ChannelVisibility.PUBLIC_INDEXABLE]: '',
+harmony-frontend/src/components/channel/ChannelSidebar.tsx:205:      (isAuthenticated || c.visibility !== ChannelVisibility.PRIVATE),
+harmony-frontend/src/components/channel/ChannelSidebar.tsx:208:    c => c.type === ChannelType.VOICE && (isAuthenticated || c.visibility !== ChannelVisibility.PRIVATE),
+harmony-frontend/src/components/channel/VisibilityToggle.tsx:81:    value: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/components/channel/VisibilityToggle.tsx:87:    value: ChannelVisibility.PUBLIC_NO_INDEX,
+harmony-frontend/src/components/channel/VisibilityToggle.tsx:93:    value: ChannelVisibility.PRIVATE,
+harmony-frontend/src/components/channel/VisibilityToggle.tsx:261:    if (value === ChannelVisibility.PRIVATE) {
+harmony-frontend/src/components/channel/GuestChannelView.tsx:4: * Wraps content in VisibilityGuard so PRIVATE channels show AccessDeniedPage.
+harmony-frontend/src/components/channel/GuestChannelView.tsx:11:  fetchPublicChannel,
+harmony-frontend/src/components/channel/GuestChannelView.tsx:17:import { VisibilityGuard } from '@/components/channel/VisibilityGuard';
+harmony-frontend/src/components/channel/GuestChannelView.tsx:95:    fetchPublicChannel(serverSlug, channelSlug),
+harmony-frontend/src/components/channel/GuestChannelView.tsx:126:        <VisibilityGuard visibility={ChannelVisibility.PRIVATE} isLoading={false}>
+harmony-frontend/src/components/channel/GuestChannelView.tsx:128:        </VisibilityGuard>
+harmony-frontend/src/components/channel/GuestChannelView.tsx:143:      <VisibilityGuard visibility={channel.visibility} isLoading={false}>
+harmony-frontend/src/components/channel/GuestChannelView.tsx:152:      </VisibilityGuard>
+harmony-frontend/src/components/channel/ChannelPageContent.tsx:7:import { VisibilityGuard } from '@/components/channel/VisibilityGuard';
+harmony-frontend/src/components/channel/ChannelPageContent.tsx:76:    <VisibilityGuard
+harmony-frontend/src/components/channel/ChannelPageContent.tsx:83:    </VisibilityGuard>
+harmony-frontend/src/components/settings/ChannelSettingsPage.tsx:349:  [ChannelVisibility.PUBLIC_INDEXABLE]: 'Public (Search Indexed)',
+harmony-frontend/src/components/settings/ChannelSettingsPage.tsx:350:  [ChannelVisibility.PUBLIC_NO_INDEX]: 'Public (Not Indexed)',
+harmony-frontend/src/components/settings/ChannelSettingsPage.tsx:351:  [ChannelVisibility.PRIVATE]: 'Private',
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:99:    value: ChannelVisibility.PRIVATE,
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:105:    value: ChannelVisibility.PUBLIC_NO_INDEX,
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:111:    value: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:155:  const [visibility, setVisibility] = useState<ChannelVisibility>(ChannelVisibility.PRIVATE);
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:291:                    // PUBLIC_INDEXABLE is unavailable for voice — reset to the nearest valid option.
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:292:                    if (opt.value === ChannelType.VOICE && visibility === ChannelVisibility.PUBLIC_INDEXABLE) {
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:293:                      setVisibility(ChannelVisibility.PUBLIC_NO_INDEX);
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:390:                // Voice channels have no text content to index, so PUBLIC_INDEXABLE is not applicable.
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:391:                type !== ChannelType.VOICE || opt.value !== ChannelVisibility.PUBLIC_INDEXABLE,
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:16:43.425Z
+
+I found a real gap, not just missing tests: the guest-view spec says `PUBLIC_NO_INDEX` is still guest-accessible, but the current public message tests enforce 404 for that state. I’m pulling the exact route lines so I can point to the mismatch cleanly.
+
+#### Tool: exec_command
+
+```sh
+nl -ba harmony-backend/src/routes/public.router.ts | sed -n '1,340p'
+```
+
+Output:
+
+```text
+     1	import { Router, Request, Response } from 'express';
+     2	import { prisma } from '../db/prisma';
+     3	import { ChannelVisibility } from '@prisma/client';
+     4	import { cacheMiddleware } from '../middleware/cache.middleware';
+     5	import { cacheService, CacheKeys, CacheTTL, sanitizeKeySegment } from '../services/cache.service';
+     6	import { tokenBucketRateLimiter } from '../middleware/rate-limit.middleware';
+     7	
+     8	export const publicRouter = Router();
+     9	
+    10	// Token bucket rate limiting per issue #110: 100 req/min (human) / 1000 req/min (verified bots)
+    11	publicRouter.use(tokenBucketRateLimiter);
+    12	
+    13	/**
+    14	 * GET /api/public/channels/:channelId/messages
+    15	 * Returns paginated messages for a PUBLIC_INDEXABLE channel.
+    16	 * Uses cache middleware with stale-while-revalidate.
+    17	 */
+    18	publicRouter.get(
+    19	  '/channels/:channelId/messages',
+    20	  cacheMiddleware({
+    21	    ttl: CacheTTL.channelMessages,
+    22	    staleTtl: CacheTTL.channelMessages, // keep stale data for an extra TTL window
+    23	    keyFn: (req: Request) =>
+    24	      CacheKeys.channelMessages(req.params.channelId, Number(req.query.page) || 1),
+    25	  }),
+    26	  async (req: Request, res: Response) => {
+    27	    try {
+    28	      const { channelId } = req.params;
+    29	      const page = Math.max(1, Number(req.query.page) || 1);
+    30	      const pageSize = 50;
+    31	
+    32	      const channel = await prisma.channel.findUnique({
+    33	        where: { id: channelId },
+    34	        select: { id: true, visibility: true },
+    35	      });
+    36	
+    37	      if (!channel || channel.visibility !== ChannelVisibility.PUBLIC_INDEXABLE) {
+    38	        res.status(404).json({ error: 'Channel not found' });
+    39	        return;
+    40	      }
+    41	
+    42	      const messages = await prisma.message.findMany({
+    43	        where: { channelId, isDeleted: false },
+    44	        orderBy: { createdAt: 'desc' },
+    45	        skip: (page - 1) * pageSize,
+    46	        take: pageSize,
+    47	        select: {
+    48	          id: true,
+    49	          content: true,
+    50	          createdAt: true,
+    51	          editedAt: true,
+    52	          author: { select: { id: true, username: true } },
+    53	        },
+    54	      });
+    55	
+    56	      res.set('Cache-Control', `public, max-age=${CacheTTL.channelMessages}`);
+    57	      res.json({ messages, page, pageSize });
+    58	    } catch (err) {
+    59	      console.error('Public messages route error:', err);
+    60	      if (!res.headersSent) {
+    61	        res.status(500).json({ error: 'Internal server error' });
+    62	      }
+    63	    }
+    64	  },
+    65	);
+    66	
+    67	/**
+    68	 * GET /api/public/channels/:channelId/messages/:messageId
+    69	 * Returns a single message from a PUBLIC_INDEXABLE channel.
+    70	 * Uses cache middleware with stale-while-revalidate.
+    71	 */
+    72	publicRouter.get(
+    73	  '/channels/:channelId/messages/:messageId',
+    74	  cacheMiddleware({
+    75	    ttl: CacheTTL.channelMessages,
+    76	    staleTtl: CacheTTL.channelMessages,
+    77	    keyFn: (req: Request) =>
+    78	      `channel:msg:${sanitizeKeySegment(req.params.channelId)}:${sanitizeKeySegment(req.params.messageId)}`,
+    79	  }),
+    80	  async (req: Request, res: Response) => {
+    81	    try {
+    82	      const { channelId, messageId } = req.params;
+    83	
+    84	      const channel = await prisma.channel.findUnique({
+    85	        where: { id: channelId },
+    86	        select: { id: true, visibility: true },
+    87	      });
+    88	
+    89	      if (!channel || channel.visibility !== ChannelVisibility.PUBLIC_INDEXABLE) {
+    90	        res.status(404).json({ error: 'Channel not found' });
+    91	        return;
+    92	      }
+    93	
+    94	      const message = await prisma.message.findFirst({
+    95	        where: { id: messageId, channelId, isDeleted: false },
+    96	        select: {
+    97	          id: true,
+    98	          content: true,
+    99	          createdAt: true,
+   100	          editedAt: true,
+   101	          author: { select: { id: true, username: true } },
+   102	        },
+   103	      });
+   104	
+   105	      if (!message) {
+   106	        res.status(404).json({ error: 'Message not found' });
+   107	        return;
+   108	      }
+   109	
+   110	      res.set('Cache-Control', `public, max-age=${CacheTTL.channelMessages}`);
+   111	      res.json(message);
+   112	    } catch (err) {
+   113	      console.error('Public message route error:', err);
+   114	      if (!res.headersSent) {
+   115	        res.status(500).json({ error: 'Internal server error' });
+   116	      }
+   117	    }
+   118	  },
+   119	);
+   120	
+   121	/**
+   122	 * GET /api/public/servers
+   123	 * Returns a list of public servers ordered by member count (desc).
+   124	 * Used by the home page to discover a default public channel to show visitors.
+   125	 */
+   126	publicRouter.get('/servers', async (_req: Request, res: Response) => {
+   127	  try {
+   128	    const servers = await prisma.server.findMany({
+   129	      where: { isPublic: true },
+   130	      orderBy: { memberCount: 'desc' },
+   131	      take: 20,
+   132	      select: {
+   133	        id: true,
+   134	        name: true,
+   135	        slug: true,
+   136	        iconUrl: true,
+   137	        description: true,
+   138	        memberCount: true,
+   139	        createdAt: true,
+   140	      },
+   141	    });
+   142	    res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+   143	    res.json(servers);
+   144	  } catch (err) {
+   145	    console.error('Public servers list route error:', err);
+   146	    res.status(500).json({ error: 'Internal server error' });
+   147	  }
+   148	});
+   149	
+   150	/**
+   151	 * GET /api/public/servers/:serverSlug
+   152	 * Returns public server info. Uses getOrRevalidate for SWR.
+   153	 * Cache key: server:{serverId}:info per §4.4.
+   154	 */
+   155	publicRouter.get('/servers/:serverSlug', async (req: Request, res: Response) => {
+   156	  try {
+   157	    const server = await prisma.server.findUnique({
+   158	      where: { slug: req.params.serverSlug },
+   159	      select: {
+   160	        id: true,
+   161	        name: true,
+   162	        slug: true,
+   163	        iconUrl: true,
+   164	        description: true,
+   165	        memberCount: true,
+   166	        createdAt: true,
+   167	      },
+   168	    });
+   169	
+   170	    if (!server) {
+   171	      res.status(404).json({ error: 'Server not found' });
+   172	      return;
+   173	    }
+   174	
+   175	    const cacheKey = CacheKeys.serverInfo(server.id);
+   176	    const cacheOpts = { ttl: CacheTTL.serverInfo, staleTtl: CacheTTL.serverInfo };
+   177	
+   178	    // Check cache state for X-Cache header
+   179	    let xCache = 'MISS';
+   180	    try {
+   181	      const entry = await cacheService.get(cacheKey);
+   182	      if (entry) {
+   183	        xCache = cacheService.isStale(entry, CacheTTL.serverInfo) ? 'STALE' : 'HIT';
+   184	      }
+   185	    } catch {
+   186	      /* Redis error */
+   187	    }
+   188	
+   189	    const data = await cacheService.getOrRevalidate(
+   190	      cacheKey,
+   191	      async () => server, // fetcher — server already fetched from DB above
+   192	      cacheOpts,
+   193	    );
+   194	
+   195	    res.set('X-Cache', xCache);
+   196	    res.set('X-Cache-Key', cacheKey);
+   197	    res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+   198	    res.json(data);
+   199	  } catch (err) {
+   200	    console.error('Public server route error:', err);
+   201	    res.status(500).json({ error: 'Internal server error' });
+   202	  }
+   203	});
+   204	
+   205	/**
+   206	 * GET /api/public/servers/:serverSlug/channels
+   207	 * Returns public channels for a server. Uses getOrRevalidate for SWR.
+   208	 * Cache key: server:{serverId}:public_channels per §4.4.
+   209	 */
+   210	publicRouter.get('/servers/:serverSlug/channels', async (req: Request, res: Response) => {
+   211	  try {
+   212	    const server = await prisma.server.findUnique({
+   213	      where: { slug: req.params.serverSlug },
+   214	      select: { id: true },
+   215	    });
+   216	
+   217	    if (!server) {
+   218	      res.status(404).json({ error: 'Server not found' });
+   219	      return;
+   220	    }
+   221	
+   222	    const cacheKey = `server:${sanitizeKeySegment(server.id)}:public_channels`;
+   223	    const cacheOpts = { ttl: CacheTTL.serverInfo, staleTtl: CacheTTL.serverInfo };
+   224	
+   225	    const fetcher = async () => {
+   226	      const channels = await prisma.channel.findMany({
+   227	        where: { serverId: server.id, visibility: ChannelVisibility.PUBLIC_INDEXABLE },
+   228	        orderBy: { position: 'asc' },
+   229	        select: { id: true, name: true, slug: true, type: true, topic: true },
+   230	      });
+   231	      return { channels };
+   232	    };
+   233	
+   234	    // Check cache state for X-Cache header
+   235	    let xCache = 'MISS';
+   236	    try {
+   237	      const entry = await cacheService.get(cacheKey);
+   238	      if (entry) {
+   239	        xCache = cacheService.isStale(entry, CacheTTL.serverInfo) ? 'STALE' : 'HIT';
+   240	      }
+   241	    } catch {
+   242	      /* Redis error */
+   243	    }
+   244	
+   245	    const data = await cacheService.getOrRevalidate(cacheKey, fetcher, cacheOpts);
+   246	
+   247	    res.set('X-Cache', xCache);
+   248	    res.set('X-Cache-Key', cacheKey);
+   249	    res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+   250	    res.json(data);
+   251	  } catch (err) {
+   252	    console.error('Public channels route error:', err);
+   253	    res.status(500).json({ error: 'Internal server error' });
+   254	  }
+   255	});
+   256	
+   257	/**
+   258	 * GET /api/public/servers/:serverSlug/channels/:channelSlug
+   259	 * Returns channel info by slug. Returns 403 for PRIVATE channels, 404 if not found.
+   260	 * Supports PUBLIC_INDEXABLE and PUBLIC_NO_INDEX channels for guest access.
+   261	 */
+   262	publicRouter.get(
+   263	  '/servers/:serverSlug/channels/:channelSlug',
+   264	  async (req: Request, res: Response) => {
+   265	    try {
+   266	      const server = await prisma.server.findUnique({
+   267	        where: { slug: req.params.serverSlug },
+   268	        select: { id: true },
+   269	      });
+   270	
+   271	      if (!server) {
+   272	        res.status(404).json({ error: 'Server not found' });
+   273	        return;
+   274	      }
+   275	
+   276	      const channel = await prisma.channel.findFirst({
+   277	        where: { serverId: server.id, slug: req.params.channelSlug },
+   278	        select: {
+   279	          id: true,
+   280	          name: true,
+   281	          slug: true,
+   282	          serverId: true,
+   283	          type: true,
+   284	          visibility: true,
+   285	          topic: true,
+   286	          position: true,
+   287	          createdAt: true,
+   288	        },
+   289	      });
+   290	
+   291	      if (!channel) {
+   292	        res.status(404).json({ error: 'Channel not found' });
+   293	        return;
+   294	      }
+   295	
+   296	      if (channel.visibility === ChannelVisibility.PRIVATE) {
+   297	        res.status(403).json({ error: 'Channel is private' });
+   298	        return;
+   299	      }
+   300	
+   301	      res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+   302	      res.json(channel);
+   303	    } catch (err) {
+   304	      console.error('Public channel route error:', err);
+   305	      res.status(500).json({ error: 'Internal server error' });
+   306	    }
+   307	  },
+   308	);
+```
+
+#### Tool: exec_command
+
+```sh
+nl -ba docs/dev-spec-guest-public-channel-view.md | sed -n '500,740p'
+```
+
+Output:
+
+````text
+   500	|----------|------|-------------|
+   501	| request.path | string | Current URL path being requested |
+   502	| channel.visibility | ChannelVisibility | Visibility state of requested channel |
+   503	| cache.status | CacheStatus | Whether response is cached (HIT/MISS/STALE) |
+   504	| guest.sessionId | string | Anonymous session identifier |
+   505	| page.loadState | LoadState | Current page loading state |
+   506	| messages.pagination | PaginationState | Current pagination position |
+   507	
+   508	> **Convention:** `is_public` (boolean) applies to **servers** — whether the server appears in discovery. `visibility` (enum: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) applies to **channels** — whether channel content is accessible to guests and/or indexed by search engines.
+   509	
+   510	### 5.2 Page Load State Machine
+   511	
+   512	```mermaid
+   513	stateDiagram-v2
+   514	    [*] --> S1 : GET /c/{server}/{channel}
+   515	
+   516	    S1 : S1: Edge Cache Check\ncache.status=CHECKING
+   517	    S2 : S2: Serve Cached\ncache.status=HIT\nresponse.source=EDGE
+   518	    S3 : S3: Origin Request\ncache.status=MISS\nrequest.forwarded=true
+   519	    S4 : S4: Visibility Check\nchannel.visibility=?
+   520	    S5 : S5: Access Denied\nerror=403 OR redirect=true
+   521	    S6 : S6: Fetch Content\nmessages=loading\nserver=loading
+   522	    S7 : S7: Render Page\npage.loadState=COMPLETE\nseo.tags=generated
+   523	    S8 : S8: Cache Response\ncache.stored=true\ncache.ttl=60s
+   524	    S9 : S9: Response Delivered\npage.loadState=DELIVERED
+   525	
+   526	    S1 --> S2 : Cache hit (valid or stale <300s)\n[return cached HTML; stale triggers background revalidation]
+   527	    S1 --> S3 : Cache miss or expired\n[forward to origin]
+   528	    S3 --> S4 : Always\n[query database]
+   529	    S4 --> S5 : visibility != PUBLIC_*\n[return 403 or redirect]
+   530	    S4 --> S6 : visibility = PUBLIC_*\n[query messages]
+   531	    S6 --> S7 : Content retrieved\n[generate HTML]
+   532	    S7 --> S8 : Rendering complete\n[store in edge cache]
+   533	    S2 --> S9 : Response ready\n[send to client]
+   534	    S8 --> S9 : Response ready\n[send to client]
+   535	    S5 --> S9 : Response ready\n[send to client]
+   536	```
+   537	
+   538	### 5.3 Message Loading State Machine (Client-Side Hydration)
+   539	
+   540	```mermaid
+   541	stateDiagram-v2
+   542	    [*] --> M1 : Page hydrated\n(initial messages rendered)
+   543	
+   544	    M1 : M1: Initial View\nmessages.count=initialBatch\npagination.hasMore=true\nscroll.position=top
+   545	    M2 : M2: Loading More\nloading=true\npagination.page++
+   546	    M3 : M3: Scrolling to Message\ntargetMessage=id\nscroll.behavior=smooth
+   547	    M4 : M4: Messages Appended\nmessages+=newBatch\nloading=false
+   548	    M5 : M5: Message Highlighted\nhighlight.visible=true\nhighlight.ttl=3s
+   549	
+   550	    M1 --> M2 : Scroll to bottom
+   551	    M1 --> M3 : Click message link
+   552	    M2 --> M4 : API returns
+   553	    M3 --> M5 : Message found
+   554	    M4 --> M1 : Return to browsing state
+   555	    M5 --> M1 : Return to browsing state
+   556	```
+   557	
+   558	### 5.4 Access Denial State Machine
+   559	
+   560	```mermaid
+   561	stateDiagram-v2
+   562	    [*] --> D1 : Private channel requested\n(visibility=PRIVATE)
+   563	
+   564	    D1 : D1: Evaluate Response\nserver.isPublic=?\nreferrer.source=?
+   565	    D2 : D2: Show Login Prompt\n"Log in to view this channel"\n+ explain why + link to join
+   566	    D3 : D3: Show Server Landing\nRedirect to /s/{server}\nShow public channels list
+   567	    D4 : D4: Show 404 Not Found\nChannel does not exist or is private\n(no info leak)
+   568	
+   569	    D1 --> D2 : From search engine\n[403 + Login prompt]
+   570	    D1 --> D3 : Server is public\n[Redirect to server landing]
+   571	    D1 --> D4 : Server is private OR channel not found\n[404 Not Found]
+   572	```
+   573	
+   574	### 5.5 Rationale
+   575	
+   576	These states were chosen to show the phases a guest can be for viewing a public channel, the states handle critical edge cases a guest can experience since the endpoints are publicily accessible such as trying to visit a private channel or channel that isn't cached. The state also has no login redirect due to the fact that this feature is supposed allow anonymous users to access public channels. Importantly each state has a clear end to each phase so the guest ins't stuck in a loop state that they can't get out off.
+   577	
+   578	---
+   579	
+   580	## 6. Flow Charts
+   581	
+   582	### 6.1 Scenario: Guest Views Public Channel from Search Result
+   583	
+   584	**Scenario Description:** A guest user clicks a search result link that leads to a public channel. The system serves the full content without any login prompts, allowing the user to immediately access the information they were searching for.
+   585	
+   586	```mermaid
+   587	flowchart TD
+   588	    Start(["START: Guest clicks search result\nURL: /c/gamedev/help-and-questions?m=abc123\nReferrer: google.com search"])
+   589	    F11["F1.1 Request reaches CloudFlare edge\nCacheRouter.checkCache()"]
+   590	    CacheHit{"F1.2: Cache hit?"}
+   591	    F13["F1.3 Serve cached HTML response"]
+   592	    F14["F1.4 Forward to origin server"]
+   593	    F15["F1.5 Parse URL params\nserverSlug, channelSlug, messageId"]
+   594	    F16["F1.6 Look up channel\nChannelRepository.findBySlug(serverSlug, channelSlug)"]
+   595	    ChExists{"F1.7: Channel exists?"}
+   596	    F18["F1.8 Return 404\nChannel not found"]
+   597	    F19["F1.9 Check visibility\nVisibilityGuard.isChannelPublic(channelId)"]
+   598	    IsPublic{"F1.10: Is PUBLIC_INDEXABLE\nor PUBLIC_NO_INDEX?"}
+   599	    F111["F1.11 Handle private channel\n(See Flow 6.2)"]
+   600	    F112["F1.12 Fetch server info\nServerRepository.getPublicInfo(serverId)"]
+   601	    F113["F1.13 Fetch public channels for sidebar\nChannelRepository.findPublicByServerId()"]
+   602	    F114["F1.14 Fetch messages\nMessageService.getMessagesForPublicView(channelId, page=1, limit=50)"]
+   603	    F115["F1.15 Filter content\nContentFilter.filterSensitiveContent()\nContentFilter.redactUserMentions()"]
+   604	    F115b["F1.15b Resolve attachments\nAttachmentService.getPublicAttachmentUrl()\nAttachmentService.isAttachmentPublic()"]
+   605	    F116["F1.16 Build public author DTOs\nAuthorService.getPublicAuthorInfo()"]
+   606	    F117["F1.17 Generate SEO data\nSEOService.generatePageTitle()\ngenerateDescription()\ngenerateStructuredData()"]
+   607	    F118["F1.18 Render HTML with Next.js SSR\n- SEO meta tags\n- Server sidebar\n- Message list\n- Guest promo banner\n- Structured data JSON-LD"]
+   608	    F119["F1.19 Set cache headers\nCache-Control: public, max-age=60, s-maxage=60\nstale-while-revalidate=300\nX-Robots-Tag: index, follow"]
+   609	    F120["F1.20 Response delivered to guest browser"]
+   610	    F121["F1.21 Browser renders page\nGuest sees full channel content"]
+   611	    MsgInUrl{"F1.22: messageId in URL?"}
+   612	    F123["F1.23 Display from top of channel"]
+   613	    F124["F1.24 Scroll to message and highlight it\nMessageLinkHandler.scrollToMessage()\nMessageLinkHandler.highlightMessage()"]
+   614	    F125["F1.25 Parse search terms from referrer URL\nSearchHighlighter.parseSearchTerms()\nSearchHighlighter.highlightMatches()"]
+   615	    End(["END: Guest viewing public channel\n- Full content visible\n- No login prompt shown\n- Search terms highlighted\n- Can navigate to other public channels"])
+   616	
+   617	    Start --> F11 --> CacheHit
+   618	    CacheHit -->|Yes| F13 --> F120
+   619	    CacheHit -->|No| F14 --> F15 --> F16 --> ChExists
+   620	    ChExists -->|No| F18 --> F120
+   621	    ChExists -->|Yes| F19 --> IsPublic
+   622	    IsPublic -->|No PRIVATE| F111 --> F120
+   623	    IsPublic -->|Yes| F112 --> F113 --> F114 --> F115 --> F115b --> F116 --> F117 --> F118 --> F119 --> F120
+   624	    F120 --> F121 --> MsgInUrl
+   625	    MsgInUrl -->|No| F123 --> F125
+   626	    MsgInUrl -->|Yes| F124 --> F125
+   627	    F125 --> End
+   628	```
+   629	
+   630	### 6.2 Scenario: Guest Requests Private Channel
+   631	
+   632	**Scenario Description:** A guest user requests a channel URL that points to a private channel. The system provides a helpful response without revealing sensitive information about the server's structure.
+   633	
+   634	```mermaid
+   635	flowchart TD
+   636	    Start(["START: Guest requests private channel\nURL: /c/company/internal-hr"])
+   637	    F21["F2.1 Visibility check returns PRIVATE\nVisibilityGuard.getVisibilityStatus()"]
+   638	    F22["F2.2 Check request context\n- Parse referrer header\n- Check if from search engine\n- Check server publicity"]
+   639	    ServerPublic{"F2.3: Server is public?"}
+   640	    F24["F2.4 Return 404\nPage not found\n(do not reveal that server or channel exists)"]
+   641	    F25["F2.5 Check referrer"]
+   642	    FromSearch{"F2.6: From search engine?"}
+   643	    F27["F2.7 Show login prompt\nThis channel requires membership to view.\nLogin / Create Account / Browse Public Channels"]
+   644	    F28["F2.8 Redirect to server landing page\n302 Redirect to /s/company\nShow list of public channels"]
+   645	    End(["END: Appropriate response served\n- No sensitive info leaked\n- User guided to available content\n- Clear explanation provided"])
+   646	
+   647	    Start --> F21 --> F22 --> ServerPublic
+   648	    ServerPublic -->|No| F24 --> End
+   649	    ServerPublic -->|Yes| F25 --> FromSearch
+   650	    FromSearch -->|Yes| F27 --> End
+   651	    FromSearch -->|No| F28 --> End
+   652	```
+   653	
+   654	### 6.3 Scenario: Guest Loads More Messages (Infinite Scroll)
+   655	
+   656	**Scenario Description:** A guest user scrolls to the bottom of the message list, triggering the infinite scroll mechanism to load older messages without a full page reload.
+   657	
+   658	```mermaid
+   659	flowchart TD
+   660	    Start(["START: Guest scrolls to bottom"])
+   661	    F31["F3.1 IntersectionObserver detects sentinel element\nInfiniteScrollHandler.onIntersect()"]
+   662	    HasMore{"F3.2: hasMore == true?"}
+   663	    F33["F3.3 Do nothing\nAll messages loaded"]
+   664	    F34["F3.4 Set loading state\nloading=true\nShow loading spinner"]
+   665	    F35["F3.5 Fetch next page\nGET /api/public/channels/{channelId}/messages\n?page={currentPage+1}&limit=50"]
+   666	    F36["F3.6 Server validates channel is still public\n(visibility could change)"]
+   667	    StillPublic{"F3.7: Still public?"}
+   668	    F38["F3.8 Return 403\nShow channel is now private message"]
+   669	    F39["F3.9 Fetch messages\nMessageRepository.findByChannelPaginated()"]
+   670	    F310["F3.10 Apply content filter\nContentFilter.filterSensitiveContent()"]
+   671	    F311["F3.11 Return JSON response\n{messages: MessageDTO[], hasMore: boolean, nextPage: number}"]
+   672	    F312["F3.12 Append messages to existing list\nMessageListComponent.appendMessages()"]
+   673	    F313["F3.13 Update state\nloading=false\nhasMore=response.hasMore\ncurrentPage++"]
+   674	    End(["END: More messages displayed\n- Seamless scroll experience\n- No page reload required\n- Loading indicator shown during fetch"])
+   675	
+   676	    Start --> F31 --> HasMore
+   677	    HasMore -->|No| F33
+   678	    HasMore -->|Yes| F34 --> F35 --> F36 --> StillPublic
+   679	    StillPublic -->|No| F38
+   680	    StillPublic -->|Yes| F39 --> F310 --> F311 --> F312 --> F313 --> End
+   681	```
+   682	
+   683	### 6.4 Scenario: Search Engine Bot Crawls Public Channel
+   684	
+   685	**Scenario Description:** A search engine bot (Googlebot, Bingbot, etc.) crawls a public channel page. The system serves optimized content with appropriate SEO signals.
+   686	
+   687	```mermaid
+   688	flowchart TD
+   689	    Start(["START: Bot requests public channel\nUser-Agent: Googlebot/2.1\nURL: /c/opensource/announcements"])
+   690	    F41["F4.1 Bot detection at edge\nBotDetector.detectBot()\nIdentified: Googlebot"]
+   691	    F42["F4.2 Apply bot-specific handling\n- Skip JS-dependent content\n- Ensure full HTML render\n- Apply bot rate limits"]
+   692	    F43SameFlow["Same visibility and content flow as F1.4-F1.18"]
+   693	    F43["F4.3 Generate bot-optimized response\n- Full message content inline\n- Structured data JSON-LD\n- Canonical URL\n- Breadcrumb schema\n- hreflang tags if i18n"]
+   694	    F44["F4.4 Set SEO headers\nX-Robots-Tag: index, follow\nLink: canonical; rel=canon\nCache-Control: public, s-maxage=3600"]
+   695	    F45["F4.5 Return HTML with structured data\nscript type=application/ld+json\n{ @context: schema.org, @type: DiscussionForumPosting, ... }"]
+   696	    End(["END: Bot crawl complete\n- Content indexed\n- Structured data parsed\n- Links discovered"])
+   697	
+   698	    Start --> F41 --> F42 --> F43SameFlow --> F43 --> F44 --> F45 --> End
+   699	```
+   700	
+   701	### 6.5 Cross-Spec Integration: VISIBILITY_CHANGED Event Consumption
+   702	
+   703	When the Channel Visibility Toggle spec emits a `VISIBILITY_CHANGED` event (via Redis Pub/Sub EventBus), the Guest Public Channel View system reacts as follows:
+   704	
+   705	| New Visibility | Guest View Action |
+   706	|---------------|-------------------|
+   707	| `PUBLIC_INDEXABLE` | Warm guest view cache for channel; begin serving public content |
+   708	| `PUBLIC_NO_INDEX` | Keep guest view cache (content still public); update `X-Robots-Tag` to `noindex` |
+   709	| `PRIVATE` | Invalidate all guest view caches for channel; return 403/404 on subsequent requests |
+   710	
+   711	**Event Payload Consumed:**
+   712	```typescript
+   713	interface VisibilityChangeEvent {
+   714	  channelId: string;        // UUID
+   715	  oldVisibility: ChannelVisibility;
+   716	  newVisibility: ChannelVisibility;
+   717	  actorId: string;          // UUID of admin who made the change
+   718	  timestamp: DateTime;
+   719	}
+   720	```
+   721	
+   722	**Cache Keys Invalidated on PRIVATE:**
+   723	- `channel:{channelId}:visibility`
+   724	- `channel:{channelId}:msgs:*` (all pages)
+   725	- `server:{serverId}:info`
+   726	
+   727	### 6.6 Rationale 
+   728	
+   729	The flow charts depict the major flow cases a guest will experience for Harmony. The first flow covers the primary case that the guest visits the public channel from search engine result, which is the primary aim for Harmony, to be able to provide public channel information to guests without the need of logging in. The second flow covers the edge case a guests tries to visit a private channel, safely redirecting them without revealing any sensitive information about the server. The third flow covers the guest loading more messages of the channel, allowing the guest to infinitely scroll older messages. The fourth flow covers the public channels to be crawlable by search engine bots, so guests searching for information related to public channels can see it. 
+   730	
+   731	---
+   732	
+   733	## 7. Development Risks and Failures
+   734	
+   735	### 7.1 Runtime Failures
+   736	
+   737	| Label | Failure Mode | User-Visible Effect | Internal Effect | Recovery Procedure | Likelihood | Impact |
+   738	|-------|--------------|--------------------|-----------------|--------------------|------------|--------|
+   739	| RF-1 | SSR render crash | 500 error page | React hydration failure | Error boundary catches; shows fallback UI | Medium | High |
+   740	| RF-2 | Database query timeout | Slow page load or timeout | Connection pool exhaustion | Query optimization; read replicas; timeout handling | Medium | Medium |
+````
+
+#### Tool: exec_command
+
+```sh
+nl -ba docs/dev-spec-channel-visibility-toggle.md | sed -n '330,490p'
+```
+
+Output:
+
+````text
+   330	### 5.2 Channel Visibility State Machine
+   331	
+   332	```mermaid
+   333	stateDiagram-v2
+   334	    [*] --> PRIVATE : Channel created (default)
+   335	
+   336	    state "PRIVATE (indexedAt=null, robots=noindex nofollow)" as PRIVATE
+   337	    state "PUBLIC_NO_INDEX (indexedAt=null, robots=noindex)" as PUBLIC_NO_INDEX
+   338	    state "PUBLIC_INDEXABLE (indexedAt=now, robots=index follow)" as PUBLIC_INDEXABLE
+   339	
+   340	    PRIVATE --> PUBLIC_NO_INDEX : setVisibility(PUBLIC_NO_INDEX)
+   341	    PRIVATE --> PUBLIC_INDEXABLE : setVisibility(PUBLIC_INDEXABLE) - add to sitemap, notify search engines
+   342	
+   343	    PUBLIC_NO_INDEX --> PRIVATE : setVisibility(PRIVATE)
+   344	    PUBLIC_NO_INDEX --> PUBLIC_INDEXABLE : setVisibility(PUBLIC_INDEXABLE) - add to sitemap, notify search engines
+   345	
+   346	    PUBLIC_INDEXABLE --> PRIVATE : setVisibility(PRIVATE) - remove from sitemap, request de-index
+   347	    PUBLIC_INDEXABLE --> PUBLIC_NO_INDEX : setVisibility(PUBLIC_NO_INDEX) - remove from sitemap, set noindex
+   348	```
+   349	
+   350	### 5.3 Admin Action State Diagram
+   351	
+   352	```mermaid
+   353	stateDiagram-v2
+   354	    [*] --> A1 : Admin views channel
+   355	
+   356	    A1 : A1: Settings Page Loaded\nisLoading=false
+   357	    A2 : A2: Confirmation Dialog\npendingVisibility=new
+   358	    A3 : A3: Updating\nisLoading=true
+   359	    A4 : A4: Error State\nerrorMessage=msg
+   360	    A5 : A5: Success State\nvisibility=updated
+   361	
+   362	    A1 --> A2 : Admin clicks toggle
+   363	    A2 --> A1 : Cancel
+   364	    A2 --> A3 : Confirm
+   365	    A3 --> A4 : Error
+   366	    A3 --> A5 : Success
+   367	    A4 --> A1 : After 3s / dismiss
+   368	    A5 --> A1 : After 3s / dismiss
+   369	```
+   370	
+   371	### 5.4 Rationale
+   372	
+   373	The first diagram correctly tracks the state changes for all possible channel states. No changes or reprompting the LLM was necessary for this section. The channel will be public, public & indexable, or private. A simplification of the roles-based access control in Discord, but covers the general idea. 
+   374	
+   375	The second diagram correctly tracks the state transitions for the channel visibility permission. It is quite simple so the model did not need to the reprompted for any changes.
+   376	
+   377	---
+   378	
+   379	## 6. Flow Charts
+   380	
+   381	### 6.1 Scenario: Admin Sets Channel to Public/Indexable
+   382	
+   383	Admin navigates to channel settings and toggles a private channel to publicly indexable. System validates permissions, updates DB, regenerates sitemap, and notifies search engines.
+   384	
+   385	```mermaid
+   386	flowchart TD
+   387	    Start(["START: Admin opens channel settings"])
+   388	    F11["F1.1 Load channel data\nChannelService.getChannel(channelId)"]
+   389	    F12["F1.2 Display current visibility toggle"]
+   390	    F13["F1.3 Show confirmation dialog"]
+   391	    Confirm{Admin confirms?}
+   392	    F15["F1.5 Cancel\nReturn to settings"]
+   393	    F16["F1.6 Send API request:\nupdateVisibility(channelId, PUBLIC_INDEXABLE)"]
+   394	    F17["F1.7 Validate JWT token"]
+   395	    TokenValid{Token valid?}
+   396	    Return401["Return 401"]
+   397	    F110["F1.10 Check admin permission"]
+   398	    HasPerm{Has permission?}
+   399	    Return403["Return 403"]
+   400	    F113["F1.13 Update visibility in DB"]
+   401	    F114["F1.14 Create audit log entry"]
+   402	    F115["F1.15 Emit VISIBILITY_CHANGED event"]
+   403	    F116["F1.16 Update sitemap"]
+   404	    F117["F1.17 Notify search engines (async)"]
+   405	    F118["F1.18 Invalidate cache"]
+   406	    F119["F1.19 Return success with updated channel"]
+   407	    SuccessResp{Success response?}
+   408	    F122["F1.22 Show error"]
+   409	    F123["F1.23 Update UI toggle"]
+   410	    End(["END: Channel is now public"])
+   411	
+   412	    Start --> F11 --> F12 --> F13 --> Confirm
+   413	    Confirm -->|No| F15
+   414	    Confirm -->|Yes| F16 --> F17 --> TokenValid
+   415	    TokenValid -->|No| Return401
+   416	    TokenValid -->|Yes| F110 --> HasPerm
+   417	    HasPerm -->|No| Return403
+   418	    HasPerm -->|Yes| F113 --> F114 --> F115 --> F116 --> F117 --> F118 --> F119 --> SuccessResp
+   419	    SuccessResp -->|No| F122
+   420	    SuccessResp -->|Yes| F123 --> End
+   421	```
+   422	
+   423	#### 6.1.1 Cross-Spec Integration: Visibility → PUBLIC_INDEXABLE
+   424	
+   425	When visibility changes to `PUBLIC_INDEXABLE`:
+   426	1. Emit `VISIBILITY_CHANGED` event via EventBus (Redis Pub/Sub)
+   427	2. **SEO Meta Tag Generation spec** consumes event → generates meta tags for the channel
+   428	3. **Guest Public Channel View spec** consumes event → warms guest view cache
+   429	
+   430	### 6.2 Scenario: Anonymous User Views Public Channel
+   431	
+   432	An anonymous user or crawler requests a public channel page. System verifies visibility and serves content with appropriate SEO headers.
+   433	
+   434	```mermaid
+   435	flowchart TD
+   436	    Start(["START: Request to /c/{serverSlug}/{channelSlug}"])
+   437	    F21["F2.1 Route to PublicChannelController"]
+   438	    F22["F2.2 Check cache:\nchannel:{channelId}:visibility"]
+   439	    CacheHit{Cache hit?}
+   440	    F24["F2.4 Query DB"]
+   441	    F26["F2.6 Cache result"]
+   442	    F25["F2.5 Use cached value"]
+   443	    ChExists{Channel exists?}
+   444	    Return404["Return 404"]
+   445	    IsPublic{"Is PUBLIC_*?"}
+   446	    Return403["Return 403"]
+   447	    F211["F2.11 Fetch messages"]
+   448	    F212["F2.12 Set X-Robots-Tag header\nPUBLIC_INDEXABLE → index,follow\nPUBLIC_NO_INDEX → noindex"]
+   449	    F213["F2.13 Add canonical URL + structured data"]
+   450	    F214["F2.14 Return HTML with SEO metadata"]
+   451	    End(["END: Response sent"])
+   452	
+   453	    Start --> F21 --> F22 --> CacheHit
+   454	    CacheHit -->|No| F24 --> F26 --> ChExists
+   455	    CacheHit -->|Yes| F25 --> ChExists
+   456	    ChExists -->|No| Return404
+   457	    ChExists -->|Yes| IsPublic
+   458	    IsPublic -->|No| Return403
+   459	    IsPublic -->|Yes| F211 --> F212 --> F213 --> F214 --> End
+   460	```
+   461	
+   462	### 6.3 Scenario: Admin Sets Channel to Private (De-indexing)
+   463	
+   464	Administrator changes a public/indexable channel back to private. System removes from sitemap and requests de-indexing.
+   465	
+   466	```mermaid
+   467	flowchart TD
+   468	    Start(["START: Admin clicks Make Private"])
+   469	    F31["F3.1 Show warning:\nSearch engines may take time to remove cached content"]
+   470	    Confirm{Admin confirms?}
+   471	    F33["F3.3 Cancel"]
+   472	    F34["F3.4 API: updateVisibility(PRIVATE)\n(Permission checks same as F1.7-F1.12)"]
+   473	    F35["F3.5 Update DB:\nvisibility=PRIVATE, indexedAt=null"]
+   474	    F36["F3.6 Create audit log"]
+   475	    F37["F3.7 Remove from sitemap"]
+   476	    F38["F3.8 Request URL removal\n(Google/Bing APIs, async)"]
+   477	    F39["F3.9 Invalidate CDN cache"]
+   478	    F310["F3.10 Return success with de-indexing notice"]
+   479	    End(["END: Channel is private"])
+   480	
+   481	    Start --> F31 --> Confirm
+   482	    Confirm -->|No| F33
+   483	    Confirm -->|Yes| F34 --> F35 --> F36 --> F37 --> F38 --> F39 --> F310 --> End
+   484	```
+   485	
+   486	#### 6.3.1 Cross-Spec Integration: Visibility → PRIVATE
+   487	
+   488	When visibility changes to `PRIVATE`:
+   489	1. Emit `VISIBILITY_CHANGED` event via EventBus (Redis Pub/Sub)
+   490	2. **SEO Meta Tag Generation spec** consumes event → deletes meta tags for the channel
+````
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:17:12.804Z
+
+Not fully.
+
+The visibility-toggle story in [dev-spec-channel-visibility-toggle.md](/Users/allen/repos/Harmony/docs/dev-spec-channel-visibility-toggle.md#L381) is covered well. The core state transitions from `PRIVATE` / `PUBLIC_NO_INDEX` / `PUBLIC_INDEXABLE` are exercised in [visibility.service.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/visibility.service.test.ts#L126), including `indexedAt`, the VOICE guard, audit logging, and `VISIBILITY_CHANGED` emission in [visibility.service.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/visibility.service.test.ts#L265), [visibility.service.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/visibility.service.test.ts#L326), and [visibility.service.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/visibility.service.test.ts#L352). The downstream pieces the spec calls out are also tested: sitemap/robots behavior in [indexing.service.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/indexing.service.test.ts#L81), admin audit-log access in [channel.getAuditLog.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/channel.getAuditLog.test.ts#L144), SSE propagation in [events.router.visibility.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/events.router.visibility.test.ts#L156), and the frontend toggle UX plus service calls in [VisibilityToggle.test.tsx](/Users/allen/repos/Harmony/harmony-frontend/src/__tests__/VisibilityToggle.test.tsx#L66) and [channelService.test.ts](/Users/allen/repos/Harmony/harmony-frontend/src/__tests__/channelService.test.ts#L129). I’d call that story substantially covered.
+
+The guest public channel view story in [dev-spec-guest-public-channel-view.md](/Users/allen/repos/Harmony/docs/dev-spec-guest-public-channel-view.md#L582) is only partially covered. There is backend coverage for the public REST API in [public.router.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/public.router.test.ts#L113), and there is some frontend service-level coverage around public channel lookup in [channelService.test.ts](/Users/allen/repos/Harmony/harmony-frontend/src/__tests__/channelService.test.ts#L129). But the actual guest-facing page flow is not directly tested: [page.tsx](/Users/allen/repos/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx#L10) has SEO metadata logic, and [GuestChannelView.tsx](/Users/allen/repos/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx#L92) implements the no-login guest render, banner, visibility guard, and message load, yet there are no direct tests for that page/component flow. The only guest-specific frontend test I found is a narrow regression around member-check logic in [issue-242-join-server-fix.test.ts](/Users/allen/repos/Harmony/harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts#L147).
+
+There is also a spec mismatch: the guest-view spec says both `PUBLIC_INDEXABLE` and `PUBLIC_NO_INDEX` should be visible to guests in the main flow at [dev-spec-guest-public-channel-view.md](/Users/allen/repos/Harmony/docs/dev-spec-guest-public-channel-view.md#L598) and in the integration table at [dev-spec-guest-public-channel-view.md](/Users/allen/repos/Harmony/docs/dev-spec-guest-public-channel-view.md#L705). But the public message routes only allow `PUBLIC_INDEXABLE` in [public.router.ts](/Users/allen/repos/Harmony/harmony-backend/src/routes/public.router.ts#L13) and [public.router.ts](/Users/allen/repos/Harmony/harmony-backend/src/routes/public.router.ts#L67), and the tests explicitly enforce 404 for `PUBLIC_NO_INDEX` in [public.router.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/public.router.test.ts#L258) and [public.router.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/public.router.test.ts#L300). Since [publicApiService.ts](/Users/allen/repos/Harmony/harmony-frontend/src/services/publicApiService.ts#L153) uses that messages endpoint, the suite is not just incomplete for this story; part of it appears to lock in behavior that conflicts with the spec.
+
+Short version: channel visibility toggle is covered well; guest public channel view is not fully covered, and the `PUBLIC_NO_INDEX` guest-content path looks under-tested and likely incorrect.
+
+### Turn 3: We had 5 test specs implemented, do these cover the user storeis? If
+
+#### 👤 User Prompt
+
+- Time: 2026-04-03T19:18:32.610Z
+
+```text
+We had 5 test specs implemented, do these cover the user storeis? If not, which test specs that we did implement covers and what are source files that we can implement tests for to cover this assignment (2 frontend source files tests and 2 backend source files test)
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:18:52.348Z
+
+I’m checking the five spec documents against the two implemented user stories, then I’ll map that to source files that actually satisfy the assignment constraints for “2 frontend files + 2 backend files.”
+
+#### Tool: exec_command
+
+```sh
+for f in docs/test-specs/*.md; do echo "FILE $f"; sed -n '1,40p' "$f"; echo; done
+```
+
+Output:
+
+````text
+FILE docs/test-specs/auth-service-spec.md
+# Auth Service Test Specification
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-backend/src/services/auth.service.ts`.
+
+It covers all exported service functions:
+
+- `authService.register`
+- `authService.login`
+- `authService.logout`
+- `authService.refreshTokens`
+- `authService.verifyAccessToken`
+
+The internal token helpers (`signAccessToken`, `signRefreshToken`, `hashToken`, `storeRefreshToken`, `ensureAdminUser`) are exercised indirectly through the main service functions.
+
+The goal is to cover the main success cases, all explicit error branches, and the auth-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+### Database Isolation
+- Use a single test database with transaction rollback per test, or use unique email/username per test (e.g., `user_${Date.now()}@test.com`) to prevent collisions across parallel test runs.
+- Seed `harmony-hq` server as a one-time fixture before all tests (not per-test).
+- Example cleanup: `await db.user.deleteMany({ where: { email: { contains: 'test' } } })`
+
+### Environment Variables & Module Initialization
+- **CRITICAL**: JWT-related env vars (secrets and expiry settings) are read at module import time (lines 14–28 of `auth.service.ts`), NOT at function call time. This includes `JWT_ACCESS_SECRET`, `JWT_REFRESH_SECRET`, `JWT_ACCESS_EXPIRES_IN`, and `JWT_REFRESH_EXPIRES_DAYS`.
+- **DO NOT** mock `process.env` after importing the service; env var changes will have no effect on any of these values.
+- **MUST** use one of these patterns whenever a test needs different values for any of the above env vars:
+  - `jest.resetModules()` before each test, then re-import `auth.service` with new env vars set
+  - OR test with the default env vars and mock `jwt.sign()` / `jwt.verify()` at the function level
+  - OR use `jest.isolateModulesAsync()` to isolate imports with different env vars
+- Example (note that both secrets and expiry env vars are set *before* importing the service module):
+  ```javascript
+  beforeEach(() => {
+    delete require.cache[require.resolve('../services/auth.service')];
+    process.env.JWT_ACCESS_SECRET = 'test-access-secret';
+    process.env.JWT_REFRESH_SECRET = 'test-refresh-secret';
+    process.env.JWT_ACCESS_EXPIRES_IN = '15m';
+    process.env.JWT_REFRESH_EXPIRES_DAYS = '7';
+
+FILE docs/test-specs/frontend-channel-service-spec.md
+# Channel Service Test Specification (Frontend)
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-frontend/src/services/channelService.ts`.
+It covers all seven exported service functions:
+
+- `getChannels`
+- `getChannel`
+- `updateVisibility`
+- `updateChannel`
+- `createChannel`
+- `getAuditLog`
+- `deleteChannel`
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Mock `trpcQuery` and `trpcMutate` from `@/lib/trpc-client` using Jest module mocking.
+- Mock `publicGet` from `@/lib/trpc-client` for tests that exercise the public REST path.
+- Reset all mocks between tests to ensure isolation.
+- Use `console.warn` spies to assert that `toFrontendChannel` and `toAuditLogEntry` emit validation warnings for malformed API responses.
+- The `getChannel` export is wrapped in React's `cache()`. Tests should call the function directly and mock the underlying transport layer rather than the cache wrapper.
+- All resolved mock payloads must conform to the `Record<string, unknown>` shapes expected by the adapter functions; omit or corrupt individual fields to exercise validation warnings.
+- `ChannelVisibility` enum values under test: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `getChannels`
+
+Purpose: fetch all channels for a server (including PRIVATE channels) via the authenticated tRPC `channel.getChannels` endpoint.
+
+Program paths:
+
+- `trpcQuery` resolves with a non-empty array; each raw record is adapted and returned.
+- `trpcQuery` resolves with `null` or `undefined`; the function returns `[]`.
+- `trpcQuery` rejects; the error propagates to the caller uncaught.
+
+### 3.2 `getChannel`
+
+FILE docs/test-specs/frontend-server-service-spec.md
+# Server Service Test Specification (Frontend)
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-frontend/src/services/serverService.ts`.
+It covers all eleven exported service functions:
+
+- `getServers`
+- `getServer`
+- `getServerAuthenticated`
+- `getServerMembers`
+- `updateServer`
+- `deleteServer`
+- `joinServer`
+- `createServer`
+- `getServerMembersWithRole`
+- `changeMemberRole`
+- `removeMember`
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Mock `trpcQuery` and `trpcMutate` from `@/lib/trpc-client` using Jest module mocking.
+- Mock `publicGet` from `@/lib/trpc-client` for tests that exercise the public REST path in `getServer`.
+- Reset all mocks between tests to ensure isolation.
+- Use `console.warn` spies to assert that `toFrontendServer` emits validation warnings for malformed API responses.
+- The `getServer` export is wrapped in React's `cache()`. Tests should call the function directly and mock the underlying transport layer rather than the cache wrapper.
+- All resolved mock payloads must conform to the `Record<string, unknown>` shapes expected by the adapter functions; omit or corrupt individual fields to exercise validation warnings.
+- `toFrontendServer` emits `console.warn` when `id`, `slug`, or `createdAt` are missing or non-string.
+- `toFrontendMember` maps unknown backend role strings to `'member'` and unknown status strings to `'offline'`.
+- Role values under test for `changeMemberRole`: `'ADMIN'`, `'MODERATOR'`, `'MEMBER'`.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `getServers`
+
+Purpose: fetch all public servers from the backend via the authenticated tRPC `server.getServers` endpoint.
+
+Program paths:
+
+FILE docs/test-specs/server-member-service-spec.md
+# Server Member Service Test Specification
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-backend/src/services/serverMember.service.ts`.
+It covers all six exported service functions:
+
+- `addOwner`
+- `joinServer`
+- `leaveServer`
+- `getServerMembers`
+- `changeRole`
+- `removeMember`
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Use a test database with isolated server, user, and membership fixtures per test.
+- Use distinct users for owner, admin, moderator, member, guest, and outsider scenarios.
+- Seed role hierarchy fixtures to match the implementation order: `OWNER`, `ADMIN`, `MODERATOR`, `MEMBER`, `GUEST`.
+- Mock or spy on `eventBus.publish` so tests can verify event emission without requiring the full event system.
+- When transaction failures or unexpected Prisma failures are simulated, assert that the original error is surfaced unless the code explicitly maps it to a `TRPCError`.
+- Validate both the direct return value and the side effects on `server.memberCount` where applicable.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `addOwner`
+
+Purpose: add the creator of a new server as an `OWNER` membership and increment the server member count.
+
+Program paths:
+
+- Owner membership is created successfully and `memberCount` is incremented.
+- Database or transaction failure bubbles to the caller.
+
+### 3.2 `joinServer`
+
+Purpose: allow a user to join a public server as a `MEMBER`.
+
+
+FILE docs/test-specs/server-service-spec.md
+# Server Service Test Specification
+
+## 1. Overview
+
+This document defines the English-language test specification for `harmony-backend/src/services/server.service.ts`.
+It covers all exported service functions and the exported utility:
+
+- `generateSlug` (exported utility)
+- `serverService.getPublicServers`
+- `serverService.getAllServers`
+- `serverService.getMemberServers`
+- `serverService.getServer`
+- `serverService.createServer`
+- `serverService.updateServer`
+- `serverService.deleteServer`
+- `serverService.incrementMemberCount`
+- `serverService.decrementMemberCount`
+- `serverService.getMembers`
+
+The internal helpers `generateUniqueSlug` and `withSlugRetry` are exercised indirectly through `createServer` and `updateServer`.
+
+The goal is to cover the main success cases, all explicit error branches, and the service-specific edge cases needed to reach at least 80% of the execution paths in this module.
+
+## 2. Shared Test Setup and Assumptions
+
+- Use a test database with isolated server, user, and membership fixtures per test.
+- Use distinct users for owner, admin, system-admin, and outsider scenarios.
+- Mock or spy on `eventBus.publish` so tests can verify event emission without requiring the full event system.
+- Mock `channelService.createDefaultChannel` and `serverMemberService.addOwner` when testing `createServer` in isolation; verify they are called with the correct arguments.
+- Mock `isSystemAdmin` to return `true` or `false` as needed per test scenario.
+- When unexpected Prisma failures are simulated, assert that the original error is surfaced unless the code explicitly maps it to a `TRPCError`.
+
+## 3. Function Purposes and Program Paths
+
+### 3.1 `generateSlug`
+
+Purpose: convert a display name to a URL-safe lowercase slug by stripping non-alphanumeric characters, collapsing whitespace into hyphens, and removing leading/trailing hyphens.
+
+Program paths:
+````
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,260p' harmony-frontend/src/services/publicApiService.ts
+```
+
+Output:
+
+```text
+/**
+ * publicApiService — server-side service for the backend public REST API.
+ * Uses fetch (not the axios api-client) so it can be called from React Server
+ * Components, generateMetadata, and other server-only contexts.
+ * React `cache` is used for request deduplication within a single render pass.
+ */
+
+import { cache } from 'react';
+import type { Server, Channel, Message } from '@/types';
+import { ChannelType, ChannelVisibility } from '@/types';
+import { API_CONFIG, CACHE_DURATION } from '@/lib/constants';
+
+type PublicServer = Omit<Server, 'ownerId'>;
+
+// ─── Response shapes from the backend ─────────────────────────────────────────
+
+interface PublicServerResponse {
+  id: string;
+  name: string;
+  slug: string;
+  iconUrl?: string;
+  description?: string;
+  memberCount: number;
+  createdAt: string;
+}
+
+interface PublicChannelResponse {
+  id: string;
+  name: string;
+  slug: string;
+  serverId: string;
+  type: string;
+  visibility: string;
+  topic?: string | null;
+  position: number;
+  createdAt: string;
+}
+
+interface PublicMessageResponse {
+  id: string;
+  content: string;
+  createdAt: string;
+  editedAt?: string | null;
+  author: { id: string; username: string };
+}
+
+interface PublicMessagesApiResponse {
+  messages: PublicMessageResponse[];
+  page: number;
+  pageSize: number;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function mapChannelType(type: string): ChannelType {
+  switch (type) {
+    case 'VOICE':
+      return ChannelType.VOICE;
+    case 'ANNOUNCEMENT':
+      return ChannelType.ANNOUNCEMENT;
+    default:
+      return ChannelType.TEXT;
+  }
+}
+
+function mapChannelVisibility(visibility: string): ChannelVisibility {
+  switch (visibility) {
+    case 'PUBLIC_NO_INDEX':
+      return ChannelVisibility.PUBLIC_NO_INDEX;
+    case 'PRIVATE':
+      return ChannelVisibility.PRIVATE;
+    default:
+      return ChannelVisibility.PUBLIC_INDEXABLE;
+  }
+}
+
+// ─── Public API functions ──────────────────────────────────────────────────────
+
+/**
+ * Fetch public server info by slug.
+ * Returns null on any error or if the server is not found (404).
+ * Deduplicated within a single render pass via React `cache`.
+ */
+export const fetchPublicServer = cache(async (serverSlug: string): Promise<PublicServer | null> => {
+  try {
+    const res = await fetch(
+      `${API_CONFIG.BASE_URL}/api/public/servers/${encodeURIComponent(serverSlug)}`,
+      { next: { revalidate: CACHE_DURATION.PUBLIC_API_REVALIDATE } },
+    );
+    if (!res.ok) return null;
+
+    const data: PublicServerResponse = await res.json();
+    const server: PublicServer = {
+      id: data.id,
+      name: data.name,
+      slug: data.slug,
+      icon: data.iconUrl,
+      description: data.description,
+      memberCount: data.memberCount,
+      createdAt: data.createdAt,
+    };
+    return server;
+  } catch {
+    return null;
+  }
+});
+
+/**
+ * Fetch a single public channel by server slug + channel slug.
+ * - Returns null if the server or channel does not exist (404).
+ * - Returns `{ isPrivate: true }` if the channel is PRIVATE (403).
+ * - Returns `{ channel, isPrivate: false }` on success (200).
+ * Deduplicated within a single render pass via React `cache`.
+ */
+export const fetchPublicChannel = cache(
+  async (
+    serverSlug: string,
+    channelSlug: string,
+  ): Promise<{ channel: Channel; isPrivate: false } | { isPrivate: true } | null> => {
+    try {
+      const res = await fetch(
+        `${API_CONFIG.BASE_URL}/api/public/servers/${encodeURIComponent(serverSlug)}/channels/${encodeURIComponent(channelSlug)}`,
+        { next: { revalidate: CACHE_DURATION.PUBLIC_API_REVALIDATE } },
+      );
+
+      if (res.status === 404) return null;
+      if (res.status === 403) return { isPrivate: true };
+      if (!res.ok) return null;
+
+      const data: PublicChannelResponse = await res.json();
+      const channel: Channel = {
+        id: data.id,
+        name: data.name,
+        slug: data.slug,
+        serverId: data.serverId,
+        type: mapChannelType(data.type),
+        visibility: mapChannelVisibility(data.visibility),
+        topic: data.topic ?? undefined,
+        position: data.position,
+        createdAt: data.createdAt,
+      };
+      return { channel, isPrivate: false };
+    } catch {
+      return null;
+    }
+  },
+);
+
+/**
+ * Fetch paginated public messages for a channel.
+ * Returns an empty list on error.
+ */
+export async function fetchPublicMessages(
+  channelId: string,
+  page = 1,
+): Promise<{ messages: Message[]; hasMore: boolean }> {
+  try {
+    const res = await fetch(
+      `${API_CONFIG.BASE_URL}/api/public/channels/${encodeURIComponent(channelId)}/messages?page=${page}`,
+    );
+    if (!res.ok) return { messages: [], hasMore: false };
+
+    const data: PublicMessagesApiResponse = await res.json();
+    const messages: Message[] = data.messages.map(m => ({
+      id: m.id,
+      channelId,
+      authorId: m.author.id,
+      author: { id: m.author.id, username: m.author.username },
+      content: m.content,
+      timestamp: m.createdAt,
+      editedAt: m.editedAt ?? undefined,
+    }));
+    return { messages, hasMore: messages.length >= data.pageSize };
+  } catch {
+    return { messages: [], hasMore: false };
+  }
+}
+
+/**
+ * Returns true if the channel is publicly accessible (not PRIVATE and not missing).
+ */
+export async function isChannelGuestAccessible(
+  serverSlug: string,
+  channelSlug: string,
+): Promise<boolean> {
+  const result = await fetchPublicChannel(serverSlug, channelSlug);
+  return result !== null && !result.isPrivate;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,320p' harmony-frontend/src/services/messageService.ts
+```
+
+Output:
+
+```text
+/**
+ * Message Service (M3 — real API implementation)
+ * Replaces mock in-memory store with backend API calls.
+ * References: dev-spec-guest-public-channel-view.md
+ */
+
+import type { Message } from '@/types';
+import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+
+// ─── Type adapters ────────────────────────────────────────────────────────────
+
+/** Maps backend message shape to frontend Message type. */
+function toFrontendMessage(raw: Record<string, unknown>, fallbackChannelId = ''): Message {
+  // Warn on missing required fields to catch backend shape mismatches early.
+  if (typeof raw.id !== 'string') console.warn('[toFrontendMessage] missing or non-string "id"');
+  if (!raw.channelId && !raw.channel_id && !fallbackChannelId) console.warn('[toFrontendMessage] missing "channelId"/"channel_id"');
+  if (!raw.createdAt && !raw.created_at && !raw.timestamp) console.warn('[toFrontendMessage] missing timestamp field');
+  const author = raw.author as Record<string, unknown> | undefined;
+  return {
+    id: raw.id as string,
+    channelId: (raw.channelId ?? raw.channel_id ?? fallbackChannelId) as string,
+    authorId: (raw.authorId ?? raw.author_id ?? author?.id ?? '') as string,
+    author: {
+      id: (author?.id ?? '') as string,
+      username: (author?.username ?? '') as string,
+      displayName: (author?.displayName ?? author?.display_name) as string | undefined,
+      avatarUrl: (author?.avatarUrl ?? author?.avatar_url) as string | undefined,
+    },
+    content: raw.content as string,
+    timestamp: (raw.createdAt ?? raw.created_at ?? raw.timestamp) as string,
+  };
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a page of messages for a channel.
+ * Uses the public REST endpoint for PUBLIC_INDEXABLE channels.
+ * Falls back to tRPC for authenticated access (pass options.serverId).
+ *
+ * Errors propagate to the caller — the UI is responsible for rendering
+ * failure state so users can distinguish a fetch error from an empty channel.
+ */
+export async function getMessages(
+  channelId: string,
+  page = 1,
+  options?: { serverId?: string },
+): Promise<{ messages: Message[]; hasMore: boolean }> {
+  // Try public endpoint first (works for PUBLIC_INDEXABLE channels).
+  // A non-2xx response throws, which we catch only to attempt the tRPC fallback.
+  try {
+    const data = await publicGet<{
+      messages: Record<string, unknown>[];
+      page: number;
+      pageSize: number;
+    }>(`/channels/${encodeURIComponent(channelId)}/messages?page=${page}`);
+
+    // null means HTTP 404 — channel not found on public API. Throw so the catch
+    // block can attempt the tRPC fallback (or re-throw if no serverId).
+    if (data === null) throw new Error(`getMessages: public channel not found for channelId=${channelId}`);
+
+    return {
+      // Public endpoint returns newest-first; populate channelId from param since
+      // the backend select does not include it.
+      messages: data.messages.map((m) => toFrontendMessage(m, channelId)),
+      hasMore: data.messages.length >= (data.pageSize ?? 50),
+    };
+  } catch (err) {
+    // Public endpoint unavailable or channel is not PUBLIC_INDEXABLE — try tRPC.
+    console.warn('[getMessages] public endpoint failed, falling back to tRPC:', err instanceof Error ? err.message : err);
+    // If serverId is not provided we cannot authenticate, so re-throw.
+    if (!options?.serverId) throw new Error('getMessages: channel is not publicly accessible and no serverId was provided');
+
+    // tRPC errors propagate to the caller.
+    const data = await trpcQuery<{
+      messages: Record<string, unknown>[];
+      nextCursor?: string;
+    }>('message.getMessages', {
+      serverId: options.serverId,
+      channelId,
+      limit: 50,
+    });
+    if (data === null) throw new Error(`getMessages: tRPC returned no data for channelId=${channelId}`);
+    // tRPC backend returns oldest-first (orderBy createdAt: 'asc'); reverse to
+    // match the public endpoint's newest-first ordering so callers get a
+    // consistent contract regardless of which path was taken.
+    return {
+      messages: [...data.messages].reverse().map((m) => toFrontendMessage(m, channelId)),
+      hasMore: !!data.nextCursor,
+    };
+  }
+}
+
+/**
+ * Sends a new message to a channel via tRPC.
+ */
+export async function sendMessage(
+  channelId: string,
+  content: string,
+  serverId?: string,
+): Promise<Message> {
+  if (!serverId) {
+    throw new Error('serverId is required for sendMessage');
+  }
+  const data = await trpcMutate<Record<string, unknown>>('message.sendMessage', {
+    serverId,
+    channelId,
+    content,
+  });
+  return toFrontendMessage(data);
+}
+
+/**
+ * Deletes a message by ID via tRPC. Returns true if deleted.
+ */
+export async function deleteMessage(
+  id: string,
+  serverId?: string,
+): Promise<boolean> {
+  if (!serverId) {
+    throw new Error('serverId is required for deleteMessage');
+  }
+  await trpcMutate('message.deleteMessage', { serverId, messageId: id });
+  return true;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,320p' harmony-backend/src/services/channel.service.ts
+```
+
+Output:
+
+```text
+import { TRPCError } from '@trpc/server';
+import { ChannelType, ChannelVisibility } from '@prisma/client';
+import { prisma } from '../db/prisma';
+import { cacheService, CacheKeys, CacheTTL, sanitizeKeySegment } from './cache.service';
+import { eventBus, EventChannels } from '../events/eventBus';
+
+export interface CreateChannelInput {
+  serverId: string;
+  name: string;
+  slug: string;
+  type: ChannelType;
+  visibility: ChannelVisibility;
+  topic?: string;
+  position?: number;
+}
+
+export interface UpdateChannelInput {
+  name?: string;
+  topic?: string;
+  position?: number;
+}
+
+export const channelService = {
+  async getChannels(serverId: string) {
+    return prisma.channel.findMany({
+      where: { serverId },
+      orderBy: { position: 'asc' },
+    });
+  },
+
+  async getChannelBySlug(serverSlug: string, channelSlug: string) {
+    const server = await prisma.server.findUnique({ where: { slug: serverSlug } });
+    if (!server) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
+    }
+
+    const channel = await prisma.channel.findUnique({
+      where: { serverId_slug: { serverId: server.id, slug: channelSlug } },
+    });
+    if (!channel) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found' });
+    }
+
+    return channel;
+  },
+
+  async createChannel(input: CreateChannelInput) {
+    const { serverId, name, slug, type, visibility, topic, position = 0 } = input;
+
+    // VOICE channels cannot be PUBLIC_INDEXABLE
+    if (type === ChannelType.VOICE && visibility === ChannelVisibility.PUBLIC_INDEXABLE) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'VOICE channels cannot have PUBLIC_INDEXABLE visibility',
+      });
+    }
+
+    // Verify server exists
+    const server = await prisma.server.findUnique({ where: { id: serverId } });
+    if (!server) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
+    }
+
+    // Check slug uniqueness per server
+    const existing = await prisma.channel.findUnique({
+      where: { serverId_slug: { serverId, slug } },
+    });
+    if (existing) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'Channel slug already exists in this server',
+      });
+    }
+
+    const channel = await prisma.channel.create({
+      data: { serverId, name, slug, type, visibility, topic, position },
+    });
+
+    // Write-through: cache new visibility and invalidate server channel list (best-effort)
+    cacheService
+      .set(CacheKeys.channelVisibility(channel.id), channel.visibility, {
+        ttl: CacheTTL.channelVisibility,
+      })
+      .catch(() => {});
+    cacheService
+      .invalidate(`server:${sanitizeKeySegment(serverId)}:public_channels`)
+      .catch(() => {});
+
+    // Notify connected clients (fire-and-forget)
+    eventBus
+      .publish(EventChannels.CHANNEL_CREATED, {
+        channelId: channel.id,
+        serverId: channel.serverId,
+        timestamp: new Date().toISOString(),
+      })
+      .catch(() => {});
+
+    return channel;
+  },
+
+  async updateChannel(channelId: string, serverId: string, patch: UpdateChannelInput) {
+    const channel = await prisma.channel.findUnique({ where: { id: channelId } });
+    if (!channel || channel.serverId !== serverId) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });
+    }
+
+    const updated = await prisma.channel.update({
+      where: { id: channelId },
+      data: {
+        ...(patch.name !== undefined && { name: patch.name }),
+        ...(patch.topic !== undefined && { topic: patch.topic }),
+        ...(patch.position !== undefined && { position: patch.position }),
+      },
+    });
+
+    // Write-through: invalidate message caches and server channel list (best-effort)
+    cacheService
+      .invalidatePattern(`channel:msgs:${sanitizeKeySegment(channelId)}:*`)
+      .catch(() => {});
+    cacheService
+      .invalidate(`server:${sanitizeKeySegment(channel.serverId)}:public_channels`)
+      .catch(() => {});
+
+    // Notify connected clients (fire-and-forget)
+    eventBus
+      .publish(EventChannels.CHANNEL_UPDATED, {
+        channelId: updated.id,
+        serverId: updated.serverId,
+        timestamp: new Date().toISOString(),
+      })
+      .catch(() => {});
+
+    return updated;
+  },
+
+  async deleteChannel(channelId: string, serverId: string) {
+    const channel = await prisma.channel.findUnique({ where: { id: channelId } });
+    if (!channel || channel.serverId !== serverId) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });
+    }
+
+    await prisma.channel.delete({ where: { id: channelId } });
+
+    // Write-through: invalidate all caches for deleted channel (best-effort)
+    cacheService.invalidate(CacheKeys.channelVisibility(channelId)).catch(() => {});
+    cacheService
+      .invalidatePattern(`channel:msgs:${sanitizeKeySegment(channelId)}:*`)
+      .catch(() => {});
+    cacheService
+      .invalidate(`server:${sanitizeKeySegment(channel.serverId)}:public_channels`)
+      .catch(() => {});
+
+    // Notify connected clients (fire-and-forget)
+    eventBus
+      .publish(EventChannels.CHANNEL_DELETED, {
+        channelId: channel.id,
+        serverId: channel.serverId,
+        timestamp: new Date().toISOString(),
+      })
+      .catch(() => {});
+  },
+
+  async createDefaultChannel(serverId: string) {
+    return channelService.createChannel({
+      serverId,
+      name: 'general',
+      slug: 'general',
+      type: ChannelType.TEXT,
+      visibility: ChannelVisibility.PRIVATE,
+      position: 0,
+    });
+  },
+};
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,260p' harmony-backend/src/routes/public.router.ts
+```
+
+Output:
+
+```text
+import { Router, Request, Response } from 'express';
+import { prisma } from '../db/prisma';
+import { ChannelVisibility } from '@prisma/client';
+import { cacheMiddleware } from '../middleware/cache.middleware';
+import { cacheService, CacheKeys, CacheTTL, sanitizeKeySegment } from '../services/cache.service';
+import { tokenBucketRateLimiter } from '../middleware/rate-limit.middleware';
+
+export const publicRouter = Router();
+
+// Token bucket rate limiting per issue #110: 100 req/min (human) / 1000 req/min (verified bots)
+publicRouter.use(tokenBucketRateLimiter);
+
+/**
+ * GET /api/public/channels/:channelId/messages
+ * Returns paginated messages for a PUBLIC_INDEXABLE channel.
+ * Uses cache middleware with stale-while-revalidate.
+ */
+publicRouter.get(
+  '/channels/:channelId/messages',
+  cacheMiddleware({
+    ttl: CacheTTL.channelMessages,
+    staleTtl: CacheTTL.channelMessages, // keep stale data for an extra TTL window
+    keyFn: (req: Request) =>
+      CacheKeys.channelMessages(req.params.channelId, Number(req.query.page) || 1),
+  }),
+  async (req: Request, res: Response) => {
+    try {
+      const { channelId } = req.params;
+      const page = Math.max(1, Number(req.query.page) || 1);
+      const pageSize = 50;
+
+      const channel = await prisma.channel.findUnique({
+        where: { id: channelId },
+        select: { id: true, visibility: true },
+      });
+
+      if (!channel || channel.visibility !== ChannelVisibility.PUBLIC_INDEXABLE) {
+        res.status(404).json({ error: 'Channel not found' });
+        return;
+      }
+
+      const messages = await prisma.message.findMany({
+        where: { channelId, isDeleted: false },
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+          editedAt: true,
+          author: { select: { id: true, username: true } },
+        },
+      });
+
+      res.set('Cache-Control', `public, max-age=${CacheTTL.channelMessages}`);
+      res.json({ messages, page, pageSize });
+    } catch (err) {
+      console.error('Public messages route error:', err);
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  },
+);
+
+/**
+ * GET /api/public/channels/:channelId/messages/:messageId
+ * Returns a single message from a PUBLIC_INDEXABLE channel.
+ * Uses cache middleware with stale-while-revalidate.
+ */
+publicRouter.get(
+  '/channels/:channelId/messages/:messageId',
+  cacheMiddleware({
+    ttl: CacheTTL.channelMessages,
+    staleTtl: CacheTTL.channelMessages,
+    keyFn: (req: Request) =>
+      `channel:msg:${sanitizeKeySegment(req.params.channelId)}:${sanitizeKeySegment(req.params.messageId)}`,
+  }),
+  async (req: Request, res: Response) => {
+    try {
+      const { channelId, messageId } = req.params;
+
+      const channel = await prisma.channel.findUnique({
+        where: { id: channelId },
+        select: { id: true, visibility: true },
+      });
+
+      if (!channel || channel.visibility !== ChannelVisibility.PUBLIC_INDEXABLE) {
+        res.status(404).json({ error: 'Channel not found' });
+        return;
+      }
+
+      const message = await prisma.message.findFirst({
+        where: { id: messageId, channelId, isDeleted: false },
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+          editedAt: true,
+          author: { select: { id: true, username: true } },
+        },
+      });
+
+      if (!message) {
+        res.status(404).json({ error: 'Message not found' });
+        return;
+      }
+
+      res.set('Cache-Control', `public, max-age=${CacheTTL.channelMessages}`);
+      res.json(message);
+    } catch (err) {
+      console.error('Public message route error:', err);
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  },
+);
+
+/**
+ * GET /api/public/servers
+ * Returns a list of public servers ordered by member count (desc).
+ * Used by the home page to discover a default public channel to show visitors.
+ */
+publicRouter.get('/servers', async (_req: Request, res: Response) => {
+  try {
+    const servers = await prisma.server.findMany({
+      where: { isPublic: true },
+      orderBy: { memberCount: 'desc' },
+      take: 20,
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        iconUrl: true,
+        description: true,
+        memberCount: true,
+        createdAt: true,
+      },
+    });
+    res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+    res.json(servers);
+  } catch (err) {
+    console.error('Public servers list route error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/public/servers/:serverSlug
+ * Returns public server info. Uses getOrRevalidate for SWR.
+ * Cache key: server:{serverId}:info per §4.4.
+ */
+publicRouter.get('/servers/:serverSlug', async (req: Request, res: Response) => {
+  try {
+    const server = await prisma.server.findUnique({
+      where: { slug: req.params.serverSlug },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        iconUrl: true,
+        description: true,
+        memberCount: true,
+        createdAt: true,
+      },
+    });
+
+    if (!server) {
+      res.status(404).json({ error: 'Server not found' });
+      return;
+    }
+
+    const cacheKey = CacheKeys.serverInfo(server.id);
+    const cacheOpts = { ttl: CacheTTL.serverInfo, staleTtl: CacheTTL.serverInfo };
+
+    // Check cache state for X-Cache header
+    let xCache = 'MISS';
+    try {
+      const entry = await cacheService.get(cacheKey);
+      if (entry) {
+        xCache = cacheService.isStale(entry, CacheTTL.serverInfo) ? 'STALE' : 'HIT';
+      }
+    } catch {
+      /* Redis error */
+    }
+
+    const data = await cacheService.getOrRevalidate(
+      cacheKey,
+      async () => server, // fetcher — server already fetched from DB above
+      cacheOpts,
+    );
+
+    res.set('X-Cache', xCache);
+    res.set('X-Cache-Key', cacheKey);
+    res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+    res.json(data);
+  } catch (err) {
+    console.error('Public server route error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/public/servers/:serverSlug/channels
+ * Returns public channels for a server. Uses getOrRevalidate for SWR.
+ * Cache key: server:{serverId}:public_channels per §4.4.
+ */
+publicRouter.get('/servers/:serverSlug/channels', async (req: Request, res: Response) => {
+  try {
+    const server = await prisma.server.findUnique({
+      where: { slug: req.params.serverSlug },
+      select: { id: true },
+    });
+
+    if (!server) {
+      res.status(404).json({ error: 'Server not found' });
+      return;
+    }
+
+    const cacheKey = `server:${sanitizeKeySegment(server.id)}:public_channels`;
+    const cacheOpts = { ttl: CacheTTL.serverInfo, staleTtl: CacheTTL.serverInfo };
+
+    const fetcher = async () => {
+      const channels = await prisma.channel.findMany({
+        where: { serverId: server.id, visibility: ChannelVisibility.PUBLIC_INDEXABLE },
+        orderBy: { position: 'asc' },
+        select: { id: true, name: true, slug: true, type: true, topic: true },
+      });
+      return { channels };
+    };
+
+    // Check cache state for X-Cache header
+    let xCache = 'MISS';
+    try {
+      const entry = await cacheService.get(cacheKey);
+      if (entry) {
+        xCache = cacheService.isStale(entry, CacheTTL.serverInfo) ? 'STALE' : 'HIT';
+      }
+    } catch {
+      /* Redis error */
+    }
+
+    const data = await cacheService.getOrRevalidate(cacheKey, fetcher, cacheOpts);
+
+    res.set('X-Cache', xCache);
+    res.set('X-Cache-Key', cacheKey);
+    res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+    res.json(data);
+  } catch (err) {
+    console.error('Public channels route error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/public/servers/:serverSlug/channels/:channelSlug
+ * Returns channel info by slug. Returns 403 for PRIVATE channels, 404 if not found.
+ * Supports PUBLIC_INDEXABLE and PUBLIC_NO_INDEX channels for guest access.
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:19:45.933Z
+
+Not really. Of the 5 spec documents, only one is directly centered on your implemented user stories, and the main guest-view path is missing the most important spec coverage.
+
+**What The 5 Specs Cover**
+- [frontend-channel-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/frontend-channel-service-spec.md) is the one that clearly covers the implemented stories. It directly covers channel visibility changes, public channel lookup by slug, and audit-log retrieval for the visibility-toggle story. It also partially supports the guest-view story because `getChannel()` tries the public path first.
+- [frontend-server-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/frontend-server-service-spec.md) is mostly server CRUD, membership, and role-management. It is not a primary spec for either implemented story.
+- [server-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/server-service-spec.md) is mostly backend server CRUD/listing. It is only indirectly related to guest discovery.
+- [server-member-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/server-member-service-spec.md) is membership/role hierarchy. It supports permissions indirectly, but not the core visibility-toggle or guest-public-content flow.
+- [auth-service-spec.md](/Users/allen/repos/Harmony/docs/test-specs/auth-service-spec.md) does not cover those two user stories; it covers authentication.
+
+**What’s Missing For Story Coverage**
+The biggest holes are:
+- No spec for [publicApiService.ts](/Users/allen/repos/Harmony/harmony-frontend/src/services/publicApiService.ts), which is the frontend service that actually powers the guest public channel page.
+- No spec for [public.router.ts](/Users/allen/repos/Harmony/harmony-backend/src/routes/public.router.ts), which is the backend public REST surface for guest access.
+- No spec for [visibility.service.ts](/Users/allen/repos/Harmony/harmony-backend/src/services/visibility.service.ts), which contains the core backend state machine for the visibility-toggle story.
+
+So if the goal is “the 4 assignment files should cover the 2 implemented user stories,” the current 5 specs do not line up well enough.
+
+**Best 2 Frontend + 2 Backend Files**
+If you want the assignment files to actually cover the two implemented stories, I would use:
+
+- Frontend: [channelService.ts](/Users/allen/repos/Harmony/harmony-frontend/src/services/channelService.ts)
+  Reason: 7 exported functions; directly covers visibility toggle, public channel lookup, and audit log.
+- Frontend: [publicApiService.ts](/Users/allen/repos/Harmony/harmony-frontend/src/services/publicApiService.ts)
+  Reason: this is the real guest-view frontend integration layer; it has 6 functions if you count the mapping helpers plus the 4 public fetch functions.
+- Backend: [channel.service.ts](/Users/allen/repos/Harmony/harmony-backend/src/services/channel.service.ts)
+  Reason: 6 service methods; it covers channel creation/update/deletion/lookup and the voice-vs-indexable guard that is part of the visibility story.
+- Backend: [public.router.ts](/Users/allen/repos/Harmony/harmony-backend/src/routes/public.router.ts)
+  Reason: this is the actual guest-public-channel backend entrypoint, with 6 route handlers covering public server/channel/message access.
+
+If you want the most story-faithful set, that is the set I’d use.
+
+One caveat: [visibility.service.ts](/Users/allen/repos/Harmony/harmony-backend/src/services/visibility.service.ts) is the single most important backend file for the toggle story, but it only has 2 main functions, so it is weak as one of the official “4 assignment files” if your instructor is strict about “at least 5 functions per file.” I would still keep tests for it, just not count it as one of the four canonical assignment files.
+
+**Bottom Line**
+Current spec set:
+- Strongly covers: `channelService.ts`
+- Indirectly/tangentially covers: `serverService.ts`, `server.service.ts`, `serverMember.service.ts`
+- Does not properly cover the guest-view implementation path: `publicApiService.ts` and `public.router.ts`
+- Does not directly spec the core toggle backend logic: `visibility.service.ts`
+
+If you want, I can turn this into a concrete replacement plan:
+1. keep `frontend-channel-service-spec.md`
+2. add `frontend-public-api-service-spec.md`
+3. add `backend-channel-service-spec.md` or reuse/adapt existing `server-service-spec.md`
+4. add `backend-public-router-spec.md`
+
+### Turn 4: Ok Make issues on the project board regarding the missing tests to add
+
+#### 👤 User Prompt
+
+- Time: 2026-04-03T19:22:38.780Z
+
+```text
+Ok Make issues on the project board regarding the missing tests to add test specs for the tests and to then implement tests to fulfill the assignment
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:23:05.654Z
+
+I’m checking the existing GitHub issues first so I don’t create duplicates, then I’ll open the missing P5 test-spec and test-implementation issues with scope tied to the user-story gaps.
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 100 --state open
+```
+
+Output:
+
+```text
+269	OPEN	Unit Tests — serverMember.service.ts	testing, backend	2026-03-31T19:27:50Z
+268	OPEN	Test Specification — serverMember.service.ts	testing, backend	2026-03-30T23:21:59Z
+267	OPEN	README Update & Final Submission	documentation, testing	2026-03-30T00:50:40Z
+265	OPEN	Unit Tests — serverService.ts (frontend)	frontend, testing	2026-03-30T00:50:34Z
+264	OPEN	Unit Tests — server.service.ts	testing, backend	2026-04-01T00:34:30Z
+245	OPEN	test: add negative guard coverage for createReply event publish		2026-03-23T03:35:54Z
+241	OPEN	fix: "Design Lab" listed as public server with description "A private server for the design team"		2026-03-23T02:47:36Z
+240	OPEN	fix: authenticated users see "Sign up or log in" on inaccessible channels		2026-03-23T02:47:30Z
+238	OPEN	fix: message compose textarea missing aria-label (accessibility)		2026-03-23T02:47:03Z
+236	OPEN	fix: pin button shown to all users; improve pin error messages		2026-03-25T15:42:28Z
+227	OPEN	refactor: introduce repository layer — centralize Prisma calls out of services		2026-03-19T22:12:05Z
+194	OPEN	chore: add structured logger utility for observability and debug		2026-03-15T03:24:07Z
+189	OPEN	Real-time: refactor SSE into a unified server-scoped endpoint	feature	2026-03-13T19:29:16Z
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search "P5 testing publicApiService public.router visibility.service channel.service serverService test spec"
+```
+
+Output:
+
+```text
+
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:23:17.477Z
+
+There are already open P5 issues for `serverService.ts`, `server.service.ts`, and `serverMember.service.ts`, so I’m narrowing the new issues to the user-story gaps that are still not tracked: the guest public API/frontend path and the missing visibility-service spec.
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"public.router" in:title,body'
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"publicApiService" in:title,body'
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"visibility.service" in:title,body'
+```
+
+Output:
+
+```text
+194	OPEN	chore: add structured logger utility for observability and debug		2026-03-15T03:24:07Z
+147	CLOSED	Fix flaky setTimeout in visibility event emission test	backend	2026-03-10T21:00:54Z
+187	CLOSED	Real-time: channel visibility changes propagate to all connected clients	feature	2026-03-21T00:53:42Z
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"channel.service.ts" in:title,body'
+```
+
+Output:
+
+```text
+194	OPEN	chore: add structured logger utility for observability and debug		2026-03-15T03:24:07Z
+185	CLOSED	Real-time: channel list updates when channels are created, renamed, or deleted	feature	2026-03-16T00:58:42Z
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:23:33.202Z
+
+I’m checking whether the matching spec issues for `server.service.ts` and `serverService.ts` already exist in closed issues, because if they don’t, I should open those too rather than only the guest-path issues.
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"Test Specification" "server.service.ts"'
+```
+
+Output:
+
+```text
+264	OPEN	Unit Tests — server.service.ts	testing, backend	2026-04-01T00:34:30Z
+259	CLOSED	Test Specification — server.service.ts	testing, backend	2026-03-31T23:28:48Z
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"Test Specification" "serverService.ts"'
+```
+
+Output:
+
+```text
+265	OPEN	Unit Tests — serverService.ts (frontend)	frontend, testing	2026-03-30T00:50:34Z
+260	CLOSED	Test Specification — serverService.ts (frontend)	frontend, testing	2026-04-01T04:32:01Z
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"Test Specification" "auth.service.ts"'
+```
+
+Output:
+
+```text
+258	CLOSED	Test Specification — auth.service.ts	testing, backend	2026-04-02T21:28:19Z
+263	CLOSED	Unit Tests — auth.service.ts	testing, backend	2026-04-03T18:26:22Z
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"frontend-channel-service-spec" OR "channelService.ts" "Test Specification"'
+```
+
+Output:
+
+```text
+261	CLOSED	Test Specification — channelService.ts (frontend)	frontend, testing	2026-03-31T23:48:23Z
+266	CLOSED	Unit Tests — channelService.ts (frontend)	frontend, testing	2026-04-03T15:53:27Z
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:24:00.534Z
+
+I found the original P5 issue pattern. I’m reading one or two of those existing testing issues so the new ones match the project board’s current format instead of introducing a different style.
+
+#### Tool: exec_command
+
+```sh
+gh issue view 264 -R acabrera04/Harmony
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 260 -R acabrera04/Harmony
+```
+
+Output:
+
+```text
+title:	Test Specification — serverService.ts (frontend)
+state:	CLOSED
+author:	acabrera04
+labels:	frontend, testing
+comments:	2
+assignees:	FardeenI
+projects:	Harmony Project Board (Done)
+milestone:	
+number:	260
+--
+## Description
+Write an English-language test specification for `harmony-frontend/src/services/serverService.ts` (11 functions).
+
+## Functions to Specify
+- `getServers`
+- `getServer`
+- `getServerAuthenticated`
+- `getServerMembers`
+- `updateServer`
+- `deleteServer`
+- `joinServer`
+- `createServer`
+- `getServerMembersWithRole`
+- `changeMemberRole`
+- `removeMember`
+
+## Requirements
+- List every function, its purpose, and all program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, API error handling (network failures, 401/403/404), and edge cases
+- Describe mock strategy for `apiClient` / `ApiClient`
+- Target 80%+ code coverage of all execution paths
+- Output: `docs/test-specs/frontend-server-service-spec.md`
+
+## Acceptance Criteria
+- [ ] All 11 functions listed with descriptions
+- [ ] Table covers happy paths for each function
+- [ ] Table covers API error handling paths
+- [ ] Mock strategy documented
+- [ ] At least one test per function
+
+**Sprint:** 3 (P5 Testing)
+**Due:** March 30, 2026
+```
+
+#### Tool: exec_command
+
+```sh
+gh project list --owner acabrera04
+```
+
+Output:
+
+```text
+4	Harmony Project Board	open	PVT_kwHOCKUww84BPCdD
+2	Book Info	open	PVT_kwHOCKUww84Ar11l
+1	CampusCal	open	PVT_kwHOCKUww84Ak2FW
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 24066,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 8000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'gh issue view 264 -R acabrera04/Harmony'
+Chunk ID: 0519ee
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 256
+Output:
+title:	Unit Tests — server.service.ts
+state:	OPEN
+author:	acabrera04
+labels:	backend, testing
+comments:	2
+assignees:	declanblanc
+projects:	Harmony Project Board (In progress)
+milestone:	
+number:	264
+--
+## Description
+Implement Jest unit tests for `harmony-backend/src/services/server.service.ts` based on the test specification from #259.
+
+## Requirements
+- Test file: `harmony-backend/tests/server.service.test.ts`
+- Mock Prisma client
+- Generate one test at a time via LLM to prevent hallucination
+- Verify no duplicate or overlapping test cases
+- Run tests locally, fix any failures
+
+## Acceptance Criteria
+- [ ] All functions from spec have at least one test
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage (run Jest with \`--coverage\`), capture report for submission
+- [ ] Tests are isolated — no cross-network calls
+
+**Sprint:** 3 (P5 Testing)
+**Due:** April 1, 2026
+**Depends on:** #259
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:24:17.965Z
+
+I’m doing one last duplicate check for `channel.service.ts` before I open anything, because that file already has tests and I only want to add a tracking issue if the P5 spec/test work truly isn’t represented yet.
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"channel.service.ts" "Test Specification" OR "Unit Tests"'
+```
+
+Output:
+
+```text
+264	OPEN	Unit Tests — server.service.ts	testing, backend	2026-04-01T00:34:30Z
+269	OPEN	Unit Tests — serverMember.service.ts	testing, backend	2026-03-31T19:27:50Z
+265	OPEN	Unit Tests — serverService.ts (frontend)	frontend, testing	2026-03-30T00:50:34Z
+263	CLOSED	Unit Tests — auth.service.ts	testing, backend	2026-04-03T18:26:22Z
+266	CLOSED	Unit Tests — channelService.ts (frontend)	frontend, testing	2026-04-03T15:53:27Z
+227	OPEN	refactor: introduce repository layer — centralize Prisma calls out of services		2026-03-19T22:12:05Z
+158	CLOSED	Write tests for reaction endpoints	testing, backend	2026-03-09T15:15:30Z
+226	CLOSED	feat: createReply should publish MESSAGE_CREATED SSE event		2026-03-23T03:36:39Z
+159	CLOSED	Write tests for reply/thread endpoints	testing, backend	2026-03-09T15:15:31Z
+224	CLOSED	Voice: export useVoiceOptional for safer consumption outside VoiceProvider	feature, frontend	2026-03-18T21:18:09Z
+180	CLOSED	Real-time messaging: other clients don't receive new messages	feature	2026-03-13T19:20:38Z
+165	CLOSED	Security: tRPC error responses expose stack traces to clients	bug, backend	2026-03-10T01:27:29Z
+112	CLOSED	Attachment Service & File Storage	feature, week-2, backend	2026-03-16T03:10:24Z
+10	CLOSED	Frontend: Implement Channel Visibility Toggle Component	feature, frontend, week-2	2026-02-16T16:54:09Z
+11	CLOSED	Frontend: Implement Guest Public Channel View	feature, frontend, week-2	2026-02-16T16:54:10Z
+188	CLOSED	Real-time: server list updates when a server is created or joined	feature	2026-03-16T01:59:56Z
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"visibility.service.ts" "Test Specification" OR "Unit Tests"'
+```
+
+Output:
+
+```text
+264	OPEN	Unit Tests — server.service.ts	testing, backend	2026-04-01T00:34:30Z
+269	OPEN	Unit Tests — serverMember.service.ts	testing, backend	2026-03-31T19:27:50Z
+265	OPEN	Unit Tests — serverService.ts (frontend)	frontend, testing	2026-03-30T00:50:34Z
+263	CLOSED	Unit Tests — auth.service.ts	testing, backend	2026-04-03T18:26:22Z
+266	CLOSED	Unit Tests — channelService.ts (frontend)	frontend, testing	2026-04-03T15:53:27Z
+227	OPEN	refactor: introduce repository layer — centralize Prisma calls out of services		2026-03-19T22:12:05Z
+158	CLOSED	Write tests for reaction endpoints	testing, backend	2026-03-09T15:15:30Z
+226	CLOSED	feat: createReply should publish MESSAGE_CREATED SSE event		2026-03-23T03:36:39Z
+159	CLOSED	Write tests for reply/thread endpoints	testing, backend	2026-03-09T15:15:31Z
+224	CLOSED	Voice: export useVoiceOptional for safer consumption outside VoiceProvider	feature, frontend	2026-03-18T21:18:09Z
+180	CLOSED	Real-time messaging: other clients don't receive new messages	feature	2026-03-13T19:20:38Z
+165	CLOSED	Security: tRPC error responses expose stack traces to clients	bug, backend	2026-03-10T01:27:29Z
+112	CLOSED	Attachment Service & File Storage	feature, week-2, backend	2026-03-16T03:10:24Z
+10	CLOSED	Frontend: Implement Channel Visibility Toggle Component	feature, frontend, week-2	2026-02-16T16:54:09Z
+11	CLOSED	Frontend: Implement Guest Public Channel View	feature, frontend, week-2	2026-02-16T16:54:10Z
+188	CLOSED	Real-time: server list updates when a server is created or joined	feature	2026-03-16T01:59:56Z
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:25:14.641Z
+
+I’m creating four board issues now: spec + tests for the missing frontend guest-public API layer, and spec + tests for the backend public router that serves the guest flow.
+
+#### Tool: exec_command
+
+```sh
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label frontend --label testing --title "Test Specification — publicApiService.ts (frontend)" --body "## Description
+Write an English-language test specification for `harmony-frontend/src/services/publicApiService.ts` to cover the guest public channel view flow used by `/c/{serverSlug}/{channelSlug}`.
+
+## Functions to Specify
+- `mapChannelType`
+- `mapChannelVisibility`
+- `fetchPublicServer`
+- `fetchPublicChannel`
+- `fetchPublicMessages`
+- `isChannelGuestAccessible`
+
+## Requirements
+- List every function, its purpose, and all program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, network failures, 403/404 handling, and cache-safe null fallbacks
+- Explicitly cover guest visibility semantics for `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, and `PRIVATE`
+- Document the mock strategy for `fetch`, React `cache`, and API response shapes
+- Tie the spec back to `docs/dev-spec-guest-public-channel-view.md`
+- Target 80%+ code coverage of the file's reachable execution paths
+- Output: `docs/test-specs/frontend-public-api-service-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 functions listed with descriptions
+- [ ] Table covers happy paths for each function
+- [ ] Table covers 403/404/error handling paths
+- [ ] `PUBLIC_INDEXABLE` / `PUBLIC_NO_INDEX` / `PRIVATE` semantics are documented
+- [ ] Mock strategy documented
+- [ ] At least one test per function
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed to cover the implemented Guest Public Channel View user story."
+```
+
+Output:
+
+```text
+zsh:1: permission denied: harmony-frontend/src/services/publicApiService.ts
+zsh:1: no such file or directory: /c/{serverSlug}/{channelSlug}
+zsh:1: command not found: mapChannelType
+zsh:1: command not found: mapChannelVisibility
+zsh:1: command not found: fetchPublicServer
+zsh:1: command not found: fetchPublicChannel
+zsh:1: command not found: fetchPublicMessages
+zsh:1: command not found: isChannelGuestAccessible
+zsh:1: command not found: PUBLIC_INDEXABLE
+zsh:1: command not found: PUBLIC_NO_INDEX
+zsh:1: command not found: PRIVATE
+zsh:1: command not found: fetch
+zsh:1: command not found: cache
+zsh:1: permission denied: docs/dev-spec-guest-public-channel-view.md
+zsh:1: no such file or directory: docs/test-specs/frontend-public-api-service-spec.md
+zsh:1: command not found: PUBLIC_INDEXABLE
+zsh:1: command not found: PUBLIC_NO_INDEX
+zsh:1: command not found: PRIVATE
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label frontend --label testing --title "Unit Tests — publicApiService.ts (frontend)" --body "## Description
+Implement Jest unit tests for `harmony-frontend/src/services/publicApiService.ts` based on the test specification for the guest public channel view path.
+
+## Requirements
+- Test file: `harmony-frontend/src/__tests__/publicApiService.test.ts`
+- Mock `fetch` and React `cache`
+- Verify no duplicate or overlapping test cases
+- Cover `fetchPublicServer`, `fetchPublicChannel`, `fetchPublicMessages`, and `isChannelGuestAccessible`
+- Cover helper mapping behavior for channel type and visibility conversion
+- Run tests locally and capture coverage
+- Ensure tests reflect the intended guest-access semantics from `docs/dev-spec-guest-public-channel-view.md`
+
+## Acceptance Criteria
+- [ ] All functions from the spec have at least one test
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `publicApiService.ts`
+- [ ] Tests are isolated — no backend network calls leave the test process
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** test specification issue for `publicApiService.ts`
+**Context:** Needed to cover the implemented Guest Public Channel View user story."
+```
+
+Output:
+
+```text
+zsh:1: permission denied: harmony-frontend/src/services/publicApiService.ts
+zsh:1: no such file or directory: harmony-frontend/src/__tests__/publicApiService.test.ts
+zsh:1: command not found: fetch
+zsh:1: command not found: cache
+zsh:1: command not found: fetchPublicServer
+zsh:1: command not found: fetchPublicChannel
+zsh:1: command not found: fetchPublicMessages
+zsh:1: command not found: isChannelGuestAccessible
+zsh:1: permission denied: docs/dev-spec-guest-public-channel-view.md
+zsh:1: command not found: publicApiService.ts
+zsh:1: command not found: publicApiService.ts
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label backend --label testing --title "Test Specification — public.router.ts" --body "## Description
+Write an English-language test specification for `harmony-backend/src/routes/public.router.ts`, the public REST surface that serves guest-accessible channel content.
+
+## Endpoints / Behaviors to Specify
+- `GET /api/public/channels/:channelId/messages`
+- `GET /api/public/channels/:channelId/messages/:messageId`
+- `GET /api/public/servers`
+- `GET /api/public/servers/:serverSlug`
+- `GET /api/public/servers/:serverSlug/channels`
+- `GET /api/public/servers/:serverSlug/channels/:channelSlug`
+
+## Requirements
+- Treat each route handler as a function under test and document its program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, 403/404/500 paths, and pagination behavior
+- Explicitly document guest visibility semantics for `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, and `PRIVATE`
+- Call out any spec/code mismatches against `docs/dev-spec-guest-public-channel-view.md` and `docs/dev-spec-channel-visibility-toggle.md`
+- Document mock strategy for Prisma, cache, and rate-limiting dependencies
+- Target 80%+ code coverage of the route file's reachable execution paths
+- Output: `docs/test-specs/public-router-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 route handlers described with program paths
+- [ ] Table covers happy paths for each handler
+- [ ] Table covers 403/404/500 handling and pagination paths
+- [ ] `PUBLIC_INDEXABLE` / `PUBLIC_NO_INDEX` / `PRIVATE` semantics are documented
+- [ ] Mock strategy documented
+- [ ] At least one test per route handler
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed to cover the implemented Guest Public Channel View user story."
+```
+
+Output:
+
+```text
+zsh:1: permission denied: harmony-backend/src/routes/public.router.ts
+zsh:1: command not found: GET
+zsh:1: command not found: GET
+zsh:1: command not found: GET
+zsh:1: command not found: GET
+zsh:1: command not found: GET
+zsh:1: command not found: GET
+zsh:1: command not found: PUBLIC_INDEXABLE
+zsh:1: command not found: PUBLIC_NO_INDEX
+zsh:1: command not found: PRIVATE
+zsh:1: permission denied: docs/dev-spec-guest-public-channel-view.md
+zsh:1: permission denied: docs/dev-spec-channel-visibility-toggle.md
+zsh:1: no such file or directory: docs/test-specs/public-router-spec.md
+zsh:1: command not found: PUBLIC_INDEXABLE
+zsh:1: command not found: PUBLIC_NO_INDEX
+zsh:1: command not found: PRIVATE
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label backend --label testing --title "Unit Tests — public.router.ts" --body "## Description
+Implement or extend Jest/Supertest tests for `harmony-backend/src/routes/public.router.ts` based on the public router test specification.
+
+## Requirements
+- Test file: `harmony-backend/tests/public.router.test.ts`
+- Mock Prisma, cache, and rate-limiter dependencies as needed
+- Verify no duplicate or overlapping test cases
+- Cover all public REST endpoints used by the guest public channel view flow
+- Include coverage for guest visibility semantics, especially `PUBLIC_NO_INDEX` vs `PRIVATE`
+- Run tests locally and capture coverage
+- Resolve or document any spec/implementation mismatch found during testing
+
+## Acceptance Criteria
+- [ ] All handlers from the spec have at least one test
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `public.router.ts`
+- [ ] Tests are isolated — no real DB/Redis/network dependencies required
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** test specification issue for `public.router.ts`
+**Context:** Needed to cover the implemented Guest Public Channel View user story and align public-route behavior with the P5 assignment deliverables."
+```
+
+Output:
+
+```text
+zsh:1: permission denied: harmony-backend/src/routes/public.router.ts
+zsh:1: permission denied: harmony-backend/tests/public.router.test.ts
+zsh:1: command not found: PUBLIC_NO_INDEX
+zsh:1: command not found: PRIVATE
+zsh:1: command not found: public.router.ts
+zsh:1: command not found: public.router.ts
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:25:23.867Z
+
+The first pass failed because shell interpolation ate the Markdown bodies. I’m recreating the issues with body files so the titles and acceptance criteria land correctly on GitHub.
+
+#### Tool: exec_command
+
+```sh
+cat > /tmp/harmony_issue_public_api_spec.md <<'EOF'
+## Description
+Write an English-language test specification for `harmony-frontend/src/services/publicApiService.ts` to cover the guest public channel view flow used by `/c/{serverSlug}/{channelSlug}`.
+
+## Functions to Specify
+- `mapChannelType`
+- `mapChannelVisibility`
+- `fetchPublicServer`
+- `fetchPublicChannel`
+- `fetchPublicMessages`
+- `isChannelGuestAccessible`
+
+## Requirements
+- List every function, its purpose, and all program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, network failures, 403/404 handling, and cache-safe null fallbacks
+- Explicitly cover guest visibility semantics for `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, and `PRIVATE`
+- Document the mock strategy for `fetch`, React `cache`, and API response shapes
+- Tie the spec back to `docs/dev-spec-guest-public-channel-view.md`
+- Target 80%+ code coverage of the file's reachable execution paths
+- Output: `docs/test-specs/frontend-public-api-service-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 functions listed with descriptions
+- [ ] Table covers happy paths for each function
+- [ ] Table covers 403/404/error handling paths
+- [ ] `PUBLIC_INDEXABLE` / `PUBLIC_NO_INDEX` / `PRIVATE` semantics are documented
+- [ ] Mock strategy documented
+- [ ] At least one test per function
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed to cover the implemented Guest Public Channel View user story.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label frontend --label testing --title "Test Specification — publicApiService.ts (frontend)" --body-file /tmp/harmony_issue_public_api_spec.md
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 95770,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc "cat > /tmp/harmony_issue_public_api_spec.md <<'EOF'
+## Description
+Write an English-language test specification for "'`harmony-frontend/src/services/publicApiService.ts` to cover the guest public channel view flow used by `/c/{serverSlug}/{channelSlug}`.
+
+## Functions to Specify
+- `mapChannelType`
+- `mapChannelVisibility`
+- `fetchPublicServer`
+- `fetchPublicChannel`
+- `fetchPublicMessages`
+- `isChannelGuestAccessible`
+
+## Requirements
+- List every function, its purpose, and all program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, network failures, 403/404 handling, and cache-safe null fallbacks
+- Explicitly cover guest visibility semantics for `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, and `PRIVATE`
+- Document the mock strategy for `fetch`, React `cache`, and API response shapes
+- Tie the spec back to `docs/dev-spec-guest-public-channel-view.md`
+- Target 80%+ code coverage of the file'"'s reachable execution paths
+- Output: "'`docs/test-specs/frontend-public-api-service-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 functions listed with descriptions
+- [ ] Table covers happy paths for each function
+- [ ] Table covers 403/404/error handling paths
+- [ ] `PUBLIC_INDEXABLE` / `PUBLIC_NO_INDEX` / `PRIVATE` semantics are documented
+- [ ] Mock strategy documented
+- [ ] At least one test per function
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed to cover the implemented Guest Public Channel View user story.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label frontend --label testing --title "Test Specification — publicApiService.ts (frontend)" --body-file /tmp/harmony_issue_public_api_spec.md'
+Chunk ID: 7ebf33
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/289
+```
+
+#### Tool: exec_command
+
+```sh
+cat > /tmp/harmony_issue_public_api_tests.md <<'EOF'
+## Description
+Implement Jest unit tests for `harmony-frontend/src/services/publicApiService.ts` based on the test specification for the guest public channel view path.
+
+## Requirements
+- Test file: `harmony-frontend/src/__tests__/publicApiService.test.ts`
+- Mock `fetch` and React `cache`
+- Verify no duplicate or overlapping test cases
+- Cover `fetchPublicServer`, `fetchPublicChannel`, `fetchPublicMessages`, and `isChannelGuestAccessible`
+- Cover helper mapping behavior for channel type and visibility conversion
+- Run tests locally and capture coverage
+- Ensure tests reflect the intended guest-access semantics from `docs/dev-spec-guest-public-channel-view.md`
+
+## Acceptance Criteria
+- [ ] All functions from the spec have at least one test
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `publicApiService.ts`
+- [ ] Tests are isolated — no backend network calls leave the test process
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** #289
+**Context:** Needed to cover the implemented Guest Public Channel View user story.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label frontend --label testing --title "Unit Tests — publicApiService.ts (frontend)" --body-file /tmp/harmony_issue_public_api_tests.md
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 20827,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc "cat > /tmp/harmony_issue_public_api_tests.md <<'EOF'
+## Description
+Implement Jest unit tests for "'`harmony-frontend/src/services/publicApiService.ts` based on the test specification for the guest public channel view path.
+
+## Requirements
+- Test file: `harmony-frontend/src/__tests__/publicApiService.test.ts`
+- Mock `fetch` and React `cache`
+- Verify no duplicate or overlapping test cases
+- Cover `fetchPublicServer`, `fetchPublicChannel`, `fetchPublicMessages`, and `isChannelGuestAccessible`
+- Cover helper mapping behavior for channel type and visibility conversion
+- Run tests locally and capture coverage
+- Ensure tests reflect the intended guest-access semantics from `docs/dev-spec-guest-public-channel-view.md`
+
+## Acceptance Criteria
+- [ ] All functions from the spec have at least one test
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `publicApiService.ts`
+- [ ] Tests are isolated — no backend network calls leave the test process
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** #289
+**Context:** Needed to cover the implemented Guest Public Channel View user story.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label frontend --label testing --title "Unit Tests — publicApiService.ts (frontend)" --body-file /tmp/harmony_issue_public_api_tests.md'
+Chunk ID: d8d3e5
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/290
+```
+
+#### Tool: exec_command
+
+```sh
+cat > /tmp/harmony_issue_public_router_spec.md <<'EOF'
+## Description
+Write an English-language test specification for `harmony-backend/src/routes/public.router.ts`, the public REST surface that serves guest-accessible channel content.
+
+## Endpoints / Behaviors to Specify
+- `GET /api/public/channels/:channelId/messages`
+- `GET /api/public/channels/:channelId/messages/:messageId`
+- `GET /api/public/servers`
+- `GET /api/public/servers/:serverSlug`
+- `GET /api/public/servers/:serverSlug/channels`
+- `GET /api/public/servers/:serverSlug/channels/:channelSlug`
+
+## Requirements
+- Treat each route handler as a function under test and document its program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, 403/404/500 paths, and pagination behavior
+- Explicitly document guest visibility semantics for `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, and `PRIVATE`
+- Call out any spec/code mismatches against `docs/dev-spec-guest-public-channel-view.md` and `docs/dev-spec-channel-visibility-toggle.md`
+- Document mock strategy for Prisma, cache, and rate-limiting dependencies
+- Target 80%+ code coverage of the route file's reachable execution paths
+- Output: `docs/test-specs/public-router-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 route handlers described with program paths
+- [ ] Table covers happy paths for each handler
+- [ ] Table covers 403/404/500 handling and pagination paths
+- [ ] `PUBLIC_INDEXABLE` / `PUBLIC_NO_INDEX` / `PRIVATE` semantics are documented
+- [ ] Mock strategy documented
+- [ ] At least one test per route handler
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed to cover the implemented Guest Public Channel View user story.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label backend --label testing --title "Test Specification — public.router.ts" --body-file /tmp/harmony_issue_public_router_spec.md
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 67842,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc "cat > /tmp/harmony_issue_public_router_spec.md <<'EOF'
+## Description
+Write an English-language test specification for "'`harmony-backend/src/routes/public.router.ts`, the public REST surface that serves guest-accessible channel content.
+
+## Endpoints / Behaviors to Specify
+- `GET /api/public/channels/:channelId/messages`
+- `GET /api/public/channels/:channelId/messages/:messageId`
+- `GET /api/public/servers`
+- `GET /api/public/servers/:serverSlug`
+- `GET /api/public/servers/:serverSlug/channels`
+- `GET /api/public/servers/:serverSlug/channels/:channelSlug`
+
+## Requirements
+- Treat each route handler as a function under test and document its program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, 403/404/500 paths, and pagination behavior
+- Explicitly document guest visibility semantics for `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, and `PRIVATE`
+- Call out any spec/code mismatches against `docs/dev-spec-guest-public-channel-view.md` and `docs/dev-spec-channel-visibility-toggle.md`
+- Document mock strategy for Prisma, cache, and rate-limiting dependencies
+- Target 80%+ code coverage of the route file'"'s reachable execution paths
+- Output: "'`docs/test-specs/public-router-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 route handlers described with program paths
+- [ ] Table covers happy paths for each handler
+- [ ] Table covers 403/404/500 handling and pagination paths
+- [ ] `PUBLIC_INDEXABLE` / `PUBLIC_NO_INDEX` / `PRIVATE` semantics are documented
+- [ ] Mock strategy documented
+- [ ] At least one test per route handler
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed to cover the implemented Guest Public Channel View user story.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label backend --label testing --title "Test Specification — public.router.ts" --body-file /tmp/harmony_issue_public_router_spec.md'
+Chunk ID: a74efb
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/291
+```
+
+#### Tool: exec_command
+
+```sh
+cat > /tmp/harmony_issue_public_router_tests.md <<'EOF'
+## Description
+Implement or extend Jest/Supertest tests for `harmony-backend/src/routes/public.router.ts` based on the public router test specification.
+
+## Requirements
+- Test file: `harmony-backend/tests/public.router.test.ts`
+- Mock Prisma, cache, and rate-limiter dependencies as needed
+- Verify no duplicate or overlapping test cases
+- Cover all public REST endpoints used by the guest public channel view flow
+- Include coverage for guest visibility semantics, especially `PUBLIC_NO_INDEX` vs `PRIVATE`
+- Run tests locally and capture coverage
+- Resolve or document any spec/implementation mismatch found during testing
+
+## Acceptance Criteria
+- [ ] All handlers from the spec have at least one test
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `public.router.ts`
+- [ ] Tests are isolated — no real DB/Redis/network dependencies required
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** #291
+**Context:** Needed to cover the implemented Guest Public Channel View user story and align public-route behavior with the P5 assignment deliverables.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label backend --label testing --title "Unit Tests — public.router.ts" --body-file /tmp/harmony_issue_public_router_tests.md
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 81100,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc "cat > /tmp/harmony_issue_public_router_tests.md <<'EOF'
+## Description
+Implement or extend Jest/Supertest tests for "'`harmony-backend/src/routes/public.router.ts` based on the public router test specification.
+
+## Requirements
+- Test file: `harmony-backend/tests/public.router.test.ts`
+- Mock Prisma, cache, and rate-limiter dependencies as needed
+- Verify no duplicate or overlapping test cases
+- Cover all public REST endpoints used by the guest public channel view flow
+- Include coverage for guest visibility semantics, especially `PUBLIC_NO_INDEX` vs `PRIVATE`
+- Run tests locally and capture coverage
+- Resolve or document any spec/implementation mismatch found during testing
+
+## Acceptance Criteria
+- [ ] All handlers from the spec have at least one test
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `public.router.ts`
+- [ ] Tests are isolated — no real DB/Redis/network dependencies required
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** #291
+**Context:** Needed to cover the implemented Guest Public Channel View user story and align public-route behavior with the P5 assignment deliverables.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label backend --label testing --title "Unit Tests — public.router.ts" --body-file /tmp/harmony_issue_public_router_tests.md'
+Chunk ID: 345bdb
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/292
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:26:33.094Z
+
+The issues are created. I’m verifying the rendered bodies once so I can fix any formatting damage from the shell quoting before I hand you the links.
+
+#### Tool: exec_command
+
+```sh
+gh issue view 289 -R acabrera04/Harmony
+```
+
+Output:
+
+```text
+title:	Test Specification — publicApiService.ts (frontend)
+state:	OPEN
+author:	acabrera04
+labels:	frontend, testing
+comments:	0
+assignees:	
+projects:	Harmony Project Board (Backlog)
+milestone:	
+number:	289
+--
+## Description
+Write an English-language test specification for `harmony-frontend/src/services/publicApiService.ts` to cover the guest public channel view flow used by `/c/{serverSlug}/{channelSlug}`.
+
+## Functions to Specify
+- `mapChannelType`
+- `mapChannelVisibility`
+- `fetchPublicServer`
+- `fetchPublicChannel`
+- `fetchPublicMessages`
+- `isChannelGuestAccessible`
+
+## Requirements
+- List every function, its purpose, and all program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, network failures, 403/404 handling, and cache-safe null fallbacks
+- Explicitly cover guest visibility semantics for `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, and `PRIVATE`
+- Document the mock strategy for `fetch`, React `cache`, and API response shapes
+- Tie the spec back to `docs/dev-spec-guest-public-channel-view.md`
+- Target 80%+ code coverage of the file's reachable execution paths
+- Output: `docs/test-specs/frontend-public-api-service-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 functions listed with descriptions
+- [ ] Table covers happy paths for each function
+- [ ] Table covers 403/404/error handling paths
+- [ ] `PUBLIC_INDEXABLE` / `PUBLIC_NO_INDEX` / `PRIVATE` semantics are documented
+- [ ] Mock strategy documented
+- [ ] At least one test per function
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed to cover the implemented Guest Public Channel View user story.
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 290 -R acabrera04/Harmony
+```
+
+Output:
+
+```text
+title:	Unit Tests — publicApiService.ts (frontend)
+state:	OPEN
+author:	acabrera04
+labels:	frontend, testing
+comments:	0
+assignees:	
+projects:	Harmony Project Board (Backlog)
+milestone:	
+number:	290
+--
+## Description
+Implement Jest unit tests for `harmony-frontend/src/services/publicApiService.ts` based on the test specification for the guest public channel view path.
+
+## Requirements
+- Test file: `harmony-frontend/src/__tests__/publicApiService.test.ts`
+- Mock `fetch` and React `cache`
+- Verify no duplicate or overlapping test cases
+- Cover `fetchPublicServer`, `fetchPublicChannel`, `fetchPublicMessages`, and `isChannelGuestAccessible`
+- Cover helper mapping behavior for channel type and visibility conversion
+- Run tests locally and capture coverage
+- Ensure tests reflect the intended guest-access semantics from `docs/dev-spec-guest-public-channel-view.md`
+
+## Acceptance Criteria
+- [ ] All functions from the spec have at least one test
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `publicApiService.ts`
+- [ ] Tests are isolated — no backend network calls leave the test process
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** #289
+**Context:** Needed to cover the implemented Guest Public Channel View user story.
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 291 -R acabrera04/Harmony
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 292 -R acabrera04/Harmony
+```
+
+Output:
+
+```text
+title:	Unit Tests — public.router.ts
+state:	OPEN
+author:	acabrera04
+labels:	backend, testing
+comments:	0
+assignees:	
+projects:	Harmony Project Board (Backlog)
+milestone:	
+number:	292
+--
+## Description
+Implement or extend Jest/Supertest tests for `harmony-backend/src/routes/public.router.ts` based on the public router test specification.
+
+## Requirements
+- Test file: `harmony-backend/tests/public.router.test.ts`
+- Mock Prisma, cache, and rate-limiter dependencies as needed
+- Verify no duplicate or overlapping test cases
+- Cover all public REST endpoints used by the guest public channel view flow
+- Include coverage for guest visibility semantics, especially `PUBLIC_NO_INDEX` vs `PRIVATE`
+- Run tests locally and capture coverage
+- Resolve or document any spec/implementation mismatch found during testing
+
+## Acceptance Criteria
+- [ ] All handlers from the spec have at least one test
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `public.router.ts`
+- [ ] Tests are isolated — no real DB/Redis/network dependencies required
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** #291
+**Context:** Needed to cover the implemented Guest Public Channel View user story and align public-route behavior with the P5 assignment deliverables.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 64705,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 5000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'gh issue view 291 -R acabrera04/Harmony'
+Chunk ID: 2dbba3
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 462
+Output:
+title:	Test Specification — public.router.ts
+state:	OPEN
+author:	acabrera04
+labels:	backend, testing
+comments:	0
+assignees:	
+projects:	Harmony Project Board (Backlog)
+milestone:	
+number:	291
+--
+## Description
+Write an English-language test specification for `harmony-backend/src/routes/public.router.ts`, the public REST surface that serves guest-accessible channel content.
+
+## Endpoints / Behaviors to Specify
+- `GET /api/public/channels/:channelId/messages`
+- `GET /api/public/channels/:channelId/messages/:messageId`
+- `GET /api/public/servers`
+- `GET /api/public/servers/:serverSlug`
+- `GET /api/public/servers/:serverSlug/channels`
+- `GET /api/public/servers/:serverSlug/channels/:channelSlug`
+
+## Requirements
+- Treat each route handler as a function under test and document its program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, 403/404/500 paths, and pagination behavior
+- Explicitly document guest visibility semantics for `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, and `PRIVATE`
+- Call out any spec/code mismatches against `docs/dev-spec-guest-public-channel-view.md` and `docs/dev-spec-channel-visibility-toggle.md`
+- Document mock strategy for Prisma, cache, and rate-limiting dependencies
+- Target 80%+ code coverage of the route file's reachable execution paths
+- Output: `docs/test-specs/public-router-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 route handlers described with program paths
+- [ ] Table covers happy paths for each handler
+- [ ] Table covers 403/404/500 handling and pagination paths
+- [ ] `PUBLIC_INDEXABLE` / `PUBLIC_NO_INDEX` / `PRIVATE` semantics are documented
+- [ ] Mock strategy documented
+- [ ] At least one test per route handler
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed to cover the implemented Guest Public Channel View user story.
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:26:53.777Z
+
+Created four new issues and added them to the Harmony Project Board backlog:
+
+- [#289 Test Specification — publicApiService.ts (frontend)](https://github.com/acabrera04/Harmony/issues/289)
+- [#290 Unit Tests — publicApiService.ts (frontend)](https://github.com/acabrera04/Harmony/issues/290)
+- [#291 Test Specification — public.router.ts](https://github.com/acabrera04/Harmony/issues/291)
+- [#292 Unit Tests — public.router.ts](https://github.com/acabrera04/Harmony/issues/292)
+
+I did not create duplicates for files already tracked in the board:
+- `server.service.ts`: #259 / #264
+- `serverService.ts`: #260 / #265
+- `channelService.ts`: #261 / #266
+- `auth.service.ts`: #258 / #263
+- `serverMember.service.ts`: #268 / #269
+
+These four new issues target the missing guest-public-channel testing path that was not already represented well in the P5 issue set.
+
+### Turn 5: Why didn't you make an issue for channelService in the
+
+#### 👤 User Prompt
+
+- Time: 2026-04-03T19:30:34.883Z
+
+```text
+Why didn't you make an issue for channelService in the backend?
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:30:50.999Z
+
+Because I scoped the new issues to what was clearly missing from the board and from story coverage.
+
+`channel.service.ts` already has substantial backend test coverage in [channel.service.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/channel.service.test.ts) and [channel.service.events.test.ts](/Users/allen/repos/Harmony/harmony-backend/tests/channel.service.events.test.ts). By contrast, the guest-view path around [public.router.ts](/Users/allen/repos/Harmony/harmony-backend/src/routes/public.router.ts) and [publicApiService.ts](/Users/allen/repos/Harmony/harmony-frontend/src/services/publicApiService.ts) was the obvious untracked gap, so I opened issues there first.
+
+That said, if the goal is not just “fill gaps” but “make the board reflect the best 2 frontend + 2 backend source files for the two implemented user stories,” then `channel.service.ts` should probably have its own P5 spec/test issues, and `server.service.ts` is a weaker fit. So the short answer is: I optimized for missing coverage, not for the cleanest assignment-file lineup.
+
+If you want, I can create:
+- `Test Specification — channel.service.ts`
+- `Unit Tests — channel.service.ts`
+
+and we can treat that as one of the canonical backend files for P5.
+
+### Turn 6: Yes, have a test spec for channel.service and to ensure that the unit
+
+#### 👤 User Prompt
+
+- Time: 2026-04-03T19:31:41.086Z
+
+```text
+Yes, have a test spec for channel.service and to ensure that the unit tests are aligned with it
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:31:49.244Z
+
+I’m checking for any existing `channel.service.ts` P5 issues first, then I’ll add a spec issue and a unit-test issue that explicitly says the tests must align with the spec.
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"channel.service.ts" "Test Specification"'
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 200 --state all --search '"channel.service.ts" "Unit Tests"'
+```
+
+Output:
+
+```text
+
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:32:11.419Z
+
+No duplicate issues exist for `channel.service.ts`. I’m creating the pair now and making the unit-test issue depend on the spec so the board reflects the alignment requirement.
+
+#### Tool: exec_command
+
+```sh
+cat > /tmp/harmony_issue_channel_service_spec.md <<'EOF'
+## Description
+Write an English-language test specification for `harmony-backend/src/services/channel.service.ts` so the P5 backend test coverage aligns with the implemented channel visibility and public-channel user stories.
+
+## Functions to Specify
+- `channelService.getChannels`
+- `channelService.getChannelBySlug`
+- `channelService.createChannel`
+- `channelService.updateChannel`
+- `channelService.deleteChannel`
+- `channelService.createDefaultChannel`
+
+## Requirements
+- List every function, its purpose, and all program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, `NOT_FOUND`, `CONFLICT`, and other explicit error branches
+- Explicitly cover the VOICE + `PUBLIC_INDEXABLE` guard and visibility-related behavior
+- Document side effects on cache invalidation and event publishing where applicable
+- Tie the spec back to `docs/dev-spec-channel-visibility-toggle.md` and `docs/dev-spec-guest-public-channel-view.md`
+- Target 80%+ code coverage of the file's reachable execution paths
+- Output: `docs/test-specs/channel-service-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 functions listed with descriptions
+- [ ] Table covers happy paths for each function
+- [ ] Table covers explicit error paths and edge cases
+- [ ] Visibility-related constraints are documented
+- [ ] Cache/event side effects are documented
+- [ ] At least one test per function
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed so backend channel tests are explicitly aligned with the implemented visibility/public-channel stories.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label backend --label testing --title "Test Specification — channel.service.ts" --body-file /tmp/harmony_issue_channel_service_spec.md
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+cat > /tmp/harmony_issue_channel_service_tests.md <<'EOF'
+## Description
+Implement or reconcile Jest unit tests for `harmony-backend/src/services/channel.service.ts` so they explicitly match the approved test specification and satisfy the P5 assignment expectations.
+
+## Requirements
+- Test file: `harmony-backend/tests/channel.service.test.ts`
+- Update existing tests as needed so every behavior claimed by the spec is actually covered
+- Verify no duplicate or significantly overlapping test cases
+- Cover CRUD behavior, slug/server lookup, visibility constraints, and default-channel creation
+- Cover cache invalidation and event publishing expectations where relevant, using mocks/spies instead of real external dependencies
+- Run tests locally and capture coverage
+- Ensure the final test inventory is traceable back to the spec tables
+
+## Acceptance Criteria
+- [ ] All functions from the spec have at least one corresponding test
+- [ ] Existing tests are reconciled with the spec; gaps and mismatches removed
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `channel.service.ts`
+- [ ] Tests are isolated — no real DB/Redis/network dependencies beyond the intended test setup
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** test specification issue for `channel.service.ts`
+**Context:** Needed to ensure backend channel-service tests are aligned with the test spec rather than only incidentally covering parts of the implementation.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label backend --label testing --title "Unit Tests — channel.service.ts" --body-file /tmp/harmony_issue_channel_service_tests.md
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 91623,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc "cat > /tmp/harmony_issue_channel_service_spec.md <<'EOF'
+## Description
+Write an English-language test specification for "'`harmony-backend/src/services/channel.service.ts` so the P5 backend test coverage aligns with the implemented channel visibility and public-channel user stories.
+
+## Functions to Specify
+- `channelService.getChannels`
+- `channelService.getChannelBySlug`
+- `channelService.createChannel`
+- `channelService.updateChannel`
+- `channelService.deleteChannel`
+- `channelService.createDefaultChannel`
+
+## Requirements
+- List every function, its purpose, and all program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, `NOT_FOUND`, `CONFLICT`, and other explicit error branches
+- Explicitly cover the VOICE + `PUBLIC_INDEXABLE` guard and visibility-related behavior
+- Document side effects on cache invalidation and event publishing where applicable
+- Tie the spec back to `docs/dev-spec-channel-visibility-toggle.md` and `docs/dev-spec-guest-public-channel-view.md`
+- Target 80%+ code coverage of the file'"'s reachable execution paths
+- Output: "'`docs/test-specs/channel-service-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 functions listed with descriptions
+- [ ] Table covers happy paths for each function
+- [ ] Table covers explicit error paths and edge cases
+- [ ] Visibility-related constraints are documented
+- [ ] Cache/event side effects are documented
+- [ ] At least one test per function
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed so backend channel tests are explicitly aligned with the implemented visibility/public-channel stories.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label backend --label testing --title "Test Specification — channel.service.ts" --body-file /tmp/harmony_issue_channel_service_spec.md'
+Chunk ID: 089d9c
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/293
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 25923,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc "cat > /tmp/harmony_issue_channel_service_tests.md <<'EOF'
+## Description
+Implement or reconcile Jest unit tests for "'`harmony-backend/src/services/channel.service.ts` so they explicitly match the approved test specification and satisfy the P5 assignment expectations.
+
+## Requirements
+- Test file: `harmony-backend/tests/channel.service.test.ts`
+- Update existing tests as needed so every behavior claimed by the spec is actually covered
+- Verify no duplicate or significantly overlapping test cases
+- Cover CRUD behavior, slug/server lookup, visibility constraints, and default-channel creation
+- Cover cache invalidation and event publishing expectations where relevant, using mocks/spies instead of real external dependencies
+- Run tests locally and capture coverage
+- Ensure the final test inventory is traceable back to the spec tables
+
+## Acceptance Criteria
+- [ ] All functions from the spec have at least one corresponding test
+- [ ] Existing tests are reconciled with the spec; gaps and mismatches removed
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `channel.service.ts`
+- [ ] Tests are isolated — no real DB/Redis/network dependencies beyond the intended test setup
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** test specification issue for `channel.service.ts`
+**Context:** Needed to ensure backend channel-service tests are aligned with the test spec rather than only incidentally covering parts of the implementation.
+EOF
+
+gh issue create -R acabrera04/Harmony -p "Harmony Project Board" --label backend --label testing --title "Unit Tests — channel.service.ts" --body-file /tmp/harmony_issue_channel_service_tests.md'
+Chunk ID: c83713
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/294
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:32:22.151Z
+
+The two `channel.service.ts` issues are created. I’m verifying the rendered bodies so the alignment/dependency language is correct before I send you the links.
+
+#### Tool: exec_command
+
+```sh
+gh issue view 293 -R acabrera04/Harmony
+```
+
+Output:
+
+```text
+title:	Test Specification — channel.service.ts
+state:	OPEN
+author:	acabrera04
+labels:	backend, testing
+comments:	0
+assignees:	
+projects:	Harmony Project Board (Backlog)
+milestone:	
+number:	293
+--
+## Description
+Write an English-language test specification for `harmony-backend/src/services/channel.service.ts` so the P5 backend test coverage aligns with the implemented channel visibility and public-channel user stories.
+
+## Functions to Specify
+- `channelService.getChannels`
+- `channelService.getChannelBySlug`
+- `channelService.createChannel`
+- `channelService.updateChannel`
+- `channelService.deleteChannel`
+- `channelService.createDefaultChannel`
+
+## Requirements
+- List every function, its purpose, and all program paths
+- Create a table with columns: **Test Purpose**, **Inputs**, **Expected Output**
+- Cover happy paths, `NOT_FOUND`, `CONFLICT`, and other explicit error branches
+- Explicitly cover the VOICE + `PUBLIC_INDEXABLE` guard and visibility-related behavior
+- Document side effects on cache invalidation and event publishing where applicable
+- Tie the spec back to `docs/dev-spec-channel-visibility-toggle.md` and `docs/dev-spec-guest-public-channel-view.md`
+- Target 80%+ code coverage of the file's reachable execution paths
+- Output: `docs/test-specs/channel-service-spec.md`
+
+## Acceptance Criteria
+- [ ] All 6 functions listed with descriptions
+- [ ] Table covers happy paths for each function
+- [ ] Table covers explicit error paths and edge cases
+- [ ] Visibility-related constraints are documented
+- [ ] Cache/event side effects are documented
+- [ ] At least one test per function
+
+**Sprint:** 3 (P5 Testing)
+**Context:** Needed so backend channel tests are explicitly aligned with the implemented visibility/public-channel stories.
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 294 -R acabrera04/Harmony
+```
+
+Output:
+
+```text
+title:	Unit Tests — channel.service.ts
+state:	OPEN
+author:	acabrera04
+labels:	backend, testing
+comments:	0
+assignees:	
+projects:	Harmony Project Board (Backlog)
+milestone:	
+number:	294
+--
+## Description
+Implement or reconcile Jest unit tests for `harmony-backend/src/services/channel.service.ts` so they explicitly match the approved test specification and satisfy the P5 assignment expectations.
+
+## Requirements
+- Test file: `harmony-backend/tests/channel.service.test.ts`
+- Update existing tests as needed so every behavior claimed by the spec is actually covered
+- Verify no duplicate or significantly overlapping test cases
+- Cover CRUD behavior, slug/server lookup, visibility constraints, and default-channel creation
+- Cover cache invalidation and event publishing expectations where relevant, using mocks/spies instead of real external dependencies
+- Run tests locally and capture coverage
+- Ensure the final test inventory is traceable back to the spec tables
+
+## Acceptance Criteria
+- [ ] All functions from the spec have at least one corresponding test
+- [ ] Existing tests are reconciled with the spec; gaps and mismatches removed
+- [ ] No hallucinated test cases for non-existent functionality
+- [ ] No duplicate or significantly overlapping tests
+- [ ] All tests pass locally
+- [ ] 80%+ code coverage for `channel.service.ts`
+- [ ] Tests are isolated — no real DB/Redis/network dependencies beyond the intended test setup
+
+**Sprint:** 3 (P5 Testing)
+**Depends on:** test specification issue for `channel.service.ts`
+**Context:** Needed to ensure backend channel-service tests are aligned with the test spec rather than only incidentally covering parts of the implementation.
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:32:26.180Z
+
+Created the two `channel.service.ts` issues on the Harmony Project Board:
+
+- [#293 Test Specification — channel.service.ts](https://github.com/acabrera04/Harmony/issues/293)
+- [#294 Unit Tests — channel.service.ts](https://github.com/acabrera04/Harmony/issues/294)
+
+The unit-test issue explicitly says the existing tests should be reconciled against the spec, not just left as-is, so the board now tracks both the spec work and the alignment work.
+
+### Turn 7: Great, now assign the issues to people on the project board. Check the
+
+#### 👤 User Prompt
+
+- Time: 2026-04-03T19:37:16.999Z
+
+```text
+Great, now assign the issues to people on the project board. Check the project board to see who the 5 people who are working on the project so you know who to assign it too. Also assign the test spec and the corresponding unit test to the same person. Give me one of them please
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:37:25.457Z
+
+I’m checking the project board and the existing P5 issue assignments now so I can pick one team member already working in that area and assign the spec and matching unit-test issue to the same person.
+
+#### Tool: exec_command
+
+```sh
+gh project item-list 4 --owner acabrera04 --limit 200
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue list -R acabrera04/Harmony --limit 100 --state all
+```
+
+Output:
+
+```text
+294	OPEN	Unit Tests — channel.service.ts	testing, backend	2026-04-03T19:32:12Z
+293	OPEN	Test Specification — channel.service.ts	testing, backend	2026-04-03T19:32:12Z
+292	OPEN	Unit Tests — public.router.ts	testing, backend	2026-04-03T19:26:20Z
+291	OPEN	Test Specification — public.router.ts	testing, backend	2026-04-03T19:26:05Z
+290	OPEN	Unit Tests — publicApiService.ts (frontend)	frontend, testing	2026-04-03T19:25:48Z
+289	OPEN	Test Specification — publicApiService.ts (frontend)	frontend, testing	2026-04-03T19:25:34Z
+269	OPEN	Unit Tests — serverMember.service.ts	testing, backend	2026-03-31T19:27:50Z
+268	OPEN	Test Specification — serverMember.service.ts	testing, backend	2026-03-30T23:21:59Z
+267	OPEN	README Update & Final Submission	documentation, testing	2026-03-30T00:50:40Z
+266	CLOSED	Unit Tests — channelService.ts (frontend)	frontend, testing	2026-04-03T15:53:27Z
+265	OPEN	Unit Tests — serverService.ts (frontend)	frontend, testing	2026-03-30T00:50:34Z
+264	OPEN	Unit Tests — server.service.ts	testing, backend	2026-04-01T00:34:30Z
+263	CLOSED	Unit Tests — auth.service.ts	testing, backend	2026-04-03T18:26:22Z
+262	CLOSED	GitHub Actions — CI Workflows (run-frontend-tests.yml + run-backend-tests.yml)	testing	2026-03-30T22:43:49Z
+261	CLOSED	Test Specification — channelService.ts (frontend)	frontend, testing	2026-03-31T23:48:23Z
+260	CLOSED	Test Specification — serverService.ts (frontend)	frontend, testing	2026-04-01T04:32:01Z
+259	CLOSED	Test Specification — server.service.ts	testing, backend	2026-03-31T23:28:48Z
+258	CLOSED	Test Specification — auth.service.ts	testing, backend	2026-04-02T21:28:19Z
+245	OPEN	test: add negative guard coverage for createReply event publish		2026-03-23T03:35:54Z
+242	CLOSED	fix: joining a server silently fails on first attempt with no user feedback		2026-03-23T16:00:22Z
+241	OPEN	fix: "Design Lab" listed as public server with description "A private server for the design team"		2026-03-23T02:47:36Z
+240	OPEN	fix: authenticated users see "Sign up or log in" on inaccessible channels		2026-03-23T02:47:30Z
+239	CLOSED	fix: pin button shown to all users; non-moderator pin returns HTTP 500		2026-03-25T15:42:35Z
+238	OPEN	fix: message compose textarea missing aria-label (accessibility)		2026-03-23T02:47:03Z
+236	OPEN	fix: pin button shown to all users; improve pin error messages		2026-03-25T15:42:28Z
+231	CLOSED	Real-time: propagate user status changes to connected clients	feature	2026-03-21T13:37:55Z
+228	CLOSED	Update Backend READMe		2026-03-22T01:30:15Z
+227	OPEN	refactor: introduce repository layer — centralize Prisma calls out of services		2026-03-19T22:12:05Z
+226	CLOSED	feat: createReply should publish MESSAGE_CREATED SSE event		2026-03-23T03:36:39Z
+224	CLOSED	Voice: export useVoiceOptional for safer consumption outside VoiceProvider	feature, frontend	2026-03-18T21:18:09Z
+223	CLOSED	Voice: user-visible error feedback when voice channel join fails	feature, frontend, ui	2026-03-18T21:18:07Z
+222	CLOSED	Voice: local user's mute/deafen state not reflected in participant list	bug, frontend	2026-03-18T21:18:05Z
+221	CLOSED	Voice: show participant lists for all channels, not just the connected one	feature, frontend	2026-03-18T21:18:04Z
+194	OPEN	chore: add structured logger utility for observability and debug		2026-03-15T03:24:07Z
+189	OPEN	Real-time: refactor SSE into a unified server-scoped endpoint	feature	2026-03-13T19:29:16Z
+188	CLOSED	Real-time: server list updates when a server is created or joined	feature	2026-03-16T01:59:56Z
+187	CLOSED	Real-time: channel visibility changes propagate to all connected clients	feature	2026-03-21T00:53:42Z
+186	CLOSED	Real-time: member list updates when users join or leave a server	feature	2026-03-23T03:52:22Z
+185	CLOSED	Real-time: channel list updates when channels are created, renamed, or deleted	feature	2026-03-16T00:58:42Z
+180	CLOSED	Real-time messaging: other clients don't receive new messages	feature	2026-03-13T19:20:38Z
+179	CLOSED	Server list shows servers the user is not a member of		2026-03-13T19:28:30Z
+173	CLOSED	Add server member list endpoint to backend tRPC router		2026-03-11T12:26:27Z
+170	CLOSED	ChannelPageContent crashes if authenticated user is not a member of every public server		2026-03-10T22:42:49Z
+169	CLOSED	createServer does not add owner to server_members		2026-03-10T22:48:20Z
+166	CLOSED	Dev setup broken: README missing Redis startup + .env missing JWT secrets	bug, documentation, backend	2026-03-10T00:57:57Z
+165	CLOSED	Security: tRPC error responses expose stack traces to clients	bug, backend	2026-03-10T01:27:29Z
+160	CLOSED	Epic: Fix non-functional message action buttons (reactions, replies, pin)	feature	2026-03-13T19:28:56Z
+159	CLOSED	Write tests for reply/thread endpoints	testing, backend	2026-03-09T15:15:31Z
+158	CLOSED	Write tests for reaction endpoints	testing, backend	2026-03-09T15:15:30Z
+157	CLOSED	Implement tRPC reply/thread procedures	backend	2026-03-09T15:15:30Z
+156	CLOSED	Implement tRPC reaction router	backend	2026-03-09T15:15:31Z
+155	CLOSED	Implement message reaction service	backend	2026-03-09T15:15:31Z
+154	CLOSED	Implement message reply service methods	backend	2026-03-09T15:15:30Z
+153	CLOSED	Wire up pin button and implement pinned messages panel	feature, frontend	2026-03-22T02:14:05Z
+152	CLOSED	Implement message reactions (schema, service, router, tests)	feature, prerequisite, backend	2026-03-23T02:56:08Z
+151	CLOSED	Implement message replies/threads (schema, service, router, tests)	feature, prerequisite, backend	2026-03-20T01:26:45Z
+147	CLOSED	Fix flaky setTimeout in visibility event emission test	backend	2026-03-10T21:00:54Z
+122	CLOSED	Frontend Integration — Voice Channels (Stretch Goal)	integration, week-2, backend	2026-03-22T00:03:54Z
+121	CLOSED	Twilio Voice Service — Real-Time Audio for Voice Channels	feature, week-2, backend	2026-03-15T23:35:06Z
+120	CLOSED	Backend README — Setup & Operations Guide	documentation, week-2, backend	2026-03-13T19:28:33Z
+119	CLOSED	Next.js Auth Middleware — Server-Side Route Protection	feature, week-2, backend	2026-03-10T21:00:16Z
+118	CLOSED	API Input Validation & Error Handling	feature, week-2, backend	2026-03-13T19:28:31Z
+117	CLOSED	Frontend Integration — Channel Visibility Toggle	integration, week-2, backend	2026-03-22T12:13:34Z
+116	CLOSED	Frontend Integration — Guest Public Channel View	integration, week-2, backend	2026-03-12T21:37:21Z
+115	CLOSED	Frontend Integration — Messages	integration, week-2, backend	2026-03-13T19:28:35Z
+114	CLOSED	Frontend Integration — Servers & Channels	integration, week-2, backend	2026-03-11T13:35:17Z
+113	CLOSED	Frontend Integration — Authentication	integration, week-2, backend	2026-03-09T21:47:51Z
+112	CLOSED	Attachment Service & File Storage	feature, week-2, backend	2026-03-16T03:10:24Z
+111	CLOSED	Event Bus — Redis Pub/Sub for Cross-Service Events	feature, week-2, backend	2026-03-07T20:36:53Z
+110	CLOSED	Rate Limiting Middleware	feature, week-2, backend	2026-03-09T14:24:34Z
+109	CLOSED	Redis Caching Layer	feature, week-2, backend	2026-03-07T18:03:36Z
+108	CLOSED	Public REST API — Channel & Server Endpoints	feature, week-2, backend	2026-03-10T02:36:02Z
+107	CLOSED	Sitemap & SEO Data Endpoints	feature, week-2, backend	2026-03-09T23:29:36Z
+106	CLOSED	Visibility Audit Log Service	feature, week-2, backend	2026-03-09T16:02:56Z
+105	CLOSED	Channel Visibility Toggle Service	feature, week-2, backend	2026-03-09T14:23:34Z
+104	CLOSED	Database Seed Data	setup, week-1, backend	2026-03-07T18:34:57Z
+103	CLOSED	Server Membership Service	feature, week-1, backend	2026-03-09T15:33:07Z
+102	CLOSED	Role-Based Permission & Authorization System	feature, prerequisite, week-1, backend	2026-03-08T17:47:08Z
+101	CLOSED	Message Service & API	feature, week-1, backend	2026-03-09T03:48:58Z
+100	CLOSED	Channel Service & API	feature, week-1, backend	2026-03-06T20:06:56Z
+99	CLOSED	Server Service & API	feature, week-1, backend	2026-03-09T14:48:34Z
+98	CLOSED	User Service & API	feature, week-1, backend	2026-03-07T21:14:55Z
+97	CLOSED	Authentication System — JWT Register/Login/Logout	feature, prerequisite, week-1, backend	2026-03-07T02:41:02Z
+96	CLOSED	Database Schema & Prisma Migrations	setup, prerequisite, week-1, backend	2026-03-05T23:42:50Z
+95	CLOSED	P4 Deliverables — Dev Spec Update & Architecture Document	documentation, prerequisite, week-1, backend	2026-03-05T04:24:57Z
+94	CLOSED	Backend Project Scaffold & Dev Environment	setup, prerequisite, week-1, backend	2026-03-04T23:39:34Z
+88	CLOSED	Build User Settings Page	feature, frontend	2026-03-02T02:35:13Z
+86	CLOSED	Implement Server Settings (name, icon, description)		2026-03-01T22:12:06Z
+84	CLOSED	Build server creation modal	feature, frontend, ui	2026-03-01T22:11:23Z
+75	CLOSED	Users need to be able to log out		2026-03-02T02:35:13Z
+72	CLOSED	Implement Permissions section in ChannelSettingsPage		2026-03-16T18:13:13Z
+71	CLOSED	Fix non-admin redirect spinner delay on /settings/* routes		2026-03-10T21:00:15Z
+51	CLOSED	Epic: Integration, Testing & Demo	frontend, integration, testing, week-2	2026-03-02T16:33:27Z
+50	CLOSED	Epic: Guest Public Channel View Feature	feature, frontend, week-2	2026-03-02T02:37:48Z
+49	CLOSED	Epic: Channel Visibility Toggle Feature	feature, frontend, week-2	2026-03-01T23:53:48Z
+48	CLOSED	Epic: Chat UI Components	frontend, ui, week-1	2026-03-01T23:53:46Z
+47	CLOSED	Epic: Core App Layout & Navigation	frontend, ui, week-1	2026-02-24T22:31:34Z
+46	CLOSED	Epic: Project Scaffolding & Setup	setup, prerequisite, week-1	2026-02-23T17:51:18Z
+44	CLOSED	Build channel creation modal	frontend, ui, week-2	2026-03-02T00:15:19Z
+43	CLOSED	Build SearchBar modal component	frontend, ui, week-2	2026-02-22T21:50:16Z
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:37:33.104Z
+
+I’ve got the issue history; now I’m pulling the current assignees from the P5 issues so I can assign this pair to one of the existing five contributors instead of inventing a new owner.
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 89832,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'gh project item-list 4 --owner acabrera04 --limit 200'
+Chunk ID: 2ac0c4
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 3708
+Output:
+Issue	Test Specification — channelService.ts (frontend)	261	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonYfk
+Issue	README Update & Final Submission	267	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonYlk
+Issue	Unit Tests — serverMember.service.ts	269	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonZGk
+Issue	Unit Tests — auth.service.ts	263	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonYjE
+Issue	Unit Tests — server.service.ts	264	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonYjw
+Issue	GitHub Actions — CI Workflows (run-frontend-tests.yml + run-backend-tests.yml)	262	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonYgI
+Issue	Test Specification — serverService.ts (frontend)	260	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonYe0
+Issue	Test Specification — server.service.ts	259	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonYeY
+Issue	Test Specification — auth.service.ts	258	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonYdI
+Issue	Test Specification — serverMember.service.ts	268	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonZGE
+Issue	Unit Tests — serverService.ts (frontend)	265	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonYkg
+Issue	Implement message replies/threads (schema, service, router, tests)	151	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAVkM
+Issue	Wire up pin button and implement pinned messages panel	153	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAVkI
+Issue	Frontend Integration — Voice Channels (Stretch Goal)	122	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfiI
+Issue	Attachment Service & File Storage	112	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfcc
+Issue	Real-time messaging: other clients don't receive new messages	180	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnNNf8
+Issue	Next.js Auth Middleware — Server-Side Route Protection	119	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfgc
+Issue	Message Service & API	101	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfWQ
+Issue	P4 Deliverables — Dev Spec Update & Architecture Document	95	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfT4
+Issue	Backend Project Scaffold & Dev Environment	94	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfTY
+Issue	Database Schema & Prisma Migrations	96	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfUY
+Issue	Authentication System — JWT Register/Login/Logout	97	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfUk
+Issue	Server Service & API	99	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfVg
+Issue	Channel Service & API	100	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfV4
+Issue	Role-Based Permission & Authorization System	102	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfXI
+Issue	Server Membership Service	103	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfXs
+Issue	Channel Visibility Toggle Service	105	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfYo
+Issue	Visibility Audit Log Service	106	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfZI
+Issue	Rate Limiting Middleware	110	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfbY
+Issue	Redis Caching Layer	109	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfbA
+Issue	Frontend Integration — Authentication	113	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfdI
+Issue	Frontend Integration — Servers & Channels	114	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfdc
+Issue	Frontend Integration — Messages	115	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfeQ
+Issue	Backend README — Setup & Operations Guide	120	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfg4
+Issue	Frontend Integration — Guest Public Channel View	116	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfec
+Issue	API Input Validation & Error Handling	118	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfgQ
+Issue	Frontend Integration — Channel Visibility Toggle	117	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrffk
+Issue	Responsive design audit and fixes	38	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljarA
+Issue	Build VisibilityToggle component	30	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljamA
+Issue	Build toast notification system	35	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljao0
+Issue	Build 404 and error pages	36	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljapo
+Issue	Integrate channel visibility with guest view	37	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljaqM
+Issue	Build ServerSidebar component (server icon list)	20	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljafQ
+Issue	Epic: Core App Layout & Navigation	47	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljdP8
+Issue	Build ChannelSidebar component	21	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljagA
+Issue	Build MessageInput component	26	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljajw
+Issue	Epic: Integration, Testing & Demo	51	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljdVk
+Issue	Build GuestPromoBanner component	33	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljanc
+Issue	Create App Router with layout routes	19	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljaes
+Issue	Event Bus — Redis Pub/Sub for Cross-Service Events	111	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfcI
+Issue	Build Auth Context and login/logout flow	34	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljaoI
+Issue	Create mock API service layer	18	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljaeA
+Issue	Create mock data layer	17	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljadg
+Issue	UI Mockups: Channel Visibility Toggle (Figma)	40	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljasA
+Issue	Build SearchBar modal component	43	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljau8
+Issue	Build VisibilityGuard component	32	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljam4
+Issue	Build MembersSidebar component	27	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljakM
+Issue	Build TopBar component	22	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljahM
+Issue	Install and configure Tailwind CSS	15	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljacQ
+Issue	Scaffold React + TypeScript + Vite project	14	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljabw
+Issue	Channel privacy settings	1	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzglWPb4
+Issue	View public channels without logging in	2	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzglWQK0
+Issue	Threads & Messages Store Relevant Data	3	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzglWRzg
+Issue	Define TypeScript types and interfaces	16	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljaco
+Issue	Build AppLayout (3-column layout shell)	23	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljahw
+Issue	Accessibility audit and fixes	39	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljaro
+Issue	UI Mockups: Guest Public Channel View (Figma)	41	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljatA
+Issue	Screen Recording: Demo Video and YouTube Upload	42	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljauM
+Issue	Epic: Project Scaffolding & Setup	46	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljdO8
+PullRequest	feat: UI design brief and mockups for channel visibility toggle (#40)	57	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgl5y2w
+PullRequest	feat: ChannelSidebar component (#21) and MessageInput component (#26)	62	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmFa04
+PullRequest	feat: Build 404, error, and server error pages (#36)	66	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmGJNY
+Issue	Build MessageItem component	25	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljajQ
+Issue	Build UserStatusBar component	28	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljakY
+Issue	Build MessageList component	24	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljaig
+Issue	Build ChannelSettingsPage	29	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljak8
+Issue	Fix non-admin redirect spinner delay on /settings/* routes	71	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmHkl8
+Issue	Implement Permissions section in ChannelSettingsPage	72	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmHksI
+PullRequest	feat(#24): MessageList — date separators, loading skeleton, scroll fixes	74	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmKfr4
+PullRequest	feat: channel creation modal (#44)	83	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmY9e8
+Issue	Build channel creation modal	44	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljavk
+Issue	Build GuestChannelView page	31	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljamc
+Issue	Build User Settings Page	88	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmay2I
+Issue	Users need to be able to log out	75	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmKkoo
+Issue	Build server creation modal	84	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmZQLE
+Issue	Implement Server Settings (name, icon, description)	86	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmabOE
+Issue	Epic: Chat UI Components	48	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljdRE
+Issue	Epic: Channel Visibility Toggle Feature	49	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljdSc
+Issue	Epic: Guest Public Channel View Feature	50	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgljdUM
+Issue	User Service & API	98	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfVM
+PullRequest	feat(user): User Service & API — closes #98	132	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgm3nUE
+Issue	Database Seed Data	104	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfYA
+PullRequest	feat(messages): message service & API (#101)	145	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgm8I10
+Issue	Fix flaky setTimeout in visibility event emission test	147	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAC1s
+Issue	Implement message reactions (schema, service, router, tests)	152	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAVj8
+Issue	Implement message reply service methods	154	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAVu0
+Issue	Implement message reaction service	155	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAVvg
+Issue	Implement tRPC reaction router	156	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAV3E
+Issue	Implement tRPC reply/thread procedures	157	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAV3c
+Issue	Write tests for reaction endpoints	158	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAV70
+Issue	Write tests for reply/thread endpoints	159	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAV9A
+Issue	Epic: Fix non-functional message action buttons (reactions, replies, pin)	160	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnAYTU
+Issue	Security: tRPC error responses expose stack traces to clients	165	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnBpqk
+Issue	Dev setup broken: README missing Redis startup + .env missing JWT secrets	166	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnBpuE
+PullRequest	test: public REST API endpoint tests (closes #108)	168	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnCVRs
+Issue	Public REST API — Channel & Server Endpoints	108	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfas
+Issue	Sitemap & SEO Data Endpoints	107	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfaE
+Issue	createServer does not add owner to server_members	169	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnCwss
+Issue	ChannelPageContent crashes if authenticated user is not a member of every public server	170	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnCwvY
+Issue	Add server member list endpoint to backend tRPC router	173	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnC6l0
+Issue	Server list shows servers the user is not a member of	179	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnNMPQ
+Issue	Real-time: channel list updates when channels are created, renamed, or deleted	185	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnVLv4
+Issue	Real-time: member list updates when users join or leave a server	186	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnVL1k
+Issue	Real-time: channel visibility changes propagate to all connected clients	187	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnVL7w
+Issue	Real-time: server list updates when a server is created or joined	188	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnVMAY
+Issue	Real-time: refactor SSE into a unified server-scoped endpoint	189	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnVMKM
+Issue	chore: add structured logger utility for observability and debug	194	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgndxIs
+PullRequest	feat: attachment service & file storage (#112)	196	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnf5PM
+Issue	Twilio Voice Service — Real-Time Audio for Voice Channels	121	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgmrfhc
+PullRequest	feat: implement message replies/threads — Issue #151	220	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnlv9A
+Issue	Voice: show participant lists for all channels, not just the connected one	221	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnyUQQ
+Issue	Voice: local user's mute/deafen state not reflected in participant list	222	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnyUeU
+Issue	Voice: user-visible error feedback when voice channel join fails	223	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnyUik
+Issue	Voice: export useVoiceOptional for safer consumption outside VoiceProvider	224	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgnyUnU
+Issue	feat: createReply should publish MESSAGE_CREATED SSE event	226	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgn4qyQ
+Issue	refactor: introduce repository layer — centralize Prisma calls out of services	227	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgn4qys
+Issue	Update Backend READMe	228	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgn9UpY
+Issue	Real-time: propagate user status changes to connected clients	231	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgn9xX0
+Issue	fix: pin button shown to all users; improve pin error messages	236	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgoDMns
+Issue	Unit Tests — channelService.ts (frontend)	266	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgonYlA
+Issue	fix: message compose textarea missing aria-label (accessibility)	238	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgoDSfc
+Issue	fix: pin button shown to all users; non-moderator pin returns HTTP 500	239	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgoDShw
+Issue	fix: authenticated users see "Sign up or log in" on inaccessible channels	240	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgoDSkQ
+Issue	fix: "Design Lab" listed as public server with description "A private server for the design team"	241	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgoDSlk
+Issue	fix: joining a server silently fails on first attempt with no user feedback	242	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgoDSnQ
+Issue	test: add negative guard coverage for createReply event publish	245	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgoDbE0
+PullRequest	docs(testing): frontend server service test specification (#260)	280	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgo1MsU
+Issue	Test Specification — publicApiService.ts (frontend)	289	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgpE9NE
+Issue	Unit Tests — publicApiService.ts (frontend)	290	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgpE9PM
+Issue	Test Specification — public.router.ts	291	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgpE9SQ
+Issue	Unit Tests — public.router.ts	292	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgpE9T4
+Issue	Test Specification — channel.service.ts	293	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgpE-Ko
+Issue	Unit Tests — channel.service.ts	294	acabrera04/Harmony	PVTI_lAHOCKUww84BPCdDzgpE-Ks
+```
+
+#### Tool: exec_command
+
+```sh
+for i in 258 259 260 261 263 264 265 268 269; do echo "ISSUE $i"; gh issue view $i -R acabrera04/Harmony --json number,title,assignees,projectItems; done
+```
+
+Output:
+
+```text
+ISSUE 258
+{"assignees":[{"id":"U_kgDOCVBL7g","login":"Aiden-Barrera","name":"Aiden Barrera","databaseId":0}],"number":258,"projectItems":[{"status":{"optionId":"98236657","name":"Done"},"title":"Harmony Project Board"}],"title":"Test Specification — auth.service.ts"}
+ISSUE 259
+{"assignees":[{"id":"MDQ6VXNlcjQ5OTM0NTc2","login":"declanblanc","name":"Declan","databaseId":0}],"number":259,"projectItems":[{"status":{"optionId":"47fc9ee4","name":"In progress"},"title":"Harmony Project Board"}],"title":"Test Specification — server.service.ts"}
+ISSUE 260
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:37:40.519Z
+
+I’ve got the board items and the first few assignees. I’m pulling the rest of the P5 assignment owners so I can pick one of the existing five and assign both issues together.
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 38052,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'for i in 258 259 260 261 263 264 265 268 269; do echo "ISSUE $i"; gh issue view $i -R acabrera04/Harmony --json number,title,assignees,projectItems; done'
+Chunk ID: 008e7d
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 478
+Output:
+{"assignees":[{"id":"U_kgDOCKOSYA","login":"FardeenI","name":"Fardeen Iqbal","databaseId":0}],"number":260,"projectItems":[{"status":{"optionId":"98236657","name":"Done"},"title":"Harmony Project Board"}],"title":"Test Specification — serverService.ts (frontend)"}
+ISSUE 261
+{"assignees":[{"id":"MDQ6VXNlcjU1MDEyNDk0","login":"AvanishKulkarni","name":"Avanish Kulkarni","databaseId":0}],"number":261,"projectItems":[{"status":{"optionId":"98236657","name":"Done"},"title":"Harmony Project Board"}],"title":"Test Specification — channelService.ts (frontend)"}
+ISSUE 263
+{"assignees":[{"id":"U_kgDOCVBL7g","login":"Aiden-Barrera","name":"Aiden Barrera","databaseId":0}],"number":263,"projectItems":[{"status":{"optionId":"98236657","name":"Done"},"title":"Harmony Project Board"}],"title":"Unit Tests — auth.service.ts"}
+ISSUE 264
+{"assignees":[{"id":"MDQ6VXNlcjQ5OTM0NTc2","login":"declanblanc","name":"Declan","databaseId":0}],"number":264,"projectItems":[{"status":{"optionId":"47fc9ee4","name":"In progress"},"title":"Harmony Project Board"}],"title":"Unit Tests — server.service.ts"}
+ISSUE 265
+{"assignees":[{"id":"U_kgDOCKOSYA","login":"FardeenI","name":"Fardeen Iqbal","databaseId":0}],"number":265,"projectItems":[{"status":{"optionId":"61e4505c","name":"Ready"},"title":"Harmony Project Board"}],"title":"Unit Tests — serverService.ts (frontend)"}
+ISSUE 268
+{"assignees":[{"id":"U_kgDOCKUwww","login":"acabrera04","name":"Allen Cabrera","databaseId":0}],"number":268,"projectItems":[{"status":{"optionId":"61e4505c","name":"Ready"},"title":"Harmony Project Board"}],"title":"Test Specification — serverMember.service.ts"}
+ISSUE 269
+{"assignees":[{"id":"U_kgDOCKUwww","login":"acabrera04","name":"Allen Cabrera","databaseId":0}],"number":269,"projectItems":[{"status":{"optionId":"22a160e4","name":"Blocked"},"title":"Harmony Project Board"}],"title":"Unit Tests — serverMember.service.ts"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:37:54.501Z
+
+I’m assigning the new `channel.service.ts` spec + unit-test pair to the same backend contributor who already owns the other backend service-spec/test work, so the board stays consistent.
+
+#### Tool: exec_command
+
+```sh
+gh issue edit 293 -R acabrera04/Harmony --add-assignee declanblanc
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue edit 294 -R acabrera04/Harmony --add-assignee declanblanc
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 76761,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'gh issue edit 293 -R acabrera04/Harmony --add-assignee declanblanc'
+Chunk ID: 96f24a
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/293
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 63520,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'gh issue edit 294 -R acabrera04/Harmony --add-assignee declanblanc'
+Chunk ID: ac2429
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/294
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:38:12.871Z
+
+I assigned the `channel.service.ts` pair. I’m verifying the assignee on both issues once before I close this out.
+
+#### Tool: exec_command
+
+```sh
+gh issue view 293 -R acabrera04/Harmony --json number,title,assignees
+```
+
+Output:
+
+```text
+{"assignees":[{"id":"MDQ6VXNlcjQ5OTM0NTc2","login":"declanblanc","name":"Declan","databaseId":0}],"number":293,"title":"Test Specification — channel.service.ts"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 294 -R acabrera04/Harmony --json number,title,assignees
+```
+
+Output:
+
+```text
+{"assignees":[{"id":"MDQ6VXNlcjQ5OTM0NTc2","login":"declanblanc","name":"Declan","databaseId":0}],"number":294,"title":"Unit Tests — channel.service.ts"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:38:21.135Z
+
+Assigned one matched pair to the same project member:
+
+- [#293 Test Specification — channel.service.ts](https://github.com/acabrera04/Harmony/issues/293) → `declanblanc`
+- [#294 Unit Tests — channel.service.ts](https://github.com/acabrera04/Harmony/issues/294) → `declanblanc`
+
+I chose `declanblanc` because the existing P5 backend service-spec/test pair for `server.service.ts` is already assigned to him, so this keeps backend service testing ownership consistent across the board.
+
+The five project members I confirmed from the existing P5 issue assignments are:
+- `Aiden-Barrera`
+- `declanblanc`
+- `FardeenI`
+- `AvanishKulkarni`
+- `acabrera04`
+
+If you want, I can assign the new `publicApiService.ts` and `public.router.ts` issue pairs next.
+
+### Turn 8: yes, do
+
+#### 👤 User Prompt
+
+- Time: 2026-04-03T19:38:38.548Z
+
+```text
+yes, do those
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:38:50.615Z
+
+I’m assigning the remaining two new pairs by feature ownership: the frontend guest-public API pair to a frontend contributor, and the backend public-router pair to a backend contributor already closest to that surface.
+
+#### Tool: exec_command
+
+```sh
+gh issue view 108 -R acabrera04/Harmony --json number,title,assignees
+```
+
+Output:
+
+```text
+{"assignees":[{"id":"U_kgDOCKOSYA","login":"FardeenI","name":"Fardeen Iqbal","databaseId":0}],"number":108,"title":"Public REST API — Channel & Server Endpoints"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 116 -R acabrera04/Harmony --json number,title,assignees
+```
+
+Output:
+
+```text
+{"assignees":[{"id":"U_kgDOCKUwww","login":"acabrera04","name":"Allen Cabrera","databaseId":0}],"number":116,"title":"Frontend Integration — Guest Public Channel View"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 117 -R acabrera04/Harmony --json number,title,assignees
+```
+
+Output:
+
+```text
+{"assignees":[{"id":"MDQ6VXNlcjU1MDEyNDk0","login":"AvanishKulkarni","name":"Avanish Kulkarni","databaseId":0}],"number":117,"title":"Frontend Integration — Channel Visibility Toggle"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:39:02.642Z
+
+I found the closest historical owners: `acabrera04` owned the frontend guest-public-channel integration, and `FardeenI` owned the backend public REST API work. I’m assigning the new issue pairs to match that ownership.
+
+#### Tool: exec_command
+
+```sh
+gh issue edit 289 -R acabrera04/Harmony --add-assignee acabrera04
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue edit 290 -R acabrera04/Harmony --add-assignee acabrera04
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue edit 291 -R acabrera04/Harmony --add-assignee FardeenI
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue edit 292 -R acabrera04/Harmony --add-assignee FardeenI
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 18291,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'gh issue edit 289 -R acabrera04/Harmony --add-assignee acabrera04'
+Chunk ID: 9a3b77
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/289
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 24935,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'gh issue edit 290 -R acabrera04/Harmony --add-assignee acabrera04'
+Chunk ID: e5a0f3
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/290
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 12452,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'gh issue edit 291 -R acabrera04/Harmony --add-assignee FardeenI'
+Chunk ID: ec3e52
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/291
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 77932,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+Command: /bin/zsh -lc 'gh issue edit 292 -R acabrera04/Harmony --add-assignee FardeenI'
+Chunk ID: 929e56
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/acabrera04/Harmony/issues/292
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:39:15.022Z
+
+The assignments are applied. I’m verifying the assignees on the four issues once so you have the exact mapping.
+
+#### Tool: exec_command
+
+```sh
+gh issue view 289 -R acabrera04/Harmony --json number,title,assignees
+```
+
+Output:
+
+```text
+{"assignees":[{"id":"U_kgDOCKUwww","login":"acabrera04","name":"Allen Cabrera","databaseId":0}],"number":289,"title":"Test Specification — publicApiService.ts (frontend)"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 290 -R acabrera04/Harmony --json number,title,assignees
+```
+
+Output:
+
+```text
+{"assignees":[{"id":"U_kgDOCKUwww","login":"acabrera04","name":"Allen Cabrera","databaseId":0}],"number":290,"title":"Unit Tests — publicApiService.ts (frontend)"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 291 -R acabrera04/Harmony --json number,title,assignees
+```
+
+Output:
+
+```text
+{"assignees":[{"id":"U_kgDOCKOSYA","login":"FardeenI","name":"Fardeen Iqbal","databaseId":0}],"number":291,"title":"Test Specification — public.router.ts"}
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 292 -R acabrera04/Harmony --json number,title,assignees
+```
+
+Output:
+
+```text
+{"assignees":[{"id":"U_kgDOCKOSYA","login":"FardeenI","name":"Fardeen Iqbal","databaseId":0}],"number":292,"title":"Unit Tests — public.router.ts"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:39:25.511Z
+
+Assigned the remaining matched pairs:
+
+- [#289 Test Specification — publicApiService.ts (frontend)](https://github.com/acabrera04/Harmony/issues/289) → `acabrera04`
+- [#290 Unit Tests — publicApiService.ts (frontend)](https://github.com/acabrera04/Harmony/issues/290) → `acabrera04`
+
+- [#291 Test Specification — public.router.ts](https://github.com/acabrera04/Harmony/issues/291) → `FardeenI`
+- [#292 Unit Tests — public.router.ts](https://github.com/acabrera04/Harmony/issues/292) → `FardeenI`
+
+I matched them by prior feature ownership:
+- `acabrera04` owned the frontend guest public channel integration work
+- `FardeenI` owned the backend public REST API work
+
+Current new assignments are now:
+- `declanblanc`: [#293](https://github.com/acabrera04/Harmony/issues/293), [#294](https://github.com/acabrera04/Harmony/issues/294)
+- `acabrera04`: [#289](https://github.com/acabrera04/Harmony/issues/289), [#290](https://github.com/acabrera04/Harmony/issues/290)
+- `FardeenI`: [#291](https://github.com/acabrera04/Harmony/issues/291), [#292](https://github.com/acabrera04/Harmony/issues/292)
+
+### Turn 9: Export this thread to a new branch and make a full PR to add it as logs
+
+#### 👤 User Prompt
+
+- Time: 2026-04-03T19:40:54.889Z
+
+```text
+Export this thread to a new branch and make a full PR to add it as logs in llm-logs/acabrera04-logs/acabrera04-tests 019d54bf-2a86-7f53-9d5f-d7ce42895cb3
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:41:11.023Z
+
+I’m exporting this session to the requested log path first, then I’ll put it on a fresh branch, commit it, push it, and open a PR with the log-only change.
+
+#### Tool: update_plan
+
+- Explanation: Export the current Codex thread to the requested llm-logs location, then create a branch, commit only the new log file, push, and open a PR.
+
+- Plan:
+  - [in_progress] Read the export and PR workflow skills plus inspect repo status
+  - [pending] Export this conversation to the requested llm-logs path
+  - [pending] Create a new branch and commit the exported log
+  - [pending] Push branch and open a full PR
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short --branch
+```
+
+Output:
+
+```text
+## main...origin/main
+?? "P4: Backend Development | CS 485 AI-Assisted Software Engineering (Sp26).html"
+?? "P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf"
+?? harmony-backend/coverage/
+?? load-test.js
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read /Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md
+```
+
+Output:
+
+````text
+---
+name: codex-conversation-exporter
+description: Export Codex session logs to Markdown using the local codex-export CLI instead of reconstructing transcripts with model tokens.
+---
+
+# Codex Conversation Exporter
+
+Use this skill when the user asks to export Codex logs, save a Codex conversation, convert a session to Markdown, or archive a transcript locally.
+
+## Rules
+
+- Prefer the local `codex-export` CLI over reconstructing a transcript in-model.
+- If the user has not identified a session, run `codex-export list` first and show the relevant candidates.
+- Default to messages plus tool activity.
+- Include hidden system/developer prompts only when the user explicitly asks for them.
+- Write to a user-visible path unless the user asks for stdout or another destination.
+- Report the output path back to the user after a file export.
+
+## Command patterns
+
+List recent sessions:
+
+```bash
+codex-export list
+codex-export list --limit 10
+codex-export list --since 2026-03-30
+```
+
+Export by thread id:
+
+```bash
+codex-export export <thread-id>
+codex-export export <thread-id> --out ~/Desktop
+codex-export export <thread-id> --messages-only
+codex-export export <thread-id> --all
+codex-export export <thread-id> --include-hidden-prompts
+codex-export export <thread-id> --stdout
+```
+
+Export by rollout path:
+
+```bash
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl --out ~/Desktop
+```
+
+## Flag guide
+
+- `--out <file-or-dir>` writes to a specific file or directory.
+- `--stdout` prints the Markdown instead of writing a file.
+- `--messages-only` omits tool calls and tool outputs.
+- `--all` includes low-level tool metadata and raw wrappers that are hidden by default.
+- `--include-hidden-prompts` includes developer/system prompt layers.
+- `--since <date>` filters `list` results.
+- `--limit <n>` caps `list` results.
+
+## Agent behavior
+
+When the user says "export this conversation" without a thread id:
+
+1. Run `codex-export list`.
+2. Identify the most likely current session from title, cwd, and recency.
+3. Export it with the default mode unless the user requested a different output.
+4. Return the exact file path written.
+
+`codex-log-export` remains available as a compatibility alias.
+````
+
+#### Tool: exec_command
+
+```sh
+rtk read /Users/allen/.codex/plugins/cache/openai-curated/github/f78e3ad49297672a905eb7afb6aa0cef34edc79e/skills/yeet/SKILL.md
+```
+
+Output:
+
+```text
+---
+name: "yeet"
+description: "Publish local changes to GitHub by confirming scope, committing intentionally, pushing the branch, and opening a draft PR through the GitHub app from this plugin, with `gh` used only as a fallback where connector coverage is insufficient."
+---
+
+# GitHub Publish Changes
+
+## Overview
+
+Use this skill only when the user explicitly wants the full publish flow from the local checkout: branch setup if needed, staging, commit, push, and opening a pull request.
+
+This workflow is hybrid:
+
+- Use local `git` for branch creation, staging, commit, and push.
+- Prefer the GitHub app from this plugin for pull request creation after the branch is on the remote.
+- Use `gh` as a fallback for current-branch PR discovery, auth checks, or PR creation when the connector path cannot infer the repository or head branch cleanly.
+
+## Prerequisites
+
+- Require GitHub CLI `gh`. Check `gh --version`. If missing, ask the user to install `gh` and stop.
+- Require authenticated `gh` session. Run `gh auth status`. If not authenticated, ask the user to run `gh auth login` (and re-run `gh auth status`) before continuing.
+- Require a local git repository with a clean understanding of which changes belong in the PR.
+
+## Naming conventions
+
+- Branch: `codex/{description}` when starting from main/master/default.
+- Commit: `{description}` (terse).
+- PR title: `[codex] {description}` summarizing the full diff.
+
+## Workflow
+
+1. Confirm intended scope.
+   - Run `git status -sb` and inspect the diff before staging.
+   - If the working tree contains unrelated changes, do not default to `git add -A`. Ask the user which files belong in the PR.
+2. Determine the branch strategy.
+   - If on `main`, `master`, or another default branch, create `codex/{description}`.
+   - Otherwise stay on the current branch.
+3. Stage only the intended changes.
+   - Prefer explicit file paths when the worktree is mixed.
+   - Use `git add -A` only when the user has confirmed the whole worktree belongs in scope.
+4. Commit tersely with the confirmed description.
+5. Run the most relevant checks available if they have not already been run.
+   - If checks fail due to missing dependencies or tools, install what is needed and rerun once.
+6. Push with tracking: `git push -u origin $(git branch --show-current)`.
+7. Open a draft PR.
+   - Prefer the GitHub app from this plugin for PR creation after the push succeeds.
+   - Derive `repository_full_name` from the remote, for example by normalizing `git remote get-url origin` or by using `gh repo view --json nameWithOwner`.
+   - Derive `head_branch` from `git branch --show-current`.
+   - Derive `base_branch` from the user request when specified; otherwise use the remote default branch, for example via `gh repo view --json defaultBranchRef`.
+   - If the branch is being pushed from a fork or the PR target differs from the remote that was just pushed, prefer `gh pr create` fallback because the connector PR creation flow expects one repository target and may not encode cross-repo head semantics cleanly.
+   - If connector-based PR creation cannot infer the repository or branch cleanly, fall back to `gh pr create --draft --fill --head $(git branch --show-current)`.
+   - Write the PR body to a temp file with real newlines when using CLI fallback so the markdown renders cleanly.
+8. Summarize the result with branch name, commit, PR target, validation, and anything the user still needs to confirm.
+
+## Write Safety
+
+- Never stage unrelated user changes silently.
+- Never push without confirming scope when the worktree is mixed.
+- Default to a draft PR unless the user explicitly asks for a ready-for-review PR.
+- If the repository does not appear to be connected to an accessible GitHub remote, stop and explain the blocker before making assumptions.
+
+## PR Body Expectations
+
+The PR description should use real Markdown prose and cover:
+
+- what changed
+- why it changed
+- the user or developer impact
+- the root cause when the PR is a fix
+- the checks used to validate it
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:41:22.734Z
+
+I’ve confirmed the worktree has unrelated untracked files, so I’ll export only the new session log, stage only that file, and leave the other local artifacts untouched.
+
+#### Tool: exec_command
+
+```sh
+codex-export list --limit 10
+```
+
+Output:
+
+```text
+THREAD_ID	CREATED_AT	TITLE	CWD	ROLLOUT_PATH
+019d54dc-50ea-72e2-bafe-66236cd577d2	2026-04-03T19:40:18.000Z	Complete this issue for me https://github.com/acabrera04/Harmony/issues/289	/Users/allen/.codex/worktrees/9495/Harmony	/Users/allen/.codex/sessions/2026/04/03/rollout-2026-04-03T15-40-18-019d54dc-50ea-72e2-bafe-66236cd577d2.jsonl
+019d54bf-2a86-7f53-9d5f-d7ce42895cb3	2026-04-03T19:08:27.000Z	Pull from main and check our progress towards [P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26).pdf](P5: Testing | CS 485 AI-Assisted Software Engineering (Sp26\).pdf)	/Users/allen/repos/Harmony	/Users/allen/.codex/sessions/2026/04/03/rollout-2026-04-03T15-08-27-019d54bf-2a86-7f53-9d5f-d7ce42895cb3.jsonl
+019d54a7-2523-7a63-87fc-6a58698cd6f3	2026-04-03T18:42:13.000Z	Building on the github integration in this branch, add support for Jira and Trello through the use of an interface design so that the dashboard can pull data from whatever project management tool capstone teams are using.	/Users/allen/repos/contribution-tracking-and-risk-warning	/Users/allen/.codex/sessions/2026/04/03/rollout-2026-04-03T14-42-13-019d54a7-2523-7a63-87fc-6a58698cd6f3.jsonl
+019d4b86-090d-7011-a445-79eb792d0013	2026-04-02T00:09:28.000Z	Review https://github.com/acabrera04/Harmony/pull/282	/Users/allen/repos/Harmony	/Users/allen/.codex/sessions/2026/04/01/rollout-2026-04-01T20-09-28-019d4b86-090d-7011-a445-79eb792d0013.jsonl
+019d49e1-de9d-70e0-8ac1-86e8a7810e68	2026-04-01T16:30:32.000Z	/Users/allen/.claude/projects/-Users-allen-repos-Harmony--claude-worktrees-issue-185/bcc77bc0-0fc5-400c-a518-726dbcd82507/subagents/agent-aa4171fa2dc417201.jsonl Export this to a readable markdown file	/Users/allen/Documents/New project	/Users/allen/.codex/sessions/2026/04/01/rollout-2026-04-01T12-30-32-019d49e1-de9d-70e0-8ac1-86e8a7810e68.jsonl
+019d49c1-8ad8-72e0-b6c0-a1fe65f2cb8b	2026-04-01T15:55:14.000Z	Evaluate our entire test suite and see if tests are actually making good tests and not conforming to the codebase	/Users/allen/repos/Harmony	/Users/allen/.codex/sessions/2026/04/01/rollout-2026-04-01T11-55-14-019d49c1-8ad8-72e0-b6c0-a1fe65f2cb8b.jsonl
+019d4716-9aff-74b2-8576-1bc14733ede2	2026-04-01T03:29:17.000Z	Can you set it up so I can run jest in the root of the repo so I don't see error messages looking at test files in vs code while I'm in the root	/Users/allen/.codex/worktrees/cb46/Harmony	/Users/allen/.codex/sessions/2026/03/31/rollout-2026-03-31T23-29-17-019d4716-9aff-74b2-8576-1bc14733ede2.jsonl
+019d467b-0a45-7763-af84-a8520933e41c	2026-04-01T00:39:21.000Z	Review https://github.com/acabrera04/Harmony/pull/277	/Users/allen/repos/Harmony	/Users/allen/.codex/sessions/2026/03/31/rollout-2026-03-31T20-39-21-019d467b-0a45-7763-af84-a8520933e41c.jsonl
+019d45fc-54a2-7841-bb04-16f7c04904d4	2026-03-31T22:20:57.000Z	Generate E2E tests	/Users/allen/.codex/worktrees/373a/Harmony	/Users/allen/.codex/sessions/2026/03/31/rollout-2026-03-31T18-20-57-019d45fc-54a2-7841-bb04-16f7c04904d4.jsonl
+019d45fc-4169-7513-9ac1-e1394811dda1	2026-03-31T22:20:52.000Z	Generate integration tests for me	/Users/allen/.codex/worktrees/1df7/Harmony	/Users/allen/.codex/sessions/2026/03/31/rollout-2026-03-31T18-20-52-019d45fc-4169-7513-9ac1-e1394811dda1.jsonl
+```
+
+#### Tool: exec_command
+
+```sh
+ls -1 /Users/allen/repos/Harmony/llm-logs/acabrera04-logs/acabrera04-tests | tail -n 20
+```
+
+Output:
+
+```text
+2026-03-30-complete-the-issue-assigned-to-me-to-update-the-ci-system-019d3f5d.md
+2026-03-30-do-issue-268-for-me-with-making-a-test-spec-019d410b.md
+2026-03-31-review-this-pr-https-github-com-acabrera04-harmony-pull-275-019d4620.md
+2026-03-31-review-this-pr-https-github-com-acabrera04-harmony-pull-276-019d4628.md
+2026-04-01-review-this-pr-https-github-com-acabrera04-harmony-pull-280-019d472d.md
+2026-04-03-review-this-pr-and-post-the-review-on-it-https-github-com-ac-019d53fe.md
+```
+
+#### Tool: exec_command
+
+```sh
+gh auth status
+```
+
+Output:
+
+```text
+github.com
+  ✓ Logged in to github.com account acabrera04 (keyring)
+  - Active account: true
+  - Git operations protocol: ssh
+  - Token: gho_************************************
+  - Token scopes: 'admin:public_key', 'gist', 'project', 'read:org', 'repo', 'workflow'
+```
+
+#### Tool: exec_command
+
+```sh
+gh repo view --json nameWithOwner,defaultBranchRef
+```
+
+Output:
+
+```text
+{"defaultBranchRef":{"name":"main"},"nameWithOwner":"acabrera04/Harmony"}
+```
+
+#### 🤖 gpt-5.4 (high)
+
+- Time: 2026-04-03T19:41:41.279Z
+
+I’ve identified the exact thread and confirmed GitHub auth. Next I’m switching to a dedicated branch, exporting the session to the requested `llm-logs` area, and then I’ll stage only that file for the PR.
+
+#### Tool: exec_command
+
+```sh
+git switch -c codex/export-thread-019d54bf
+```
+
+Output:
+
+```text
+Switched to a new branch 'codex/export-thread-019d54bf'
+```
+
+#### Tool: exec_command
+
+```sh
+codex-export export 019d54bf-2a86-7f53-9d5f-d7ce42895cb3 --out /Users/allen/repos/Harmony/llm-logs/acabrera04-logs/acabrera04-tests/019d54bf-2a86-7f53-9d5f-d7ce42895cb3.md
+```


### PR DESCRIPTION
## Summary
- export Codex thread `019d54bf-2a86-7f53-9d5f-d7ce42895cb3` to the repository log archive
- add the exported markdown transcript under `llm-logs/acabrera04-logs/acabrera04-tests/`

## Why
This preserves the full session requested by the user in the same location as the other `acabrera04-tests` Codex logs.

## Validation
- exported the thread with `codex-export export 019d54bf-2a86-7f53-9d5f-d7ce42895cb3 --out /Users/allen/repos/Harmony/llm-logs/acabrera04-logs/acabrera04-tests/019d54bf-2a86-7f53-9d5f-d7ce42895cb3.md`
- staged and committed only the new log file
- pushed branch `codex/export-thread-019d54bf`
