### PR TITLE
[codex] Document manual test instructions in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ cd ..
 
 The root package exposes convenience scripts that delegate to each app:
 
+Commands that execute backend tests still depend on the PostgreSQL, Redis, `.env`, and Prisma setup documented in the backend section below.
+
 ```bash
 # Run frontend and backend tests
 npm run test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,105 @@
 # Harmony
-A search engine indexible chat application
+
+Harmony is a search-engine-indexable chat application with a Next.js frontend and an Express + tRPC backend.
+
+## Repository Layout
+
+- `harmony-frontend/`: Next.js application for the client UI
+- `harmony-backend/`: Express + tRPC API, Prisma schema, and Redis-backed eventing/cache
+- `docs/`: project specs and architecture documents
+- `llm-logs/`: saved LLM interaction logs for deliverables
+
+## Manual Test Instructions
+
+Install dependencies in both application directories before running tests:
+
+```bash
+cd harmony-frontend
+npm install
+
+cd ../harmony-backend
+npm install
+
+cd ..
+```
+
+### Run Tests From The Repository Root
+
+The root package exposes convenience scripts that delegate to each app:
+
+```bash
+# Run frontend and backend tests
+npm run test
+
+# Run only frontend tests
+npm run test:frontend
+
+# Run only backend tests
+npm run test:backend
+```
+
+### Frontend Tests
+
+Frontend tests live in `harmony-frontend/src/__tests__/`.
+
+- Framework/runtime: Next.js 16, React 19, TypeScript 5
+- Test runner: Jest 30 with `ts-jest`
+- Test environment: `jest-environment-jsdom`
+- Testing libraries: `@testing-library/react`, `@testing-library/jest-dom`, `@testing-library/user-event`
+
+Run them manually from the frontend directory:
+
+```bash
+cd harmony-frontend
+npm test
+```
+
+You can also target a single test file when needed:
+
+```bash
+cd harmony-frontend
+npm test -- src/__tests__/utils.test.ts
+```
+
+### Backend Tests
+
+Backend tests live in `harmony-backend/tests/`.
+
+- Framework/runtime: Node.js 20+, Express 4, tRPC 11, TypeScript 5
+- Test runner: Jest 29 with `ts-jest`
+- Test environment: Node
+- Testing libraries: `supertest` for HTTP integration tests
+- Data/services used by tests: Prisma with PostgreSQL, Redis for cache/event-bus coverage, `dotenv` for environment loading
+
+Some backend tests are pure unit tests, but many integration tests require PostgreSQL and Redis to be running locally.
+
+Manual backend test setup:
+
+```bash
+cd harmony-backend
+
+# Create local env file
+cp .env.example .env
+
+# Start Postgres and Redis
+docker compose up -d
+
+# Apply Prisma migrations
+npx prisma migrate deploy
+
+# Run the backend test suite
+npm test
+```
+
+If you want to run a single backend test file:
+
+```bash
+cd harmony-backend
+npm test -- tests/app.test.ts
+```
+
+## Additional Project Docs
+
+- Frontend details: `harmony-frontend/README.md`
+- Backend details: `harmony-backend/README.md`
+- Workflow rules for agents: `WORKFLOW.md`


### PR DESCRIPTION
## Summary
- expand the root README into a repo-level overview
- add manual frontend test instructions with frameworks, libraries, and exact commands
- add manual backend test instructions with required local setup for `.env`, Postgres, Redis, and Prisma migrations

## Why
Issue #267 requires the project README to document how to manually run frontend and backend tests using the repository's actual tooling.

## Impact
Team members and reviewers can now run the documented frontend and backend test flows from the repo root or the individual app directories without guessing setup steps.

## Validation
- `npm --prefix harmony-frontend run lint`
- `npm --prefix harmony-backend run lint` (passes with existing warnings only)
- `npm run test` from repo root: frontend passed; backend hit unrelated flaky failures in default Jest parallel mode (`tests/eventBus.test.ts`, then `tests/cache.middleware.test.ts` on rerun)
- `npm --prefix harmony-backend test -- --runInBand`

## Notes
- Backend tests passed in stable serial mode with `--runInBand`; the observed failures appear to be pre-existing Jest flakiness unrelated to this README-only change.
- Closes #267 for the README portion.