### PR TITLE
fix: show correct message for authenticated users on inaccessible cha…

### DIFF
--- a/harmony-frontend/src/__tests__/VisibilityGuard.test.tsx
+++ b/harmony-frontend/src/__tests__/VisibilityGuard.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * VisibilityGuard.test.tsx — Issue #240
+ *
+ * Ensures that authenticated users who lack access to a PRIVATE channel see
+ * a permission-denied message rather than "Sign up or log in" copy.
+ */
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { VisibilityGuard } from '../components/channel/VisibilityGuard';
+import { ChannelVisibility } from '../types';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ back: jest.fn() }),
+  usePathname: () => '/test-server/general',
+}));
+
+const mockUseAuth = jest.fn();
+
+jest.mock('../hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderGuard(overrides?: Partial<Parameters<typeof VisibilityGuard>[0]>) {
+  return render(
+    <VisibilityGuard visibility={ChannelVisibility.PRIVATE} {...overrides}>
+      <div>Channel content</div>
+    </VisibilityGuard>,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('VisibilityGuard — unauthenticated user on PRIVATE channel', () => {
+  it('shows "Sign up or log in" message', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      isAdmin: () => false,
+    });
+
+    renderGuard();
+
+    expect(screen.getByText(/sign up or log in/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /create account/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  it('does not show the channel content', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      isAdmin: () => false,
+    });
+
+    renderGuard();
+
+    expect(screen.queryByText('Channel content')).not.toBeInTheDocument();
+  });
+});
+
+describe('VisibilityGuard — authenticated non-admin on PRIVATE channel', () => {
+  it('does NOT show "Sign up or log in" message', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isAdmin: () => false,
+    });
+
+    renderGuard({ isServerAdmin: false });
+
+    expect(screen.queryByText(/sign up or log in/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a permission-denied message', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isAdmin: () => false,
+    });
+
+    renderGuard({ isServerAdmin: false });
+
+    expect(screen.getByText(/you don't have permission/i)).toBeInTheDocument();
+  });
+
+  it('does not show login or signup CTAs', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isAdmin: () => false,
+    });
+
+    renderGuard({ isServerAdmin: false });
+
+    expect(screen.queryByRole('link', { name: /create account/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /log in/i })).not.toBeInTheDocument();
+  });
+
+  it('does not show the channel content', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isAdmin: () => false,
+    });
+
+    renderGuard({ isServerAdmin: false });
+
+    expect(screen.queryByText('Channel content')).not.toBeInTheDocument();
+  });
+});
+
+describe('VisibilityGuard — authenticated admin on PRIVATE channel', () => {
+  it('renders children for a server admin', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isAdmin: () => false,
+    });
+
+    renderGuard({ isServerAdmin: true });
+
+    expect(screen.getByText('Channel content')).toBeInTheDocument();
+  });
+
+  it('renders children for a system admin (isAdmin returns true)', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      isAdmin: () => true,
+    });
+
+    renderGuard({ isServerAdmin: false });
+
+    expect(screen.getByText('Channel content')).toBeInTheDocument();
+  });
+});
+
+describe('VisibilityGuard — public channels', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      isAdmin: () => false,
+    });
+  });
+
+  it('renders children for PUBLIC_INDEXABLE', () => {
+    renderGuard({ visibility: ChannelVisibility.PUBLIC_INDEXABLE });
+    expect(screen.getByText('Channel content')).toBeInTheDocument();
+  });
+
+  it('renders children for PUBLIC_NO_INDEX', () => {
+    renderGuard({ visibility: ChannelVisibility.PUBLIC_NO_INDEX });
+    expect(screen.getByText('Channel content')).toBeInTheDocument();
+  });
+});

--- a/harmony-frontend/src/components/channel/VisibilityGuard.tsx
+++ b/harmony-frontend/src/components/channel/VisibilityGuard.tsx
@@ -5,7 +5,9 @@
  * Visibility rules:
  *   PUBLIC_INDEXABLE  → render children
  *   PUBLIC_NO_INDEX   → render children (same guest experience)
- *   PRIVATE           → render AccessDeniedPage
+ *   PRIVATE           → unauthenticated: AccessDeniedPage (with login/signup CTAs)
+ *                       authenticated non-admin/non-owner: NoPermissionPage
+ *                       authenticated admin/owner: render children
  *
  * Ref: dev-spec-guest-public-channel-view.md — VisibilityGuard (C1.2)
  */
@@ -191,7 +193,7 @@ export interface VisibilityGuardProps {
    * The ownerId of the server that owns this channel. When provided,
    * VisibilityGuard uses it to check whether the authenticated user is an
    * admin/owner and therefore allowed to view PRIVATE channels. Authenticated
-   * non-admin members are shown AccessDeniedPage for PRIVATE channels, covering
+   * non-admin members are shown NoPermissionPage for PRIVATE channels, covering
    * the direct-URL access path that the real-time SSE redirect cannot guard.
    */
   serverOwnerId?: string;

--- a/harmony-frontend/src/components/channel/VisibilityGuard.tsx
+++ b/harmony-frontend/src/components/channel/VisibilityGuard.tsx
@@ -77,7 +77,7 @@ function VisibilityError({ message }: { message?: string }) {
   );
 }
 
-// ─── Access denied page (PRIVATE channel) ────────────────────────────────────
+// ─── Access denied page (PRIVATE channel — unauthenticated) ──────────────────
 
 function AccessDeniedPage() {
   const router = useRouter();
@@ -130,6 +130,49 @@ function AccessDeniedPage() {
             Go Back
           </button>
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── No permission page (PRIVATE channel — authenticated, not admin/owner) ────
+
+function NoPermissionPage() {
+  const router = useRouter();
+
+  return (
+    <div className='flex h-screen flex-1 items-center justify-center bg-[#36393f] p-8'>
+      <div className='flex max-w-sm flex-col items-center gap-5 text-center'>
+        {/* Lock icon */}
+        <div className='flex h-16 w-16 items-center justify-center rounded-full bg-[#40444b]'>
+          <svg
+            className='h-8 w-8 text-gray-300'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth={2}
+          >
+            <rect x='3' y='11' width='18' height='11' rx='2' ry='2' />
+            <path d='M7 11V7a5 5 0 0 1 10 0v4' />
+          </svg>
+        </div>
+
+        {/* Copy */}
+        <div>
+          <h2 className='text-xl font-semibold text-white'>This channel is private</h2>
+          <p className='mt-2 text-sm text-gray-400'>
+            You don&apos;t have permission to view this channel. You may need to join this server or
+            contact an administrator to request access.
+          </p>
+        </div>
+
+        {/* CTA */}
+        <button
+          onClick={() => router.back()}
+          className='flex w-full cursor-pointer items-center justify-center rounded-md border border-white/20 bg-[#40444b] px-4 py-2.5 text-sm font-semibold text-gray-200 transition-colors hover:bg-[#3d4148]'
+        >
+          Go Back
+        </button>
       </div>
     </div>
   );
@@ -210,7 +253,7 @@ export function VisibilityGuard({
     // 'member' for non-system-admin users (mapBackendUser hardcodes this).
     const userIsAdminOrOwner = isAdmin(serverOwnerId) || isServerAdmin;
     if (!userIsAdminOrOwner) {
-      return <AccessDeniedPage />;
+      return <NoPermissionPage />;
     }
   }
 


### PR DESCRIPTION
…nnels

Authenticated users who navigate directly to a PRIVATE channel they lack access to were seeing "Sign up or log in to request access" — messaging intended only for unauthenticated visitors.

Add a NoPermissionPage component displayed to authenticated non-admin users, showing "You don't have permission to view this channel" without login/signup CTAs. AccessDeniedPage with its auth CTAs is now only shown to unauthenticated users.

Adds VisibilityGuard tests covering both states (issue #240).