### PR TITLE
feat(#321): add frontend production SEO config

### DIFF
--- a/docs/p4-backend-modules.md
+++ b/docs/p4-backend-modules.md
@@ -1244,8 +1244,8 @@ Implementation code is located in:
 | Public channel detail | Returns a public channel's metadata. |
 | Public messages | Paginated messages from `PUBLIC_INDEXABLE` channels only (50/page). |
 | Single message | Returns a single message from a `PUBLIC_INDEXABLE` channel. |
-| robots.txt | Allows crawling of `/c/` routes; disallows `/api/`, `/trpc/`. |
-| Dynamic sitemap | Generates per-server XML sitemaps of `PUBLIC_INDEXABLE` channels. |
+| robots.txt | Transitional backend source for crawler directives; the frontend apex domain is the canonical public host. |
+| Dynamic sitemap | Generates XML data that frontend sitemap entrypoints proxy to crawlers on the apex domain. |
 | Caching | Stale-while-revalidate pattern. Adds `Cache-Control` and `X-Cache` headers. |
 | Rate limiting | 100 req/min for humans; 1000 req/min for verified bots. |
 
@@ -1256,7 +1256,8 @@ Implementation code is located in:
 ```mermaid
 flowchart TD
     Crawler[Search Engine / Browser] -->|HTTP GET| PublicRouter
-    Crawler -->|GET robots.txt / sitemap| SEORouter
+    Crawler -->|GET robots.txt / sitemap| Frontend["Frontend apex domain"]
+    Frontend -->|SEO XML fetch| SEORouter
     PublicRouter -->|rate limit| RateLimiter[Token Bucket]
     PublicRouter -->|cache check| CacheService[Redis]
     PublicRouter -->|query| Prisma[(PostgreSQL)]
@@ -1266,7 +1267,7 @@ flowchart TD
     IndexingService -->|query channels| Prisma
 ```
 
-**Design justification:** The public API is completely separate from the tRPC layer because crawlers and external consumers require plain HTTP with standard caching headers. The stale-while-revalidate pattern ensures fast responses for frequently-accessed public pages while keeping data fresh in the background. Per-server sitemaps keep XML file sizes manageable and allow incremental re-crawling.
+**Design justification:** The public API is completely separate from the tRPC layer because crawlers and external consumers require plain HTTP with standard caching headers. The frontend apex domain owns canonical SEO artifacts in production, while backend SEO routes continue to generate the underlying XML/text that frontend route handlers proxy on the public host. The stale-while-revalidate pattern ensures fast responses for frequently-accessed public pages while keeping data fresh in the background. Per-server sitemaps keep XML file sizes manageable and allow incremental re-crawling.
 
 ### 3. Data Abstraction
 
@@ -1291,8 +1292,9 @@ This module reads from the same PostgreSQL tables as the authenticated modules (
 | GET | `/api/public/servers/:serverSlug/channels/:channelSlug` | Public channel info |
 | GET | `/api/public/channels/:channelId/messages` | Paginated messages (PUBLIC_INDEXABLE only) |
 | GET | `/api/public/channels/:channelId/messages/:messageId` | Single message |
-| GET | `/robots.txt` | Crawler directives |
-| GET | `/sitemap/:serverSlug.xml` | Dynamic XML sitemap |
+| GET | `/robots.txt` | Transitional crawler directives source for frontend proxying |
+| GET | `/sitemap-index.xml` | Sitemap index XML consumed by the frontend sitemap entrypoint |
+| GET | `/sitemap/:serverSlug.xml` | Dynamic XML sitemap consumed by frontend per-server sitemap entrypoints |
 
 ### 6. Class/Method/Field Declarations
 
@@ -1305,11 +1307,13 @@ export const seoRouter: Router;      // Express
 export const indexingService = {
   addToSitemap(channelId: string): Promise<void>;
   removeFromSitemap(channelId: string): Promise<void>;
+  generateSitemapIndex(): Promise<string>;
   generateSitemap(serverSlug: string): Promise<string | null>;
   onVisibilityChanged(payload: { channelId; oldVisibility; newVisibility }): Promise<void>;
 };
 
 export const CacheKeys_Sitemap = {
+  index: string;
   serverSitemap(serverSlug: string): string;
 };
 
@@ -1353,6 +1357,7 @@ classDiagram
     }
 
     class seoRouter {
+        +GET /sitemap-index.xml
         +GET /robots.txt
         +GET /sitemap/:serverSlug.xml
     }
@@ -1360,6 +1365,7 @@ classDiagram
     class indexingService {
         +addToSitemap(channelId) void
         +removeFromSitemap(channelId) void
+        +generateSitemapIndex() string
         +generateSitemap(serverSlug) string
         +onVisibilityChanged(payload) void
     }

--- a/harmony-backend/.env.example
+++ b/harmony-backend/.env.example
@@ -14,6 +14,9 @@ REDIS_URL=redis://:devsecret@localhost:6379
 # Frontend origin allowed by CORS
 FRONTEND_URL=http://localhost:3000
 
+# Canonical public frontend origin used for generated public links and sitemaps
+BASE_URL=http://localhost:3000
+
 # Demo-only seed gate (set true only for explicit demo seeding flows)
 HARMONY_DEMO_MODE=false
 

--- a/harmony-backend/README.md
+++ b/harmony-backend/README.md
@@ -8,6 +8,7 @@ Express + tRPC server for the Harmony chat application.
 > [`docs/unified-backend-architecture.md`](../docs/unified-backend-architecture.md)
 
 The architecture doc covers:
+
 - **Module map** — what each module (M-B1–M-B7, M-D1–M-D3) owns and its boundaries
 - **Class diagrams** — all services, repositories, controllers, entities, and DTOs
 - **Data model** — ER diagram for all shared database tables
@@ -22,59 +23,59 @@ The architecture doc covers:
 
 ### Frameworks & Runtime
 
-| Dependency | Version | Purpose |
-|---|---|---|
-| **Node.js** | ≥ 20 | JavaScript runtime (required) |
-| **Express** | ^4.21 | HTTP server and middleware layer |
-| **tRPC** (`@trpc/server`) | ^11.0 | Type-safe RPC API layer over Express |
-| **TypeScript** | ^5.8 | Compile-time type safety; compiled to `dist/` via `tsc` |
+| Dependency                | Version | Purpose                                                 |
+| ------------------------- | ------- | ------------------------------------------------------- |
+| **Node.js**               | ≥ 20    | JavaScript runtime (required)                           |
+| **Express**               | ^4.21   | HTTP server and middleware layer                        |
+| **tRPC** (`@trpc/server`) | ^11.0   | Type-safe RPC API layer over Express                    |
+| **TypeScript**            | ^5.8    | Compile-time type safety; compiled to `dist/` via `tsc` |
 
 ### Database & Caching
 
-| Dependency | Version | Purpose |
-|---|---|---|
-| **Prisma** (`prisma` + `@prisma/client`) | ^5.22 | ORM for PostgreSQL — schema migrations, queries, and type generation |
-| **ioredis** | ^5.10 | Redis client for visibility caching and the Pub/Sub event bus |
+| Dependency                               | Version | Purpose                                                              |
+| ---------------------------------------- | ------- | -------------------------------------------------------------------- |
+| **Prisma** (`prisma` + `@prisma/client`) | ^5.22   | ORM for PostgreSQL — schema migrations, queries, and type generation |
+| **ioredis**                              | ^5.10   | Redis client for visibility caching and the Pub/Sub event bus        |
 
 ### Authentication & Security
 
-| Dependency | Version | Purpose |
-|---|---|---|
-| **jsonwebtoken** | ^9.0 | Issues and verifies JWT access and refresh tokens |
-| **bcryptjs** | ^3.0 | Password hashing (bcrypt) |
-| **helmet** | ^8.1 | Sets security-related HTTP headers |
-| **express-rate-limit** | ^8.3 | Per-IP rate limiting on auth and mutation endpoints |
-| **cors** | ^2.8 | CORS policy enforcement; restricted to `FRONTEND_URL` |
-| **zod** | ^3.24 | Runtime input validation for all API boundaries |
+| Dependency             | Version | Purpose                                               |
+| ---------------------- | ------- | ----------------------------------------------------- |
+| **jsonwebtoken**       | ^9.0    | Issues and verifies JWT access and refresh tokens     |
+| **bcryptjs**           | ^3.0    | Password hashing (bcrypt)                             |
+| **helmet**             | ^8.1    | Sets security-related HTTP headers                    |
+| **express-rate-limit** | ^8.3    | Per-IP rate limiting on auth and mutation endpoints   |
+| **cors**               | ^2.8    | CORS policy enforcement; restricted to `FRONTEND_URL` |
+| **zod**                | ^3.24   | Runtime input validation for all API boundaries       |
 
 ### File Handling
 
-| Dependency | Version | Purpose |
-|---|---|---|
-| **multer** | ^2.1 | Multipart form-data parsing for file uploads |
-| **file-type** | ^21.3 | MIME-type detection from file bytes (not filename extension) |
+| Dependency    | Version | Purpose                                                      |
+| ------------- | ------- | ------------------------------------------------------------ |
+| **multer**    | ^2.1    | Multipart form-data parsing for file uploads                 |
+| **file-type** | ^21.3   | MIME-type detection from file bytes (not filename extension) |
 
 ### External Services
 
-| Dependency | Version | Purpose | Required? |
-|---|---|---|---|
-| **Twilio** (`twilio`) | ^5.13 | Programmable Video — issues Access Tokens for voice channels | Optional — falls back to mock mode when credentials are absent or `TWILIO_MOCK=true` |
+| Dependency            | Version | Purpose                                                      | Required?                                                                            |
+| --------------------- | ------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| **Twilio** (`twilio`) | ^5.13   | Programmable Video — issues Access Tokens for voice channels | Optional — falls back to mock mode when credentials are absent or `TWILIO_MOCK=true` |
 
 ### Deployment
 
-| Dependency | Version | Purpose |
-|---|---|---|
-| **serverless-http** | ^3.2 | Wraps the Express app for AWS Lambda deployment |
+| Dependency          | Version | Purpose                                         |
+| ------------------- | ------- | ----------------------------------------------- |
+| **serverless-http** | ^3.2    | Wraps the Express app for AWS Lambda deployment |
 
 ### Development & Testing
 
-| Dependency | Version | Purpose |
-|---|---|---|
-| **Jest** + **ts-jest** | ^29 | Unit and integration test runner |
-| **supertest** | ^7.0 | HTTP integration testing against the Express app |
-| **tsx** | ^4.19 | TypeScript execution for dev server (`tsx watch`) and seed scripts |
-| **eslint** + **prettier** | ^9 / ^3 | Linting and formatting |
-| **dotenv** | ^17 | Loads `.env` during local development |
+| Dependency                | Version | Purpose                                                            |
+| ------------------------- | ------- | ------------------------------------------------------------------ |
+| **Jest** + **ts-jest**    | ^29     | Unit and integration test runner                                   |
+| **supertest**             | ^7.0    | HTTP integration testing against the Express app                   |
+| **tsx**                   | ^4.19   | TypeScript execution for dev server (`tsx watch`) and seed scripts |
+| **eslint** + **prettier** | ^9 / ^3 | Linting and formatting                                             |
+| **dotenv**                | ^17     | Loads `.env` during local development                              |
 
 ---
 
@@ -86,25 +87,25 @@ The primary relational database. All persistent application state lives here.
 
 **Tables created by Prisma migrations:**
 
-| Table | Reads | Writes | Notes |
-|---|---|---|---|
-| `users` | Auth, profile lookups | Registration, profile updates | Stores hashed passwords; never raw |
-| `refresh_tokens` | Token rotation and revocation | Login (issue), logout (revoke) | Stores SHA-256 hash of token, not the raw token |
-| `servers` | Server listing, membership checks | Create/delete server | `is_public` flag controls search indexability |
-| `server_members` | Role checks, member lists | Join/leave, role changes | Composite PK `(user_id, server_id)` |
-| `channels` | Message routing, visibility checks | Create/update/delete channel | `visibility` enum: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE` |
-| `messages` | Channel history, thread reads | Send, edit, soft-delete | Soft delete via `is_deleted`; reply count denormalised on parent |
-| `attachments` | Message attachment display | File upload completion | References S3-hosted URLs |
-| `visibility_audit_log` | Compliance queries | Any visibility change | 7-year retention requirement — do **not** purge within window |
-| `generated_meta_tags` | SEO meta tag serving | LLM-generated tag writes | `needs_regeneration` flag triggers regeneration job |
+| Table                  | Reads                              | Writes                         | Notes                                                               |
+| ---------------------- | ---------------------------------- | ------------------------------ | ------------------------------------------------------------------- |
+| `users`                | Auth, profile lookups              | Registration, profile updates  | Stores hashed passwords; never raw                                  |
+| `refresh_tokens`       | Token rotation and revocation      | Login (issue), logout (revoke) | Stores SHA-256 hash of token, not the raw token                     |
+| `servers`              | Server listing, membership checks  | Create/delete server           | `is_public` flag controls search indexability                       |
+| `server_members`       | Role checks, member lists          | Join/leave, role changes       | Composite PK `(user_id, server_id)`                                 |
+| `channels`             | Message routing, visibility checks | Create/update/delete channel   | `visibility` enum: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE` |
+| `messages`             | Channel history, thread reads      | Send, edit, soft-delete        | Soft delete via `is_deleted`; reply count denormalised on parent    |
+| `attachments`          | Message attachment display         | File upload completion         | References S3-hosted URLs                                           |
+| `visibility_audit_log` | Compliance queries                 | Any visibility change          | 7-year retention requirement — do **not** purge within window       |
+| `generated_meta_tags`  | SEO meta tag serving               | LLM-generated tag writes       | `needs_regeneration` flag triggers regeneration job                 |
 
 ### Redis
 
 Used for two independent concerns — both must be running for full functionality:
 
-| Use | Key pattern | Reads | Writes |
-|---|---|---|---|
-| **Visibility cache** | `channel:vis:<channelId>` | Every channel visibility check | On visibility change, on cache miss |
+| Use                   | Key pattern                            | Reads                          | Writes                                |
+| --------------------- | -------------------------------------- | ------------------------------ | ------------------------------------- |
+| **Visibility cache**  | `channel:vis:<channelId>`              | Every channel visibility check | On visibility change, on cache miss   |
 | **Pub/Sub event bus** | Channels: `member:statusChanged`, etc. | WebSocket gateway (subscriber) | Any service publishing a domain event |
 
 > Losing Redis connectivity degrades — but does not crash — the server. Visibility lookups fall through to PostgreSQL; real-time events stop propagating.
@@ -115,22 +116,23 @@ Used for two independent concerns — both must be running for full functionalit
 
 Copy `.env.example` to `.env` before running locally. All variables with no default listed are **required**.
 
-| Variable | Default | Description |
-|---|---|---|
-| `NODE_ENV` | `development` | `development` \| `production` \| `test` |
-| `PORT` | `4000` | HTTP listen port |
-| `DATABASE_URL` | *(see example)* | PostgreSQL connection string |
-| `REDIS_URL` | *(see example)* | Redis connection string (include password) |
-| `FRONTEND_URL` | `http://localhost:3000` | Allowed CORS origin |
-| `JWT_ACCESS_SECRET` | — | **Required.** Sign/verify access tokens. Must be 32+ random chars in production. |
-| `JWT_REFRESH_SECRET` | — | **Required.** Sign/verify refresh tokens. Must be 32+ random chars in production. |
-| `JWT_ACCESS_EXPIRES_IN` | `15m` | Access token TTL (`jsonwebtoken` duration string) |
-| `JWT_REFRESH_EXPIRES_DAYS` | `7` | Refresh token TTL in days |
-| `TWILIO_ACCOUNT_SID` | — | Optional. Twilio Account SID for voice channels. |
-| `TWILIO_API_KEY` | — | Optional. Twilio API Key SID. |
-| `TWILIO_API_SECRET` | — | Optional. Twilio API Key Secret. |
-| `TWILIO_MOCK` | `false` | Set `true` to stub Twilio locally without real credentials. Auto-enabled when credentials are missing. |
-| `HARMONY_DEMO_MODE` | `false` | Set `true` only when running `npm run db:seed:demo`. |
+| Variable                   | Default                 | Description                                                                                            |
+| -------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| `NODE_ENV`                 | `development`           | `development` \| `production` \| `test`                                                                |
+| `PORT`                     | `4000`                  | HTTP listen port                                                                                       |
+| `DATABASE_URL`             | _(see example)_         | PostgreSQL connection string                                                                           |
+| `REDIS_URL`                | _(see example)_         | Redis connection string (include password)                                                             |
+| `FRONTEND_URL`             | `http://localhost:3000` | Allowed CORS origin                                                                                    |
+| `BASE_URL`                 | `http://localhost:3000` | Canonical public frontend origin used for generated public links and sitemap XML                       |
+| `JWT_ACCESS_SECRET`        | —                       | **Required.** Sign/verify access tokens. Must be 32+ random chars in production.                       |
+| `JWT_REFRESH_SECRET`       | —                       | **Required.** Sign/verify refresh tokens. Must be 32+ random chars in production.                      |
+| `JWT_ACCESS_EXPIRES_IN`    | `15m`                   | Access token TTL (`jsonwebtoken` duration string)                                                      |
+| `JWT_REFRESH_EXPIRES_DAYS` | `7`                     | Refresh token TTL in days                                                                              |
+| `TWILIO_ACCOUNT_SID`       | —                       | Optional. Twilio Account SID for voice channels.                                                       |
+| `TWILIO_API_KEY`           | —                       | Optional. Twilio API Key SID.                                                                          |
+| `TWILIO_API_SECRET`        | —                       | Optional. Twilio API Key Secret.                                                                       |
+| `TWILIO_MOCK`              | `false`                 | Set `true` to stub Twilio locally without real credentials. Auto-enabled when credentials are missing. |
+| `HARMONY_DEMO_MODE`        | `false`                 | Set `true` only when running `npm run db:seed:demo`.                                                   |
 
 ---
 
@@ -182,6 +184,7 @@ npm start
 ```
 
 The server listens on `PORT` (default `4000`). Confirm it's up:
+
 ```bash
 curl http://localhost:4000/health
 ```

--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -53,6 +53,8 @@ export function createApp() {
   });
 
   // SEO endpoints (robots.txt, sitemaps) — before auth so they're publicly accessible
+  // Backend SEO routes remain available as transitional XML sources; the
+  // frontend apex domain owns the canonical crawler-facing entrypoints.
   app.use(seoRouter);
 
   // Auth endpoints

--- a/harmony-backend/src/routes/seo.router.ts
+++ b/harmony-backend/src/routes/seo.router.ts
@@ -1,8 +1,14 @@
 /**
- * SEO routes — sitemap.xml and robots.txt endpoints.
+ * SEO routes — backend XML sources for sitemap.xml and robots.txt.
  *
+ * The deployment architecture makes the frontend apex domain the canonical
+ * crawler-facing SEO surface. These backend routes continue to generate the
+ * underlying XML/text so frontend route handlers can proxy them on the public
+ * host without asking crawlers to use the API subdomain directly.
+ *
+ * - GET /sitemap-index.xml       — sitemap index consumed by the frontend host
  * - GET /sitemap/:serverSlug.xml — dynamic sitemap of PUBLIC_INDEXABLE channels
- * - GET /robots.txt              — allow crawling of /c/ routes
+ * - GET /robots.txt              — legacy/transitional robots directives
  */
 
 import { Router, Request, Response } from 'express';
@@ -10,13 +16,23 @@ import { indexingService } from '../services/indexing.service';
 
 export const seoRouter = Router();
 
+seoRouter.get('/sitemap-index.xml', async (_req: Request, res: Response) => {
+  try {
+    const xml = await indexingService.generateSitemapIndex();
+    res.set('Content-Type', 'application/xml');
+    res.set('Cache-Control', 'public, max-age=300');
+    res.send(xml);
+  } catch (err) {
+    console.error('Sitemap index generation error:', err);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  }
+});
+
 /**
  * GET /robots.txt
  * Instructs crawlers to allow /c/ routes (public channel pages).
- *
- * NOTE: A machine-readable `Sitemap:` directive requires a sitemap index
- * endpoint (e.g. /sitemap-index.xml) that aggregates per-server sitemaps.
- * This is tracked as a follow-up — see issue #107 comments.
  */
 seoRouter.get('/robots.txt', (_req: Request, res: Response) => {
   const body = [
@@ -24,6 +40,7 @@ seoRouter.get('/robots.txt', (_req: Request, res: Response) => {
     'Allow: /c/',
     'Disallow: /api/',
     'Disallow: /trpc/',
+    `Sitemap: ${process.env.BASE_URL ?? 'https://harmony.chat'}/sitemap.xml`,
   ].join('\n');
 
   res.set('Content-Type', 'text/plain');
@@ -34,7 +51,7 @@ seoRouter.get('/robots.txt', (_req: Request, res: Response) => {
 /**
  * GET /sitemap/:serverSlug.xml
  * Returns a dynamic XML sitemap containing all PUBLIC_INDEXABLE channels
- * for the given server.
+ * for the given server. The frontend proxies this route on the apex domain.
  */
 seoRouter.get('/sitemap/:serverSlug.xml', async (req: Request, res: Response) => {
   try {

--- a/harmony-backend/src/services/indexing.service.ts
+++ b/harmony-backend/src/services/indexing.service.ts
@@ -4,6 +4,7 @@
  * Provides:
  *   - addToSitemap(channelId)   — marks a channel for sitemap inclusion
  *   - removeFromSitemap(channelId) — removes a channel from sitemap
+ *   - generateSitemapIndex() — builds the sitemap index consumed by the frontend
  *   - generateSitemap(serverSlug)  — builds XML sitemap for a server
  *
  * Listens to VISIBILITY_CHANGED events to keep sitemap data in sync.
@@ -18,10 +19,31 @@ const SITEMAP_CACHE_TTL = 300; // 5 minutes
 const BASE_URL = process.env.BASE_URL ?? 'https://harmony.chat';
 
 export const CacheKeys_Sitemap = {
+  index: 'sitemap:index',
   serverSitemap: (serverSlug: string) => `sitemap:${sanitizeKeySegment(serverSlug)}`,
 };
 
 export const indexingService = {
+  /**
+   * Generate the sitemap index consumed by the frontend apex-domain route
+   * handler. The backend remains the XML producer, while the frontend owns the
+   * crawler-facing hostname in production.
+   */
+  async generateSitemapIndex(): Promise<string> {
+    return cacheService.getOrRevalidate(
+      CacheKeys_Sitemap.index,
+      async () => {
+        const servers = await prisma.server.findMany({
+          where: { isPublic: true },
+          orderBy: { memberCount: 'desc' },
+          select: { slug: true },
+        });
+        return buildSitemapIndexXml(servers.map((server) => server.slug));
+      },
+      { ttl: SITEMAP_CACHE_TTL },
+    );
+  },
+
   /**
    * Invalidate the sitemap cache for the channel's server so the channel
    * appears in the next generated sitemap.
@@ -115,6 +137,17 @@ function buildSitemapXml(
     .join('\n');
 
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>`;
+}
+
+function buildSitemapIndexXml(serverSlugs: string[]): string {
+  const sitemaps = serverSlugs
+    .map(
+      (serverSlug) =>
+        `  <sitemap>\n    <loc>${escapeXml(BASE_URL)}/sitemap/${encodeURIComponent(serverSlug)}</loc>\n  </sitemap>`,
+    )
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${sitemaps}\n</sitemapindex>`;
 }
 
 function escapeXml(str: string): string {

--- a/harmony-backend/tests/indexing.service.test.ts
+++ b/harmony-backend/tests/indexing.service.test.ts
@@ -79,6 +79,15 @@ afterAll(async () => {
 });
 
 describe('indexingService.generateSitemap', () => {
+  it('generates a sitemap index that points crawlers at the frontend host', async () => {
+    const xml = await indexingService.generateSitemapIndex();
+
+    expect(xml).not.toBeNull();
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(xml).toContain(`/sitemap/${serverSlug}`);
+  });
+
   it('returns null for non-existent server', async () => {
     const result = await indexingService.generateSitemap('non-existent-server-slug');
     expect(result).toBeNull();
@@ -138,9 +147,7 @@ describe('indexingService.onVisibilityChanged', () => {
       newVisibility: 'PUBLIC_INDEXABLE',
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.stringContaining('sitemap:'),
-    );
+    expect(invalidateSpy).toHaveBeenCalledWith(expect.stringContaining('sitemap:'));
   });
 
   it('invalidates sitemap cache when channel leaves PUBLIC_INDEXABLE', async () => {
@@ -152,9 +159,7 @@ describe('indexingService.onVisibilityChanged', () => {
       newVisibility: 'PRIVATE',
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.stringContaining('sitemap:'),
-    );
+    expect(invalidateSpy).toHaveBeenCalledWith(expect.stringContaining('sitemap:'));
   });
 
   it('does not invalidate cache when visibility change does not involve PUBLIC_INDEXABLE', async () => {
@@ -178,6 +183,17 @@ describe('GET /robots.txt', () => {
     expect(res.text).toContain('Allow: /c/');
     expect(res.text).toContain('Disallow: /api/');
     expect(res.text).toContain('Disallow: /trpc/');
+    expect(res.text).toContain('Sitemap:');
+  });
+});
+
+describe('GET /sitemap-index.xml', () => {
+  it('returns the sitemap index for the frontend host', async () => {
+    const res = await request(app).get('/sitemap-index.xml');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/xml/);
+    expect(res.text).toContain(`/sitemap/${serverSlug}`);
   });
 });
 

--- a/harmony-backend/tests/seo.router.test.ts
+++ b/harmony-backend/tests/seo.router.test.ts
@@ -1,0 +1,57 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../src/services/indexing.service', () => ({
+  indexingService: {
+    generateSitemapIndex: jest.fn(),
+    generateSitemap: jest.fn(),
+  },
+}));
+
+import { seoRouter } from '../src/routes/seo.router';
+import { indexingService } from '../src/services/indexing.service';
+
+const mockIndexingService = indexingService as unknown as {
+  generateSitemapIndex: jest.Mock;
+  generateSitemap: jest.Mock;
+};
+
+describe('seoRouter', () => {
+  const app = express();
+  app.use(seoRouter);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a sitemap index sourced from indexingService', async () => {
+    mockIndexingService.generateSitemapIndex.mockResolvedValue(
+      '<?xml version="1.0"?><sitemapindex />',
+    );
+
+    const res = await request(app).get('/sitemap-index.xml');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/xml/);
+    expect(res.headers['cache-control']).toContain('max-age=300');
+    expect(res.text).toContain('<sitemapindex');
+  });
+
+  it('returns a per-server sitemap sourced from indexingService', async () => {
+    mockIndexingService.generateSitemap.mockResolvedValue('<?xml version="1.0"?><urlset />');
+
+    const res = await request(app).get('/sitemap/demo.xml');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/xml/);
+    expect(mockIndexingService.generateSitemap).toHaveBeenCalledWith('demo');
+  });
+
+  it('includes the frontend sitemap entrypoint in robots.txt', async () => {
+    const res = await request(app).get('/robots.txt');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('User-agent: *');
+    expect(res.text).toContain('Sitemap: https://harmony.chat/sitemap.xml');
+  });
+});

--- a/harmony-frontend/.env.example
+++ b/harmony-frontend/.env.example
@@ -1,12 +1,5 @@
-# API Configuration
+# Frontend canonical origin used for absolute public URLs and metadata.
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+
+# Public backend API origin used by browser and server-side frontend code.
 NEXT_PUBLIC_API_URL=http://localhost:4000
-
-# Database (for future reference)
-DATABASE_URL=
-
-# Redis (for future reference)
-REDIS_URL=
-
-# Authentication (for future reference)
-NEXTAUTH_SECRET=
-NEXTAUTH_URL=http://localhost:3000

--- a/harmony-frontend/README.md
+++ b/harmony-frontend/README.md
@@ -127,6 +127,17 @@ Copy `.env.example` to `.env.local` and fill in your values:
 cp .env.example .env.local
 ```
 
+Required runtime values:
+
+- `NEXT_PUBLIC_BASE_URL`: canonical frontend origin used for absolute public URLs, `metadataBase`,
+  `robots.txt`, and sitemap entrypoints
+- `NEXT_PUBLIC_API_URL`: public backend API origin used by browser code and server-side frontend
+  fetches
+
+Per `docs/deployment/deployment-architecture.md`, the frontend apex domain owns the public SEO
+contract. The frontend hosts canonical URLs, `metadataBase`, `robots.txt`, and sitemap entrypoints,
+while backend sitemap routes remain internal/transitional XML sources.
+
 ## Code Quality
 
 - **Linting**: `npm run lint`

--- a/harmony-frontend/src/__tests__/runtime-config.test.ts
+++ b/harmony-frontend/src/__tests__/runtime-config.test.ts
@@ -1,0 +1,43 @@
+import {
+  getApiBaseUrl,
+  getChannelUrl,
+  getPublicBaseUrl,
+  getPublicMetadataBase,
+} from '@/lib/runtime-config';
+
+describe('runtime-config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses localhost fallbacks when env vars are unset', () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    delete process.env.NEXT_PUBLIC_API_URL;
+
+    expect(getPublicBaseUrl()).toBe('http://localhost:3000');
+    expect(getApiBaseUrl()).toBe('http://localhost:4000');
+    expect(getPublicMetadataBase().toString()).toBe('http://localhost:3000/');
+  });
+
+  it('normalizes configured base URLs by trimming trailing slashes', () => {
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://harmony.chat/';
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.harmony.chat///';
+
+    expect(getPublicBaseUrl()).toBe('https://harmony.chat');
+    expect(getApiBaseUrl()).toBe('https://api.harmony.chat');
+  });
+
+  it('builds absolute, encoded public channel URLs', () => {
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://harmony.chat/';
+
+    expect(getChannelUrl('server slug', 'general chat')).toBe(
+      'https://harmony.chat/c/server%20slug/general%20chat',
+    );
+  });
+});

--- a/harmony-frontend/src/__tests__/runtime-config.test.ts
+++ b/harmony-frontend/src/__tests__/runtime-config.test.ts
@@ -40,4 +40,16 @@ describe('runtime-config', () => {
       'https://harmony.chat/c/server%20slug/general%20chat',
     );
   });
+
+  it('throws when a configured public base URL is malformed', () => {
+    process.env.NEXT_PUBLIC_BASE_URL = 'harmony.chat';
+
+    expect(() => getPublicBaseUrl()).toThrow('Invalid NEXT_PUBLIC_BASE_URL value');
+  });
+
+  it('throws when a configured API base URL is malformed', () => {
+    process.env.NEXT_PUBLIC_API_URL = 'api.harmony.chat';
+
+    expect(() => getApiBaseUrl()).toThrow('Invalid NEXT_PUBLIC_API_URL value');
+  });
 });

--- a/harmony-frontend/src/__tests__/seo-routes.test.ts
+++ b/harmony-frontend/src/__tests__/seo-routes.test.ts
@@ -1,0 +1,98 @@
+import { GET as getRobots } from '@/app/robots.txt/route';
+import { GET as getSitemapIndex } from '@/app/sitemap.xml/route';
+import { GET as getServerSitemap } from '@/app/sitemap/[serverSlug]/route';
+
+const originalEnv = process.env;
+const originalFetch = global.fetch;
+const originalRequest = global.Request;
+const originalResponse = global.Response;
+
+class TestHeaders {
+  private values = new Map<string, string>();
+
+  constructor(init?: Record<string, string>) {
+    Object.entries(init ?? {}).forEach(([key, value]) => {
+      this.values.set(key.toLowerCase(), value);
+    });
+  }
+
+  get(key: string): string | null {
+    return this.values.get(key.toLowerCase()) ?? null;
+  }
+}
+
+class TestResponse {
+  readonly status: number;
+  readonly ok: boolean;
+  readonly headers: TestHeaders;
+  private readonly body: string;
+
+  constructor(body = '', init: { status?: number; headers?: Record<string, string> } = {}) {
+    this.body = body;
+    this.status = init.status ?? 200;
+    this.ok = this.status >= 200 && this.status < 300;
+    this.headers = new TestHeaders(init.headers);
+  }
+
+  async text(): Promise<string> {
+    return this.body;
+  }
+}
+
+class TestRequest {
+  constructor(public readonly url: string) {}
+}
+
+describe('frontend SEO route handlers', () => {
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_BASE_URL: 'https://harmony.chat',
+      NEXT_PUBLIC_API_URL: 'https://api.harmony.chat',
+    };
+    global.Request = TestRequest as unknown as typeof global.Request;
+    global.Response = TestResponse as unknown as typeof global.Response;
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+    global.Request = originalRequest;
+    global.Response = originalResponse;
+  });
+
+  it('serves robots.txt from the frontend host with a sitemap directive', async () => {
+    const response = await getRobots();
+
+    expect(response.headers.get('content-type')).toContain('text/plain');
+    await expect(response.text()).resolves.toContain('Sitemap: https://harmony.chat/sitemap.xml');
+  });
+
+  it('proxies the sitemap index from the backend API origin', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      new Response('<sitemapindex />', { status: 200 }),
+    );
+
+    const response = await getSitemapIndex();
+
+    expect(global.fetch).toHaveBeenCalledWith('https://api.harmony.chat/sitemap-index.xml', {
+      cache: 'no-store',
+    });
+    await expect(response.text()).resolves.toBe('<sitemapindex />');
+    expect(response.headers.get('content-type')).toContain('application/xml');
+  });
+
+  it('proxies per-server sitemap XML from the backend API origin', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(new Response('<urlset />', { status: 200 }));
+
+    const response = await getServerSitemap(new Request('https://harmony.chat/sitemap/demo'), {
+      params: Promise.resolve({ serverSlug: 'demo' }),
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('https://api.harmony.chat/sitemap/demo.xml', {
+      cache: 'no-store',
+    });
+    await expect(response.text()).resolves.toBe('<urlset />');
+  });
+});

--- a/harmony-frontend/src/__tests__/seo-routes.test.ts
+++ b/harmony-frontend/src/__tests__/seo-routes.test.ts
@@ -25,7 +25,7 @@ class TestResponse {
   readonly status: number;
   readonly ok: boolean;
   readonly headers: TestHeaders;
-  private readonly body: string;
+  readonly body: string;
 
   constructor(body = '', init: { status?: number; headers?: Record<string, string> } = {}) {
     this.body = body;

--- a/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+++ b/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { GuestChannelView } from '@/components/channel/GuestChannelView';
 import { fetchPublicServer, fetchPublicChannel } from '@/services/publicApiService';
 import { ChannelVisibility } from '@/types';
+import { getChannelUrl } from '@/lib/runtime-config';
 
 interface PageProps {
   params: Promise<{ serverSlug: string; channelSlug: string }>;
@@ -20,7 +21,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
   const description = channel?.topic ?? server?.description ?? `Join ${serverName} on Harmony`;
   const title = `${channelName} - ${serverName} | Harmony`;
-  const canonicalUrl = `/c/${serverSlug}/${channelSlug}`;
+  const canonicalUrl = getChannelUrl(serverSlug, channelSlug);
 
   return {
     title,

--- a/harmony-frontend/src/app/layout.tsx
+++ b/harmony-frontend/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { Providers } from './providers';
+import { APP_DESCRIPTION, APP_NAME } from '@/lib/constants';
+import { getPublicMetadataBase } from '@/lib/runtime-config';
 import './globals.css';
 
 const inter = Inter({
@@ -9,8 +11,9 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: 'Harmony',
-  description: 'A search engine indexable chat application',
+  metadataBase: getPublicMetadataBase(),
+  title: APP_NAME,
+  description: APP_DESCRIPTION,
 };
 
 export default function RootLayout({

--- a/harmony-frontend/src/app/robots.txt/route.ts
+++ b/harmony-frontend/src/app/robots.txt/route.ts
@@ -1,0 +1,25 @@
+import { getPublicBaseUrl } from '@/lib/runtime-config';
+
+export const revalidate = 3600;
+
+/**
+ * The frontend apex domain owns the crawler-facing robots.txt contract in
+ * production. This route stays on the public host even if the backend still
+ * generates transitional SEO payloads internally.
+ */
+export async function GET() {
+  const body = [
+    'User-agent: *',
+    'Allow: /c/',
+    'Disallow: /api/',
+    'Disallow: /trpc/',
+    `Sitemap: ${getPublicBaseUrl()}/sitemap.xml`,
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/harmony-frontend/src/app/sitemap.xml/route.ts
+++ b/harmony-frontend/src/app/sitemap.xml/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
     });
   }
 
-  return new Response(await response.text(), {
+  return new Response(response.body, {
     headers: {
       'Content-Type': 'application/xml; charset=utf-8',
       'Cache-Control': 'public, max-age=300, stale-while-revalidate=300',

--- a/harmony-frontend/src/app/sitemap.xml/route.ts
+++ b/harmony-frontend/src/app/sitemap.xml/route.ts
@@ -1,0 +1,28 @@
+import { getApiBaseUrl } from '@/lib/runtime-config';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * The crawler-facing sitemap index lives on the frontend apex host. The XML is
+ * still sourced from the backend so the backend remains the data producer while
+ * the frontend owns the public SEO entrypoint.
+ */
+export async function GET() {
+  const response = await fetch(`${getApiBaseUrl()}/sitemap-index.xml`, {
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    return new Response('Unable to generate sitemap index.', {
+      status: response.status === 404 ? 404 : 502,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  return new Response(await response.text(), {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=300, stale-while-revalidate=300',
+    },
+  });
+}

--- a/harmony-frontend/src/app/sitemap/[serverSlug]/route.ts
+++ b/harmony-frontend/src/app/sitemap/[serverSlug]/route.ts
@@ -24,7 +24,7 @@ export async function GET(_request: Request, context: RouteContext) {
     });
   }
 
-  return new Response(await response.text(), {
+  return new Response(response.body, {
     headers: {
       'Content-Type': 'application/xml; charset=utf-8',
       'Cache-Control': 'public, max-age=300, stale-while-revalidate=300',

--- a/harmony-frontend/src/app/sitemap/[serverSlug]/route.ts
+++ b/harmony-frontend/src/app/sitemap/[serverSlug]/route.ts
@@ -1,0 +1,33 @@
+import { getApiBaseUrl } from '@/lib/runtime-config';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteContext {
+  params: Promise<{ serverSlug: string }>;
+}
+
+/**
+ * Per-server sitemap entrypoints stay on the frontend host and proxy the
+ * backend XML generator at request time so crawlers never need the API domain
+ * as the primary SEO surface.
+ */
+export async function GET(_request: Request, context: RouteContext) {
+  const { serverSlug } = await context.params;
+  const response = await fetch(`${getApiBaseUrl()}/sitemap/${encodeURIComponent(serverSlug)}.xml`, {
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    return new Response('Sitemap not found.', {
+      status: response.status === 404 ? 404 : 502,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  return new Response(await response.text(), {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=300, stale-while-revalidate=300',
+    },
+  });
+}

--- a/harmony-frontend/src/contexts/VoiceContext.tsx
+++ b/harmony-frontend/src/contexts/VoiceContext.tsx
@@ -29,6 +29,7 @@ import {
 } from 'react';
 import { apiClient, getAccessToken } from '@/lib/api-client';
 import { useToast } from '@/hooks/useToast';
+import { getApiBaseUrl } from '@/lib/runtime-config';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -628,7 +629,7 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
       const token = getAccessToken();
       if (!channelId || !serverId || !token) return;
 
-      const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+      const baseUrl = getApiBaseUrl();
       fetch(`${baseUrl}/trpc/voice.leave`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },

--- a/harmony-frontend/src/hooks/useChannelEvents.ts
+++ b/harmony-frontend/src/hooks/useChannelEvents.ts
@@ -20,6 +20,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { Message } from '@/types/message';
 import type { Server } from '@/types/server';
 import { getAccessToken } from '@/lib/api-client';
+import { getApiBaseUrl } from '@/lib/runtime-config';
 
 export interface UseChannelEventsOptions {
   channelId: string;
@@ -64,7 +65,7 @@ export function useChannelEvents({
   useEffect(() => {
     if (!enabled || !channelId) return;
 
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
+    const apiUrl = getApiBaseUrl();
     const token = getAccessToken();
     if (!token) return; // unauthenticated — don't attempt connection
     const url = `${apiUrl}/api/events/channel/${channelId}?token=${encodeURIComponent(token)}`;

--- a/harmony-frontend/src/hooks/useServerEvents.ts
+++ b/harmony-frontend/src/hooks/useServerEvents.ts
@@ -29,6 +29,7 @@ import { useEffect, useLayoutEffect, useRef } from 'react';
 import type { Channel, ChannelVisibility } from '@/types/channel';
 import type { User, UserStatus } from '@/types/user';
 import { getAccessToken } from '@/lib/api-client';
+import { getApiBaseUrl } from '@/lib/runtime-config';
 
 export interface UseServerEventsOptions {
   serverId: string;
@@ -84,7 +85,7 @@ export function useServerEvents({
   useEffect(() => {
     if (!enabled || !serverId) return;
 
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
+    const apiUrl = getApiBaseUrl();
     const token = getAccessToken();
     if (!token) return;
 

--- a/harmony-frontend/src/lib/constants.ts
+++ b/harmony-frontend/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { getApiBaseUrl } from './runtime-config';
+
 /**
  * Application-wide constants
  * Aligned with dev spec requirements
@@ -10,7 +12,9 @@ export const APP_DESCRIPTION = 'Search-engine-indexable chat platform';
  * API Configuration
  */
 export const API_CONFIG = {
-  BASE_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000',
+  get BASE_URL() {
+    return getApiBaseUrl();
+  },
   TIMEOUT: 30000, // 30 seconds
 } as const;
 

--- a/harmony-frontend/src/lib/runtime-config.ts
+++ b/harmony-frontend/src/lib/runtime-config.ts
@@ -1,8 +1,9 @@
 const LOCAL_FRONTEND_URL = 'http://localhost:3000';
 const LOCAL_API_URL = 'http://localhost:4000';
 
-function normalizeBaseUrl(value: string | undefined, fallback: string): string {
-  const candidate = value?.trim() || fallback;
+function normalizeBaseUrl(value: string | undefined, fallback: string, envVarName: string): string {
+  const configuredValue = value?.trim();
+  const candidate = configuredValue || fallback;
 
   try {
     const url = new URL(candidate);
@@ -11,16 +12,26 @@ function normalizeBaseUrl(value: string | undefined, fallback: string): string {
     url.hash = '';
     return url.toString().replace(/\/$/, '');
   } catch {
+    if (configuredValue) {
+      throw new Error(
+        `Invalid ${envVarName} value "${configuredValue}". Expected an absolute URL including scheme, for example https://harmony.chat.`,
+      );
+    }
+
     return fallback;
   }
 }
 
 export function getPublicBaseUrl(): string {
-  return normalizeBaseUrl(process.env.NEXT_PUBLIC_BASE_URL, LOCAL_FRONTEND_URL);
+  return normalizeBaseUrl(
+    process.env.NEXT_PUBLIC_BASE_URL,
+    LOCAL_FRONTEND_URL,
+    'NEXT_PUBLIC_BASE_URL',
+  );
 }
 
 export function getApiBaseUrl(): string {
-  return normalizeBaseUrl(process.env.NEXT_PUBLIC_API_URL, LOCAL_API_URL);
+  return normalizeBaseUrl(process.env.NEXT_PUBLIC_API_URL, LOCAL_API_URL, 'NEXT_PUBLIC_API_URL');
 }
 
 export function getPublicMetadataBase(): URL {

--- a/harmony-frontend/src/lib/runtime-config.ts
+++ b/harmony-frontend/src/lib/runtime-config.ts
@@ -1,0 +1,32 @@
+const LOCAL_FRONTEND_URL = 'http://localhost:3000';
+const LOCAL_API_URL = 'http://localhost:4000';
+
+function normalizeBaseUrl(value: string | undefined, fallback: string): string {
+  const candidate = value?.trim() || fallback;
+
+  try {
+    const url = new URL(candidate);
+    url.pathname = url.pathname.replace(/\/+$/, '');
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return fallback;
+  }
+}
+
+export function getPublicBaseUrl(): string {
+  return normalizeBaseUrl(process.env.NEXT_PUBLIC_BASE_URL, LOCAL_FRONTEND_URL);
+}
+
+export function getApiBaseUrl(): string {
+  return normalizeBaseUrl(process.env.NEXT_PUBLIC_API_URL, LOCAL_API_URL);
+}
+
+export function getPublicMetadataBase(): URL {
+  return new URL(`${getPublicBaseUrl()}/`);
+}
+
+export function getChannelUrl(serverSlug: string, channelSlug: string): string {
+  return `${getPublicBaseUrl()}/c/${encodeURIComponent(serverSlug)}/${encodeURIComponent(channelSlug)}`;
+}

--- a/harmony-frontend/src/lib/trpc-client.ts
+++ b/harmony-frontend/src/lib/trpc-client.ts
@@ -14,8 +14,6 @@ import { TrpcHttpError } from './trpc-errors';
 
 export { TrpcHttpError } from './trpc-errors';
 
-const BASE = API_CONFIG.BASE_URL;
-
 // ─── Auth helper ──────────────────────────────────────────────────────────────
 
 /**
@@ -42,7 +40,7 @@ export async function publicGet<T>(path: string): Promise<T | null> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 10_000);
   try {
-    const res = await fetch(`${BASE}/api/public${path}`, {
+    const res = await fetch(`${API_CONFIG.BASE_URL}/api/public${path}`, {
       next: { revalidate: 60 }, // ISR: revalidate every 60s
       signal: controller.signal,
     });
@@ -63,7 +61,7 @@ export async function publicGet<T>(path: string): Promise<T | null> {
  * Input is JSON-serialized as a query parameter.
  */
 export async function trpcQuery<T>(procedure: string, input?: unknown): Promise<T> {
-  const url = new URL(`${BASE}/trpc/${procedure}`);
+  const url = new URL(`${API_CONFIG.BASE_URL}/trpc/${procedure}`);
   if (input !== undefined) {
     url.searchParams.set('input', JSON.stringify(input));
   }
@@ -115,7 +113,7 @@ export async function trpcMutate<T>(procedure: string, input?: unknown): Promise
   const timeoutId = setTimeout(() => controller.abort(), 10_000);
   let res: Response;
   try {
-    res = await fetch(`${BASE}/trpc/${procedure}`, {
+    res = await fetch(`${API_CONFIG.BASE_URL}/trpc/${procedure}`, {
       method: 'POST',
       headers,
       body: JSON.stringify(input ?? {}),

--- a/harmony-frontend/src/lib/utils.ts
+++ b/harmony-frontend/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { isAxiosError } from 'axios';
+import { getChannelUrl as getCanonicalChannelUrl } from './runtime-config';
 
 /**
  * Utility function to merge Tailwind CSS classes
@@ -84,15 +85,16 @@ export function formatTimeOnly(date: Date | string): string {
  *   - Plain Error instances with a message
  *   - Falls back to the provided `fallback` string
  */
-export function getUserErrorMessage(err: unknown, fallback = 'Something went wrong. Please try again.'): string {
+export function getUserErrorMessage(
+  err: unknown,
+  fallback = 'Something went wrong. Please try again.',
+): string {
   if (isAxiosError(err)) {
     const data = err.response?.data;
     if (data) {
       // Validation errors: { error: "Validation failed", details: [{ message: "..." }] }
       if (Array.isArray(data.details) && data.details.length > 0) {
-        const messages = data.details
-          .map((d: { message?: string }) => d.message)
-          .filter(Boolean);
+        const messages = data.details.map((d: { message?: string }) => d.message).filter(Boolean);
         if (messages.length > 0) return messages.join('. ');
       }
       // REST endpoints: { error: "Invalid credentials" }
@@ -123,6 +125,5 @@ export function truncate(text: string, maxLength: number): string {
  * Generate a canonical URL for a public channel
  */
 export function getChannelUrl(serverSlug: string, channelSlug: string): string {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
-  return `${baseUrl}/c/${serverSlug}/${channelSlug}`;
+  return getCanonicalChannelUrl(serverSlug, channelSlug);
 }


### PR DESCRIPTION
## Summary
- align frontend canonical URL ownership with the deployment architecture
- add frontend-owned robots and sitemap entrypoints that proxy backend XML sources
- add backend sitemap index support and tests for the SEO handoff

## Testing
- npm run build (harmony-frontend)
- npx jest --runInBand src/__tests__/runtime-config.test.ts src/__tests__/seo-routes.test.ts src/__tests__/utils.test.ts src/__tests__/publicApiService.test.ts src/__tests__/useChannelEvents.test.tsx src/__tests__/useServerEvents.test.tsx (harmony-frontend)
- npm run build (harmony-backend)
- npx jest --runInBand tests/app.test.ts tests/public.router.test.ts tests/seo.router.test.ts (harmony-backend)

## Notes
- `harmony-backend/tests/indexing.service.test.ts` still requires a configured `DATABASE_URL` and was not runnable in this worktree.
- Closes #321