### PR TITLE
[codex] add frontend-safe logging

### DIFF
--- a/harmony-frontend/src/__tests__/channelService.test.ts
+++ b/harmony-frontend/src/__tests__/channelService.test.ts
@@ -98,7 +98,10 @@ describe('channelService', () => {
 
   describe('getChannels', () => {
     it('returns mapped channels from tRPC query', async () => {
-      const raw = [makeRawChannel(), makeRawChannel({ id: 'ch-2', name: 'random', slug: 'random' })];
+      const raw = [
+        makeRawChannel(),
+        makeRawChannel({ id: 'ch-2', name: 'random', slug: 'random' }),
+      ];
       mockedTrpcQuery.mockResolvedValue(raw);
 
       const result = await getChannels('srv-1');
@@ -213,9 +216,16 @@ describe('channelService', () => {
       const result = await getChannel('my-server', 'general');
 
       expect(result).toBeNull();
-      expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('my-server/general'),
-        expect.any(Error),
+      expect(console.warn).toHaveBeenCalledWith(
+        '[frontend]',
+        expect.objectContaining({
+          message: 'Channel lookup failed',
+          fields: expect.objectContaining({
+            feature: 'channel-service',
+            event: 'get_channel_failed',
+            procedure: 'channel.getChannel',
+          }),
+        }),
       );
     });
 
@@ -227,19 +237,17 @@ describe('channelService', () => {
     });
 
     it('fills default position=0 and createdAt=epoch for public hit missing those fields', async () => {
-      mockedPublicGet
-        .mockResolvedValueOnce({ id: 'srv-1' } as never)
-        .mockResolvedValueOnce({
-          channels: [
-            {
-              id: 'ch-pub',
-              name: 'public-chan',
-              slug: 'public-chan',
-              type: 'TEXT',
-              // position and createdAt intentionally omitted
-            },
-          ],
-        } as never);
+      mockedPublicGet.mockResolvedValueOnce({ id: 'srv-1' } as never).mockResolvedValueOnce({
+        channels: [
+          {
+            id: 'ch-pub',
+            name: 'public-chan',
+            slug: 'public-chan',
+            type: 'TEXT',
+            // position and createdAt intentionally omitted
+          },
+        ],
+      } as never);
 
       const result = await getChannel('my-server', 'public-chan');
 
@@ -564,10 +572,18 @@ describe('channelService', () => {
 
       await getChannels('srv-1');
 
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('missing or non-string "id"'));
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('missing or non-string "serverId"'));
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('missing or non-string "slug"'));
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('missing or non-string "createdAt"'));
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing or non-string "id"'),
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing or non-string "serverId"'),
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing or non-string "slug"'),
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing or non-string "createdAt"'),
+      );
     });
   });
 
@@ -603,10 +619,18 @@ describe('channelService', () => {
 
       await getAuditLog('srv-1', 'ch-1');
 
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('missing or non-string "id"'));
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('missing or non-string "channelId"'));
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('missing or non-string "actorId"'));
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('missing or non-string "action"'));
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing or non-string "id"'),
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing or non-string "channelId"'),
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing or non-string "actorId"'),
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing or non-string "action"'),
+      );
     });
 
     it('defaults to epoch timestamp when timestamp is invalid', async () => {

--- a/harmony-frontend/src/__tests__/frontend-logger.test.ts
+++ b/harmony-frontend/src/__tests__/frontend-logger.test.ts
@@ -1,0 +1,50 @@
+import { buildFrontendLogEntry, sanitizeLogMetadata } from '../lib/frontend-logger';
+
+describe('frontend-logger', () => {
+  it('drops sensitive and unapproved metadata fields', () => {
+    const fields = sanitizeLogMetadata({
+      component: 'api-client',
+      feature: 'auth',
+      event: 'refresh_failed',
+      email: 'user@example.com',
+      username: 'alice',
+      content: 'secret message',
+      token: 'secret-token',
+      body: { password: 'secret' },
+      headers: { authorization: 'Bearer secret' },
+    });
+
+    expect(fields).toEqual({
+      component: 'api-client',
+      feature: 'auth',
+      event: 'refresh_failed',
+    });
+  });
+
+  it('sanitizes route-like fields and only keeps safe error details', () => {
+    const entry = buildFrontendLogEntry('error', 'Request failed', {
+      component: 'trpc-client',
+      route: '/channels/general?token=secret&email=user@example.com',
+      target: 'https://example.com/trpc/message.send?input=%7B%22content%22%3A%22hello%22%7D',
+      error: {
+        name: 'TrpcHttpError',
+        message: 'user@example.com should not leak',
+        status: 500,
+        digest: 'abc123',
+        stack: 'stack trace',
+      },
+    });
+
+    expect(entry.runtime).toBe('browser');
+    expect(entry.fields).toEqual({
+      component: 'trpc-client',
+      route: '/channels/general',
+      target: '/trpc/message.send',
+      errorName: 'TrpcHttpError',
+      statusCode: 500,
+      digest: 'abc123',
+    });
+    expect(entry.fields).not.toHaveProperty('message');
+    expect(entry.fields).not.toHaveProperty('stack');
+  });
+});

--- a/harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts
+++ b/harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts
@@ -16,6 +16,11 @@
 // jest.mock() calls. This allows them to be referenced inside mock factories.
 
 const mockSetSessionCookie = jest.fn().mockResolvedValue(undefined);
+const mockFrontendLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
 
 // Capture the response error interceptor handler when api-client registers it.
 // We invoke the handler directly in tests to trigger the refresh logic.
@@ -50,6 +55,10 @@ const mockAxiosPost = jest.fn().mockResolvedValue({
 jest.mock('@/app/actions/session', () => ({
   setSessionCookie: mockSetSessionCookie,
   clearSessionCookie: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/frontend-logger', () => ({
+  createFrontendLogger: jest.fn(() => mockFrontendLogger),
 }));
 
 jest.mock('axios', () => ({
@@ -138,6 +147,14 @@ describe('Fix 1 — api-client: setSessionCookie is called after token refresh',
 
     // setSessionCookie was still attempted despite the failure (best-effort)
     expect(setSessionCookie).toHaveBeenCalledWith('refreshed-access-token');
+    expect(mockFrontendLogger.warn).toHaveBeenCalledWith(
+      'Server session cookie sync failed after token refresh',
+      expect.objectContaining({
+        feature: 'auth',
+        event: 'cookie_sync_failed',
+        route: '/api/auth/refresh',
+      }),
+    );
   });
 });
 

--- a/harmony-frontend/src/__tests__/trpc-client.test.ts
+++ b/harmony-frontend/src/__tests__/trpc-client.test.ts
@@ -2,6 +2,16 @@ jest.mock('next/headers', () => ({
   cookies: jest.fn(),
 }));
 
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+jest.mock('../lib/frontend-logger', () => ({
+  createFrontendLogger: jest.fn(() => mockLogger),
+}));
+
 import { cookies } from 'next/headers';
 import { publicGet, TrpcHttpError, trpcMutate, trpcQuery } from '../lib/trpc-client';
 
@@ -59,6 +69,15 @@ describe('trpc-client', () => {
       mockFetch.mockResolvedValue(createTextResponse('', 500));
 
       await expect(publicGet('/servers/failing')).rejects.toThrow('Public API error: 500');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Public API request failed',
+        expect.objectContaining({
+          feature: 'public-api',
+          event: 'http_failure',
+          route: '/servers/failing',
+          statusCode: 500,
+        }),
+      );
     });
   });
 
@@ -126,6 +145,16 @@ describe('trpc-client', () => {
           status: 403,
         }),
       );
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'tRPC query failed',
+        expect.objectContaining({
+          feature: 'trpc',
+          event: 'http_failure',
+          procedure: 'channel.getChannels',
+          route: '/trpc/channel.getChannels',
+          statusCode: 403,
+        }),
+      );
     });
 
     it('throws when the tRPC query response is missing result.data', async () => {
@@ -136,6 +165,14 @@ describe('trpc-client', () => {
 
       await expect(trpcQuery('channel.getChannels')).rejects.toThrow(
         'tRPC query [channel.getChannels]: response missing result.data',
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'tRPC query response missing result.data',
+        expect.objectContaining({
+          feature: 'trpc',
+          event: 'invalid_response',
+          procedure: 'channel.getChannels',
+        }),
       );
     });
   });
@@ -201,6 +238,16 @@ describe('trpc-client', () => {
           status: 400,
         }),
       );
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'tRPC mutation failed',
+        expect.objectContaining({
+          feature: 'trpc',
+          event: 'http_failure',
+          procedure: 'channel.createChannel',
+          route: '/trpc/channel.createChannel',
+          statusCode: 400,
+        }),
+      );
     });
 
     it('throws when the mutation response is missing result.data', async () => {
@@ -211,6 +258,14 @@ describe('trpc-client', () => {
 
       await expect(trpcMutate('channel.createChannel')).rejects.toThrow(
         'tRPC mutation [channel.createChannel]: response missing result.data',
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'tRPC mutation response missing result.data',
+        expect.objectContaining({
+          feature: 'trpc',
+          event: 'invalid_response',
+          procedure: 'channel.createChannel',
+        }),
       );
     });
   });

--- a/harmony-frontend/src/__tests__/useChannelEvents.test.tsx
+++ b/harmony-frontend/src/__tests__/useChannelEvents.test.tsx
@@ -117,9 +117,11 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockEventSourceInstance = null;
   process.env = { ...originalEnv, NEXT_PUBLIC_API_URL: API_URL };
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 });
 
 afterEach(() => {
+  jest.restoreAllMocks();
   process.env = originalEnv;
 });
 
@@ -303,6 +305,17 @@ describe('useChannelEvents — edge cases', () => {
 
     // Malformed JSON should not call the handler
     expect(onMessageCreated).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      '[frontend]',
+      expect.objectContaining({
+        message: 'Dropped malformed channel SSE payload',
+        fields: expect.objectContaining({
+          feature: 'channel-events',
+          event: 'payload_parse_failed',
+          operation: 'message:created',
+        }),
+      }),
+    );
   });
 
   it('removes event listeners on unmount', () => {
@@ -397,5 +410,31 @@ describe('useChannelEvents — onServerUpdated', () => {
       mockEventSourceInstance!.removeEventListener.mock.calls as [string, unknown][]
     ).map(([type]) => type);
     expect(removedTypes).toContain('server:updated');
+  });
+
+  it('logs when the EventSource connection fails before opening', () => {
+    renderHook(() =>
+      useChannelEvents({
+        channelId: CHANNEL_ID,
+        onMessageCreated: jest.fn(),
+        onMessageEdited: jest.fn(),
+        onMessageDeleted: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateError();
+    });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[frontend]',
+      expect.objectContaining({
+        message: 'Channel SSE connection failed',
+        fields: expect.objectContaining({
+          feature: 'channel-events',
+          event: 'stream_failed',
+        }),
+      }),
+    );
   });
 });

--- a/harmony-frontend/src/__tests__/useServerEvents.test.tsx
+++ b/harmony-frontend/src/__tests__/useServerEvents.test.tsx
@@ -118,9 +118,11 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockEventSourceInstance = null;
   process.env = { ...originalEnv, NEXT_PUBLIC_API_URL: API_URL };
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 });
 
 afterEach(() => {
+  jest.restoreAllMocks();
   process.env = originalEnv;
 });
 
@@ -235,7 +237,10 @@ describe('useServerEvents — channel events', () => {
     );
 
     act(() => {
-      mockEventSourceInstance!.simulateEvent('channel:updated', { ...MOCK_CHANNEL, name: 'renamed' });
+      mockEventSourceInstance!.simulateEvent('channel:updated', {
+        ...MOCK_CHANNEL,
+        name: 'renamed',
+      });
     });
 
     expect(onChannelUpdated).toHaveBeenCalledTimes(1);
@@ -389,6 +394,17 @@ describe('useServerEvents — member events', () => {
     }).not.toThrow();
 
     expect(onMemberJoined).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      '[frontend]',
+      expect.objectContaining({
+        message: 'Dropped malformed server SSE payload',
+        fields: expect.objectContaining({
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          operation: 'member:joined',
+        }),
+      }),
+    );
   });
 });
 
@@ -601,5 +617,31 @@ describe('useServerEvents — channel:visibility-changed events', () => {
     }).not.toThrow();
 
     expect(onChannelVisibilityChanged).not.toHaveBeenCalled();
+  });
+
+  it('logs when the EventSource connection fails before opening', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateError();
+    });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[frontend]',
+      expect.objectContaining({
+        message: 'Server SSE connection failed',
+        fields: expect.objectContaining({
+          feature: 'server-events',
+          event: 'stream_failed',
+        }),
+      }),
+    );
   });
 });

--- a/harmony-frontend/src/app/actions/createChannel.ts
+++ b/harmony-frontend/src/app/actions/createChannel.ts
@@ -13,8 +13,11 @@
  */
 
 import { revalidatePath } from 'next/cache';
+import { createFrontendLogger } from '@/lib/frontend-logger';
 import { ChannelType, ChannelVisibility, type Channel } from '@/types';
 import { createChannel, getChannels } from '@/services/channelService';
+
+const logger = createFrontendLogger({ component: 'create-channel-action' });
 
 export interface CreateChannelInput {
   serverId: string;
@@ -45,20 +48,13 @@ export async function createChannelAction(input: CreateChannelInput): Promise<Ch
 
   // Validate slug: non-empty, starts/ends with alphanumeric, only [a-z0-9-].
   const slug = input.slug;
-  if (
-    !slug ||
-    !/^[a-z0-9]/.test(slug) ||
-    !/[a-z0-9]$/.test(slug) ||
-    /[^a-z0-9-]/.test(slug)
-  ) {
+  if (!slug || !/^[a-z0-9]/.test(slug) || !/[a-z0-9]$/.test(slug) || /[^a-z0-9-]/.test(slug)) {
     throw new Error('Invalid channel name');
   }
 
   // Sanitize topic — clamp to 1024 chars, coerce non-strings to undefined.
   const topic =
-    typeof input.topic === 'string'
-      ? input.topic.trim().slice(0, 1024) || undefined
-      : undefined;
+    typeof input.topic === 'string' ? input.topic.trim().slice(0, 1024) || undefined : undefined;
 
   // Compute position server-side so concurrent creates don't collide on the
   // same client-supplied value.
@@ -83,7 +79,12 @@ export async function createChannelAction(input: CreateChannelInput): Promise<Ch
     revalidatePath(`/settings/${input.serverSlug}`, 'layout');
   } catch (err) {
     // Revalidation failure is non-fatal but log so stale-cache issues are diagnosable.
-    console.error('[createChannelAction] revalidatePath failed:', err instanceof Error ? err.message : err);
+    logger.warn('Channel creation path revalidation failed', {
+      feature: 'next-runtime',
+      event: 'revalidate_failed',
+      route: `/channels/${input.serverSlug}`,
+      error: err,
+    });
   }
 
   return newChannel;

--- a/harmony-frontend/src/app/actions/createChannel.ts
+++ b/harmony-frontend/src/app/actions/createChannel.ts
@@ -73,18 +73,23 @@ export async function createChannelAction(input: CreateChannelInput): Promise<Ch
 
   // Revalidate only the server-scoped paths so unrelated server pages are not
   // unnecessarily invalidated on every channel creation.
-  try {
-    revalidatePath(`/channels/${input.serverSlug}`, 'layout');
-    revalidatePath(`/c/${input.serverSlug}`, 'layout');
-    revalidatePath(`/settings/${input.serverSlug}`, 'layout');
-  } catch (err) {
-    // Revalidation failure is non-fatal but log so stale-cache issues are diagnosable.
-    logger.warn('Channel creation path revalidation failed', {
-      feature: 'next-runtime',
-      event: 'revalidate_failed',
-      route: `/channels/${input.serverSlug}`,
-      error: err,
-    });
+  for (const target of [
+    `/channels/${input.serverSlug}`,
+    `/c/${input.serverSlug}`,
+    `/settings/${input.serverSlug}`,
+  ]) {
+    try {
+      revalidatePath(target, 'layout');
+    } catch (err) {
+      // Revalidation failure is non-fatal but log the exact target so stale-cache
+      // issues can be traced back to the failing path.
+      logger.warn('Channel creation path revalidation failed', {
+        feature: 'next-runtime',
+        event: 'revalidate_failed',
+        route: target,
+        error: err,
+      });
+    }
   }
 
   return newChannel;

--- a/harmony-frontend/src/app/error.tsx
+++ b/harmony-frontend/src/app/error.tsx
@@ -9,6 +9,8 @@
 
 import { useEffect } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { createFrontendLogger } from '@/lib/frontend-logger';
 
 interface ErrorPageProps {
   error: Error & { digest?: string };
@@ -16,10 +18,19 @@ interface ErrorPageProps {
 }
 
 export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  const pathname = usePathname();
+
   useEffect(() => {
-    // Log to an error reporting service in the future
-    console.error('[ErrorPage]', error);
-  }, [error]);
+    createFrontendLogger({ component: 'app-error-boundary' }).error(
+      'Route segment error boundary rendered',
+      {
+        feature: 'react-error-boundary',
+        event: 'render_error_boundary',
+        route: pathname ?? '/',
+        error,
+      },
+    );
+  }, [error, pathname]);
 
   return (
     <div className='flex min-h-screen flex-col items-center justify-center bg-discord-bg-primary px-4 text-center'>

--- a/harmony-frontend/src/app/global-error.tsx
+++ b/harmony-frontend/src/app/global-error.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useEffect } from 'react';
+import { createFrontendLogger } from '@/lib/frontend-logger';
 
 interface ServerErrorPageProps {
   error: Error & { digest?: string };
@@ -17,8 +18,15 @@ interface ServerErrorPageProps {
 
 export default function ServerErrorPage({ error, reset }: ServerErrorPageProps) {
   useEffect(() => {
-    // Log to an error reporting service in the future
-    console.error('[ServerError]', error);
+    createFrontendLogger({ component: 'global-error-boundary' }).error(
+      'Root error boundary rendered',
+      {
+        feature: 'react-error-boundary',
+        event: 'render_root_error_boundary',
+        route: typeof window !== 'undefined' ? window.location.pathname : '/',
+        error,
+      },
+    );
   }, [error]);
 
   return (

--- a/harmony-frontend/src/app/global-error.tsx
+++ b/harmony-frontend/src/app/global-error.tsx
@@ -23,7 +23,7 @@ export default function ServerErrorPage({ error, reset }: ServerErrorPageProps) 
       {
         feature: 'react-error-boundary',
         event: 'render_root_error_boundary',
-        route: typeof window !== 'undefined' ? window.location.pathname : '/',
+        route: window.location.pathname,
         error,
       },
     );

--- a/harmony-frontend/src/contexts/VoiceContext.tsx
+++ b/harmony-frontend/src/contexts/VoiceContext.tsx
@@ -28,8 +28,11 @@ import {
   type ReactNode,
 } from 'react';
 import { apiClient, getAccessToken } from '@/lib/api-client';
+import { createFrontendLogger } from '@/lib/frontend-logger';
 import { useToast } from '@/hooks/useToast';
 import { getApiBaseUrl } from '@/lib/runtime-config';
+
+const logger = createFrontendLogger({ component: 'voice-context' });
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -106,7 +109,9 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
   const [connectedChannelId, setConnectedChannelId] = useState<string | null>(null);
   const [connectedChannelName, setConnectedChannelName] = useState<string | null>(null);
   const [participants, setParticipants] = useState<VoiceParticipant[]>([]);
-  const [channelParticipants, setChannelParticipants] = useState<Record<string, VoiceParticipant[]>>({});
+  const [channelParticipants, setChannelParticipants] = useState<
+    Record<string, VoiceParticipant[]>
+  >({});
   const [dominantSpeakerId, setDominantSpeakerId] = useState<string | null>(null);
   const [localSpeaking, setLocalSpeaking] = useState(false);
   const [isMuted, setIsMutedState] = useState(false);
@@ -152,10 +157,12 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
           .trpcQuery<VoiceParticipant[]>('voice.getParticipants', { serverId, channelId })
           .then(ps => setChannelParticipants(prev => ({ ...prev, [channelId]: ps })))
           .catch((err: unknown) => {
-            console.error(
-              '[VoiceContext] getParticipants error for', channelId,
-              err instanceof Error ? err.message : err,
-            );
+            logger.warn('Voice participants fetch failed', {
+              feature: 'voice',
+              event: 'participants_fetch_failed',
+              operation: 'voice.getParticipants',
+              error: err,
+            });
           }),
       ),
     );
@@ -163,7 +170,7 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
 
   const resetVoiceState = useCallback(() => {
     // Detach all remote audio elements before clearing other state.
-    remoteAudioTracksRef.current.forEach((tracks) => {
+    remoteAudioTracksRef.current.forEach(tracks => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       tracks.forEach((track: any) => {
         track.detach().forEach((el: HTMLAudioElement) => el.remove());
@@ -222,8 +229,12 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
         await apiClient.trpcMutation('voice.leave', { channelId, serverId });
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      console.error('[VoiceContext] leave error:', message);
+      logger.warn('Voice leave mutation failed', {
+        feature: 'voice',
+        event: 'leave_failed',
+        operation: 'voice.leave',
+        error: err,
+      });
     } finally {
       // Remove local user from channelParticipants so the sidebar updates immediately.
       // Must happen before resetVoiceState, which clears localParticipantIdentityRef.
@@ -288,8 +299,9 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
         // Start local audio level detection for the speaking ring.
         // Web Audio API is used instead of relying solely on Twilio's dominantSpeakerChanged,
         // which requires multiple participants and doesn't fire for the local user alone.
-        const mediaTrack = (localAudioTrackRef.current as { mediaStreamTrack?: MediaStreamTrack } | null)
-          ?.mediaStreamTrack;
+        const mediaTrack = (
+          localAudioTrackRef.current as { mediaStreamTrack?: MediaStreamTrack } | null
+        )?.mediaStreamTrack;
         if (mediaTrack) {
           try {
             // Pin to 48 kHz — WebRTC's native rate — so the OS audio driver does not
@@ -327,15 +339,23 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
               }
             }, 100);
           } catch (e) {
-            console.error('[VoiceContext] audio level detection setup error:', e);
+            logger.warn('Voice speaking detection setup failed', {
+              feature: 'voice',
+              event: 'speaking_detection_setup_failed',
+              operation: 'audio-level-detection',
+              error: e,
+            });
           }
         }
-
 
         // Merge remote participants already in the room and attach their audio.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         room.participants.forEach((participant: any) => {
-          const newEntry: VoiceParticipant = { userId: participant.identity, muted: false, deafened: false };
+          const newEntry: VoiceParticipant = {
+            userId: participant.identity,
+            muted: false,
+            deafened: false,
+          };
           setParticipants(prev =>
             prev.some(p => p.userId === participant.identity) ? prev : [...prev, newEntry],
           );
@@ -359,7 +379,11 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         room.on('participantConnected', (participant: any) => {
-          const newEntry: VoiceParticipant = { userId: participant.identity, muted: false, deafened: false };
+          const newEntry: VoiceParticipant = {
+            userId: participant.identity,
+            muted: false,
+            deafened: false,
+          };
           setParticipants(prev =>
             prev.some(p => p.userId === participant.identity) ? prev : [...prev, newEntry],
           );
@@ -442,18 +466,32 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
           resetVoiceState();
           // Fire-and-forget: keep Redis in sync on unexpected disconnect.
           if (cId && sId) {
-            apiClient.trpcMutation('voice.leave', { channelId: cId, serverId: sId }).catch((err: unknown) => {
-              console.error('[VoiceContext] disconnect leave error:', err instanceof Error ? err.message : err);
-            });
+            apiClient
+              .trpcMutation('voice.leave', { channelId: cId, serverId: sId })
+              .catch((err: unknown) => {
+                logger.warn('Voice disconnect cleanup failed', {
+                  feature: 'voice',
+                  event: 'disconnect_leave_failed',
+                  operation: 'voice.leave',
+                  error: err,
+                });
+              });
           }
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error';
-        console.error('[VoiceContext] joinChannel error:', message, err);
+        logger.error('Voice channel join failed', {
+          feature: 'voice',
+          event: 'join_failed',
+          operation: 'voice.join',
+          error: err,
+        });
         // Distinguish getUserMedia device errors from Twilio server errors for actionable toasts.
         const isDeviceError =
           err instanceof DOMException &&
-          (err.name === 'NotFoundError' || err.name === 'NotReadableError' || err.name === 'OverconstrainedError' || err.name === 'NotAllowedError');
+          (err.name === 'NotFoundError' ||
+            err.name === 'NotReadableError' ||
+            err.name === 'OverconstrainedError' ||
+            err.name === 'NotAllowedError');
         const toastMessage = isDeviceError
           ? err instanceof DOMException && err.name === 'NotAllowedError'
             ? 'Microphone access denied. Click the lock icon in your address bar and allow microphone permission, then try again.'
@@ -488,7 +526,7 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
     const localIdentity = localParticipantIdentityRef.current;
     const channelId = connectedChannelIdRef.current;
     if (localIdentity) {
-      setParticipants(prev => prev.map(p => p.userId === localIdentity ? { ...p, muted } : p));
+      setParticipants(prev => prev.map(p => (p.userId === localIdentity ? { ...p, muted } : p)));
       if (channelId) {
         setChannelParticipants(prev => ({
           ...prev,
@@ -517,7 +555,9 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
         isMutedRef.current = !muted;
         setIsMutedState(!muted);
         if (localIdentity) {
-          setParticipants(prev => prev.map(p => p.userId === localIdentity ? { ...p, muted: !muted } : p));
+          setParticipants(prev =>
+            prev.map(p => (p.userId === localIdentity ? { ...p, muted: !muted } : p)),
+          );
           if (channelId) {
             setChannelParticipants(prev => ({
               ...prev,
@@ -527,8 +567,12 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
             }));
           }
         }
-        const message = err instanceof Error ? err.message : 'Unknown error';
-        console.error('[VoiceContext] updateState (mute) error:', message);
+        logger.warn('Voice mute update failed', {
+          feature: 'voice',
+          event: 'mute_update_failed',
+          operation: 'voice.updateState',
+          error: err,
+        });
       }
     }
   }, []);
@@ -556,7 +600,7 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
     const localIdentity = localParticipantIdentityRef.current;
     const channelId = connectedChannelIdRef.current;
     if (localIdentity) {
-      setParticipants(prev => prev.map(p => p.userId === localIdentity ? { ...p, deafened } : p));
+      setParticipants(prev => prev.map(p => (p.userId === localIdentity ? { ...p, deafened } : p)));
       if (channelId) {
         setChannelParticipants(prev => ({
           ...prev,
@@ -582,7 +626,9 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
         isDeafenedRef.current = !deafened;
         setIsDeafenedState(!deafened);
         if (localIdentity) {
-          setParticipants(prev => prev.map(p => p.userId === localIdentity ? { ...p, deafened: !deafened } : p));
+          setParticipants(prev =>
+            prev.map(p => (p.userId === localIdentity ? { ...p, deafened: !deafened } : p)),
+          );
           if (channelId) {
             setChannelParticipants(prev => ({
               ...prev,
@@ -592,8 +638,12 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
             }));
           }
         }
-        const message = err instanceof Error ? err.message : 'Unknown error';
-        console.error('[VoiceContext] updateState (deafen) error:', message);
+        logger.warn('Voice deafen update failed', {
+          feature: 'voice',
+          event: 'deafen_update_failed',
+          operation: 'voice.updateState',
+          error: err,
+        });
       }
     }
   }, []);
@@ -613,7 +663,12 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
       // Cannot await in a cleanup function, so errors are logged only.
       if (channelId && serverId) {
         apiClient.trpcMutation('voice.leave', { channelId, serverId }).catch((err: unknown) => {
-          console.error('[VoiceContext] unmount leave error:', err instanceof Error ? err.message : err);
+          logger.warn('Voice unmount cleanup failed', {
+            feature: 'voice',
+            event: 'unmount_leave_failed',
+            operation: 'voice.leave',
+            error: err,
+          });
         });
       }
     };
@@ -632,10 +687,19 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
       const baseUrl = getApiBaseUrl();
       fetch(`${baseUrl}/trpc/voice.leave`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
         body: JSON.stringify({ channelId, serverId }),
         keepalive: true,
-      }).catch(() => { /* fire-and-forget */ });
+      }).catch(error => {
+        logger.warn('Voice keepalive leave request failed', {
+          feature: 'voice',
+          event: 'keepalive_leave_failed',
+          operation: 'voice.leave',
+          source: 'beforeunload',
+          target: '/trpc/voice.leave',
+          error,
+        });
+      });
     }
 
     window.addEventListener('beforeunload', handleBeforeUnload);

--- a/harmony-frontend/src/hooks/useChannelEvents.ts
+++ b/harmony-frontend/src/hooks/useChannelEvents.ts
@@ -20,7 +20,10 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { Message } from '@/types/message';
 import type { Server } from '@/types/server';
 import { getAccessToken } from '@/lib/api-client';
+import { createFrontendLogger } from '@/lib/frontend-logger';
 import { getApiBaseUrl } from '@/lib/runtime-config';
+
+const logger = createFrontendLogger({ component: 'use-channel-events' });
 
 export interface UseChannelEventsOptions {
   channelId: string;
@@ -77,8 +80,15 @@ export function useChannelEvents({
       try {
         const msg = JSON.parse(event.data) as Message;
         onCreatedRef.current(msg);
-      } catch {
-        // Ignore malformed payloads — server bug or network corruption
+      } catch (error) {
+        logger.warn('Dropped malformed channel SSE payload', {
+          feature: 'channel-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'message:created',
+          target: '/api/events/channel/[channelId]',
+          error,
+        });
       }
     };
 
@@ -86,8 +96,15 @@ export function useChannelEvents({
       try {
         const msg = JSON.parse(event.data) as Message;
         onEditedRef.current(msg);
-      } catch {
-        // Ignore malformed payloads
+      } catch (error) {
+        logger.warn('Dropped malformed channel SSE payload', {
+          feature: 'channel-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'message:edited',
+          target: '/api/events/channel/[channelId]',
+          error,
+        });
       }
     };
 
@@ -95,8 +112,15 @@ export function useChannelEvents({
       try {
         const payload = JSON.parse(event.data) as { messageId: string };
         onDeletedRef.current(payload.messageId);
-      } catch {
-        // Ignore malformed payloads
+      } catch (error) {
+        logger.warn('Dropped malformed channel SSE payload', {
+          feature: 'channel-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'message:deleted',
+          target: '/api/events/channel/[channelId]',
+          error,
+        });
       }
     };
 
@@ -104,8 +128,15 @@ export function useChannelEvents({
       try {
         const server = JSON.parse(event.data) as Server;
         onServerUpdatedRef.current?.(server);
-      } catch {
-        // Ignore malformed payloads
+      } catch (error) {
+        logger.warn('Dropped malformed channel SSE payload', {
+          feature: 'channel-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'server:updated',
+          target: '/api/events/channel/[channelId]',
+          error,
+        });
       }
     };
 
@@ -126,6 +157,12 @@ export function useChannelEvents({
     };
     es.onerror = () => {
       setIsConnected(false);
+      logger.warn('Channel SSE connection failed', {
+        feature: 'channel-events',
+        event: everOpened ? 'stream_disconnected' : 'stream_failed',
+        source: 'sse',
+        target: '/api/events/channel/[channelId]',
+      });
       if (!everOpened) {
         // Never successfully opened — likely a 401/403. Stop retrying.
         es.close();

--- a/harmony-frontend/src/hooks/useServerEvents.ts
+++ b/harmony-frontend/src/hooks/useServerEvents.ts
@@ -29,7 +29,10 @@ import { useEffect, useLayoutEffect, useRef } from 'react';
 import type { Channel, ChannelVisibility } from '@/types/channel';
 import type { User, UserStatus } from '@/types/user';
 import { getAccessToken } from '@/lib/api-client';
+import { createFrontendLogger } from '@/lib/frontend-logger';
 import { getApiBaseUrl } from '@/lib/runtime-config';
+
+const logger = createFrontendLogger({ component: 'use-server-events' });
 
 export interface UseServerEventsOptions {
   serverId: string;
@@ -96,8 +99,15 @@ export function useServerEvents({
       try {
         const channel = JSON.parse(event.data) as Channel;
         onCreatedRef.current(channel);
-      } catch {
-        // Ignore malformed payloads
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'channel:created',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
       }
     };
 
@@ -105,8 +115,15 @@ export function useServerEvents({
       try {
         const channel = JSON.parse(event.data) as Channel;
         onUpdatedRef.current(channel);
-      } catch {
-        // Ignore malformed payloads
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'channel:updated',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
       }
     };
 
@@ -114,8 +131,15 @@ export function useServerEvents({
       try {
         const payload = JSON.parse(event.data) as { channelId: string };
         onDeletedRef.current(payload.channelId);
-      } catch {
-        // Ignore malformed payloads
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'channel:deleted',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
       }
     };
 
@@ -123,8 +147,15 @@ export function useServerEvents({
       try {
         const user = JSON.parse(event.data) as User;
         onMemberJoinedRef.current?.(user);
-      } catch {
-        // Ignore malformed payloads
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'member:joined',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
       }
     };
 
@@ -132,8 +163,15 @@ export function useServerEvents({
       try {
         const payload = JSON.parse(event.data) as { userId: string };
         onMemberLeftRef.current?.(payload.userId);
-      } catch {
-        // Ignore malformed payloads
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'member:left',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
       }
     };
 
@@ -141,8 +179,15 @@ export function useServerEvents({
       try {
         const payload = JSON.parse(event.data) as { id: string; status: UserStatus };
         onMemberStatusChangedRef.current?.(payload);
-      } catch {
-        // Ignore malformed payloads
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'member:statusChanged',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
       }
     };
 
@@ -152,8 +197,15 @@ export function useServerEvents({
         const payload = JSON.parse(event.data) as Channel & { oldVisibility: ChannelVisibility };
         const { oldVisibility, ...channel } = payload;
         onVisibilityChangedRef.current?.(channel, oldVisibility);
-      } catch {
-        // Ignore malformed payloads
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'channel:visibility-changed',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
       }
     };
 
@@ -171,6 +223,12 @@ export function useServerEvents({
       everOpened = true;
     };
     es.onerror = () => {
+      logger.warn('Server SSE connection failed', {
+        feature: 'server-events',
+        event: everOpened ? 'stream_disconnected' : 'stream_failed',
+        source: 'sse',
+        target: '/api/events/server/[serverId]',
+      });
       if (!everOpened) {
         // Never successfully opened — likely 401/403. Stop retrying.
         es.close();

--- a/harmony-frontend/src/lib/api-client.ts
+++ b/harmony-frontend/src/lib/api-client.ts
@@ -4,6 +4,7 @@ import axios, {
   type InternalAxiosRequestConfig,
 } from 'axios';
 import { API_CONFIG } from './constants';
+import { createFrontendLogger } from './frontend-logger';
 import { setSessionCookie } from '@/app/actions/session';
 
 // ─── Token storage ────────────────────────────────────────────────────────────
@@ -12,6 +13,7 @@ import { setSessionCookie } from '@/app/actions/session';
 // Refresh token is stored in localStorage so users stay logged-in across reloads.
 
 const REFRESH_TOKEN_KEY = 'harmony_refresh_token';
+const logger = createFrontendLogger({ component: 'api-client' });
 
 let _accessToken: string | null = null;
 let _isRefreshing = false;
@@ -93,10 +95,25 @@ class ApiClient {
       response => response,
       async error => {
         const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+        const statusCode =
+          typeof error.response?.status === 'number' ? error.response.status : undefined;
+        const method =
+          typeof originalRequest?.method === 'string'
+            ? originalRequest.method.toUpperCase()
+            : undefined;
+        const route = typeof originalRequest?.url === 'string' ? originalRequest.url : undefined;
 
-        if (error.response?.status === 401 && !originalRequest._retry) {
+        if (statusCode === 401 && !originalRequest._retry) {
           const refreshToken = getRefreshToken();
           if (!refreshToken) {
+            logger.warn('Auth session refresh skipped because no refresh token is stored', {
+              feature: 'auth',
+              event: 'refresh_skipped',
+              method,
+              route,
+              statusCode,
+              reason: 'missing_refresh_token',
+            });
             clearTokens();
             return Promise.reject(error);
           }
@@ -131,17 +148,33 @@ class ApiClient {
             // the in-memory token is refreshed and all server-side calls return 401.
             try {
               await setSessionCookie(newAt);
-            } catch {
+            } catch (sessionError) {
               // Best-effort — if the Server Action fails, keep going. The in-memory token
               // is still valid for client-side calls; the user may see a 401 on the next
               // server-side render but a page refresh will recover.
+              logger.warn('Server session cookie sync failed after token refresh', {
+                feature: 'auth',
+                event: 'cookie_sync_failed',
+                method: 'POST',
+                route: '/api/auth/refresh',
+                retryCount: 1,
+                error: sessionError,
+              });
             }
             notifyRefreshQueue(newAt);
 
             originalRequest.headers = originalRequest.headers ?? {};
             originalRequest.headers.Authorization = `Bearer ${newAt}`;
             return this.client(originalRequest);
-          } catch {
+          } catch (refreshError) {
+            logger.error('Auth session refresh failed', {
+              feature: 'auth',
+              event: 'refresh_failed',
+              method: 'POST',
+              route: '/api/auth/refresh',
+              retryCount: 1,
+              error: refreshError,
+            });
             clearTokens();
             notifyRefreshQueue(null);
             if (typeof window !== 'undefined') {
@@ -151,6 +184,17 @@ class ApiClient {
           } finally {
             _isRefreshing = false;
           }
+        }
+
+        if (statusCode === undefined || statusCode >= 500) {
+          logger.error('Browser API request failed', {
+            feature: 'browser-api',
+            event: 'request_failed',
+            method,
+            route,
+            statusCode,
+            error,
+          });
         }
 
         return Promise.reject(error);

--- a/harmony-frontend/src/lib/frontend-logger.ts
+++ b/harmony-frontend/src/lib/frontend-logger.ts
@@ -1,0 +1,149 @@
+type FrontendLogLevel = 'info' | 'warn' | 'error';
+type FrontendRuntime = 'browser' | 'next-server';
+type FrontendLogValue = string | number | boolean;
+
+export interface FrontendLogEntry {
+  service: 'frontend';
+  runtime: FrontendRuntime;
+  level: FrontendLogLevel;
+  message: string;
+  timestamp: string;
+  fields: Record<string, FrontendLogValue>;
+}
+
+export interface FrontendLogger {
+  info: (message: string, metadata?: Record<string, unknown>) => void;
+  warn: (message: string, metadata?: Record<string, unknown>) => void;
+  error: (message: string, metadata?: Record<string, unknown>) => void;
+}
+
+const PATH_FIELDS = new Set(['route', 'target']);
+const ALLOWED_METADATA_KEYS = new Set([
+  'attempt',
+  'component',
+  'correlationId',
+  'digest',
+  'errorCode',
+  'errorName',
+  'event',
+  'feature',
+  'method',
+  'operation',
+  'phase',
+  'procedure',
+  'reason',
+  'requestId',
+  'retryCount',
+  'route',
+  'scope',
+  'source',
+  'statusCode',
+  'target',
+  'transport',
+]);
+
+function detectRuntime(): FrontendRuntime {
+  return typeof window === 'undefined' ? 'next-server' : 'browser';
+}
+
+function toSafePath(value: string): string {
+  try {
+    if (/^https?:\/\//.test(value)) {
+      return new URL(value).pathname || '/';
+    }
+  } catch {}
+
+  const [withoutQuery] = value.split(/[?#]/, 1);
+  return withoutQuery || '/';
+}
+
+function toSafeLogValue(key: string, value: unknown): FrontendLogValue | undefined {
+  if (typeof value === 'string') {
+    return PATH_FIELDS.has(key) ? toSafePath(value) : value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  return undefined;
+}
+
+function extractSafeErrorFields(error: unknown): Record<string, FrontendLogValue> {
+  if (!error || typeof error !== 'object') {
+    return {};
+  }
+
+  const candidate = error as Record<string, unknown>;
+  const safeFields: Record<string, FrontendLogValue> = {};
+
+  if (typeof candidate.name === 'string') safeFields.errorName = candidate.name;
+  if (typeof candidate.code === 'string') safeFields.errorCode = candidate.code;
+  if (typeof candidate.digest === 'string') safeFields.digest = candidate.digest;
+  if (typeof candidate.status === 'number') safeFields.statusCode = candidate.status;
+
+  return safeFields;
+}
+
+export function sanitizeLogMetadata(
+  metadata: Record<string, unknown> = {},
+): Record<string, FrontendLogValue> {
+  const safeFields: Record<string, FrontendLogValue> = {};
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (key === 'error' || key === 'err') {
+      Object.assign(safeFields, extractSafeErrorFields(value));
+      continue;
+    }
+
+    if (!ALLOWED_METADATA_KEYS.has(key)) {
+      continue;
+    }
+
+    const safeValue = toSafeLogValue(key, value);
+    if (safeValue !== undefined) {
+      safeFields[key] = safeValue;
+    }
+  }
+
+  return safeFields;
+}
+
+export function buildFrontendLogEntry(
+  level: FrontendLogLevel,
+  message: string,
+  metadata: Record<string, unknown> = {},
+): FrontendLogEntry {
+  return {
+    service: 'frontend',
+    runtime: detectRuntime(),
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    fields: sanitizeLogMetadata(metadata),
+  };
+}
+
+function writeLog(
+  level: FrontendLogLevel,
+  message: string,
+  metadata?: Record<string, unknown>,
+): void {
+  const entry = buildFrontendLogEntry(level, message, metadata);
+  const writer = console[level] ?? console.error;
+  writer('[frontend]', entry);
+}
+
+export function createFrontendLogger(bindings: Record<string, unknown> = {}): FrontendLogger {
+  return {
+    info(message, metadata) {
+      writeLog('info', message, { ...bindings, ...metadata });
+    },
+    warn(message, metadata) {
+      writeLog('warn', message, { ...bindings, ...metadata });
+    },
+    error(message, metadata) {
+      writeLog('error', message, { ...bindings, ...metadata });
+    },
+  };
+}

--- a/harmony-frontend/src/lib/trpc-client.ts
+++ b/harmony-frontend/src/lib/trpc-client.ts
@@ -10,9 +10,12 @@
 
 import { API_CONFIG } from './constants';
 import { cookies } from 'next/headers';
+import { createFrontendLogger } from './frontend-logger';
 import { TrpcHttpError } from './trpc-errors';
 
 export { TrpcHttpError } from './trpc-errors';
+
+const logger = createFrontendLogger({ component: 'trpc-client' });
 
 // ─── Auth helper ──────────────────────────────────────────────────────────────
 
@@ -39,19 +42,38 @@ async function getAuthToken(): Promise<string | undefined> {
 export async function publicGet<T>(path: string): Promise<T | null> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 10_000);
+  let res: Response;
   try {
-    const res = await fetch(`${API_CONFIG.BASE_URL}/api/public${path}`, {
+    res = await fetch(`${API_CONFIG.BASE_URL}/api/public${path}`, {
       next: { revalidate: 60 }, // ISR: revalidate every 60s
       signal: controller.signal,
     });
-    if (!res.ok) {
-      if (res.status === 404) return null;
-      throw new Error(`Public API error: ${res.status}`);
-    }
-    return res.json() as Promise<T>;
+  } catch (error) {
+    logger.error('Public API request threw before completion', {
+      feature: 'public-api',
+      event: 'request_exception',
+      method: 'GET',
+      route: path,
+      error,
+    });
+    throw error;
   } finally {
     clearTimeout(timeoutId);
   }
+
+  if (!res.ok) {
+    if (res.status === 404) return null;
+    logger.warn('Public API request failed', {
+      feature: 'public-api',
+      event: 'http_failure',
+      method: 'GET',
+      route: path,
+      statusCode: res.status,
+    });
+    throw new Error(`Public API error: ${res.status}`);
+  }
+
+  return res.json() as Promise<T>;
 }
 
 // ─── tRPC HTTP helpers ────────────────────────────────────────────────────────
@@ -81,19 +103,45 @@ export async function trpcQuery<T>(procedure: string, input?: unknown): Promise<
       cache: 'no-store',
       signal: controller.signal,
     });
+  } catch (error) {
+    logger.error('tRPC query request threw before completion', {
+      feature: 'trpc',
+      event: 'request_exception',
+      method: 'GET',
+      procedure,
+      route: `/trpc/${procedure}`,
+      error,
+    });
+    throw error;
   } finally {
     clearTimeout(timeoutId);
   }
 
   if (!res.ok) {
     const body = await res.text();
+    logger.warn('tRPC query failed', {
+      feature: 'trpc',
+      event: 'http_failure',
+      method: 'GET',
+      procedure,
+      route: `/trpc/${procedure}`,
+      statusCode: res.status,
+    });
     throw new TrpcHttpError(procedure, res.status, body);
   }
 
   const json = await res.json();
   const data = json.result?.data;
-  if (data === undefined)
+  if (data === undefined) {
+    logger.error('tRPC query response missing result.data', {
+      feature: 'trpc',
+      event: 'invalid_response',
+      method: 'GET',
+      procedure,
+      route: `/trpc/${procedure}`,
+    });
     throw new Error(`tRPC query [${procedure}]: response missing result.data`);
+  }
   return data as T;
 }
 
@@ -119,18 +167,44 @@ export async function trpcMutate<T>(procedure: string, input?: unknown): Promise
       body: JSON.stringify(input ?? {}),
       signal: controller.signal,
     });
+  } catch (error) {
+    logger.error('tRPC mutation request threw before completion', {
+      feature: 'trpc',
+      event: 'request_exception',
+      method: 'POST',
+      procedure,
+      route: `/trpc/${procedure}`,
+      error,
+    });
+    throw error;
   } finally {
     clearTimeout(timeoutId);
   }
 
   if (!res.ok) {
     const body = await res.text();
+    logger.warn('tRPC mutation failed', {
+      feature: 'trpc',
+      event: 'http_failure',
+      method: 'POST',
+      procedure,
+      route: `/trpc/${procedure}`,
+      statusCode: res.status,
+    });
     throw new TrpcHttpError(procedure, res.status, body);
   }
 
   const json = await res.json();
   const data = json.result?.data;
-  if (data === undefined)
+  if (data === undefined) {
+    logger.error('tRPC mutation response missing result.data', {
+      feature: 'trpc',
+      event: 'invalid_response',
+      method: 'POST',
+      procedure,
+      route: `/trpc/${procedure}`,
+    });
     throw new Error(`tRPC mutation [${procedure}]: response missing result.data`);
+  }
   return data as T;
 }

--- a/harmony-frontend/src/services/channelService.ts
+++ b/harmony-frontend/src/services/channelService.ts
@@ -5,8 +5,11 @@
  */
 
 import { cache } from 'react';
+import { createFrontendLogger } from '@/lib/frontend-logger';
 import { ChannelVisibility, type Channel } from '@/types';
 import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+
+const logger = createFrontendLogger({ component: 'channel-service' });
 
 // ─── Type adapters ────────────────────────────────────────────────────────────
 
@@ -104,10 +107,13 @@ export const getChannel = cache(
       if (!data) return null;
       return toFrontendChannel(data);
     } catch (error) {
-      console.error(
-        `[channelService.getChannel] API call failed for "${serverSlug}/${channelSlug}":`,
+      logger.warn('Channel lookup failed', {
+        feature: 'channel-service',
+        event: 'get_channel_failed',
+        procedure: 'channel.getChannel',
+        route: '/trpc/channel.getChannel',
         error,
-      );
+      });
       return null;
     }
   },

--- a/harmony-frontend/src/services/messageService.ts
+++ b/harmony-frontend/src/services/messageService.ts
@@ -4,8 +4,11 @@
  * References: dev-spec-guest-public-channel-view.md
  */
 
+import { createFrontendLogger } from '@/lib/frontend-logger';
 import type { Message } from '@/types';
 import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+
+const logger = createFrontendLogger({ component: 'message-service' });
 
 // ─── Type adapters ────────────────────────────────────────────────────────────
 
@@ -13,8 +16,10 @@ import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
 function toFrontendMessage(raw: Record<string, unknown>, fallbackChannelId = ''): Message {
   // Warn on missing required fields to catch backend shape mismatches early.
   if (typeof raw.id !== 'string') console.warn('[toFrontendMessage] missing or non-string "id"');
-  if (!raw.channelId && !raw.channel_id && !fallbackChannelId) console.warn('[toFrontendMessage] missing "channelId"/"channel_id"');
-  if (!raw.createdAt && !raw.created_at && !raw.timestamp) console.warn('[toFrontendMessage] missing timestamp field');
+  if (!raw.channelId && !raw.channel_id && !fallbackChannelId)
+    console.warn('[toFrontendMessage] missing "channelId"/"channel_id"');
+  if (!raw.createdAt && !raw.created_at && !raw.timestamp)
+    console.warn('[toFrontendMessage] missing timestamp field');
   const author = raw.author as Record<string, unknown> | undefined;
   return {
     id: raw.id as string,
@@ -57,19 +62,29 @@ export async function getMessages(
 
     // null means HTTP 404 — channel not found on public API. Throw so the catch
     // block can attempt the tRPC fallback (or re-throw if no serverId).
-    if (data === null) throw new Error(`getMessages: public channel not found for channelId=${channelId}`);
+    if (data === null)
+      throw new Error(`getMessages: public channel not found for channelId=${channelId}`);
 
     return {
       // Public endpoint returns newest-first; populate channelId from param since
       // the backend select does not include it.
-      messages: data.messages.map((m) => toFrontendMessage(m, channelId)),
+      messages: data.messages.map(m => toFrontendMessage(m, channelId)),
       hasMore: data.messages.length >= (data.pageSize ?? 50),
     };
   } catch (err) {
     // Public endpoint unavailable or channel is not PUBLIC_INDEXABLE — try tRPC.
-    console.warn('[getMessages] public endpoint failed, falling back to tRPC:', err instanceof Error ? err.message : err);
+    logger.warn('Public message fetch failed; falling back to tRPC', {
+      feature: 'message-service',
+      event: 'public_fetch_failed',
+      procedure: 'publicGet',
+      route: '/channels/[channelId]/messages',
+      error: err,
+    });
     // If serverId is not provided we cannot authenticate, so re-throw.
-    if (!options?.serverId) throw new Error('getMessages: channel is not publicly accessible and no serverId was provided');
+    if (!options?.serverId)
+      throw new Error(
+        'getMessages: channel is not publicly accessible and no serverId was provided',
+      );
 
     // tRPC errors propagate to the caller.
     const data = await trpcQuery<{
@@ -80,12 +95,13 @@ export async function getMessages(
       channelId,
       limit: 50,
     });
-    if (data === null) throw new Error(`getMessages: tRPC returned no data for channelId=${channelId}`);
+    if (data === null)
+      throw new Error(`getMessages: tRPC returned no data for channelId=${channelId}`);
     // tRPC backend returns oldest-first (orderBy createdAt: 'asc'); reverse to
     // match the public endpoint's newest-first ordering so callers get a
     // consistent contract regardless of which path was taken.
     return {
-      messages: [...data.messages].reverse().map((m) => toFrontendMessage(m, channelId)),
+      messages: [...data.messages].reverse().map(m => toFrontendMessage(m, channelId)),
       hasMore: !!data.nextCursor,
     };
   }
@@ -113,10 +129,7 @@ export async function sendMessage(
 /**
  * Deletes a message by ID via tRPC. Returns true if deleted.
  */
-export async function deleteMessage(
-  id: string,
-  serverId?: string,
-): Promise<boolean> {
+export async function deleteMessage(id: string, serverId?: string): Promise<boolean> {
   if (!serverId) {
     throw new Error('serverId is required for deleteMessage');
   }

--- a/harmony-frontend/src/services/serverService.ts
+++ b/harmony-frontend/src/services/serverService.ts
@@ -5,8 +5,11 @@
  */
 
 import { cache } from 'react';
+import { createFrontendLogger } from '@/lib/frontend-logger';
 import type { Server, User, CreateServerInput, ServerMemberInfo } from '@/types';
 import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+
+const logger = createFrontendLogger({ component: 'server-service' });
 
 // ─── Type adapters ────────────────────────────────────────────────────────────
 
@@ -15,7 +18,8 @@ function toFrontendServer(raw: Record<string, unknown>): Server {
   // Warn on missing required fields to catch backend shape mismatches early.
   if (typeof raw.id !== 'string') console.warn('[toFrontendServer] missing or non-string "id"');
   if (typeof raw.slug !== 'string') console.warn('[toFrontendServer] missing or non-string "slug"');
-  if (typeof raw.createdAt !== 'string') console.warn('[toFrontendServer] missing or non-string "createdAt"');
+  if (typeof raw.createdAt !== 'string')
+    console.warn('[toFrontendServer] missing or non-string "createdAt"');
   return {
     id: raw.id as string,
     name: raw.name as string,
@@ -52,7 +56,13 @@ export const getServer = cache(async (slug: string): Promise<Server | null> => {
     if (!data) return null;
     return toFrontendServer(data);
   } catch (error) {
-    console.error(`[serverService.getServer] API call failed for slug "${slug}":`, error);
+    logger.warn('Public server lookup failed', {
+      feature: 'server-service',
+      event: 'get_server_failed',
+      procedure: 'publicGet',
+      route: '/servers/[slug]',
+      error,
+    });
     return null;
   }
 });
@@ -110,7 +120,14 @@ export async function getServerAuthenticated(slug: string): Promise<Server | nul
     const data = await trpcQuery<Record<string, unknown>>('server.getServer', { slug });
     if (!data) return null;
     return toFrontendServer(data);
-  } catch {
+  } catch (error) {
+    logger.warn('Authenticated server lookup failed', {
+      feature: 'server-service',
+      event: 'get_server_authenticated_failed',
+      procedure: 'server.getServer',
+      route: '/trpc/server.getServer',
+      error,
+    });
     return null;
   }
 }
@@ -125,7 +142,13 @@ export async function getServerMembers(serverId: string): Promise<User[]> {
     const data = await trpcQuery<BackendServerMember[]>('server.getMembers', { serverId });
     return (data ?? []).map(toFrontendMember);
   } catch (error) {
-    console.warn('[serverService.getServerMembers] failed, returning []:', error);
+    logger.warn('Server member lookup failed; returning []', {
+      feature: 'server-service',
+      event: 'get_server_members_failed',
+      procedure: 'server.getMembers',
+      route: '/trpc/server.getMembers',
+      error,
+    });
     return [];
   }
 }
@@ -190,13 +213,15 @@ const BACKEND_ROLE_MAP: Record<string, ServerMemberInfo['role']> = {
  * Returns all members of a server with their role info, sorted by role hierarchy.
  */
 export async function getServerMembersWithRole(serverId: string): Promise<ServerMemberInfo[]> {
-  const data = await trpcQuery<Array<{
-    userId: string;
-    serverId: string;
-    role: string;
-    joinedAt: string;
-    user: { id: string; username: string; displayName: string; avatarUrl: string | null };
-  }>>('serverMember.getMembers', { serverId });
+  const data = await trpcQuery<
+    Array<{
+      userId: string;
+      serverId: string;
+      role: string;
+      joinedAt: string;
+      user: { id: string; username: string; displayName: string; avatarUrl: string | null };
+    }>
+  >('serverMember.getMembers', { serverId });
   return (data ?? []).map(m => ({
     userId: m.userId,
     username: m.user.username,


### PR DESCRIPTION
## Summary
Adds a frontend-safe structured logger for the Next.js app and integrates it into the highest-value frontend/runtime failure paths.

## What Changed
- added a shared frontend logger with whitelist-based metadata sanitization
- stripped query strings from logged routes/targets and only kept safe error fields like `name`, `status`, and `digest`
- wired structured logging into App Router error boundaries, browser API/tRPC failures, SSE/connectivity failures, Next runtime revalidation failures, and voice cleanup/connectivity failures
- added regression tests for sanitization and the new logging paths

## Privacy Constraints
- does not intentionally log emails, usernames, message content, tokens, cookies, auth headers, raw request/response bodies, or raw error payloads
- only logs operational metadata such as component, feature, route path, event type, procedure, method, and status code

## Why
Frontend failures were still difficult to diagnose in production, and the backend logging work already established the need for structured observability. The frontend needed a separate implementation with stricter privacy boundaries.

## Validation
- `npx tsc --noEmit`
- `npm run lint`
- `npm test -- --runInBand`

Closes #343.