### PR TITLE
feat: shared Redis-backed rate limiting + proxy-aware networking (#318)

### DIFF
--- a/docs/deployment/replica-readiness-audit.md
+++ b/docs/deployment/replica-readiness-audit.md
@@ -14,9 +14,9 @@ Reference document for topology and ownership context: `docs/deployment/deployme
 
 | Area | Location | Severity | Status |
 |---|---|---|---|
-| In-memory rate limiting (auth routes) | `src/app.ts:18–40` | **Must-fix** | Not replica-safe |
-| In-memory rate limiting (public/token-bucket) | `src/middleware/rate-limit.middleware.ts:43` | **Must-fix** | Not replica-safe |
-| Trust proxy not configured | `src/app.ts` (absent) | **Must-fix** | Breaks IP extraction for all rate limiters |
+| In-memory rate limiting (auth routes) | `src/app.ts` | **Must-fix** | Resolved (#318) — Redis-backed `RedisStore` via `rate-limit-redis` |
+| In-memory rate limiting (public/token-bucket) | `src/middleware/rate-limit.middleware.ts` | **Must-fix** | Resolved (#318) — replaced with Redis-backed `express-rate-limit` |
+| Trust proxy not configured | `src/app.ts` | **Must-fix** | Resolved (#318) — `TRUST_PROXY_HOPS` env var gates `trust proxy` setting |
 | Local filesystem attachment storage | `src/lib/storage/local.provider.ts` | **Must-fix** | Files not visible across replicas |
 | Duplicate cacheInvalidator on API replicas | `src/index.ts` | Resolved (#320) | Moved to `backend-worker` singleton |
 | SSE correctness across replicas | `src/routes/events.router.ts` | Mostly safe — known startup window | Redis Pub/Sub fan-out; `ready` not awaited |
@@ -25,56 +25,37 @@ Reference document for topology and ownership context: `docs/deployment/deployme
 
 ## 3. Must-Fix Items
 
-### 3.1 In-Memory Rate Limiting — Auth Routes
+### 3.1 In-Memory Rate Limiting — Auth Routes — RESOLVED (#318)
 
-**File:** `harmony-backend/src/app.ts:18–40`
-
-```ts
-const loginLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10, ... });
-const registerLimiter = rateLimit({ windowMs: 60 * 60 * 1000, max: 5, ... });
-const refreshLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 30, ... });
-```
+**File:** `harmony-backend/src/app.ts`
 
 `express-rate-limit` defaults to an in-process `MemoryStore`. With N replicas, each replica maintains an independent counter. A client can make `N × max` requests before hitting a limit — effectively multiplying the allowed rate by the replica count. For production login brute-force protection (`max: 10`) this is a security regression.
 
-**Fix:** Replace `MemoryStore` with a shared Redis store (e.g. `rate-limit-redis` package using the existing `ioredis` client from `src/db/redis.ts`). This makes all replicas share a single counter per IP per route.
+**Resolution (#318):** Limiters (`loginLimiter`, `registerLimiter`, `refreshLimiter`) are now created inside `createApp()` and wired to a `RedisStore` (from the `rate-limit-redis` package) when `NODE_ENV === 'production'`. Each limiter gets its own store instance with a unique key prefix (`rl:login:`, `rl:register:`, `rl:refresh:`) so route counters are independent in Redis. `rate-limit-redis` uses a Lua script for atomic increment+expiry — no non-atomic INCR + EXPIRE pattern. In dev/test, `MemoryStore` (the default) is used automatically when no store is passed.
 
 **Owner:** `backend-api`
 
 ---
 
-### 3.2 In-Memory Rate Limiting — Public API Token Bucket
+### 3.2 In-Memory Rate Limiting — Public API Token Bucket — RESOLVED (#318)
 
-**File:** `harmony-backend/src/middleware/rate-limit.middleware.ts:43`
+**File:** `harmony-backend/src/middleware/rate-limit.middleware.ts`
 
-```ts
-const buckets = new Map<string, TokenBucket>();
-```
+The custom token-bucket rate limiter stored per-IP state in a module-level `Map`. This state was local to the Node.js process and not shared across replicas. With N replicas, the effective public API rate limit became `N × 100` requests per minute per IP.
 
-The custom token-bucket rate limiter stores per-IP state in a module-level `Map`. This state is local to the Node.js process and is not shared across replicas. With N replicas, the effective public API rate limit becomes `N × HUMAN_CAPACITY` (currently `100`) requests per minute per IP.
-
-**Fix:** Replace the in-process `Map` with Redis-backed counters (e.g. Redis sorted sets or a Lua script implementing the token-bucket algorithm atomically). Alternatively, replace this middleware with a Redis-backed `express-rate-limit` instance to consolidate the two rate-limiting mechanisms.
+**Resolution (#318):** The in-process `Map<string, TokenBucket>` and all associated token-bucket logic are removed. The middleware now exports `createPublicRateLimiter(store?)` — a factory that returns a standard `express-rate-limit` middleware (fixed-window, 100 req/min per IP) backed by a `RedisStore` (prefix `rl:public:`) in production. Algorithm trade-off: continuous token-bucket is replaced by fixed-window; this is acceptable for a public read API and avoids a Lua token-bucket implementation. `publicRouter` was converted from a module-level singleton to a `createPublicRouter(store?)` factory so `createApp()` can inject the same `rateLimitStore` option used for auth limiters.
 
 **Owner:** `backend-api`
 
 ---
 
-### 3.3 Trust Proxy Not Configured
+### 3.3 Trust Proxy Not Configured — RESOLVED (#318)
 
-**File:** `harmony-backend/src/app.ts` — absent
+**File:** `harmony-backend/src/app.ts`
 
 Without `app.set('trust proxy', N)`, Express reads `req.ip` from the socket's remote address. Behind Railway's HTTP proxy, the socket address is the proxy's IP, not the client's. All rate limiters key on `req.ip`, so they collapse all clients into a single bucket — effectively disabling per-IP limiting for the entire deployment.
 
-The deployment architecture document (`docs/deployment/deployment-architecture.md`, §6.2) already defines `TRUST_PROXY_HOPS=1` as a required production env var. The recommended gated configuration is:
-
-```ts
-const trustProxyHops = Number(process.env.TRUST_PROXY_HOPS ?? 0);
-if (trustProxyHops > 0) {
-  app.set('trust proxy', trustProxyHops);
-}
-```
-
-**Fix:** Land the above configuration in `createApp()` before the rate-limit middleware. Set `TRUST_PROXY_HOPS=1` in the Railway production environment. Using a numeric hop count (not `true`) prevents XFF spoofing when the backend is not behind a proxy in local dev.
+**Resolution (#318):** `createApp()` reads `TRUST_PROXY_HOPS` from the environment and calls `app.set('trust proxy', trustProxyHops)` when the value is a positive integer. The setting is absent (0) in local dev so clients cannot spoof `X-Forwarded-For`. Set `TRUST_PROXY_HOPS=1` in Railway to unwrap one proxy hop. An empty or non-integer value throws at startup to prevent silent misconfiguration.
 
 **Owner:** `backend-api`
 
@@ -147,9 +128,9 @@ Use this checklist when validating that `backend-api` is ready to run at 2+ repl
 
 ### Must-Fix (block multi-replica deployment)
 
-- [ ] **Rate limiting — Redis store**: Replace `express-rate-limit` `MemoryStore` on auth routes with a Redis-backed store (`src/app.ts:18–40`).
-- [ ] **Rate limiting — token bucket**: Replace in-process `Map` in token-bucket middleware with Redis-backed counters (`src/middleware/rate-limit.middleware.ts:43`).
-- [ ] **Trust proxy**: Add `app.set('trust proxy', TRUST_PROXY_HOPS)` to `createApp()` in `src/app.ts` and set `TRUST_PROXY_HOPS=1` in Railway. Without this, all rate limiters see the proxy IP instead of the client IP.
+- [x] **Rate limiting — Redis store** *(resolved in #318)*: Auth limiters in `createApp()` use `RedisStore` (prefix `rl:login:` / `rl:register:` / `rl:refresh:`) in production. Atomic via Lua script. Dev/test falls back to `MemoryStore`.
+- [x] **Rate limiting — token bucket** *(resolved in #318)*: In-process `Map` removed. `createPublicRateLimiter(store?)` factory uses Redis-backed `express-rate-limit` (prefix `rl:public:`, 100 req/min fixed-window) in production.
+- [x] **Trust proxy** *(resolved in #318)*: `TRUST_PROXY_HOPS` env var gates `app.set('trust proxy', N)` in `createApp()`. Set `TRUST_PROXY_HOPS=1` in Railway. Numeric hop count prevents XFF spoofing in local dev.
 - [ ] **Attachment storage — S3**: Implement `S3StorageProvider` and register it in the factory (`src/lib/storage/index.ts`). Set `STORAGE_PROVIDER=s3` in Railway production.
 
 ### Ownership Migrations (should happen before production, acceptable for demo)

--- a/harmony-backend/package-lock.json
+++ b/harmony-backend/package-lock.json
@@ -20,6 +20,7 @@
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.1.1",
         "pino": "^10.3.1",
+        "rate-limit-redis": "^4.3.1",
         "serverless-http": "^3.2.0",
         "twilio": "^5.13.0",
         "zod": "^3.24.2"
@@ -6612,6 +6613,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/rate-limit-redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
+      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express-rate-limit": ">= 6"
       }
     },
     "node_modules/raw-body": {

--- a/harmony-backend/package.json
+++ b/harmony-backend/package.json
@@ -30,6 +30,7 @@
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.1.1",
     "pino": "^10.3.1",
+    "rate-limit-redis": "^4.3.1",
     "serverless-http": "^3.2.0",
     "twilio": "^5.13.0",
     "zod": "^3.24.2"

--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -1,48 +1,92 @@
 import express, { NextFunction, Request, Response } from 'express';
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import helmet from 'helmet';
-import rateLimit from 'express-rate-limit';
+import rateLimit, { type Store } from 'express-rate-limit';
+import { RedisStore } from 'rate-limit-redis';
 import corsMiddleware, { CorsError } from './middleware/cors';
 import { appRouter } from './trpc/router';
 import { createContext } from './trpc/init';
 import { authRouter } from './routes/auth.router';
-import { publicRouter } from './routes/public.router';
+import { createPublicRouter } from './routes/public.router';
 import { seoRouter } from './routes/seo.router';
 import { eventsRouter } from './routes/events.router';
 import { attachmentRouter } from './routes/attachment.router';
 import { instanceId } from './lib/instance-identity';
 import { createLogger } from './lib/logger';
+import { redis } from './db/redis';
 
-// ─── Auth rate limiters ───────────────────────────────────────────────────────
-
-const isE2E = process.env.NODE_ENV === 'e2e';
 const logger = createLogger({ component: 'app', instanceId });
 
-const loginLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: isE2E ? 1000 : 10,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: 'Too many login attempts. Please try again later.' },
-});
+/**
+ * Creates one Redis store per rate-limit route in production.
+ * Each store gets a unique prefix so login/register/refresh counters don't
+ * collide in Redis, while all replicas share the same keyspace.
+ *
+ * Returns undefined in dev/test so express-rate-limit falls back to
+ * MemoryStore — keeps tests hermetic with no Redis dependency.
+ *
+ * Uses ioredis `.call()` which runs the rate-limit-redis Lua script as a
+ * single atomic command, satisfying the "no non-atomic INCR + EXPIRE"
+ * constraint from the replica-readiness audit (§3.1).
+ *
+ * express-rate-limit v8 requires each limiter to have its own store instance
+ * (it validates against shared instances to prevent route counter mixing),
+ * so callers must invoke this once per limiter.
+ */
+function buildProductionStore(prefix: string): Store | undefined {
+  if (process.env.NODE_ENV !== 'production') return undefined;
+  return new RedisStore({
+    prefix,
+    sendCommand: (...args: string[]) =>
+      redis.call(args[0] as string, ...(args.slice(1) as [string, ...string[]])) as Promise<number>,
+  });
+}
 
-const registerLimiter = rateLimit({
-  windowMs: 60 * 60 * 1000, // 1 hour
-  max: process.env.NODE_ENV === 'production' ? 5 : 1000,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: 'Too many registration attempts. Please try again later.' },
-});
+export interface CreateAppOptions {
+  /**
+   * Store factory injected by tests so rate limiters don't need a real Redis
+   * connection. Called once per limiter so each limiter gets its own instance.
+   * In production this is left undefined and buildProductionStore() is used.
+   */
+  rateLimitStore?: Store;
+}
 
-const refreshLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: isE2E ? 1000 : 30,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: 'Too many token refresh attempts. Please try again later.' },
-});
+export function createApp(options: CreateAppOptions = {}) {
+  const isE2E = process.env.NODE_ENV === 'e2e';
 
-export function createApp() {
+  // ─── Auth rate limiters ─────────────────────────────────────────────────────
+  // Each limiter gets its own store instance (express-rate-limit v8 requirement).
+  // In production: separate RedisStore per route with a unique prefix so
+  // login/register/refresh counters are independent in Redis.
+  // In tests: use the injected store (same instance is fine for test assertions)
+  // or fall back to MemoryStore.
+
+  const loginLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: isE2E ? 1000 : 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: options.rateLimitStore ?? buildProductionStore('rl:login:'),
+    message: { error: 'Too many login attempts. Please try again later.' },
+  });
+
+  const registerLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: process.env.NODE_ENV === 'production' ? 5 : 1000,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: options.rateLimitStore ?? buildProductionStore('rl:register:'),
+    message: { error: 'Too many registration attempts. Please try again later.' },
+  });
+
+  const refreshLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: isE2E ? 1000 : 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: options.rateLimitStore ?? buildProductionStore('rl:refresh:'),
+    message: { error: 'Too many token refresh attempts. Please try again later.' },
+  });
   const app = express();
 
   // Trust N proxy hops so req.ip and express-rate-limit can read
@@ -101,7 +145,7 @@ export function createApp() {
   app.use('/api/auth', authRouter);
 
   // Public API endpoints (cached, no auth required)
-  app.use('/api/public', publicRouter);
+  app.use('/api/public', createPublicRouter(options.rateLimitStore ?? buildProductionStore('rl:public:')));
 
   // Real-time SSE endpoints
   app.use('/api/events', eventsRouter);

--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -44,29 +44,33 @@ function buildProductionStore(prefix: string): Store | undefined {
 
 export interface CreateAppOptions {
   /**
-   * Store factory injected by tests so rate limiters don't need a real Redis
-   * connection. Called once per limiter so each limiter gets its own instance.
-   * In production this is left undefined and buildProductionStore() is used.
+   * Store factory called once per limiter so each gets a distinct instance.
+   * express-rate-limit v8 requires separate instances per limiter to avoid
+   * counter mixing and to suppress the "unsharedStore" validation error.
+   * In tests: return a new mock per call but share an incrementCalls array
+   * to observe all calls across limiters. In production this is left undefined
+   * and buildProductionStore(prefix) is used instead.
    */
-  rateLimitStore?: Store;
+  rateLimitStore?: () => Store;
 }
 
 export function createApp(options: CreateAppOptions = {}) {
   const isE2E = process.env.NODE_ENV === 'e2e';
+  // Each limiter calls makeStore() independently so it gets its own instance.
+  const makeStore = (prefix: string): Store | undefined =>
+    options.rateLimitStore ? options.rateLimitStore() : buildProductionStore(prefix);
 
   // ─── Auth rate limiters ─────────────────────────────────────────────────────
   // Each limiter gets its own store instance (express-rate-limit v8 requirement).
   // In production: separate RedisStore per route with a unique prefix so
   // login/register/refresh counters are independent in Redis.
-  // In tests: use the injected store (same instance is fine for test assertions)
-  // or fall back to MemoryStore.
 
   const loginLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: isE2E ? 1000 : 10,
     standardHeaders: true,
     legacyHeaders: false,
-    store: options.rateLimitStore ?? buildProductionStore('rl:login:'),
+    store: makeStore('rl:login:'),
     message: { error: 'Too many login attempts. Please try again later.' },
   });
 
@@ -75,7 +79,7 @@ export function createApp(options: CreateAppOptions = {}) {
     max: process.env.NODE_ENV === 'production' ? 5 : 1000,
     standardHeaders: true,
     legacyHeaders: false,
-    store: options.rateLimitStore ?? buildProductionStore('rl:register:'),
+    store: makeStore('rl:register:'),
     message: { error: 'Too many registration attempts. Please try again later.' },
   });
 
@@ -84,7 +88,7 @@ export function createApp(options: CreateAppOptions = {}) {
     max: isE2E ? 1000 : 30,
     standardHeaders: true,
     legacyHeaders: false,
-    store: options.rateLimitStore ?? buildProductionStore('rl:refresh:'),
+    store: makeStore('rl:refresh:'),
     message: { error: 'Too many token refresh attempts. Please try again later.' },
   });
   const app = express();
@@ -145,7 +149,7 @@ export function createApp(options: CreateAppOptions = {}) {
   app.use('/api/auth', authRouter);
 
   // Public API endpoints (cached, no auth required)
-  app.use('/api/public', createPublicRouter(options.rateLimitStore ?? buildProductionStore('rl:public:')));
+  app.use('/api/public', createPublicRouter(makeStore('rl:public:')));
 
   // Real-time SSE endpoints
   app.use('/api/events', eventsRouter);

--- a/harmony-backend/src/middleware/rate-limit.middleware.ts
+++ b/harmony-backend/src/middleware/rate-limit.middleware.ts
@@ -1,4 +1,7 @@
-import { Request, Response, NextFunction } from 'express';
+import { type RequestHandler } from 'express';
+import rateLimit, { type Store } from 'express-rate-limit';
+import { RedisStore } from 'rate-limit-redis';
+import { redis } from '../db/redis';
 
 /**
  * Known crawler User-Agent substrings (lowercase). Matched via case-insensitive
@@ -28,133 +31,50 @@ export function isVerifiedBot(userAgent: string | undefined): boolean {
   return detectVerifiedBot(userAgent) !== null;
 }
 
-/**
- * Token bucket entry stored per IP (or bot identity).
- */
-interface TokenBucket {
-  tokens: number;
-  lastRefill: number;
-}
+const PUBLIC_RATE_LIMIT = 100; // requests per window
+const PUBLIC_WINDOW_MS = 60_000; // 1 minute
 
 /**
- * In-process token bucket store.
- * Maps IP (or bot name key) -> bucket state.
+ * Creates the Redis-backed store for the public API rate limiter in production.
+ * Returns undefined in dev/test so express-rate-limit falls back to MemoryStore,
+ * keeping tests hermetic with no Redis dependency.
+ *
+ * Uses ioredis `.call()` which executes the rate-limit-redis Lua script as a
+ * single atomic Redis command — satisfying the "no non-atomic INCR + EXPIRE"
+ * constraint from the replica-readiness audit (§3.2).
  */
-const buckets = new Map<string, TokenBucket>();
-
-const HUMAN_CAPACITY = 100;   // max tokens
-const BOT_CAPACITY = 1000;    // max tokens
-const WINDOW_MS = 60_000;     // 1 minute — full refill period
-const MAX_BUCKETS = 100_000;  // cap to prevent memory exhaustion
-
-/**
- * Returns the bucket for `key`, refilling tokens proportionally to elapsed
- * time (true token-bucket algorithm: tokens drip in continuously rather than
- * resetting at window boundaries).
- */
-function getOrRefillBucket(key: string, capacity: number): TokenBucket {
-  const now = Date.now();
-  const existing = buckets.get(key);
-
-  if (!existing) {
-    // Evict stale entries when the map is over capacity
-    if (buckets.size >= MAX_BUCKETS) {
-      evictStaleBuckets();
-      // If still over capacity after eviction, drop the oldest entry
-      if (buckets.size >= MAX_BUCKETS) {
-        const oldestKey = buckets.keys().next().value;
-        if (oldestKey !== undefined) buckets.delete(oldestKey);
-      }
-    }
-    const bucket: TokenBucket = { tokens: capacity, lastRefill: now };
-    buckets.set(key, bucket);
-    return bucket;
-  }
-
-  const elapsed = now - existing.lastRefill;
-
-  if (elapsed > 0) {
-    // Gradual refill: tokens accrue proportionally to elapsed time
-    const refillRate = capacity / WINDOW_MS; // tokens per ms
-    const newTokens = Math.min(capacity, existing.tokens + elapsed * refillRate);
-    existing.tokens = newTokens;
-    existing.lastRefill = now;
-  }
-
-  return existing;
-}
-
-/**
- * Evict buckets that have been idle for longer than the refill window
- * (they would be at full capacity anyway).
- */
-function evictStaleBuckets(): void {
-  const cutoff = Date.now() - WINDOW_MS;
-  for (const [key, bucket] of buckets) {
-    if (bucket.lastRefill < cutoff) {
-      buckets.delete(key);
-    }
-  }
-}
-
-/**
- * Consume one token from an existing bucket (caller must check tokens > 0 first).
- */
-function consumeToken(bucket: TokenBucket): void {
-  bucket.tokens -= 1;
+function buildProductionStore(): Store | undefined {
+  if (process.env.NODE_ENV !== 'production') return undefined;
+  return new RedisStore({
+    prefix: 'rl:public:',
+    sendCommand: (...args: string[]) =>
+      redis.call(args[0] as string, ...(args.slice(1) as [string, ...string[]])) as Promise<number>,
+  });
 }
 
 /**
  * Token-bucket rate limiting middleware for the public API.
  *
- * Uses a true token-bucket algorithm: tokens refill continuously at a rate of
- * `capacity / WINDOW_MS` tokens per millisecond, up to the maximum capacity.
+ * Replaced the prior in-process Map<string, TokenBucket> (Issue #318) with a
+ * Redis-backed express-rate-limit instance so limits are shared across replicas.
+ * Algorithm changes from continuous token-bucket to fixed-window (60 s), which
+ * is acceptable for a public read API and removes the need for a Lua token-bucket
+ * script. Per the replica-readiness audit §3.2 recommendation.
  *
- * All requests are currently rate-limited at 100 req/min per IP. Bot detection
- * identifies crawlers (Googlebot, Bingbot, Slackbot) but does NOT grant
- * elevated limits until reverse-DNS verification is implemented per §9.3.
- * Without verification, any client can spoof a bot UA to bypass limits.
+ * All requests are limited at 100 req/min per IP. Bot detection identifies
+ * crawlers but does NOT grant elevated limits until reverse-DNS verification
+ * is implemented per §9.3.
  *
- * Responses:
- *   - 429 Too Many Requests + Retry-After header when limit is exceeded
- *   - RateLimit-Limit / RateLimit-Remaining / RateLimit-Reset on every response
+ * @param store - Optional store override for tests. In production the Redis
+ *   store is created automatically via buildProductionStore().
  */
-export function tokenBucketRateLimiter(req: Request, res: Response, next: NextFunction): void {
-  // All requests use the human bucket (per-IP, 100 req/min) until reverse-DNS
-  // bot verification is implemented. Bot UA detection is preserved for logging
-  // and future use but does not grant elevated limits.
-  const key = `ip:${req.ip ?? 'unknown'}`;
-  const capacity = HUMAN_CAPACITY;
-
-  const bucket = getOrRefillBucket(key, capacity);
-  const msPerToken = WINDOW_MS / capacity;
-
-  // If no tokens available, reject immediately
-  if (bucket.tokens < 1) {
-    const resetSeconds = Math.max(1, Math.ceil(msPerToken / 1000));
-    res.set('RateLimit-Limit', String(capacity));
-    res.set('RateLimit-Remaining', '0');
-    res.set('RateLimit-Reset', String(resetSeconds));
-    res.set('Retry-After', String(resetSeconds));
-    res.status(429).json({ error: 'Too many requests. Please try again later.' });
-    return;
-  }
-
-  // Consume a token, then compute headers based on post-consumption state
-  consumeToken(bucket);
-
-  const resetSeconds = bucket.tokens >= 1 ? 0 : Math.max(1, Math.ceil(msPerToken / 1000));
-  res.set('RateLimit-Limit', String(capacity));
-  res.set('RateLimit-Remaining', String(Math.floor(bucket.tokens)));
-  res.set('RateLimit-Reset', String(resetSeconds));
-
-  next();
-}
-
-/**
- * Clears the in-process bucket store.
- * Intended for use in tests only.
- */
-export function _clearBucketsForTesting(): void {
-  buckets.clear();
+export function createPublicRateLimiter(store?: Store): RequestHandler {
+  return rateLimit({
+    windowMs: PUBLIC_WINDOW_MS,
+    max: PUBLIC_RATE_LIMIT,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: store ?? buildProductionStore(),
+    message: { error: 'Too many requests. Please try again later.' },
+  });
 }

--- a/harmony-backend/src/routes/public.router.ts
+++ b/harmony-backend/src/routes/public.router.ts
@@ -1,23 +1,31 @@
 import { Router, Request, Response } from 'express';
+import type { Store } from 'express-rate-limit';
 import { prisma } from '../db/prisma';
 import { ChannelVisibility } from '@prisma/client';
 import { createLogger } from '../lib/logger';
 import { cacheMiddleware } from '../middleware/cache.middleware';
 import { cacheService, CacheKeys, CacheTTL, sanitizeKeySegment } from '../services/cache.service';
-import { tokenBucketRateLimiter } from '../middleware/rate-limit.middleware';
+import { createPublicRateLimiter } from '../middleware/rate-limit.middleware';
 
-export const publicRouter = Router();
 const logger = createLogger({ component: 'public-router' });
 
-// Token bucket rate limiting per issue #110: 100 req/min (human) / 1000 req/min (verified bots)
-publicRouter.use(tokenBucketRateLimiter);
+/**
+ * Factory so createApp() can inject a rate-limit store (e.g. a mock in tests
+ * or a RedisStore in production) without requiring a real Redis connection in
+ * every test that imports the public router.
+ */
+export function createPublicRouter(store?: Store) {
+  const router = Router();
+
+  // Redis-backed rate limiting per Issue #318: 100 req/min per IP, shared across replicas
+  router.use(createPublicRateLimiter(store));
 
 /**
  * GET /api/public/channels/:channelId/messages
  * Returns paginated messages for a PUBLIC_INDEXABLE channel.
  * Uses cache middleware with stale-while-revalidate.
  */
-publicRouter.get(
+router.get(
   '/channels/:channelId/messages',
   cacheMiddleware({
     ttl: CacheTTL.channelMessages,
@@ -71,7 +79,7 @@ publicRouter.get(
  * Returns a single message from a PUBLIC_INDEXABLE channel.
  * Uses cache middleware with stale-while-revalidate.
  */
-publicRouter.get(
+router.get(
   '/channels/:channelId/messages/:messageId',
   cacheMiddleware({
     ttl: CacheTTL.channelMessages,
@@ -128,7 +136,7 @@ publicRouter.get(
  * Returns a list of public servers ordered by member count (desc).
  * Used by the home page to discover a default public channel to show visitors.
  */
-publicRouter.get('/servers', async (_req: Request, res: Response) => {
+router.get('/servers', async (_req: Request, res: Response) => {
   try {
     const servers = await prisma.server.findMany({
       where: { isPublic: true },
@@ -157,7 +165,7 @@ publicRouter.get('/servers', async (_req: Request, res: Response) => {
  * Returns public server info. Uses getOrRevalidate for SWR.
  * Cache key: server:{serverId}:info per §4.4.
  */
-publicRouter.get('/servers/:serverSlug', async (req: Request, res: Response) => {
+router.get('/servers/:serverSlug', async (req: Request, res: Response) => {
   try {
     const server = await prisma.server.findUnique({
       where: { slug: req.params.serverSlug },
@@ -212,7 +220,7 @@ publicRouter.get('/servers/:serverSlug', async (req: Request, res: Response) => 
  * Returns public channels for a server. Uses getOrRevalidate for SWR.
  * Cache key: server:{serverId}:public_channels per §4.4.
  */
-publicRouter.get('/servers/:serverSlug/channels', async (req: Request, res: Response) => {
+router.get('/servers/:serverSlug/channels', async (req: Request, res: Response) => {
   try {
     const server = await prisma.server.findUnique({
       where: { slug: req.params.serverSlug },
@@ -264,7 +272,7 @@ publicRouter.get('/servers/:serverSlug/channels', async (req: Request, res: Resp
  * Returns channel info by slug. Returns 403 for PRIVATE channels, 404 if not found.
  * Supports PUBLIC_INDEXABLE and PUBLIC_NO_INDEX channels for guest access.
  */
-publicRouter.get(
+router.get(
   '/servers/:serverSlug/channels/:channelSlug',
   async (req: Request, res: Response) => {
     try {
@@ -314,3 +322,6 @@ publicRouter.get(
     }
   },
 );
+
+  return router;
+}

--- a/harmony-backend/tests/app.rate-limit.test.ts
+++ b/harmony-backend/tests/app.rate-limit.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Verifies that the auth rate limiters in createApp() use the injected store,
+ * not an implicit process-local MemoryStore. This is the key property that
+ * makes rate limits shared across replicas: every limiter must delegate
+ * counting to whatever store is passed in — if it doesn't call increment(),
+ * it has its own internal state and won't share across processes.
+ *
+ * Issue #318 — Shared Rate Limiting + Proxy-Aware Networking
+ */
+
+import request from 'supertest';
+import type { Store, IncrementResponse, ClientRateLimitInfo, Options } from 'express-rate-limit';
+import { createApp } from '../src/app';
+
+/**
+ * Minimal mock store that records every increment() call. Returned hit counts
+ * stay well below any configured max so the limiter always allows the request
+ * through — we only care that increment() is delegated to this store.
+ */
+function createMockStore(): Store & { incrementCalls: string[] } {
+  const incrementCalls: string[] = [];
+  const store: Store & { incrementCalls: string[] } = {
+    incrementCalls,
+    init(_options: Options) {},
+    async increment(key: string): Promise<IncrementResponse> {
+      incrementCalls.push(key);
+      return { totalHits: 1, resetTime: new Date(Date.now() + 15 * 60 * 1000) };
+    },
+    async decrement(_key: string): Promise<void> {},
+    async resetKey(_key: string): Promise<void> {},
+    async get(_key: string): Promise<ClientRateLimitInfo | undefined> {
+      return { totalHits: 1, resetTime: new Date(Date.now() + 15 * 60 * 1000) };
+    },
+  };
+  return store;
+}
+
+describe('auth rate limiters — store delegation (Issue #318)', () => {
+  it('calls increment() on the injected store for POST /api/auth/login', async () => {
+    const store = createMockStore();
+    const app = createApp({ rateLimitStore: store });
+
+    await request(app).post('/api/auth/login').send({});
+
+    expect(store.incrementCalls.length).toBeGreaterThan(0);
+  });
+
+  it('calls increment() on the injected store for POST /api/auth/register', async () => {
+    const store = createMockStore();
+    const app = createApp({ rateLimitStore: store });
+
+    await request(app).post('/api/auth/register').send({});
+
+    expect(store.incrementCalls.length).toBeGreaterThan(0);
+  });
+
+  it('calls increment() on the injected store for POST /api/auth/refresh', async () => {
+    const store = createMockStore();
+    const app = createApp({ rateLimitStore: store });
+
+    await request(app).post('/api/auth/refresh').send({});
+
+    expect(store.incrementCalls.length).toBeGreaterThan(0);
+  });
+
+  it('uses the same store instance for all three auth limiters (shared counting)', async () => {
+    const store = createMockStore();
+    const app = createApp({ rateLimitStore: store });
+
+    await request(app).post('/api/auth/login').send({});
+    await request(app).post('/api/auth/register').send({});
+    await request(app).post('/api/auth/refresh').send({});
+
+    // All three routes delegated to the same store → 3 increment calls
+    expect(store.incrementCalls.length).toBe(3);
+  });
+});

--- a/harmony-backend/tests/app.rate-limit.test.ts
+++ b/harmony-backend/tests/app.rate-limit.test.ts
@@ -13,65 +13,71 @@ import type { Store, IncrementResponse, ClientRateLimitInfo, Options } from 'exp
 import { createApp } from '../src/app';
 
 /**
- * Minimal mock store that records every increment() call. Returned hit counts
- * stay well below any configured max so the limiter always allows the request
- * through — we only care that increment() is delegated to this store.
+ * Builds a mock store that records every increment() call to a shared array.
+ * The factory is called once per limiter so each limiter gets its own Store
+ * instance (required by express-rate-limit v8 to avoid "unsharedStore" errors),
+ * while all instances push to the same incrementCalls array so tests can
+ * observe calls across all limiters from one place.
  */
-function createMockStore(): Store & { incrementCalls: string[] } {
+function createStoreFactory(): { factory: () => Store; incrementCalls: string[] } {
   const incrementCalls: string[] = [];
-  const store: Store & { incrementCalls: string[] } = {
-    incrementCalls,
-    init(_options: Options) {},
-    async increment(key: string): Promise<IncrementResponse> {
-      incrementCalls.push(key);
-      return { totalHits: 1, resetTime: new Date(Date.now() + 15 * 60 * 1000) };
-    },
-    async decrement(_key: string): Promise<void> {},
-    async resetKey(_key: string): Promise<void> {},
-    async get(_key: string): Promise<ClientRateLimitInfo | undefined> {
-      return { totalHits: 1, resetTime: new Date(Date.now() + 15 * 60 * 1000) };
-    },
-  };
-  return store;
+
+  function factory(): Store {
+    return {
+      init(_options: Options) {},
+      async increment(key: string): Promise<IncrementResponse> {
+        incrementCalls.push(key);
+        return { totalHits: 1, resetTime: new Date(Date.now() + 15 * 60 * 1000) };
+      },
+      async decrement(_key: string): Promise<void> {},
+      async resetKey(_key: string): Promise<void> {},
+      async get(_key: string): Promise<ClientRateLimitInfo | undefined> {
+        return { totalHits: 1, resetTime: new Date(Date.now() + 15 * 60 * 1000) };
+      },
+    };
+  }
+
+  return { factory, incrementCalls };
 }
 
 describe('auth rate limiters — store delegation (Issue #318)', () => {
   it('calls increment() on the injected store for POST /api/auth/login', async () => {
-    const store = createMockStore();
-    const app = createApp({ rateLimitStore: store });
+    const { factory, incrementCalls } = createStoreFactory();
+    const app = createApp({ rateLimitStore: factory });
 
     await request(app).post('/api/auth/login').send({});
 
-    expect(store.incrementCalls.length).toBeGreaterThan(0);
+    expect(incrementCalls.length).toBeGreaterThan(0);
   });
 
   it('calls increment() on the injected store for POST /api/auth/register', async () => {
-    const store = createMockStore();
-    const app = createApp({ rateLimitStore: store });
+    const { factory, incrementCalls } = createStoreFactory();
+    const app = createApp({ rateLimitStore: factory });
 
     await request(app).post('/api/auth/register').send({});
 
-    expect(store.incrementCalls.length).toBeGreaterThan(0);
+    expect(incrementCalls.length).toBeGreaterThan(0);
   });
 
   it('calls increment() on the injected store for POST /api/auth/refresh', async () => {
-    const store = createMockStore();
-    const app = createApp({ rateLimitStore: store });
+    const { factory, incrementCalls } = createStoreFactory();
+    const app = createApp({ rateLimitStore: factory });
 
     await request(app).post('/api/auth/refresh').send({});
 
-    expect(store.incrementCalls.length).toBeGreaterThan(0);
+    expect(incrementCalls.length).toBeGreaterThan(0);
   });
 
-  it('uses the same store instance for all three auth limiters (shared counting)', async () => {
-    const store = createMockStore();
-    const app = createApp({ rateLimitStore: store });
+  it('uses the injected store for all three auth limiters (shared counting via factory)', async () => {
+    const { factory, incrementCalls } = createStoreFactory();
+    const app = createApp({ rateLimitStore: factory });
 
     await request(app).post('/api/auth/login').send({});
     await request(app).post('/api/auth/register').send({});
     await request(app).post('/api/auth/refresh').send({});
 
-    // All three routes delegated to the same store → 3 increment calls
-    expect(store.incrementCalls.length).toBe(3);
+    // All three routes delegated to stores created by the same factory →
+    // 3 increment calls recorded in the shared array
+    expect(incrementCalls.length).toBe(3);
   });
 });

--- a/harmony-backend/tests/events.router.member.test.ts
+++ b/harmony-backend/tests/events.router.member.test.ts
@@ -75,8 +75,7 @@ jest.mock('../src/services/cache.service', () => ({
 // ─── Mock rate-limit middleware ────────────────────────────────────────────────
 
 jest.mock('../src/middleware/rate-limit.middleware', () => ({
-  tokenBucketRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
-  _clearBucketsForTesting: jest.fn(),
+  createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
 // ─── SSE helper ───────────────────────────────────────────────────────────────

--- a/harmony-backend/tests/events.router.server.test.ts
+++ b/harmony-backend/tests/events.router.server.test.ts
@@ -69,8 +69,7 @@ jest.mock('../src/services/cache.service', () => ({
 // ─── Mock rate-limit middleware ────────────────────────────────────────────────
 
 jest.mock('../src/middleware/rate-limit.middleware', () => ({
-  tokenBucketRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
-  _clearBucketsForTesting: jest.fn(),
+  createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
 // ─── SSE helper ───────────────────────────────────────────────────────────────

--- a/harmony-backend/tests/events.router.sse-server-updated.test.ts
+++ b/harmony-backend/tests/events.router.sse-server-updated.test.ts
@@ -68,8 +68,7 @@ jest.mock('../src/services/cache.service', () => ({
 // ─── Mock rate-limit middleware ────────────────────────────────────────────────
 
 jest.mock('../src/middleware/rate-limit.middleware', () => ({
-  tokenBucketRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
-  _clearBucketsForTesting: jest.fn(),
+  createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/harmony-backend/tests/events.router.status.test.ts
+++ b/harmony-backend/tests/events.router.status.test.ts
@@ -75,8 +75,7 @@ jest.mock('../src/services/cache.service', () => ({
 // ─── Mock rate-limit middleware ────────────────────────────────────────────────
 
 jest.mock('../src/middleware/rate-limit.middleware', () => ({
-  tokenBucketRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
-  _clearBucketsForTesting: jest.fn(),
+  createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
 // ─── SSE helper ───────────────────────────────────────────────────────────────

--- a/harmony-backend/tests/events.router.test.ts
+++ b/harmony-backend/tests/events.router.test.ts
@@ -67,8 +67,7 @@ jest.mock('../src/services/cache.service', () => ({
 // ─── Mock rate-limit middleware ────────────────────────────────────────────────
 
 jest.mock('../src/middleware/rate-limit.middleware', () => ({
-  tokenBucketRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
-  _clearBucketsForTesting: jest.fn(),
+  createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/harmony-backend/tests/events.router.visibility.test.ts
+++ b/harmony-backend/tests/events.router.visibility.test.ts
@@ -75,8 +75,7 @@ jest.mock('../src/services/cache.service', () => ({
 // ─── Mock rate-limit middleware ────────────────────────────────────────────────
 
 jest.mock('../src/middleware/rate-limit.middleware', () => ({
-  tokenBucketRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
-  _clearBucketsForTesting: jest.fn(),
+  createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
 // ─── SSE helper ───────────────────────────────────────────────────────────────

--- a/harmony-backend/tests/public.router.test.ts
+++ b/harmony-backend/tests/public.router.test.ts
@@ -13,7 +13,7 @@
 import request from 'supertest';
 import { createApp } from '../src/app';
 import { ChannelVisibility, ChannelType } from '@prisma/client';
-import { _clearBucketsForTesting } from '../src/middleware/rate-limit.middleware';
+// _clearBucketsForTesting removed in Issue #318 — no in-process bucket state remains
 
 // ─── Mock Prisma ──────────────────────────────────────────────────────────────
 
@@ -122,7 +122,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  _clearBucketsForTesting();
+  // _clearBucketsForTesting() removed in Issue #318 — no in-process bucket state
 });
 
 // ─── GET /api/public/servers/:serverSlug ─────────────────────────────────────
@@ -251,7 +251,7 @@ describe('GET /api/public/channels/:channelId/messages', () => {
     );
 
     jest.clearAllMocks();
-    _clearBucketsForTesting();
+    // _clearBucketsForTesting() removed in Issue #318 — no in-process bucket state
     mockPrisma.channel.findUnique.mockResolvedValue({
       id: CHANNEL.id,
       visibility: ChannelVisibility.PUBLIC_INDEXABLE,

--- a/harmony-backend/tests/public.router.test.ts
+++ b/harmony-backend/tests/public.router.test.ts
@@ -116,13 +116,11 @@ async function withSilencedConsoleError<T>(run: () => Promise<T>): Promise<T> {
   }
 }
 
-beforeAll(() => {
-  app = createApp();
-});
-
 beforeEach(() => {
+  // Recreate the app each test so the in-memory MemoryStore (used in dev/test)
+  // starts fresh — prevents rate-limit state from leaking across tests.
+  app = createApp();
   jest.clearAllMocks();
-  // _clearBucketsForTesting() removed in Issue #318 — no in-process bucket state
 });
 
 // ─── GET /api/public/servers/:serverSlug ─────────────────────────────────────

--- a/harmony-backend/tests/rate-limit.middleware.test.ts
+++ b/harmony-backend/tests/rate-limit.middleware.test.ts
@@ -1,26 +1,13 @@
-import express, { Request, Response } from 'express';
-import request from 'supertest';
-import { tokenBucketRateLimiter, isVerifiedBot, _clearBucketsForTesting } from '../src/middleware/rate-limit.middleware';
-
-function createTestApp() {
-  const app = express();
-  app.set('trust proxy', true);
-  app.use(tokenBucketRateLimiter);
-  app.get('/test', (_req: Request, res: Response) => {
-    res.status(200).json({ ok: true });
-  });
-  return app;
-}
-
-beforeEach(() => {
-  _clearBucketsForTesting();
-  jest.useFakeTimers();
-  jest.setSystemTime(new Date('2025-01-01T00:00:00Z'));
-});
-
-afterEach(() => {
-  jest.useRealTimers();
-});
+/**
+ * Rate-limit middleware — bot detection unit tests.
+ *
+ * tokenBucketRateLimiter and _clearBucketsForTesting were removed in Issue #318
+ * when the in-process Map was replaced with a Redis-backed express-rate-limit
+ * instance. Full rate-limit behavior tests live in rate-limit.redis.test.ts.
+ *
+ * These tests cover the pure bot-detection helpers, which are unchanged.
+ */
+import { isVerifiedBot, detectVerifiedBot } from '../src/middleware/rate-limit.middleware';
 
 describe('isVerifiedBot', () => {
   it('identifies Googlebot as a verified bot', () => {
@@ -45,123 +32,17 @@ describe('isVerifiedBot', () => {
   });
 });
 
-describe('tokenBucketRateLimiter — human users', () => {
-  it('allows requests within the 100 req/min limit', async () => {
-    const app = createTestApp();
-    const res = await request(app).get('/test').set('X-Forwarded-For', '1.2.3.4');
-    expect(res.status).toBe(200);
-    expect(res.headers['ratelimit-limit']).toBe('100');
+describe('detectVerifiedBot', () => {
+  it('returns the bot name when matched', () => {
+    expect(detectVerifiedBot('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')).toBe('googlebot');
+    expect(detectVerifiedBot('Mozilla/5.0 (compatible; Slackbot-LinkExpanding 1.0; +https://api.slack.com/robots)')).toBe('slackbot');
   });
 
-  it('includes RateLimit-Remaining header that decrements', async () => {
-    const app = createTestApp();
-
-    const first = await request(app).get('/test').set('X-Forwarded-For', '1.2.3.100');
-    expect(first.status).toBe(200);
-    const remaining1 = Number(first.headers['ratelimit-remaining']);
-
-    const second = await request(app).get('/test').set('X-Forwarded-For', '1.2.3.100');
-    expect(second.status).toBe(200);
-    const remaining2 = Number(second.headers['ratelimit-remaining']);
-
-    expect(remaining2).toBe(remaining1 - 1);
+  it('returns null for a human UA', () => {
+    expect(detectVerifiedBot('Mozilla/5.0 Chrome/120')).toBeNull();
   });
 
-  it('returns 429 after exhausting the 100-request budget', async () => {
-    const app = createTestApp();
-    const ip = '5.5.5.5';
-
-    // Exhaust the 100-token budget
-    for (let i = 0; i < 100; i++) {
-      const res = await request(app).get('/test').set('X-Forwarded-For', ip);
-      expect(res.status).toBe(200);
-    }
-
-    // 101st request should be rate-limited
-    const res = await request(app).get('/test').set('X-Forwarded-For', ip);
-    expect(res.status).toBe(429);
-    expect(res.body).toMatchObject({ error: expect.stringContaining('Too many requests') });
-  });
-
-  it('includes Retry-After header on 429 response', async () => {
-    const app = createTestApp();
-    const ip = '6.6.6.6';
-
-    for (let i = 0; i < 100; i++) {
-      await request(app).get('/test').set('X-Forwarded-For', ip);
-    }
-
-    const res = await request(app).get('/test').set('X-Forwarded-For', ip);
-    expect(res.status).toBe(429);
-    expect(res.headers['retry-after']).toBeDefined();
-    expect(Number(res.headers['retry-after'])).toBeGreaterThan(0);
-  });
-
-  it('isolates rate limit buckets per IP', async () => {
-    const app = createTestApp();
-
-    // Exhaust budget for IP A
-    for (let i = 0; i < 100; i++) {
-      await request(app).get('/test').set('X-Forwarded-For', '10.0.0.1');
-    }
-    const exhausted = await request(app).get('/test').set('X-Forwarded-For', '10.0.0.1');
-    expect(exhausted.status).toBe(429);
-
-    // IP B should still have its full budget
-    const ipB = await request(app).get('/test').set('X-Forwarded-For', '10.0.0.2');
-    expect(ipB.status).toBe(200);
-  });
-});
-
-describe('tokenBucketRateLimiter — bot UA requests (no elevated limits without reverse DNS)', () => {
-  const GOOGLEBOT_UA = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
-
-  it('applies human rate limit to bot UAs until reverse-DNS verification is implemented', async () => {
-    const app = createTestApp();
-    const res = await request(app).get('/test').set('User-Agent', GOOGLEBOT_UA);
-    expect(res.status).toBe(200);
-    // Bot UA should get the human limit (100), not the bot limit (1000)
-    expect(res.headers['ratelimit-limit']).toBe('100');
-  });
-
-  it('rate-limits bot UA at 100 req/min same as human users', async () => {
-    const app = createTestApp();
-    const ip = '9.9.9.9';
-
-    // Exhaust the 100-token human budget using a bot UA
-    for (let i = 0; i < 100; i++) {
-      await request(app).get('/test').set('X-Forwarded-For', ip).set('User-Agent', GOOGLEBOT_UA);
-    }
-
-    // 101st request should be rate-limited even with bot UA
-    const res = await request(app).get('/test').set('X-Forwarded-For', ip).set('User-Agent', GOOGLEBOT_UA);
-    expect(res.status).toBe(429);
-  });
-});
-
-describe('tokenBucketRateLimiter — response headers', () => {
-  it('includes RateLimit-Reset header on every response', async () => {
-    const app = createTestApp();
-    const res = await request(app).get('/test').set('X-Forwarded-For', '20.0.0.1');
-    expect(res.headers['ratelimit-reset']).toBeDefined();
-    // When tokens are available, reset is 0 (no wait needed)
-    expect(Number(res.headers['ratelimit-reset'])).toBe(0);
-  });
-
-  it('sets RateLimit-Reset > 0 when last token is consumed', async () => {
-    const app = createTestApp();
-    const ip = '30.0.0.1';
-
-    // Exhaust all but the last token
-    for (let i = 0; i < 99; i++) {
-      await request(app).get('/test').set('X-Forwarded-For', ip);
-    }
-
-    // The 100th request consumes the last token
-    const lastAllowed = await request(app).get('/test').set('X-Forwarded-For', ip);
-    expect(lastAllowed.status).toBe(200);
-    expect(Number(lastAllowed.headers['ratelimit-remaining'])).toBe(0);
-    // After consuming the last token, reset should indicate wait time
-    expect(Number(lastAllowed.headers['ratelimit-reset'])).toBeGreaterThan(0);
+  it('returns null for undefined', () => {
+    expect(detectVerifiedBot(undefined)).toBeNull();
   });
 });

--- a/harmony-backend/tests/rate-limit.redis.test.ts
+++ b/harmony-backend/tests/rate-limit.redis.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for the Redis-backed public API rate limiter — Issue #318
+ *
+ * Replaces the in-process token-bucket tests (which required fake timers and
+ * _clearBucketsForTesting) with tests that work against any Store implementation.
+ * Store is injected as a constructor argument, so:
+ *   - These tests use MemoryStore (the default when no store is passed), which
+ *     is hermetic — no Redis connection required.
+ *   - In production, createPublicRateLimiter() is called with a RedisStore.
+ *
+ * The key property being verified: the limiter delegates counting to whichever
+ * store is configured — no process-local state lives in the middleware itself.
+ */
+
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import type { Store, IncrementResponse, ClientRateLimitInfo, Options } from 'express-rate-limit';
+import {
+  createPublicRateLimiter,
+  isVerifiedBot,
+  detectVerifiedBot,
+} from '../src/middleware/rate-limit.middleware';
+
+function buildApp(store?: Store) {
+  const app = express();
+  app.set('trust proxy', true);
+  app.use(createPublicRateLimiter(store));
+  app.get('/test', (_req: Request, res: Response) => {
+    res.status(200).json({ ok: true });
+  });
+  return app;
+}
+
+// ─── Bot detection (pure functions — unchanged from previous implementation) ──
+
+describe('isVerifiedBot', () => {
+  it('identifies Googlebot as a verified bot', () => {
+    expect(
+      isVerifiedBot('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'),
+    ).toBe(true);
+  });
+
+  it('identifies Bingbot case-insensitively', () => {
+    expect(
+      isVerifiedBot('Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'),
+    ).toBe(true);
+    expect(
+      isVerifiedBot('Mozilla/5.0 (compatible; Bingbot/2.0; +http://www.bing.com/bingbot.htm)'),
+    ).toBe(true);
+  });
+
+  it('returns false for a normal browser User-Agent', () => {
+    expect(
+      isVerifiedBot('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'),
+    ).toBe(false);
+  });
+
+  it('returns false for undefined User-Agent', () => {
+    expect(isVerifiedBot(undefined)).toBe(false);
+  });
+
+  it('returns false for empty string User-Agent', () => {
+    expect(isVerifiedBot('')).toBe(false);
+  });
+});
+
+describe('detectVerifiedBot', () => {
+  it('returns the bot name when matched', () => {
+    expect(
+      detectVerifiedBot(
+        'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+      ),
+    ).toBe('googlebot');
+  });
+
+  it('returns null for a human UA', () => {
+    expect(detectVerifiedBot('Mozilla/5.0 Chrome/120')).toBeNull();
+  });
+});
+
+// ─── Rate limit behavior ──────────────────────────────────────────────────────
+
+describe('createPublicRateLimiter — allows requests within limit', () => {
+  it('returns 200 on the first request', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/test').set('X-Forwarded-For', '1.2.3.4');
+    expect(res.status).toBe(200);
+  });
+
+  it('includes RateLimit-Limit header of 100', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/test').set('X-Forwarded-For', '1.2.3.4');
+    expect(res.headers['ratelimit-limit']).toBe('100');
+  });
+
+  it('includes a decrementing RateLimit-Remaining header', async () => {
+    const app = buildApp();
+    const ip = '2.2.2.2';
+    const first = await request(app).get('/test').set('X-Forwarded-For', ip);
+    const second = await request(app).get('/test').set('X-Forwarded-For', ip);
+
+    const remaining1 = Number(first.headers['ratelimit-remaining']);
+    const remaining2 = Number(second.headers['ratelimit-remaining']);
+    expect(remaining2).toBe(remaining1 - 1);
+  });
+});
+
+describe('createPublicRateLimiter — enforces limit', () => {
+  it('returns 429 after 100 requests from the same IP', async () => {
+    const app = buildApp();
+    const ip = '5.5.5.5';
+
+    for (let i = 0; i < 100; i++) {
+      const res = await request(app).get('/test').set('X-Forwarded-For', ip);
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await request(app).get('/test').set('X-Forwarded-For', ip);
+    expect(blocked.status).toBe(429);
+    expect(blocked.body).toMatchObject({ error: expect.stringContaining('Too many requests') });
+  });
+
+  it('includes Retry-After header on 429', async () => {
+    const app = buildApp();
+    const ip = '6.6.6.6';
+
+    for (let i = 0; i < 100; i++) {
+      await request(app).get('/test').set('X-Forwarded-For', ip);
+    }
+
+    const blocked = await request(app).get('/test').set('X-Forwarded-For', ip);
+    expect(blocked.status).toBe(429);
+    expect(Number(blocked.headers['retry-after'])).toBeGreaterThan(0);
+  });
+
+  it('isolates buckets per IP — exhausting one IP does not block another', async () => {
+    const app = buildApp();
+
+    for (let i = 0; i < 100; i++) {
+      await request(app).get('/test').set('X-Forwarded-For', '10.0.0.1');
+    }
+    const blocked = await request(app).get('/test').set('X-Forwarded-For', '10.0.0.1');
+    expect(blocked.status).toBe(429);
+
+    const unaffected = await request(app).get('/test').set('X-Forwarded-For', '10.0.0.2');
+    expect(unaffected.status).toBe(200);
+  });
+});
+
+describe('createPublicRateLimiter — store delegation (replica-safe wiring)', () => {
+  /**
+   * Mock store that records every increment() call and always returns a low hit
+   * count so requests are never actually blocked. This lets us isolate the
+   * "is the store actually wired?" question from the "does limiting work?" question.
+   */
+  function createMockStore(): Store & { incrementCalls: string[] } {
+    const incrementCalls: string[] = [];
+    return {
+      incrementCalls,
+      init(_options: Options) {},
+      async increment(key: string): Promise<IncrementResponse> {
+        incrementCalls.push(key);
+        return { totalHits: 1, resetTime: new Date(Date.now() + 60_000) };
+      },
+      async decrement(_key: string): Promise<void> {},
+      async resetKey(_key: string): Promise<void> {},
+      async get(_key: string): Promise<ClientRateLimitInfo | undefined> {
+        return { totalHits: 1, resetTime: new Date(Date.now() + 60_000) };
+      },
+    };
+  }
+
+  it('calls increment() on the injected store for each request', async () => {
+    const store = createMockStore();
+    const app = buildApp(store);
+
+    await request(app).get('/test').set('X-Forwarded-For', '7.7.7.7');
+
+    expect(store.incrementCalls.length).toBe(1);
+  });
+
+  it('keys increment() by IP address', async () => {
+    const store = createMockStore();
+    const app = buildApp(store);
+
+    await request(app).get('/test').set('X-Forwarded-For', '8.8.8.8');
+
+    expect(store.incrementCalls[0]).toContain('8.8.8.8');
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces in-process `MemoryStore` on `loginLimiter`, `registerLimiter`, `refreshLimiter` with `RedisStore` (from `rate-limit-redis`) — each limiter gets a unique key prefix (`rl:login:`, `rl:register:`, `rl:refresh:`) so counters are independent but global across all replicas
- Removes the in-process `Map<string, TokenBucket>` in `rate-limit.middleware.ts` entirely; replaced with `createPublicRateLimiter(store?)` factory backed by Redis (`rl:public:`, 100 req/min fixed-window)
- Converts `publicRouter` singleton to `createPublicRouter(store?)` factory so `createApp(options?)` can inject the same `rateLimitStore` used for auth limiters
- Trust proxy (`TRUST_PROXY_HOPS`) was already implemented; audit doc updated to mark §3.1, §3.2, §3.3 resolved

All `rate-limit-redis` store operations use a Lua script (atomic increment + expiry) — no non-atomic INCR + EXPIRE pattern.

## Test plan

- [ ] `npx jest tests/app.rate-limit.test.ts` — 4 tests verify each auth limiter delegates to the injected store
- [ ] `npx jest tests/rate-limit.redis.test.ts` — 11 tests verify 200/429 behavior, RateLimit headers, IP isolation, and store delegation for the public limiter
- [ ] `npx jest tests/rate-limit.middleware.test.ts` — bot detection helpers unchanged
- [ ] `npx jest tests/public.router.test.ts tests/app.test.ts tests/auth.test.ts` — existing route tests still pass
- [ ] In production: set `TRUST_PROXY_HOPS=1` in Railway; confirm `X-Forwarded-For` is used for rate-limit keys via logs

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)