### PR TITLE
fix: reconnect SSE EventSource with fresh token after drop (issue #366)

### DIFF
--- a/harmony-frontend/src/hooks/useChannelEvents.ts
+++ b/harmony-frontend/src/hooks/useChannelEvents.ts
@@ -174,8 +174,8 @@ export function useChannelEvents({
         source: 'sse',
         target: '/api/events/channel/[channelId]',
       });
-      if (!everOpened) {
-        // Never successfully opened — likely a 401/403. Stop retrying.
+      if (!everOpened && reconnectCountRef.current === 0) {
+        // Never successfully opened on the first attempt — likely a 401/403. Stop retrying.
         es.close();
         return;
       }

--- a/harmony-frontend/src/hooks/useChannelEvents.ts
+++ b/harmony-frontend/src/hooks/useChannelEvents.ts
@@ -19,8 +19,11 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { Message } from '@/types/message';
 import type { Server } from '@/types/server';
-import { getAccessToken } from '@/lib/api-client';
+import { getAccessToken, refreshAccessToken } from '@/lib/api-client';
 import { getApiBaseUrl } from '@/lib/runtime-config';
+
+const MAX_RECONNECT_ATTEMPTS = 3;
+const RECONNECT_DELAY_MS = 2_000;
 
 export interface UseChannelEventsOptions {
   channelId: string;
@@ -46,6 +49,12 @@ export function useChannelEvents({
   enabled = true,
 }: UseChannelEventsOptions): UseChannelEventsResult {
   const [isConnected, setIsConnected] = useState(false);
+  // Incrementing this triggers the effect to re-run with a fresh token after a
+  // dropped connection (e.g. token expiry). Capped at MAX_RECONNECT_ATTEMPTS.
+  const [reconnectKey, setReconnectKey] = useState(0);
+  // Tracks how many consecutive reconnect attempts have been made so we can
+  // apply a growing delay and bail out after repeated failures.
+  const reconnectCountRef = useRef(0);
 
   // Keep stable references to callbacks so the effect doesn't re-run on every render.
   // Updated via useLayoutEffect (before paint) so the EventSource handlers always call
@@ -119,9 +128,11 @@ export function useChannelEvents({
     // server or a network error before the stream started) — close immediately
     // instead of letting EventSource retry with a stale/invalid token.
     let everOpened = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
     es.onopen = () => {
       everOpened = true;
+      reconnectCountRef.current = 0; // reset budget on successful connection
       setIsConnected(true);
     };
     es.onerror = () => {
@@ -129,10 +140,32 @@ export function useChannelEvents({
       if (!everOpened) {
         // Never successfully opened — likely a 401/403. Stop retrying.
         es.close();
+        return;
       }
+
+      // The connection was previously healthy but dropped (e.g. network blip,
+      // server restart, or the access token expired and the backend rejected the
+      // EventSource auto-reconnect attempt). Stop the native retry loop (which
+      // would keep hammering the server with the same stale token) and
+      // proactively refresh the token before reconnecting.
+      es.close();
+      const attempt = reconnectCountRef.current;
+      if (attempt >= MAX_RECONNECT_ATTEMPTS) return; // give up after cap
+
+      reconnectCountRef.current += 1;
+      const delay = RECONNECT_DELAY_MS * reconnectCountRef.current;
+      reconnectTimer = setTimeout(() => {
+        // Attempt a silent token refresh so the next EventSource URL carries a
+        // valid token even when the user has been idle (no API calls to trigger
+        // the axios interceptor refresh).
+        refreshAccessToken().finally(() => {
+          setReconnectKey(k => k + 1);
+        });
+      }, delay);
     };
 
     return () => {
+      if (reconnectTimer !== null) clearTimeout(reconnectTimer);
       es.removeEventListener('message:created', handleCreated);
       es.removeEventListener('message:edited', handleEdited);
       es.removeEventListener('message:deleted', handleDeleted);
@@ -140,7 +173,7 @@ export function useChannelEvents({
       es.close();
       setIsConnected(false);
     };
-  }, [channelId, enabled]);
+  }, [channelId, enabled, reconnectKey]);
 
   return { isConnected };
 }

--- a/harmony-frontend/src/hooks/useServerEvents.ts
+++ b/harmony-frontend/src/hooks/useServerEvents.ts
@@ -240,8 +240,8 @@ export function useServerEvents({
         source: 'sse',
         target: '/api/events/server/[serverId]',
       });
-      if (!everOpened) {
-        // Never successfully opened — likely 401/403. Stop retrying.
+      if (!everOpened && reconnectCountRef.current === 0) {
+        // Never successfully opened on the first attempt — likely 401/403. Stop retrying.
         es.close();
         return;
       }

--- a/harmony-frontend/src/hooks/useServerEvents.ts
+++ b/harmony-frontend/src/hooks/useServerEvents.ts
@@ -25,11 +25,14 @@
 
 'use client';
 
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { Channel, ChannelVisibility } from '@/types/channel';
 import type { User, UserStatus } from '@/types/user';
-import { getAccessToken } from '@/lib/api-client';
+import { getAccessToken, refreshAccessToken } from '@/lib/api-client';
 import { getApiBaseUrl } from '@/lib/runtime-config';
+
+const MAX_RECONNECT_ATTEMPTS = 3;
+const RECONNECT_DELAY_MS = 2_000;
 
 export interface UseServerEventsOptions {
   serverId: string;
@@ -63,6 +66,12 @@ export function useServerEvents({
   onChannelVisibilityChanged,
   enabled = true,
 }: UseServerEventsOptions): void {
+  // Incrementing this triggers the effect to re-run with a fresh token after a
+  // dropped connection (e.g. token expiry). Capped at MAX_RECONNECT_ATTEMPTS.
+  const [reconnectKey, setReconnectKey] = useState(0);
+  // Tracks how many consecutive reconnect attempts have been made.
+  const reconnectCountRef = useRef(0);
+
   // Keep stable references to callbacks so the effect doesn't re-run on every render.
   const onCreatedRef = useRef(onChannelCreated);
   const onUpdatedRef = useRef(onChannelUpdated);
@@ -166,18 +175,36 @@ export function useServerEvents({
     es.addEventListener('channel:visibility-changed', handleVisibilityChanged);
 
     let everOpened = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
     es.onopen = () => {
       everOpened = true;
+      reconnectCountRef.current = 0; // reset budget on successful connection
     };
     es.onerror = () => {
       if (!everOpened) {
         // Never successfully opened — likely 401/403. Stop retrying.
         es.close();
+        return;
       }
+
+      // Connection dropped after being healthy. Stop native retry (stale token)
+      // and schedule a reconnect with a proactive token refresh.
+      es.close();
+      const attempt = reconnectCountRef.current;
+      if (attempt >= MAX_RECONNECT_ATTEMPTS) return;
+
+      reconnectCountRef.current += 1;
+      const delay = RECONNECT_DELAY_MS * reconnectCountRef.current;
+      reconnectTimer = setTimeout(() => {
+        refreshAccessToken().finally(() => {
+          setReconnectKey(k => k + 1);
+        });
+      }, delay);
     };
 
     return () => {
+      if (reconnectTimer !== null) clearTimeout(reconnectTimer);
       es.removeEventListener('channel:created', handleCreated);
       es.removeEventListener('channel:updated', handleUpdated);
       es.removeEventListener('channel:deleted', handleDeleted);
@@ -187,5 +214,5 @@ export function useServerEvents({
       es.removeEventListener('channel:visibility-changed', handleVisibilityChanged);
       es.close();
     };
-  }, [serverId, enabled]);
+  }, [serverId, enabled, reconnectKey]);
 }

--- a/harmony-frontend/src/lib/api-client.ts
+++ b/harmony-frontend/src/lib/api-client.ts
@@ -196,3 +196,55 @@ class ApiClient {
 }
 
 export const apiClient = new ApiClient();
+
+/**
+ * Proactively refreshes the access token using the stored refresh token.
+ * Safe to call from SSE hooks before reconnecting after a dropped connection.
+ *
+ * Reuses the module-level _isRefreshing/_refreshQueue so concurrent calls
+ * (e.g. an interceptor refresh already in flight) are coalesced rather than
+ * issuing a second /refresh request.
+ *
+ * On failure the function returns silently — it does NOT redirect or clear
+ * tokens. The caller (SSE reconnect logic) should proceed with whatever token
+ * is currently in memory; if that token is also expired the EventSource will
+ * fail cleanly on its next connection attempt.
+ */
+export async function refreshAccessToken(): Promise<void> {
+  if (typeof window === 'undefined') return;
+
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return;
+
+  // Piggyback on an in-flight interceptor refresh rather than racing it.
+  if (_isRefreshing) {
+    await new Promise<void>(resolve => {
+      _refreshQueue.push(() => resolve());
+    });
+    return;
+  }
+
+  _isRefreshing = true;
+  try {
+    const res = await axios.post<{ accessToken: string; refreshToken: string }>(
+      `${API_CONFIG.BASE_URL}/api/auth/refresh`,
+      { refreshToken },
+    );
+    const { accessToken: newAt, refreshToken: newRt } = res.data;
+    setTokens(newAt, newRt);
+    try {
+      await setSessionCookie(newAt);
+    } catch {
+      // Best-effort — same rationale as the interceptor refresh path
+    }
+    notifyRefreshQueue(newAt);
+  } catch {
+    // Silent failure: do not redirect or clear tokens.
+    // The SSE reconnect path will attempt the connection with the stale token
+    // and fail cleanly (everOpened=false → es.close()) rather than logging the
+    // user out just because they were idle in another tab.
+    notifyRefreshQueue(null);
+  } finally {
+    _isRefreshing = false;
+  }
+}

--- a/llm-logs/2026-04-15-231219-session-13cc8330.md
+++ b/llm-logs/2026-04-15-231219-session-13cc8330.md
@@ -1,0 +1,899 @@
+# Session Log 2026-04-15-231219
+
+## User
+
+Complete https://github.com/CS485-Harmony/Harmony/issues/366 on a new branch
+
+## Assistant
+
+**Tool call: `ToolSearch`**
+```json
+{
+  "query": "select:WebFetch,TaskCreate",
+  "max_results": 2
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 366 --repo CS485-Harmony/Harmony",
+  "description": "View GitHub issue #366"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 366 --repo CS485-Harmony/Harmony --comments",
+  "description": "View issue comments"
+}
+```
+
+## Assistant
+
+Let me explore the codebase to understand the real-time messaging implementation.
+
+## Assistant
+
+**Tool call: `Agent`**
+```json
+{
+  "description": "Explore real-time messaging implementation",
+  "subagent_type": "Explore",
+  "prompt": "I'm investigating a bug where messages/text don't appear automatically in real-time across different browser sessions on the same machine (or cloud deployment). This is likely a WebSocket or SSE (Server-Sent Events) issue.\n\nPlease explore the Harmony codebase at /Users/bigfa/Documents/GitHub/Harmony and find:\n1. How real-time messaging is implemented (WebSockets, SSE, polling, etc.)\n2. Any subscription/event handling code in the backend (harmony-backend/)\n3. Any real-time update code in the frontend (harmony-frontend/)\n4. Any Redis pub/sub or event bus code\n5. Any session/connection management code\n\nFocus on files related to: subscriptions, events, SSE, WebSocket, Redis pub/sub, message streaming. Report file paths and key code sections."
+}
+```
+
+## Assistant
+
+Let me read the key files to identify the root cause of the bug.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useChannelEvents.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/routes/events.router.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/events/eventBus.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib -name \"api-client.ts\" -o -name \"runtime-config.ts\" | head -5",
+  "description": "Find api-client and runtime-config files"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useServerListSync.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/api-client.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src -name \"*.tsx\" -o -name \"*.ts\" | xargs grep -l \"getRefreshToken\\|harmony_refresh_token\\|silentRefresh\\|initAuth\\|autoRefresh\" 2>/dev/null | head -10",
+  "description": "Find files that use the refresh token"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/HarmonyShell.tsx",
+  "offset": 1,
+  "limit": 100
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/authService.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src -name \"useAuth*\" -o -name \"AuthContext*\" | head -5",
+  "description": "Find auth hooks"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/context/AuthContext.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useServerEvents.ts"
+}
+```
+
+## Assistant
+
+Let me check the token TTL and any existing refresh infrastructure.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"expiresIn\\|accessTokenTTL\\|ACCESS_TOKEN\\|JWT_EXPIRES\\|jwtExpires\\|15m\\|30m\\|1h\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src --include=\"*.ts\" -l | head -5",
+  "description": "Find token expiry settings"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"expiresIn\\|expires\\|TTL\\|15m\\|30m\\|1h\\|ACCESS\\|REFRESH\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auth.service.ts | head -20",
+  "description": "Check token expiry in auth service"
+}
+```
+
+## Assistant
+
+Now I have enough context. Let me consult the advisor before writing the fix.
+
+## Assistant
+
+**Tool call: `TaskCreate`**
+```json
+{
+  "subject": "Create feature branch for issue #366",
+  "description": "Create git branch feature/issue-366-sse-reconnect-stale-token off main"
+}
+```
+
+## Assistant
+
+**Tool call: `ToolSearch`**
+```json
+{
+  "query": "select:TaskUpdate",
+  "max_results": 1
+}
+```
+
+## Assistant
+
+**Tool call: `TaskUpdate`**
+```json
+{
+  "taskId": "1",
+  "status": "in_progress"
+}
+```
+
+## Assistant
+
+**Tool call: `TaskCreate`**
+```json
+{
+  "subject": "Export refreshAccessToken() from api-client.ts",
+  "description": "Add a proactive token refresh function that can be called by SSE hooks before reconnecting. Must reuse existing _isRefreshing/_refreshQueue state. Must NOT redirect or clear tokens on failure."
+}
+```
+
+## Assistant
+
+**Tool call: `TaskCreate`**
+```json
+{
+  "subject": "Fix stale-token retry loop in useChannelEvents",
+  "description": "Add reconnectKey state + reconnectCount ref. On onerror after everOpened: close ES, call refreshAccessToken(), then schedule reconnect with delay (2s * count, max 3 retries). Reset count on onopen."
+}
+```
+
+## Assistant
+
+**Tool call: `TaskCreate`**
+```json
+{
+  "subject": "Fix stale-token retry loop in useServerEvents",
+  "description": "Same fix as useChannelEvents: reconnectKey, reconnectCount ref, onerror close+refresh+delay pattern."
+}
+```
+
+## Assistant
+
+**Tool call: `TaskCreate`**
+```json
+{
+  "subject": "Run tests and verify fix",
+  "description": "Run frontend tests and backend tests. Verify no regressions."
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b feature/issue-366-sse-reconnect-stale-token",
+  "description": "Create feature branch"
+}
+```
+
+## Assistant
+
+**Tool call: `TaskUpdate`**
+```json
+{
+  "taskId": "1",
+  "status": "completed"
+}
+```
+
+## Assistant
+
+**Tool call: `TaskUpdate`**
+```json
+{
+  "taskId": "2",
+  "status": "in_progress"
+}
+```
+
+## Assistant
+
+Now let me implement the `refreshAccessToken()` function in `api-client.ts`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/api-client.ts",
+  "old_string": "import axios, {\n  type AxiosInstance,\n  type AxiosRequestConfig,\n  type InternalAxiosRequestConfig,\n} from 'axios';\nimport { API_CONFIG } from './constants';\nimport { setSessionCookie } from '@/app/actions/session';",
+  "new_string": "import axios, {\n  type AxiosInstance,\n  type AxiosRequestConfig,\n  type InternalAxiosRequestConfig,\n} from 'axios';\nimport { API_CONFIG } from './constants';\nimport { setSessionCookie } from '@/app/actions/session';\n\n// Re-export for use in SSE hooks that need to import refresh separately\nexport type { AxiosRequestConfig };"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/api-client.ts",
+  "old_string": "import axios, {\n  type AxiosInstance,\n  type AxiosRequestConfig,\n  type InternalAxiosRequestConfig,\n} from 'axios';\nimport { API_CONFIG } from './constants';\nimport { setSessionCookie } from '@/app/actions/session';\n\n// Re-export for use in SSE hooks that need to import refresh separately\nexport type { AxiosRequestConfig };",
+  "new_string": "import axios, {\n  type AxiosInstance,\n  type AxiosRequestConfig,\n  type InternalAxiosRequestConfig,\n} from 'axios';\nimport { API_CONFIG } from './constants';\nimport { setSessionCookie } from '@/app/actions/session';"
+}
+```
+
+## Assistant
+
+Now let me add the `refreshAccessToken` function at the end of the file, before the `apiClient` export:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/api-client.ts",
+  "old_string": "export const apiClient = new ApiClient();",
+  "new_string": "export const apiClient = new ApiClient();\n\n/**\n * Proactively refreshes the access token using the stored refresh token.\n * Safe to call from SSE hooks before reconnecting after a dropped connection.\n *\n * Reuses the module-level _isRefreshing/_refreshQueue so concurrent calls\n * (e.g. an interceptor refresh already in flight) are coalesced rather than\n * issuing a second /refresh request.\n *\n * On failure the function returns silently \u2014 it does NOT redirect or clear\n * tokens. The caller (SSE reconnect logic) should proceed with whatever token\n * is currently in memory; if that token is also expired the EventSource will\n * fail cleanly on its next connection attempt.\n */\nexport async function refreshAccessToken(): Promise<void> {\n  if (typeof window === 'undefined') return;\n\n  const refreshToken = getRefreshToken();\n  if (!refreshToken) return;\n\n  // Piggyback on an in-flight interceptor refresh rather than racing it.\n  if (_isRefreshing) {\n    await new Promise<void>(resolve => {\n      _refreshQueue.push(() => resolve());\n    });\n    return;\n  }\n\n  _isRefreshing = true;\n  try {\n    const res = await axios.post<{ accessToken: string; refreshToken: string }>(\n      `${API_CONFIG.BASE_URL}/api/auth/refresh`,\n      { refreshToken },\n    );\n    const { accessToken: newAt, refreshToken: newRt } = res.data;\n    setTokens(newAt, newRt);\n    try {\n      await setSessionCookie(newAt);\n    } catch {\n      // Best-effort \u2014 same rationale as the interceptor refresh path\n    }\n    notifyRefreshQueue(newAt);\n  } catch {\n    // Silent failure: do not redirect or clear tokens.\n    // The SSE reconnect path will attempt the connection with the stale token\n    // and fail cleanly (everOpened=false \u2192 es.close()) rather than logging the\n    // user out just because they were idle in another tab.\n    notifyRefreshQueue(null);\n  } finally {\n    _isRefreshing = false;\n  }\n}"
+}
+```
+
+## Assistant
+
+Now let me fix `useChannelEvents.ts`:
+
+## Assistant
+
+**Tool call: `TaskUpdate`**
+```json
+{
+  "taskId": "2",
+  "status": "completed"
+}
+```
+
+## Assistant
+
+**Tool call: `TaskUpdate`**
+```json
+{
+  "taskId": "3",
+  "status": "in_progress"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useChannelEvents.ts",
+  "old_string": "import { useEffect, useLayoutEffect, useRef, useState } from 'react';\nimport type { Message } from '@/types/message';\nimport type { Server } from '@/types/server';\nimport { getAccessToken } from '@/lib/api-client';\nimport { getApiBaseUrl } from '@/lib/runtime-config';",
+  "new_string": "import { useEffect, useLayoutEffect, useRef, useState } from 'react';\nimport type { Message } from '@/types/message';\nimport type { Server } from '@/types/server';\nimport { getAccessToken, refreshAccessToken } from '@/lib/api-client';\nimport { getApiBaseUrl } from '@/lib/runtime-config';\n\nconst MAX_RECONNECT_ATTEMPTS = 3;\nconst RECONNECT_DELAY_MS = 2_000;"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useChannelEvents.ts",
+  "old_string": "export function useChannelEvents({\n  channelId,\n  onMessageCreated,\n  onMessageEdited,\n  onMessageDeleted,\n  onServerUpdated,\n  enabled = true,\n}: UseChannelEventsOptions): UseChannelEventsResult {\n  const [isConnected, setIsConnected] = useState(false);\n\n  // Keep stable references to callbacks so the effect doesn't re-run on every render.\n  // Updated via useLayoutEffect (before paint) so the EventSource handlers always call\n  // the latest version without the effect needing them as dependencies.\n  const onCreatedRef = useRef(onMessageCreated);\n  const onEditedRef = useRef(onMessageEdited);\n  const onDeletedRef = useRef(onMessageDeleted);\n  const onServerUpdatedRef = useRef(onServerUpdated);\n\n  useLayoutEffect(() => {\n    onCreatedRef.current = onMessageCreated;\n    onEditedRef.current = onMessageEdited;\n    onDeletedRef.current = onMessageDeleted;\n    onServerUpdatedRef.current = onServerUpdated;\n  });\n\n  useEffect(() => {\n    if (!enabled || !channelId) return;\n\n    const apiUrl = getApiBaseUrl();\n    const token = getAccessToken();\n    if (!token) return; // unauthenticated \u2014 don't attempt connection\n    const url = `${apiUrl}/api/events/channel/${channelId}?token=${encodeURIComponent(token)}`;\n    const es = new EventSource(url);\n\n    // \u2500\u2500 Event handlers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    const handleCreated = (event: MessageEvent<string>) => {\n      try {\n        const msg = JSON.parse(event.data) as Message;\n        onCreatedRef.current(msg);\n      } catch {\n        // Ignore malformed payloads \u2014 server bug or network corruption\n      }\n    };\n\n    const handleEdited = (event: MessageEvent<string>) => {\n      try {\n        const msg = JSON.parse(event.data) as Message;\n        onEditedRef.current(msg);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleDeleted = (event: MessageEvent<string>) => {\n      try {\n        const payload = JSON.parse(event.data) as { messageId: string };\n        onDeletedRef.current(payload.messageId);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleServerUpdated = (event: MessageEvent<string>) => {\n      try {\n        const server = JSON.parse(event.data) as Server;\n        onServerUpdatedRef.current?.(server);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    es.addEventListener('message:created', handleCreated);\n    es.addEventListener('message:edited', handleEdited);\n    es.addEventListener('message:deleted', handleDeleted);\n    es.addEventListener('server:updated', handleServerUpdated);\n\n    // Track whether the connection ever opened successfully.\n    // If onerror fires before onopen it's a permanent failure (4xx/5xx from the\n    // server or a network error before the stream started) \u2014 close immediately\n    // instead of letting EventSource retry with a stale/invalid token.\n    let everOpened = false;\n\n    es.onopen = () => {\n      everOpened = true;\n      setIsConnected(true);\n    };\n    es.onerror = () => {\n      setIsConnected(false);\n      if (!everOpened) {\n        // Never successfully opened \u2014 likely a 401/403. Stop retrying.\n        es.close();\n      }\n    };\n\n    return () => {\n      es.removeEventListener('message:created', handleCreated);\n      es.removeEventListener('message:edited', handleEdited);\n      es.removeEventListener('message:deleted', handleDeleted);\n      es.removeEventListener('server:updated', handleServerUpdated);\n      es.close();\n      setIsConnected(false);\n    };\n  }, [channelId, enabled]);\n\n  return { isConnected };\n}",
+  "new_string": "export function useChannelEvents({\n  channelId,\n  onMessageCreated,\n  onMessageEdited,\n  onMessageDeleted,\n  onServerUpdated,\n  enabled = true,\n}: UseChannelEventsOptions): UseChannelEventsResult {\n  const [isConnected, setIsConnected] = useState(false);\n  // Incrementing this triggers the effect to re-run with a fresh token after a\n  // dropped connection (e.g. token expiry). Capped at MAX_RECONNECT_ATTEMPTS.\n  const [reconnectKey, setReconnectKey] = useState(0);\n  // Tracks how many consecutive reconnect attempts have been made so we can\n  // apply a growing delay and bail out after repeated failures.\n  const reconnectCountRef = useRef(0);\n\n  // Keep stable references to callbacks so the effect doesn't re-run on every render.\n  // Updated via useLayoutEffect (before paint) so the EventSource handlers always call\n  // the latest version without the effect needing them as dependencies.\n  const onCreatedRef = useRef(onMessageCreated);\n  const onEditedRef = useRef(onMessageEdited);\n  const onDeletedRef = useRef(onMessageDeleted);\n  const onServerUpdatedRef = useRef(onServerUpdated);\n\n  useLayoutEffect(() => {\n    onCreatedRef.current = onMessageCreated;\n    onEditedRef.current = onMessageEdited;\n    onDeletedRef.current = onMessageDeleted;\n    onServerUpdatedRef.current = onServerUpdated;\n  });\n\n  useEffect(() => {\n    if (!enabled || !channelId) return;\n\n    const apiUrl = getApiBaseUrl();\n    const token = getAccessToken();\n    if (!token) return; // unauthenticated \u2014 don't attempt connection\n    const url = `${apiUrl}/api/events/channel/${channelId}?token=${encodeURIComponent(token)}`;\n    const es = new EventSource(url);\n\n    // \u2500\u2500 Event handlers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n    const handleCreated = (event: MessageEvent<string>) => {\n      try {\n        const msg = JSON.parse(event.data) as Message;\n        onCreatedRef.current(msg);\n      } catch {\n        // Ignore malformed payloads \u2014 server bug or network corruption\n      }\n    };\n\n    const handleEdited = (event: MessageEvent<string>) => {\n      try {\n        const msg = JSON.parse(event.data) as Message;\n        onEditedRef.current(msg);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleDeleted = (event: MessageEvent<string>) => {\n      try {\n        const payload = JSON.parse(event.data) as { messageId: string };\n        onDeletedRef.current(payload.messageId);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleServerUpdated = (event: MessageEvent<string>) => {\n      try {\n        const server = JSON.parse(event.data) as Server;\n        onServerUpdatedRef.current?.(server);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    es.addEventListener('message:created', handleCreated);\n    es.addEventListener('message:edited', handleEdited);\n    es.addEventListener('message:deleted', handleDeleted);\n    es.addEventListener('server:updated', handleServerUpdated);\n\n    // Track whether the connection ever opened successfully.\n    // If onerror fires before onopen it's a permanent failure (4xx/5xx from the\n    // server or a network error before the stream started) \u2014 close immediately\n    // instead of letting EventSource retry with a stale/invalid token.\n    let everOpened = false;\n    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;\n\n    es.onopen = () => {\n      everOpened = true;\n      reconnectCountRef.current = 0; // reset budget on successful connection\n      setIsConnected(true);\n    };\n    es.onerror = () => {\n      setIsConnected(false);\n      if (!everOpened) {\n        // Never successfully opened \u2014 likely a 401/403. Stop retrying.\n        es.close();\n        return;\n      }\n\n      // The connection was previously healthy but dropped (e.g. network blip,\n      // server restart, or the access token expired and the backend rejected the\n      // EventSource auto-reconnect attempt). Stop the native retry loop (which\n      // would keep hammering the server with the same stale token) and\n      // proactively refresh the token before reconnecting.\n      es.close();\n      const attempt = reconnectCountRef.current;\n      if (attempt >= MAX_RECONNECT_ATTEMPTS) return; // give up after cap\n\n      reconnectCountRef.current += 1;\n      const delay = RECONNECT_DELAY_MS * reconnectCountRef.current;\n      reconnectTimer = setTimeout(() => {\n        // Attempt a silent token refresh so the next EventSource URL carries a\n        // valid token even when the user has been idle (no API calls to trigger\n        // the axios interceptor refresh).\n        refreshAccessToken().finally(() => {\n          setReconnectKey(k => k + 1);\n        });\n      }, delay);\n    };\n\n    return () => {\n      if (reconnectTimer !== null) clearTimeout(reconnectTimer);\n      es.removeEventListener('message:created', handleCreated);\n      es.removeEventListener('message:edited', handleEdited);\n      es.removeEventListener('message:deleted', handleDeleted);\n      es.removeEventListener('server:updated', handleServerUpdated);\n      es.close();\n      setIsConnected(false);\n    };\n  }, [channelId, enabled, reconnectKey]);\n\n  return { isConnected };\n}"
+}
+```
+
+## Assistant
+
+**Tool call: `TaskUpdate`**
+```json
+{
+  "taskId": "3",
+  "status": "completed"
+}
+```
+
+## Assistant
+
+**Tool call: `TaskUpdate`**
+```json
+{
+  "taskId": "4",
+  "status": "in_progress"
+}
+```
+
+## Assistant
+
+Now fix `useServerEvents.ts` with the same pattern:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useServerEvents.ts",
+  "old_string": "import { useEffect, useLayoutEffect, useRef } from 'react';\nimport type { Channel, ChannelVisibility } from '@/types/channel';\nimport type { User, UserStatus } from '@/types/user';\nimport { getAccessToken } from '@/lib/api-client';\nimport { getApiBaseUrl } from '@/lib/runtime-config';",
+  "new_string": "import { useEffect, useLayoutEffect, useRef, useState } from 'react';\nimport type { Channel, ChannelVisibility } from '@/types/channel';\nimport type { User, UserStatus } from '@/types/user';\nimport { getAccessToken, refreshAccessToken } from '@/lib/api-client';\nimport { getApiBaseUrl } from '@/lib/runtime-config';\n\nconst MAX_RECONNECT_ATTEMPTS = 3;\nconst RECONNECT_DELAY_MS = 2_000;"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useServerEvents.ts",
+  "old_string": "export function useServerEvents({\n  serverId,\n  onChannelCreated,\n  onChannelUpdated,\n  onChannelDeleted,\n  onMemberJoined,\n  onMemberLeft,\n  onMemberStatusChanged,\n  onChannelVisibilityChanged,\n  enabled = true,\n}: UseServerEventsOptions): void {\n  // Keep stable references to callbacks so the effect doesn't re-run on every render.\n  const onCreatedRef = useRef(onChannelCreated);\n  const onUpdatedRef = useRef(onChannelUpdated);\n  const onDeletedRef = useRef(onChannelDeleted);\n  const onMemberJoinedRef = useRef(onMemberJoined);\n  const onMemberLeftRef = useRef(onMemberLeft);\n  const onMemberStatusChangedRef = useRef(onMemberStatusChanged);\n  const onVisibilityChangedRef = useRef(onChannelVisibilityChanged);\n\n  useLayoutEffect(() => {\n    onCreatedRef.current = onChannelCreated;\n    onUpdatedRef.current = onChannelUpdated;\n    onDeletedRef.current = onChannelDeleted;\n    onMemberJoinedRef.current = onMemberJoined;\n    onMemberLeftRef.current = onMemberLeft;\n    onMemberStatusChangedRef.current = onMemberStatusChanged;\n    onVisibilityChangedRef.current = onChannelVisibilityChanged;\n  });\n\n  useEffect(() => {\n    if (!enabled || !serverId) return;\n\n    const apiUrl = getApiBaseUrl();\n    const token = getAccessToken();\n    if (!token) return;\n\n    const url = `${apiUrl}/api/events/server/${serverId}?token=${encodeURIComponent(token)}`;\n    const es = new EventSource(url);\n\n    const handleCreated = (event: MessageEvent<string>) => {\n      try {\n        const channel = JSON.parse(event.data) as Channel;\n        onCreatedRef.current(channel);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleUpdated = (event: MessageEvent<string>) => {\n      try {\n        const channel = JSON.parse(event.data) as Channel;\n        onUpdatedRef.current(channel);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleDeleted = (event: MessageEvent<string>) => {\n      try {\n        const payload = JSON.parse(event.data) as { channelId: string };\n        onDeletedRef.current(payload.channelId);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleMemberJoined = (event: MessageEvent<string>) => {\n      try {\n        const user = JSON.parse(event.data) as User;\n        onMemberJoinedRef.current?.(user);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleMemberLeft = (event: MessageEvent<string>) => {\n      try {\n        const payload = JSON.parse(event.data) as { userId: string };\n        onMemberLeftRef.current?.(payload.userId);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleMemberStatusChanged = (event: MessageEvent<string>) => {\n      try {\n        const payload = JSON.parse(event.data) as { id: string; status: UserStatus };\n        onMemberStatusChangedRef.current?.(payload);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleVisibilityChanged = (event: MessageEvent<string>) => {\n      try {\n        // The backend sends the full updated channel object plus oldVisibility.\n        const payload = JSON.parse(event.data) as Channel & { oldVisibility: ChannelVisibility };\n        const { oldVisibility, ...channel } = payload;\n        onVisibilityChangedRef.current?.(channel, oldVisibility);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    es.addEventListener('channel:created', handleCreated);\n    es.addEventListener('channel:updated', handleUpdated);\n    es.addEventListener('channel:deleted', handleDeleted);\n    es.addEventListener('member:joined', handleMemberJoined);\n    es.addEventListener('member:left', handleMemberLeft);\n    es.addEventListener('member:statusChanged', handleMemberStatusChanged);\n    es.addEventListener('channel:visibility-changed', handleVisibilityChanged);\n\n    let everOpened = false;\n\n    es.onopen = () => {\n      everOpened = true;\n    };\n    es.onerror = () => {\n      if (!everOpened) {\n        // Never successfully opened \u2014 likely 401/403. Stop retrying.\n        es.close();\n      }\n    };\n\n    return () => {\n      es.removeEventListener('channel:created', handleCreated);\n      es.removeEventListener('channel:updated', handleUpdated);\n      es.removeEventListener('channel:deleted', handleDeleted);\n      es.removeEventListener('member:joined', handleMemberJoined);\n      es.removeEventListener('member:left', handleMemberLeft);\n      es.removeEventListener('member:statusChanged', handleMemberStatusChanged);\n      es.removeEventListener('channel:visibility-changed', handleVisibilityChanged);\n      es.close();\n    };\n  }, [serverId, enabled]);\n}",
+  "new_string": "export function useServerEvents({\n  serverId,\n  onChannelCreated,\n  onChannelUpdated,\n  onChannelDeleted,\n  onMemberJoined,\n  onMemberLeft,\n  onMemberStatusChanged,\n  onChannelVisibilityChanged,\n  enabled = true,\n}: UseServerEventsOptions): void {\n  // Incrementing this triggers the effect to re-run with a fresh token after a\n  // dropped connection (e.g. token expiry). Capped at MAX_RECONNECT_ATTEMPTS.\n  const [reconnectKey, setReconnectKey] = useState(0);\n  // Tracks how many consecutive reconnect attempts have been made.\n  const reconnectCountRef = useRef(0);\n\n  // Keep stable references to callbacks so the effect doesn't re-run on every render.\n  const onCreatedRef = useRef(onChannelCreated);\n  const onUpdatedRef = useRef(onChannelUpdated);\n  const onDeletedRef = useRef(onChannelDeleted);\n  const onMemberJoinedRef = useRef(onMemberJoined);\n  const onMemberLeftRef = useRef(onMemberLeft);\n  const onMemberStatusChangedRef = useRef(onMemberStatusChanged);\n  const onVisibilityChangedRef = useRef(onChannelVisibilityChanged);\n\n  useLayoutEffect(() => {\n    onCreatedRef.current = onChannelCreated;\n    onUpdatedRef.current = onChannelUpdated;\n    onDeletedRef.current = onChannelDeleted;\n    onMemberJoinedRef.current = onMemberJoined;\n    onMemberLeftRef.current = onMemberLeft;\n    onMemberStatusChangedRef.current = onMemberStatusChanged;\n    onVisibilityChangedRef.current = onChannelVisibilityChanged;\n  });\n\n  useEffect(() => {\n    if (!enabled || !serverId) return;\n\n    const apiUrl = getApiBaseUrl();\n    const token = getAccessToken();\n    if (!token) return;\n\n    const url = `${apiUrl}/api/events/server/${serverId}?token=${encodeURIComponent(token)}`;\n    const es = new EventSource(url);\n\n    const handleCreated = (event: MessageEvent<string>) => {\n      try {\n        const channel = JSON.parse(event.data) as Channel;\n        onCreatedRef.current(channel);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleUpdated = (event: MessageEvent<string>) => {\n      try {\n        const channel = JSON.parse(event.data) as Channel;\n        onUpdatedRef.current(channel);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleDeleted = (event: MessageEvent<string>) => {\n      try {\n        const payload = JSON.parse(event.data) as { channelId: string };\n        onDeletedRef.current(payload.channelId);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleMemberJoined = (event: MessageEvent<string>) => {\n      try {\n        const user = JSON.parse(event.data) as User;\n        onMemberJoinedRef.current?.(user);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleMemberLeft = (event: MessageEvent<string>) => {\n      try {\n        const payload = JSON.parse(event.data) as { userId: string };\n        onMemberLeftRef.current?.(payload.userId);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleMemberStatusChanged = (event: MessageEvent<string>) => {\n      try {\n        const payload = JSON.parse(event.data) as { id: string; status: UserStatus };\n        onMemberStatusChangedRef.current?.(payload);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    const handleVisibilityChanged = (event: MessageEvent<string>) => {\n      try {\n        // The backend sends the full updated channel object plus oldVisibility.\n        const payload = JSON.parse(event.data) as Channel & { oldVisibility: ChannelVisibility };\n        const { oldVisibility, ...channel } = payload;\n        onVisibilityChangedRef.current?.(channel, oldVisibility);\n      } catch {\n        // Ignore malformed payloads\n      }\n    };\n\n    es.addEventListener('channel:created', handleCreated);\n    es.addEventListener('channel:updated', handleUpdated);\n    es.addEventListener('channel:deleted', handleDeleted);\n    es.addEventListener('member:joined', handleMemberJoined);\n    es.addEventListener('member:left', handleMemberLeft);\n    es.addEventListener('member:statusChanged', handleMemberStatusChanged);\n    es.addEventListener('channel:visibility-changed', handleVisibilityChanged);\n\n    let everOpened = false;\n    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;\n\n    es.onopen = () => {\n      everOpened = true;\n      reconnectCountRef.current = 0; // reset budget on successful connection\n    };\n    es.onerror = () => {\n      if (!everOpened) {\n        // Never successfully opened \u2014 likely 401/403. Stop retrying.\n        es.close();\n        return;\n      }\n\n      // Connection dropped after being healthy. Stop native retry (stale token)\n      // and schedule a reconnect with a proactive token refresh.\n      es.close();\n      const attempt = reconnectCountRef.current;\n      if (attempt >= MAX_RECONNECT_ATTEMPTS) return;\n\n      reconnectCountRef.current += 1;\n      const delay = RECONNECT_DELAY_MS * reconnectCountRef.current;\n      reconnectTimer = setTimeout(() => {\n        refreshAccessToken().finally(() => {\n          setReconnectKey(k => k + 1);\n        });\n      }, delay);\n    };\n\n    return () => {\n      if (reconnectTimer !== null) clearTimeout(reconnectTimer);\n      es.removeEventListener('channel:created', handleCreated);\n      es.removeEventListener('channel:updated', handleUpdated);\n      es.removeEventListener('channel:deleted', handleDeleted);\n      es.removeEventListener('member:joined', handleMemberJoined);\n      es.removeEventListener('member:left', handleMemberLeft);\n      es.removeEventListener('member:statusChanged', handleMemberStatusChanged);\n      es.removeEventListener('channel:visibility-changed', handleVisibilityChanged);\n      es.close();\n    };\n  }, [serverId, enabled, reconnectKey]);\n}"
+}
+```
+
+## Assistant
+
+**Tool call: `TaskUpdate`**
+```json
+{
+  "taskId": "4",
+  "status": "completed"
+}
+```
+
+## Assistant
+
+**Tool call: `TaskUpdate`**
+```json
+{
+  "taskId": "5",
+  "status": "in_progress"
+}
+```
+
+## Assistant
+
+Now let's run the tests:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npm test -- --passWithNoTests 2>&1 | tail -30",
+  "description": "Run frontend tests",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All 208 tests pass. Let me also verify the TypeScript compilation:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1 | head -30",
+  "description": "TypeScript type check",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+No type errors. Now let me post an issue comment and open the PR:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && gh issue comment 366 --body \"**[AI Agent \u2014 Starting]**\n\nInvestigated the real-time SSE architecture. Root cause identified:\n\nWhen an EventSource connection drops after being successfully opened (\\`everOpened = true\\`), the existing error handler lets the browser's native EventSource auto-retry \u2014 but it retries with the **same URL** containing the expired token baked in. The server returns 401 on every reconnect attempt, leaving the session in a silent infinite retry loop where new messages never appear.\n\nThis explains the intermittent cross-session behavior: the bug manifests whenever an SSE connection drops (network blip, server restart, Vercel cold start) after the 15-minute access token has expired \u2014 which is more likely in concurrent-session scenarios where tokens rotate via the refresh flow.\n\n**Fix in progress on branch \\`feature/issue-366-sse-reconnect-stale-token\\`:**\n- \\`api-client.ts\\`: export \\`refreshAccessToken()\\` for proactive background refresh\n- \\`useChannelEvents.ts\\`: close EventSource on post-open errors, refresh token, then reconnect (up to 3 attempts with growing delay)\n- \\`useServerEvents.ts\\`: same fix\" 2>&1",
+  "description": "Post opening comment to issue"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add harmony-frontend/src/lib/api-client.ts harmony-frontend/src/hooks/useChannelEvents.ts harmony-frontend/src/hooks/useServerEvents.ts && git diff --staged --stat",
+  "description": "Stage changed files and show diff stat"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git commit -m \"$(cat <<'EOF'\nfix: reconnect SSE EventSource with fresh token after connection drop (#366)\n\nWhen an EventSource dropped after onopen fired, the native auto-retry\nreused the same URL \u2014 baking in the expired access token and silently\nlooping on 401s forever. Messages stopped appearing across all sessions\nuntil a page reload.\n\nFix:\n- On onerror after everOpened, close the EventSource immediately to stop\n  the stale-token retry loop, call refreshAccessToken(), then schedule a\n  reconnect (up to 3 attempts, delay grows by 2s per attempt)\n- Export refreshAccessToken() from api-client.ts \u2014 proactively refreshes\n  via the shared _isRefreshing/_refreshQueue state so it coalesces with\n  any in-flight axios interceptor refresh. Does not redirect or clear\n  tokens on failure (conservative: SSE reconnect should not log users out)\n- Apply the same fix to both useChannelEvents and useServerEvents\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit the fix"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin feature/issue-366-sse-reconnect-stale-token 2>&1",
+  "description": "Push branch to remote"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --title \"fix: reconnect SSE EventSource with fresh token after drop (issue #366)\" --body \"$(cat <<'EOF'\n## Summary\n\nFixes #366 \u2014 text not appearing automatically across sessions.\n\n**Root cause:** When an `EventSource` connection dropped _after_ being successfully opened, the browser's native auto-retry reused the same URL \u2014 including the expired JWT access token baked into the query string. The server rejected every reconnect attempt with 401, leaving the session in a silent infinite retry loop. Since the `onerror` handler only closed the connection if it had _never_ successfully opened, a previously-working session would silently stop receiving all real-time events (messages, channel updates, member changes) until the user reloaded the page.\n\nThis is intermittent because it requires two conditions together: (1) the SSE connection drops for any reason (network blip, Vercel cold start, server restart), and (2) the 15-minute access token has since expired. Multi-session scenarios increase the likelihood because the refresh-token rotation can rotate the token in one tab, leaving another tab unable to silently refresh.\n\n**Changes (`harmony-frontend`):**\n\n- **`src/lib/api-client.ts`** \u2014 export `refreshAccessToken()`: a proactive token refresh that reuses the module-level `_isRefreshing`/`_refreshQueue` state so it coalesces with any concurrent axios interceptor refresh. Fails silently (no redirect, no `clearTokens`) \u2014 appropriate for background SSE reconnect.\n\n- **`src/hooks/useChannelEvents.ts`** \u2014 on `onerror` after `everOpened`: close the EventSource immediately (stops the stale-token retry loop), call `refreshAccessToken()`, then schedule a reconnect via `reconnectKey` state increment. Up to 3 attempts with a growing 2 s \u00d7 n delay. Resets count on successful `onopen`.\n\n- **`src/hooks/useServerEvents.ts`** \u2014 identical fix for the server-scoped SSE stream.\n\n## Test plan\n\n- [x] All 208 existing frontend unit tests pass (`npm test` in `harmony-frontend/`)\n- [x] TypeScript compiles without errors (`tsc --noEmit`)\n- [ ] Manual: open two browser tabs on the same channel; send a message from one \u2014 verify it appears in the other without a reload\n- [ ] Manual: let a session stay idle for >15 min; send a message from another tab \u2014 verify it appears after the reconnect delay (\u22646 s for 3rd attempt)\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\" 2>&1",
+  "description": "Create pull request"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 366 --body \"**[AI Agent \u2014 Complete]**\n\nPR #372 is open: https://github.com/CS485-Harmony/Harmony/pull/372\n\n**Root cause:** \\`EventSource\\` auto-retries on error using the same URL \u2014 with the expired access token baked in. Once the connection had ever opened (\\`everOpened = true\\`), the error handler never closed it, resulting in an infinite 401 retry loop where no real-time events were delivered.\n\n**Fix (3 files in \\`harmony-frontend/\\`):**\n1. \\`api-client.ts\\` \u2014 \\`refreshAccessToken()\\`: proactive background refresh reusing the shared \\`_isRefreshing\\`/\\`_refreshQueue\\` state; fails silently (no redirect)\n2. \\`useChannelEvents.ts\\` \u2014 on post-open error: close EventSource, refresh token, reconnect (\u22643 attempts, 2s/4s/6s delay, reset on success)  \n3. \\`useServerEvents.ts\\` \u2014 same fix\n\nAll 208 existing tests pass.\" 2>&1",
+  "description": "Post completion comment to issue"
+}
+```
+
+## Assistant
+
+**Tool call: `TaskUpdate`**
+```json
+{
+  "taskId": "5",
+  "status": "completed"
+}
+```
+
+## Assistant
+
+PR is open: **CS485-Harmony/Harmony#372**
+
+---
+
+**Root cause:** The `EventSource` API auto-retries dropped connections using the same URL. Since the access token is baked into the query string at connection time, any reconnect after the 15-minute token expires gets rejected with 401. The existing `onerror` handler only closed the connection if it had *never* opened — so a previously-healthy session would silently loop on 401s forever, with no real-time events delivered.
+
+This explains the intermittent multi-session behavior: it hits when an SSE connection drops (network blip, Vercel cold start, server restart) after the token has expired — more likely when multiple tabs are rotating tokens independently.
+
+**Changes (3 files in `harmony-frontend/src/`):**
+
+| File | Change |
+|---|---|
+| `lib/api-client.ts` | Export `refreshAccessToken()` — proactive background refresh reusing the shared `_isRefreshing`/`_refreshQueue` state. Fails silently (no redirect, no token clear). |
+| `hooks/useChannelEvents.ts` | On `onerror` after `everOpened`: close EventSource immediately, call `refreshAccessToken()`, then reconnect via `reconnectKey` state increment. Up to 3 attempts with growing 2s delay. Resets count on successful open. |
+| `hooks/useServerEvents.ts` | Identical fix for the server-scoped SSE stream. |
+
+All 208 existing tests pass.
+
+## User
+
+open a PR
+
+## Assistant
+
+The PR is already open — it was created at the end of the previous step:
+
+**CS485-Harmony/Harmony#372** — [fix: reconnect SSE EventSource with fresh token after drop (issue #366)](https://github.com/CS485-Harmony/Harmony/pull/372)
+
+## User
+
+The PR has merge conflicts - please resolve them
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git fetch origin main && git merge origin/main 2>&1",
+  "description": "Fetch main and merge to find conflicts"
+}
+```
+
+## Assistant
+
+The conflicts are all in the import blocks — main added a `frontend-logger`, my branch added `refreshAccessToken`. Let me read each conflicted file and resolve them.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useChannelEvents.ts",
+  "limit": 40
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useServerEvents.ts",
+  "limit": 45
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/api-client.ts",
+  "limit": 15
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/api-client.ts",
+  "offset": 195
+}
+```
+
+## Assistant
+
+`api-client.ts` merged cleanly. The two hooks just need both imports combined. Let me resolve them:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useChannelEvents.ts",
+  "old_string": "<<<<<<< HEAD\nimport { getAccessToken, refreshAccessToken } from '@/lib/api-client';\nimport { getApiBaseUrl } from '@/lib/runtime-config';\n\nconst MAX_RECONNECT_ATTEMPTS = 3;\nconst RECONNECT_DELAY_MS = 2_000;\n=======\nimport { getAccessToken } from '@/lib/api-client';\nimport { createFrontendLogger } from '@/lib/frontend-logger';\nimport { getApiBaseUrl } from '@/lib/runtime-config';\n\nconst logger = createFrontendLogger({ component: 'use-channel-events' });\n>>>>>>> origin/main",
+  "new_string": "import { getAccessToken, refreshAccessToken } from '@/lib/api-client';\nimport { createFrontendLogger } from '@/lib/frontend-logger';\nimport { getApiBaseUrl } from '@/lib/runtime-config';\n\nconst logger = createFrontendLogger({ component: 'use-channel-events' });\n\nconst MAX_RECONNECT_ATTEMPTS = 3;\nconst RECONNECT_DELAY_MS = 2_000;"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useServerEvents.ts",
+  "old_string": "<<<<<<< HEAD\nimport { getAccessToken, refreshAccessToken } from '@/lib/api-client';\nimport { getApiBaseUrl } from '@/lib/runtime-config';\n\nconst MAX_RECONNECT_ATTEMPTS = 3;\nconst RECONNECT_DELAY_MS = 2_000;\n=======\nimport { getAccessToken } from '@/lib/api-client';\nimport { createFrontendLogger } from '@/lib/frontend-logger';\nimport { getApiBaseUrl } from '@/lib/runtime-config';\n\nconst logger = createFrontendLogger({ component: 'use-server-events' });\n>>>>>>> origin/main",
+  "new_string": "import { getAccessToken, refreshAccessToken } from '@/lib/api-client';\nimport { createFrontendLogger } from '@/lib/frontend-logger';\nimport { getApiBaseUrl } from '@/lib/runtime-config';\n\nconst logger = createFrontendLogger({ component: 'use-server-events' });\n\nconst MAX_RECONNECT_ATTEMPTS = 3;\nconst RECONNECT_DELAY_MS = 2_000;"
+}
+```
+
+## Assistant
+
+Now verify no remaining conflict markers and run tests:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"<<<<<<\\|>>>>>>>\\|=======\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useChannelEvents.ts /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useServerEvents.ts /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/api-client.ts 2>&1",
+  "description": "Check for remaining conflict markers"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npx tsc --noEmit 2>&1 | head -20",
+  "description": "TypeScript check",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test -- --passWithNoTests 2>&1 | tail -10",
+  "description": "Run frontend tests",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All 212 tests pass. Now commit and push:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-frontend/src/hooks/useChannelEvents.ts harmony-frontend/src/hooks/useServerEvents.ts harmony-frontend/src/lib/api-client.ts && git commit -m \"$(cat <<'EOF'\nchore: resolve merge conflicts with main\n\nMerge main's frontend-logger additions into the SSE reconnect fix.\nBoth changes coexist: logger for observability, reconnectKey+refreshAccessToken\nfor stale-token recovery.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\" && git push 2>&1",
+  "description": "Commit merge resolution and push"
+}
+```
+
+## Assistant
+
+Conflicts resolved and pushed. The merge combined both sets of changes:
+
+- **From main:** `createFrontendLogger` + `logger` instance added to both hooks (for observability)
+- **From this branch:** `refreshAccessToken` import + `MAX_RECONNECT_ATTEMPTS`/`RECONNECT_DELAY_MS` constants + the reconnect logic
+
+PR #372 should now show no merge conflicts.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "DATE=$(date +%Y-%m-%d)\nTIME=$(date +%H%M%S)\nSESSION_ID=\"13cc8330-7fc3-4b00-8c5a-9f5b714dc0e2\"\nSHORT_ID=\"${SESSION_ID:0:8}\"\nOUTFILE=\"llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md\"\necho \"OUTFILE=$OUTFILE\"\necho \"DATE=$DATE\"\necho \"TIME=$TIME\"\necho \"SHORT_ID=$SHORT_ID\"",
+  "description": "Determine output filename"
+}
+```
+


### PR DESCRIPTION
## Summary

Fixes #366 — text not appearing automatically across sessions.

**Root cause:** When an `EventSource` connection dropped _after_ being successfully opened, the browser's native auto-retry reused the same URL — including the expired JWT access token baked into the query string. The server rejected every reconnect attempt with 401, leaving the session in a silent infinite retry loop. Since the `onerror` handler only closed the connection if it had _never_ successfully opened, a previously-working session would silently stop receiving all real-time events (messages, channel updates, member changes) until the user reloaded the page.

This is intermittent because it requires two conditions together: (1) the SSE connection drops for any reason (network blip, Vercel cold start, server restart), and (2) the 15-minute access token has since expired. Multi-session scenarios increase the likelihood because the refresh-token rotation can rotate the token in one tab, leaving another tab unable to silently refresh.

**Changes (`harmony-frontend`):**

- **`src/lib/api-client.ts`** — export `refreshAccessToken()`: a proactive token refresh that reuses the module-level `_isRefreshing`/`_refreshQueue` state so it coalesces with any concurrent axios interceptor refresh. Fails silently (no redirect, no `clearTokens`) — appropriate for background SSE reconnect.

- **`src/hooks/useChannelEvents.ts`** — on `onerror` after `everOpened`: close the EventSource immediately (stops the stale-token retry loop), call `refreshAccessToken()`, then schedule a reconnect via `reconnectKey` state increment. Up to 3 attempts with a growing 2 s × n delay. Resets count on successful `onopen`.

- **`src/hooks/useServerEvents.ts`** — identical fix for the server-scoped SSE stream.

## Test plan

- [x] All 208 existing frontend unit tests pass (`npm test` in `harmony-frontend/`)
- [x] TypeScript compiles without errors (`tsc --noEmit`)
- [ ] Manual: open two browser tabs on the same channel; send a message from one — verify it appears in the other without a reload
- [ ] Manual: let a session stay idle for >15 min; send a message from another tab — verify it appears after the reconnect delay (≤6 s for 3rd attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)