### PR TITLE
fix: graceful empty states for login redirects and inaccessible channels

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# dev.sh — start Docker services, backend, and frontend for local development
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$REPO_ROOT/harmony-backend"
+FRONTEND_DIR="$REPO_ROOT/harmony-frontend"
+
+# ── Docker ────────────────────────────────────────────────────────────────────
+echo "==> Checking Docker services (postgres, redis)..."
+cd "$BACKEND_DIR"
+
+# Start any services that are not already running
+docker compose up -d
+
+echo "==> Docker services ready."
+
+# ── Prisma migrations ─────────────────────────────────────────────────────────
+echo "==> Applying Prisma migrations..."
+cd "$BACKEND_DIR"
+npx prisma migrate deploy
+echo "==> Migrations up to date."
+
+# ── Backend ───────────────────────────────────────────────────────────────────
+echo "==> Starting backend (npm run dev)..."
+cd "$BACKEND_DIR"
+npm run dev &
+BACKEND_PID=$!
+
+# ── Frontend ──────────────────────────────────────────────────────────────────
+echo "==> Starting frontend (npm run dev)..."
+cd "$FRONTEND_DIR"
+npm run dev &
+FRONTEND_PID=$!
+
+echo ""
+echo "Backend PID : $BACKEND_PID"
+echo "Frontend PID: $FRONTEND_PID"
+echo ""
+echo "Press Ctrl+C to stop both servers."
+
+# Forward Ctrl+C to both child processes
+trap 'echo ""; echo "Stopping..."; kill $BACKEND_PID $FRONTEND_PID 2>/dev/null; exit 0' INT TERM
+
+wait $BACKEND_PID $FRONTEND_PID

--- a/dev.sh
+++ b/dev.sh
@@ -39,7 +39,23 @@ echo "Frontend PID: $FRONTEND_PID"
 echo ""
 echo "Press Ctrl+C to stop both servers."
 
-# Forward Ctrl+C to both child processes
-trap 'echo ""; echo "Stopping..."; kill $BACKEND_PID $FRONTEND_PID 2>/dev/null; exit 0' INT TERM
+cleanup() {
+  local exit_code="${1:-0}"
+  trap - INT TERM EXIT
+  echo ""
+  echo "Stopping..."
+  kill "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || true
+  wait "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || true
+  exit "$exit_code"
+}
 
-wait $BACKEND_PID $FRONTEND_PID
+trap 'cleanup 130' INT
+trap 'cleanup 143' TERM
+trap 'cleanup $?' EXIT
+
+set +e
+wait -n "$BACKEND_PID" "$FRONTEND_PID"
+FIRST_EXIT_CODE=$?
+set -e
+
+cleanup "$FIRST_EXIT_CODE"

--- a/harmony-frontend/src/app/channels/[serverSlug]/page.tsx
+++ b/harmony-frontend/src/app/channels/[serverSlug]/page.tsx
@@ -1,8 +1,10 @@
-import { redirect, notFound } from 'next/navigation';
+import { redirect } from 'next/navigation';
 import { getServers } from '@/services/serverService';
 import { getChannels } from '@/services/channelService';
 import { publicGet } from '@/lib/trpc-client';
-import { ChannelType } from '@/types';
+import { ChannelType, ChannelVisibility } from '@/types';
+import { EmptyShell } from '@/components/layout/EmptyShell';
+import { NoChannelsContent } from '@/components/channel/NoChannelsContent';
 
 interface PageProps {
   params: Promise<{ serverSlug: string }>;
@@ -11,7 +13,13 @@ interface PageProps {
 export default async function ServerPage({ params }: PageProps) {
   const { serverSlug } = await params;
 
-  const servers = await getServers();
+  let servers;
+  try {
+    servers = await getServers();
+  } catch {
+    // Backend rejected the auth token (expired or invalid) — send to login.
+    redirect('/auth/login');
+  }
   const server = servers.find(s => s.slug === serverSlug);
 
   // Not in the user's member list — try the public channel view instead.
@@ -21,7 +29,8 @@ export default async function ServerPage({ params }: PageProps) {
     );
     const firstPublic = result?.channels?.[0];
     if (firstPublic) redirect(`/c/${serverSlug}/${firstPublic.slug}`);
-    notFound();
+    // Server not found publicly either — fall back to channels index.
+    redirect('/channels');
   }
 
   let channels;
@@ -34,13 +43,56 @@ export default async function ServerPage({ params }: PageProps) {
     );
     const firstPublic = result?.channels?.[0];
     if (firstPublic) redirect(`/c/${serverSlug}/${firstPublic.slug}`);
-    notFound();
+    // No public channels either — fall back to channels index.
+    redirect('/channels');
   }
 
+  // Only route to non-PRIVATE text/announcement channels. PRIVATE channels require
+  // an admin/owner role to read; routing a regular member there causes VisibilityGuard
+  // to show a dead-end full-screen "no permission" page with no navigation. Admins
+  // can still reach private channels by clicking them in the channel sidebar.
   const firstChannel = channels
-    .filter(c => c.type === ChannelType.TEXT || c.type === ChannelType.ANNOUNCEMENT)
+    .filter(
+      c =>
+        (c.type === ChannelType.TEXT || c.type === ChannelType.ANNOUNCEMENT) &&
+        c.visibility !== ChannelVisibility.PRIVATE,
+    )
     .sort((a, b) => a.position - b.position)[0];
-  if (!firstChannel) notFound();
 
-  redirect(`/channels/${serverSlug}/${firstChannel.slug}`);
+  if (firstChannel) {
+    redirect(`/channels/${serverSlug}/${firstChannel.slug}`);
+  }
+
+  // No non-private navigable channel found. Fetch all channels across every server
+  // so ServerRail can derive default channel slugs for navigation.
+  const allChannels = (
+    await Promise.all(
+      servers.map(s =>
+        s.id === server.id ? Promise.resolve(channels) : getChannels(s.id).catch(() => []),
+      ),
+    )
+  ).flat();
+
+  // Determine what to show in the main area:
+  //   • Text/announcement channels exist but are all PRIVATE → user lacks permission
+  //   • No channels at all → empty server
+  //   • Only voice channels → user CAN access them; leave main blank so they can join
+  const hasInaccessibleTextChannels = channels.some(
+    c =>
+      (c.type === ChannelType.TEXT || c.type === ChannelType.ANNOUNCEMENT) &&
+      c.visibility === ChannelVisibility.PRIVATE,
+  );
+  const showNoAccessMessage = channels.length === 0 || hasInaccessibleTextChannels;
+
+  return (
+    <EmptyShell
+      servers={servers}
+      currentServer={server}
+      channels={channels}
+      allChannels={allChannels}
+      basePath='/channels'
+    >
+      {showNoAccessMessage ? <NoChannelsContent /> : null}
+    </EmptyShell>
+  );
 }

--- a/harmony-frontend/src/app/channels/[serverSlug]/page.tsx
+++ b/harmony-frontend/src/app/channels/[serverSlug]/page.tsx
@@ -1,8 +1,9 @@
 import { redirect } from 'next/navigation';
 import { getServers } from '@/services/serverService';
 import { getChannels } from '@/services/channelService';
-import { publicGet } from '@/lib/trpc-client';
+import { publicGet, TrpcHttpError } from '@/lib/trpc-client';
 import { ChannelType, ChannelVisibility } from '@/types';
+import type { Server, Channel } from '@/types';
 import { EmptyShell } from '@/components/layout/EmptyShell';
 import { NoChannelsContent } from '@/components/channel/NoChannelsContent';
 
@@ -13,12 +14,14 @@ interface PageProps {
 export default async function ServerPage({ params }: PageProps) {
   const { serverSlug } = await params;
 
-  let servers;
+  let servers: Server[];
   try {
     servers = await getServers();
-  } catch {
-    // Backend rejected the auth token (expired or invalid) — send to login.
-    redirect('/auth/login');
+  } catch (err) {
+    // Only redirect to login for auth failures; rethrow other errors (network, 5xx) so
+    // Next.js surfaces them honestly rather than masking them as an auth problem.
+    if (err instanceof TrpcHttpError && err.status === 401) redirect('/auth/login');
+    throw err;
   }
   const server = servers.find(s => s.slug === serverSlug);
 
@@ -33,7 +36,7 @@ export default async function ServerPage({ params }: PageProps) {
     redirect('/channels');
   }
 
-  let channels;
+  let channels: Channel[];
   try {
     channels = await getChannels(server.id);
   } catch {
@@ -84,11 +87,22 @@ export default async function ServerPage({ params }: PageProps) {
   );
   const showNoAccessMessage = channels.length === 0 || hasInaccessibleTextChannels;
 
+  // Only show channels members can actually navigate to in the sidebar. Private
+  // text/announcement channels are excluded so regular members don't see links they
+  // can't open; voice channels are kept so members can still join them.
+  const sidebarChannels = showNoAccessMessage
+    ? channels.filter(
+        c =>
+          c.type === ChannelType.VOICE ||
+          c.visibility !== ChannelVisibility.PRIVATE,
+      )
+    : channels;
+
   return (
     <EmptyShell
       servers={servers}
       currentServer={server}
-      channels={channels}
+      channels={sidebarChannels}
       allChannels={allChannels}
       basePath='/channels'
     >

--- a/harmony-frontend/src/app/channels/page.tsx
+++ b/harmony-frontend/src/app/channels/page.tsx
@@ -1,17 +1,28 @@
 import { redirect } from 'next/navigation';
 import { getServers } from '@/services/serverService';
-import { NoServersView } from '@/components/channel/NoServersView';
+import { EmptyShell } from '@/components/layout/EmptyShell';
+import { NoServersContent } from '@/components/channel/NoServersContent';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * /channels index — redirects to the user's first server,
- * or renders NoServersView with a "Create a Server" prompt if they haven't joined any.
+ * /channels index — redirects to the user's first server, or renders the
+ * empty shell with a "no servers" prompt if the user hasn't joined any.
  */
 export default async function ChannelsPage() {
-  const servers = await getServers();
+  let servers;
+  try {
+    servers = await getServers();
+  } catch {
+    // Backend rejected the auth token (expired or invalid) — send to login.
+    redirect('/auth/login');
+  }
   const first = servers[0];
   if (first) redirect(`/channels/${first.slug}`);
 
-  return <NoServersView />;
+  return (
+    <EmptyShell servers={[]} basePath='/channels'>
+      <NoServersContent />
+    </EmptyShell>
+  );
 }

--- a/harmony-frontend/src/app/channels/page.tsx
+++ b/harmony-frontend/src/app/channels/page.tsx
@@ -1,7 +1,9 @@
 import { redirect } from 'next/navigation';
 import { getServers } from '@/services/serverService';
+import { TrpcHttpError } from '@/lib/trpc-client';
 import { EmptyShell } from '@/components/layout/EmptyShell';
 import { NoServersContent } from '@/components/channel/NoServersContent';
+import type { Server } from '@/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -10,12 +12,14 @@ export const dynamic = 'force-dynamic';
  * empty shell with a "no servers" prompt if the user hasn't joined any.
  */
 export default async function ChannelsPage() {
-  let servers;
+  let servers: Server[];
   try {
     servers = await getServers();
-  } catch {
-    // Backend rejected the auth token (expired or invalid) — send to login.
-    redirect('/auth/login');
+  } catch (err) {
+    // Only redirect to login for auth failures; rethrow other errors (network, 5xx) so
+    // Next.js surfaces them honestly rather than masking them as an auth problem.
+    if (err instanceof TrpcHttpError && err.status === 401) redirect('/auth/login');
+    throw err;
   }
   const first = servers[0];
   if (first) redirect(`/channels/${first.slug}`);

--- a/harmony-frontend/src/components/channel/ChannelPageContent.tsx
+++ b/harmony-frontend/src/components/channel/ChannelPageContent.tsx
@@ -1,4 +1,4 @@
-import { notFound, redirect } from 'next/navigation';
+import { redirect } from 'next/navigation';
 import { getServers, getServerMembers } from '@/services/serverService';
 import { getChannels } from '@/services/channelService';
 import { getMessages } from '@/services/messageService';
@@ -18,9 +18,17 @@ export async function ChannelPageContent({
   channelSlug,
   isGuestView = false,
 }: ChannelPageContentProps) {
-  const servers = await getServers();
+  let servers;
+  try {
+    servers = await getServers();
+  } catch {
+    // Backend rejected the auth token (expired or invalid) — send to login.
+    redirect('/auth/login');
+  }
   const server = servers.find(s => s.slug === serverSlug);
-  if (!server) notFound();
+  // Server not found in member list — redirect to channels index which resolves
+  // the user's first valid server dynamically.
+  if (!server) redirect('/channels');
 
   let serverChannels;
   try {
@@ -30,7 +38,8 @@ export async function ChannelPageContent({
     redirect(`/c/${serverSlug}/${channelSlug}`);
   }
   const channel = serverChannels.find(c => c.slug === channelSlug);
-  if (!channel) notFound();
+  // Channel not found — redirect to channels index rather than showing a dead-end 404.
+  if (!channel) redirect('/channels');
 
   // Gather all channels across servers for cross-server navigation.
   // Use .catch(() => []) so a FORBIDDEN error for servers the authenticated

--- a/harmony-frontend/src/components/channel/ChannelPageContent.tsx
+++ b/harmony-frontend/src/components/channel/ChannelPageContent.tsx
@@ -3,8 +3,10 @@ import { getServers, getServerMembers } from '@/services/serverService';
 import { getChannels } from '@/services/channelService';
 import { getMessages } from '@/services/messageService';
 import { getCurrentUser } from '@/services/authService';
+import { TrpcHttpError } from '@/lib/trpc-client';
 import { HarmonyShell } from '@/components/layout/HarmonyShell';
 import { VisibilityGuard } from '@/components/channel/VisibilityGuard';
+import type { Server } from '@/types';
 
 interface ChannelPageContentProps {
   serverSlug: string;
@@ -18,12 +20,14 @@ export async function ChannelPageContent({
   channelSlug,
   isGuestView = false,
 }: ChannelPageContentProps) {
-  let servers;
+  let servers: Server[];
   try {
     servers = await getServers();
-  } catch {
-    // Backend rejected the auth token (expired or invalid) — send to login.
-    redirect('/auth/login');
+  } catch (err) {
+    // Only redirect to login for auth failures; rethrow other errors (network, 5xx) so
+    // Next.js surfaces them honestly rather than masking them as an auth problem.
+    if (err instanceof TrpcHttpError && err.status === 401) redirect('/auth/login');
+    throw err;
   }
   const server = servers.find(s => s.slug === serverSlug);
   // Server not found in member list — redirect to channels index which resolves

--- a/harmony-frontend/src/components/channel/NoChannelsContent.tsx
+++ b/harmony-frontend/src/components/channel/NoChannelsContent.tsx
@@ -1,0 +1,21 @@
+/**
+ * NoChannelsContent — empty-state content rendered inside EmptyShell when the
+ * user is a member of the server but has no accessible text or announcement
+ * channels (e.g. all channels are private and they lack the required role).
+ *
+ * Designed to be mounted as children of EmptyShell, which provides the outer
+ * 3-column layout (ServerRail + ChannelSidebar with empty channel list).
+ */
+
+export function NoChannelsContent() {
+  return (
+    <div className='text-center'>
+      <p className='text-xl font-bold text-white'>No accessible channels</p>
+      <p className='mt-2 text-sm text-gray-400'>
+        You don&apos;t have access to any channels in this server.
+        <br />
+        Contact a server admin to get access.
+      </p>
+    </div>
+  );
+}

--- a/harmony-frontend/src/components/channel/NoServersContent.tsx
+++ b/harmony-frontend/src/components/channel/NoServersContent.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+/**
+ * NoServersContent — empty-state content rendered inside EmptyShell when the
+ * user has no server memberships. Offers paths to browse public servers or
+ * create a new one.
+ *
+ * Designed to be mounted as children of EmptyShell, which provides the outer
+ * 3-column layout (ServerRail + empty main area).
+ */
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
+import { BrowseServersModal } from '@/components/server-rail/BrowseServersModal';
+import type { Server, Channel } from '@/types';
+
+export function NoServersContent() {
+  const router = useRouter();
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isBrowseOpen, setIsBrowseOpen] = useState(false);
+
+  function handleCreated(server: Server, defaultChannel: Channel) {
+    router.push(`/channels/${server.slug}/${defaultChannel.slug}`);
+  }
+
+  return (
+    <div className='text-center'>
+      <p className='text-xl font-bold text-white'>No servers yet</p>
+      <p className='mt-2 text-sm text-gray-400'>
+        You haven&apos;t joined any servers. Find a community or create your own.
+      </p>
+
+      <div className='mt-6 flex justify-center gap-3'>
+        <button
+          type='button'
+          onClick={() => setIsBrowseOpen(true)}
+          className='rounded bg-[#3ba55c] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#2d7d46]'
+        >
+          Browse Servers
+        </button>
+        <button
+          type='button'
+          onClick={() => setIsCreateOpen(true)}
+          className='rounded bg-[#5865f2] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#4752c4]'
+        >
+          Create a Server
+        </button>
+      </div>
+
+      <CreateServerModal
+        isOpen={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+        onCreated={handleCreated}
+      />
+
+      {/* User has no servers yet, so all public servers will show "Join". */}
+      <BrowseServersModal
+        isOpen={isBrowseOpen}
+        onClose={() => setIsBrowseOpen(false)}
+        joinedServerIds={new Set()}
+        defaultChannelByServerId={new Map()}
+        basePath='/channels'
+      />
+    </div>
+  );
+}

--- a/harmony-frontend/src/components/channel/NoServersContent.tsx
+++ b/harmony-frontend/src/components/channel/NoServersContent.tsx
@@ -6,23 +6,15 @@
  * create a new one.
  *
  * Designed to be mounted as children of EmptyShell, which provides the outer
- * 3-column layout (ServerRail + empty main area).
+ * 3-column layout (ServerRail + empty main area) and owns the modal state via
+ * EmptyShellModalContext. Buttons delegate to those shell-owned modals so there
+ * is only one modal tree on the page.
  */
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
-import { BrowseServersModal } from '@/components/server-rail/BrowseServersModal';
-import type { Server, Channel } from '@/types';
+import { useEmptyShellModals } from '@/components/layout/EmptyShell';
 
 export function NoServersContent() {
-  const router = useRouter();
-  const [isCreateOpen, setIsCreateOpen] = useState(false);
-  const [isBrowseOpen, setIsBrowseOpen] = useState(false);
-
-  function handleCreated(server: Server, defaultChannel: Channel) {
-    router.push(`/channels/${server.slug}/${defaultChannel.slug}`);
-  }
+  const shellModals = useEmptyShellModals();
 
   return (
     <div className='text-center'>
@@ -34,34 +26,19 @@ export function NoServersContent() {
       <div className='mt-6 flex justify-center gap-3'>
         <button
           type='button'
-          onClick={() => setIsBrowseOpen(true)}
+          onClick={() => shellModals?.openBrowseServers()}
           className='rounded bg-[#3ba55c] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#2d7d46]'
         >
           Browse Servers
         </button>
         <button
           type='button'
-          onClick={() => setIsCreateOpen(true)}
+          onClick={() => shellModals?.openCreateServer()}
           className='rounded bg-[#5865f2] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#4752c4]'
         >
           Create a Server
         </button>
       </div>
-
-      <CreateServerModal
-        isOpen={isCreateOpen}
-        onClose={() => setIsCreateOpen(false)}
-        onCreated={handleCreated}
-      />
-
-      {/* User has no servers yet, so all public servers will show "Join". */}
-      <BrowseServersModal
-        isOpen={isBrowseOpen}
-        onClose={() => setIsBrowseOpen(false)}
-        joinedServerIds={new Set()}
-        defaultChannelByServerId={new Map()}
-        basePath='/channels'
-      />
     </div>
   );
 }

--- a/harmony-frontend/src/components/layout/EmptyShell.tsx
+++ b/harmony-frontend/src/components/layout/EmptyShell.tsx
@@ -1,0 +1,134 @@
+/**
+ * EmptyShell — 3-column layout for states where no channel is active.
+ *
+ * Used for:
+ *   - "no servers": ServerRail with no entries, no channel sidebar, empty-state content
+ *   - "no channels": ServerRail with servers, channel sidebar (no active channel), empty-state content
+ *
+ * Keeps the full ServerRail + Browse/Create server modals functional so the user
+ * can join or create a server without leaving the shell.
+ */
+
+'use client';
+
+import { useState, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { ServerRail } from '@/components/server-rail/ServerRail';
+import { ChannelSidebar } from '@/components/channel/ChannelSidebar';
+import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
+import { BrowseServersModal } from '@/components/server-rail/BrowseServersModal';
+import { useAuth } from '@/hooks/useAuth';
+import { useServerListSync } from '@/hooks/useServerListSync';
+import { ChannelType } from '@/types';
+import type { ReactNode } from 'react';
+import type { Server, Channel } from '@/types';
+
+export interface EmptyShellProps {
+  servers: Server[];
+  /** When provided, the channel sidebar is rendered for this server. */
+  currentServer?: Server;
+  /** Channels to display in the sidebar (pass [] for "empty channel list" appearance). */
+  channels?: Channel[];
+  /** All channels across every server — used by ServerRail to derive default channel per server. */
+  allChannels?: Channel[];
+  children: ReactNode;
+  basePath?: string;
+}
+
+export function EmptyShell({
+  servers,
+  currentServer,
+  channels = [],
+  allChannels = [],
+  children,
+  basePath = '/channels',
+}: EmptyShellProps) {
+  const { user: authUser, isAuthenticated, isLoading: isAuthLoading } = useAuth();
+  const router = useRouter();
+  const [isCreateServerOpen, setIsCreateServerOpen] = useState(false);
+  const [isBrowseServersOpen, setIsBrowseServersOpen] = useState(false);
+  const [localServers, setLocalServers] = useState<Server[]>(servers);
+  const { notifyServerCreated, notifyServerJoined } = useServerListSync();
+
+  const defaultChannelByServerId = useMemo(() => {
+    const map = new Map<string, string>();
+    const textOrAnn = allChannels
+      .filter(c => c.type === ChannelType.TEXT || c.type === ChannelType.ANNOUNCEMENT)
+      .sort((a, b) => a.position - b.position);
+    for (const ch of textOrAnn) {
+      if (!map.has(ch.serverId)) map.set(ch.serverId, ch.slug);
+    }
+    return map;
+  }, [allChannels]);
+
+  // Fallback guest user — mirrors the pattern used in HarmonyShell.
+  const currentUser = authUser ?? {
+    id: 'guest',
+    username: 'Guest',
+    displayName: 'Guest',
+    status: 'online' as const,
+    role: 'guest' as const,
+  };
+
+  function handleServerCreated(server: Server, defaultChannel: Channel) {
+    setLocalServers(prev => [...prev, server]);
+    notifyServerCreated(server.id);
+    router.push(`${basePath}/${server.slug}/${defaultChannel.slug}`);
+  }
+
+  return (
+    <div className='flex h-screen overflow-hidden bg-[#202225] font-sans'>
+      <ServerRail
+        servers={localServers}
+        allChannels={allChannels}
+        currentServerId={currentServer?.id ?? ''}
+        basePath={basePath}
+        onBrowseServers={isAuthenticated ? () => setIsBrowseServersOpen(true) : undefined}
+        onAddServer={
+          isAuthLoading
+            ? undefined
+            : () => {
+                if (!isAuthenticated) {
+                  router.push('/auth/login');
+                  return;
+                }
+                setIsCreateServerOpen(true);
+              }
+        }
+      />
+
+      {currentServer && (
+        <ChannelSidebar
+          server={currentServer}
+          channels={channels}
+          currentChannelId=''
+          currentUser={currentUser}
+          isOpen={false}
+          onClose={() => {}}
+          basePath={basePath}
+          isAuthenticated={isAuthenticated}
+          serverId={currentServer.id}
+        />
+      )}
+
+      <main className='flex flex-1 items-center justify-center bg-[#36393f]'>
+        {children}
+      </main>
+
+      <CreateServerModal
+        isOpen={isCreateServerOpen}
+        onClose={() => setIsCreateServerOpen(false)}
+        onCreated={handleServerCreated}
+      />
+
+      <BrowseServersModal
+        isOpen={isBrowseServersOpen}
+        onClose={() => setIsBrowseServersOpen(false)}
+        joinedServerIds={new Set(localServers.map(s => s.id))}
+        defaultChannelByServerId={defaultChannelByServerId}
+        basePath={basePath}
+        onJoined={notifyServerJoined}
+      />
+    </div>
+  );
+}

--- a/harmony-frontend/src/components/layout/EmptyShell.tsx
+++ b/harmony-frontend/src/components/layout/EmptyShell.tsx
@@ -11,17 +11,29 @@
 
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, createContext, useContext } from 'react';
 import { useRouter } from 'next/navigation';
 import { ServerRail } from '@/components/server-rail/ServerRail';
 import { ChannelSidebar } from '@/components/channel/ChannelSidebar';
 import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
 import { BrowseServersModal } from '@/components/server-rail/BrowseServersModal';
+import { VoiceProvider } from '@/contexts/VoiceContext';
 import { useAuth } from '@/hooks/useAuth';
 import { useServerListSync } from '@/hooks/useServerListSync';
-import { ChannelType } from '@/types';
+import { ChannelType, ChannelVisibility } from '@/types';
 import type { ReactNode } from 'react';
 import type { Server, Channel } from '@/types';
+
+// Module-internal context so NoServersContent (a child) can trigger shell-owned modals
+// without duplicating modal state or mounting duplicate modal trees.
+const EmptyShellModalContext = createContext<{
+  openBrowseServers: () => void;
+  openCreateServer: () => void;
+} | null>(null);
+
+export function useEmptyShellModals() {
+  return useContext(EmptyShellModalContext);
+}
 
 export interface EmptyShellProps {
   servers: Server[];
@@ -48,18 +60,33 @@ export function EmptyShell({
   const [isCreateServerOpen, setIsCreateServerOpen] = useState(false);
   const [isBrowseServersOpen, setIsBrowseServersOpen] = useState(false);
   const [localServers, setLocalServers] = useState<Server[]>(servers);
+  const [prevServers, setPrevServers] = useState<Server[]>(servers);
+  if (prevServers !== servers) {
+    setPrevServers(servers);
+    setLocalServers(servers);
+  }
   const { notifyServerCreated, notifyServerJoined } = useServerListSync();
 
   const defaultChannelByServerId = useMemo(() => {
     const map = new Map<string, string>();
     const textOrAnn = allChannels
-      .filter(c => c.type === ChannelType.TEXT || c.type === ChannelType.ANNOUNCEMENT)
+      .filter(
+        c =>
+          (c.type === ChannelType.TEXT || c.type === ChannelType.ANNOUNCEMENT) &&
+          c.visibility !== ChannelVisibility.PRIVATE,
+      )
       .sort((a, b) => a.position - b.position);
     for (const ch of textOrAnn) {
       if (!map.has(ch.serverId)) map.set(ch.serverId, ch.slug);
     }
     return map;
   }, [allChannels]);
+
+  // Voice channel IDs for VoiceProvider — scoped to the current server's channels.
+  const voiceChannelIds = useMemo(
+    () => channels.filter(c => c.type === ChannelType.VOICE).map(c => c.id),
+    [channels],
+  );
 
   // Fallback guest user — mirrors the pattern used in HarmonyShell.
   const currentUser = authUser ?? {
@@ -76,59 +103,76 @@ export function EmptyShell({
     router.push(`${basePath}/${server.slug}/${defaultChannel.slug}`);
   }
 
-  return (
-    <div className='flex h-screen overflow-hidden bg-[#202225] font-sans'>
-      <ServerRail
-        servers={localServers}
-        allChannels={allChannels}
-        currentServerId={currentServer?.id ?? ''}
-        basePath={basePath}
-        onBrowseServers={isAuthenticated ? () => setIsBrowseServersOpen(true) : undefined}
-        onAddServer={
-          isAuthLoading
-            ? undefined
-            : () => {
-                if (!isAuthenticated) {
-                  router.push('/auth/login');
-                  return;
-                }
-                setIsCreateServerOpen(true);
-              }
-        }
-      />
-
-      {currentServer && (
-        <ChannelSidebar
-          server={currentServer}
-          channels={channels}
-          currentChannelId=''
-          currentUser={currentUser}
-          isOpen={false}
-          onClose={() => {}}
+  const content = (
+    <EmptyShellModalContext.Provider
+      value={{
+        openBrowseServers: () => setIsBrowseServersOpen(true),
+        openCreateServer: () => setIsCreateServerOpen(true),
+      }}
+    >
+      <div className='flex h-screen overflow-hidden bg-[#202225] font-sans'>
+        <ServerRail
+          servers={localServers}
+          allChannels={allChannels}
+          currentServerId={currentServer?.id ?? ''}
           basePath={basePath}
-          isAuthenticated={isAuthenticated}
-          serverId={currentServer.id}
+          onBrowseServers={isAuthenticated ? () => setIsBrowseServersOpen(true) : undefined}
+          onAddServer={
+            isAuthLoading
+              ? undefined
+              : () => {
+                  if (!isAuthenticated) {
+                    router.push('/auth/login');
+                    return;
+                  }
+                  setIsCreateServerOpen(true);
+                }
+          }
         />
-      )}
 
-      <main className='flex flex-1 items-center justify-center bg-[#36393f]'>
-        {children}
-      </main>
+        {currentServer && (
+          <ChannelSidebar
+            server={currentServer}
+            channels={channels}
+            currentChannelId=''
+            currentUser={currentUser}
+            isOpen={false}
+            onClose={() => {}}
+            basePath={basePath}
+            isAuthenticated={isAuthenticated}
+            serverId={currentServer.id}
+          />
+        )}
 
-      <CreateServerModal
-        isOpen={isCreateServerOpen}
-        onClose={() => setIsCreateServerOpen(false)}
-        onCreated={handleServerCreated}
-      />
+        <main className='flex flex-1 items-center justify-center bg-[#36393f]'>
+          {children}
+        </main>
 
-      <BrowseServersModal
-        isOpen={isBrowseServersOpen}
-        onClose={() => setIsBrowseServersOpen(false)}
-        joinedServerIds={new Set(localServers.map(s => s.id))}
-        defaultChannelByServerId={defaultChannelByServerId}
-        basePath={basePath}
-        onJoined={notifyServerJoined}
-      />
-    </div>
+        <CreateServerModal
+          isOpen={isCreateServerOpen}
+          onClose={() => setIsCreateServerOpen(false)}
+          onCreated={handleServerCreated}
+        />
+
+        <BrowseServersModal
+          isOpen={isBrowseServersOpen}
+          onClose={() => setIsBrowseServersOpen(false)}
+          joinedServerIds={new Set(localServers.map(s => s.id))}
+          defaultChannelByServerId={defaultChannelByServerId}
+          basePath={basePath}
+          onJoined={notifyServerJoined}
+        />
+      </div>
+    </EmptyShellModalContext.Provider>
   );
+
+  // VoiceProvider is only needed when a server is active (enables voice channel joining).
+  if (currentServer) {
+    return (
+      <VoiceProvider serverId={currentServer.id} voiceChannelIds={voiceChannelIds}>
+        {content}
+      </VoiceProvider>
+    );
+  }
+  return content;
 }

--- a/harmony-frontend/src/components/server-rail/ServerRail.tsx
+++ b/harmony-frontend/src/components/server-rail/ServerRail.tsx
@@ -11,7 +11,6 @@ import { useMemo, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { DEFAULT_HOME_PATH } from '@/lib/constants';
 import { ChannelType } from '@/types';
 import type { Server, Channel } from '@/types';
 
@@ -122,14 +121,9 @@ export function ServerRail({
     return map;
   }, [allChannels]);
 
-  // Home links to a stable, hardcoded entry point (DEFAULT_HOME_PATH) rather
-  // than deriving from servers[0], which would change if server ordering changes.
-  //
-  // TODO: When real user/server data is wired up, revisit this. "Home" should
-  // ideally navigate to the user's DM inbox or a personalized landing route —
-  // not a hardcoded server channel. Update DEFAULT_HOME_PATH or replace this
-  // with a user-context-aware route at that point.
-  const homeHref = `${basePath}${DEFAULT_HOME_PATH}`;
+  // Home navigates to /channels which dynamically resolves the user's first
+  // server/channel, rather than a hardcoded slug that may not exist.
+  const homeHref = '/channels';
 
   return (
     <nav

--- a/llm-logs/2026-04-16-133946-session-15e32eb5.md
+++ b/llm-logs/2026-04-16-133946-session-15e32eb5.md
@@ -1,0 +1,981 @@
+# Session Log 2026-04-16-133946
+
+## User
+
+<command-message>resolve-reviews</command-message>
+<command-name>/resolve-reviews</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/resolve-reviews
+
+Automatically resolve all review comments (both human and bot) on the current PR. Uses a two-phase workflow: fix all existing issues, then poll for new ones until quiet.
+
+## Prerequisites
+
+All commands below use `npx agent-reviews`. If the project uses a different package manager, substitute the appropriate runner (e.g., `pnpm dlx agent-reviews` for pnpm, `yarn dlx agent-reviews` for Yarn, `bunx agent-reviews` for Bun). Honor the user's package manager preference throughout.
+
+**Cloud environments only** (e.g., Codespaces, remote agents): verify git author identity so CI checks can map commits to the user. Run `git config --global --get user.email` and if empty or a placeholder, set it manually. Skip this check in local environments.
+
+## Phase 1: FETCH & FIX (synchronous)
+
+### Step 1: Fetch All Comments (Expanded)
+
+Run `npx agent-reviews --unanswered --expanded`
+
+The CLI auto-detects the current branch, finds the associated PR, and authenticates via `gh` CLI or environment variables. If anything fails (no token, no PR, CLI not installed), it exits with a clear error message.
+
+This shows all unanswered comments (both human and bot) with full detail: complete comment body (no truncation), diff hunk (code context), and all replies. Each comment shows its ID in brackets (e.g., `[12345678]`).
+
+If zero comments are returned, print "No unanswered comments found" and skip to Phase 2.
+
+### Step 3: Process Each Unanswered Comment
+
+For each comment from the expanded output, apply the appropriate evaluation based on whether the author is a bot or a human.
+
+#### For Bot Comments
+
+Read the referenced code and determine:
+
+1. **TRUE POSITIVE** - A real bug that needs fixing
+2. **FALSE POSITIVE** - Not actually a bug (intentional behavior, bot misunderstanding)
+3. **UNCERTAIN** - Not sure; ask the user
+
+**Likely TRUE POSITIVE:**
+- Code obviously violates stated behavior
+- Missing null checks on potentially undefined values
+- Type mismatches or incorrect function signatures
+- Logic errors in conditionals
+- Missing error handling for documented failure cases
+
+**Likely FALSE POSITIVE:**
+- Bot doesn't understand the framework/library patterns
+- Code is intentionally structured that way (with comments explaining why)
+- Bot is flagging style preferences, not bugs
+- The "bug" is actually a feature or intentional behavior
+- Bot misread the code flow
+
+#### For Human Comments
+
+Read the referenced code and the reviewer's comment. Human reviewers are generally more accurate and context-aware than bots. Determine:
+
+1. **ACTIONABLE** - The reviewer identified a real issue or requested a concrete change
+2. **DISCUSSION** - The comment raises a valid point but the right approach is unclear
+3. **ALREADY ADDRESSED** - The concern has already been fixed or is no longer relevant
+
+**Likely ACTIONABLE:**
+- Reviewer points out a bug or logic error
+- Reviewer requests a specific code change
+- Reviewer identifies missing edge cases or error handling
+
+**Likely DISCUSSION -- ask the user:**
+- Reviewer suggests an architectural change you're unsure about
+- Comment involves a tradeoff (performance vs readability, etc.)
+- The feedback is subjective without team consensus
+
+#### When UNCERTAIN -- ask the user
+
+For both bot and human comments:
+- The fix would require architectural changes
+- You're genuinely unsure if the behavior is intentional
+- Multiple valid interpretations exist
+- The fix could have unintended side effects
+
+#### Act on Evaluation
+
+**If TRUE POSITIVE / ACTIONABLE:** Fix the code. Track the comment ID and a brief description of the fix.
+
+**If FALSE POSITIVE:** Do NOT change the code. Track the comment ID and the reason it's not a real bug.
+
+**If DISCUSSION:** Ask the user to consult the PR author. Apply their decision and track it.
+
+**If ALREADY ADDRESSED:** Track the comment ID and note why.
+
+**If UNCERTAIN:** Ask the user. If they say skip, track it as skipped.
+
+Do NOT reply to comments yet. Replies happen after the commit (Step 5).
+
+### Step 4: Commit and Push
+
+After evaluating and fixing ALL unanswered comments:
+
+1. Run your project's lint and type-check
+2. Stage, commit, and push:
+   ```bash
+   git add -A
+   git commit -m "fix: address PR review findings
+
+   {List of changes made, grouped by reviewer/bot}"
+   git push
+   ```
+3. Capture the commit hash from the output.
+
+### Step 5: Reply to All Comments
+
+Now that the commit hash exists, reply to every processed comment. The `--resolve` flag marks the review thread as resolved on GitHub.
+
+**For each TRUE POSITIVE / ACTIONABLE:**
+
+Run `npx agent-reviews --reply <comment_id> "Fixed in {hash}. {Brief description of the fix}" --resolve`
+
+**For each FALSE POSITIVE:**
+
+Run `npx agent-reviews --reply <comment_id> "Won't fix: {reason}. {Explanation of why this is intentional or not applicable}" --resolve`
+
+**For each DISCUSSION (after user decision):**
+
+Run `npx agent-reviews --reply <comment_id> "{Outcome}. {Explanation of the decision and any changes made}" --resolve`
+
+**For each ALREADY ADDRESSED:**
+
+Run `npx agent-reviews --reply <comment_id> "Already addressed. {Explanation of when/how this was fixed}" --resolve`
+
+**For each SKIPPED:**
+
+Run `npx agent-reviews --reply <comment_id> "Skipped per user request" --resolve`
+
+**DO NOT start Phase 2 until all replies are posted.**
+
+---
+
+## Phase 2: POLL FOR NEW COMMENTS (loop until quiet)
+
+The watcher exits immediately when new comments are found (after a 5s grace period to catch batch posts). This means you run it in a loop: start watcher, process any comments it returns, restart watcher, repeat until the watcher times out with no new comments.
+
+### Step 6: Start Watcher Loop
+
+Repeat the following until the watcher exits with no new comments:
+
+**6a.** Launch the watcher in the background:
+
+Run `npx agent-reviews --watch` as a background task.
+
+**6b.** Wait for the background command to complete (default 10 minutes; override with `--timeout`).
+
+**6c.** Check the output:
+
+- **If new comments were found** (output contains `EXITING WITH NEW COMMENTS`):
+  1. Use `--detail <id>` to read each new comment's full detail
+  2. Process them exactly as in Phase 1, Steps 3-5 (evaluate, fix, commit, push, reply)
+  3. **Go back to Step 6a** to restart the watcher
+
+- **If no new comments** (output contains `WATCH COMPLETE`):
+  Stop looping and move to the Summary Report.
+
+---
+
+## Summary Report
+
+After both phases complete, provide a summary:
+
+```text
+## PR Review Resolution Summary
+
+### Results
+- Fixed: X issues
+- Already addressed: X
+- Won't fix (false positives): X
+- Discussion resolved: X
+- Skipped per user: X
+
+### By Reviewer/Bot
+#### cursor[bot]
+- {description} - Fixed in {commit}
+- {description} - Won't fix: {reason}
+
+#### @reviewer-name
+- {description} - Fixed in {commit}
+
+### Status
+All findings addressed. Watch completed.
+```
+
+## Important Notes
+
+### Response Policy
+- **Every comment gets a response** - No silent ignores
+- For bots: responses help train them and prevent re-raised false positives
+- For humans: replies keep reviewers informed and unblock approvals
+
+### User Interaction
+- Ask the user when uncertain about a finding
+- Don't guess on architectural or business logic questions
+- It's better to ask than to make a wrong fix or wrong dismissal
+- Human reviewers often have context you don't - defer to the author when unsure
+
+### Best Practices
+- Verify findings before fixing - bots have false positives, humans rarely do
+- Keep fixes minimal and focused - don't refactor unrelated code
+- Ensure type-check and lint pass before committing
+- Group related fixes into a single commit
+- Copilot `suggestion` blocks often contain ready-to-use fixes
+- If a human reviewer suggests a specific code change, prefer their version unless it introduces issues
+
+## Assistant
+
+I'll start by fetching all unanswered review comments on the current PR.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --unanswered --expanded 2>&1",
+  "description": "Fetch all unanswered PR review comments"
+}
+```
+
+## Assistant
+
+Let me read the relevant files to understand the current state before evaluating each comment.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/EmptyShell.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/NoServersContent.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels/page.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels/[serverSlug]/page.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/server-rail/ServerRail.tsx",
+  "offset": 110,
+  "limit": 50
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/HarmonyShell.tsx",
+  "offset": 165,
+  "limit": 30
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/ChannelPageContent.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/dev.sh"
+}
+```
+
+## Assistant
+
+Let me check the VoiceProvider usage in HarmonyShell to evaluate the human reviewer's comment.
+
+## Assistant
+
+**Tool call: `Grep`**
+```json
+{
+  "pattern": "VoiceProvider",
+  "path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src",
+  "output_mode": "content"
+}
+```
+
+## Assistant
+
+**Tool call: `Grep`**
+```json
+{
+  "pattern": "useVoiceOptional",
+  "path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src",
+  "output_mode": "content"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/ChannelSidebar.tsx",
+  "offset": 180,
+  "limit": 40
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/HarmonyShell.tsx",
+  "offset": 125,
+  "limit": 15
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/HarmonyShell.tsx",
+  "offset": 360,
+  "limit": 15
+}
+```
+
+## Assistant
+
+Now I have a clear picture of all issues. Let me check the getServers return type and the types import path.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"export.*getServers\\|function getServers\\|getServers.*returns\\|Promise.*Server\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/serverService.ts | head -20",
+  "description": "Check getServers return type"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/server-rail/ServerRail.tsx",
+  "offset": 1,
+  "limit": 30
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"ChannelVisibility\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/types/index.ts | head -5",
+  "description": "Check ChannelVisibility in types"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -rn \"export.*ChannelVisibility\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/types/ 2>/dev/null | head -5",
+  "description": "Find ChannelVisibility export"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"ChannelVisibility\\|export.*from\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/types/index.ts | head -20",
+  "description": "Check types index exports"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"export.*getChannels\\|function getChannels\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/channelService.ts | head -5",
+  "description": "Check getChannels return type"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npx tsc --noEmit 2>&1 | head -40",
+  "description": "Run TypeScript check to see current errors"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/serverService.ts",
+  "offset": 1,
+  "limit": 60
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"UNAUTHORIZED\\|401\\|throw\\|TRPCClientError\\|class.*Error\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/trpc-client.ts | head -20",
+  "description": "Check trpc-client error types"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"TrpcHttpError\\|class Trpc\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/trpc-client.ts | head -10",
+  "description": "Find TrpcHttpError class definition"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/trpc-errors.ts",
+  "description": "Read TrpcHttpError definition"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/c/ 2>/dev/null",
+  "description": "Check if /c index page exists"
+}
+```
+
+## Assistant
+
+I now have a clear picture of all 10 comments. Let me call advisor before making changes.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/contexts/VoiceContext.tsx",
+  "offset": 98,
+  "limit": 50
+}
+```
+
+## Assistant
+
+Now I have everything I need. Let me make all the changes.
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/EmptyShell.tsx",
+  "content": "/**\n * EmptyShell \u2014 3-column layout for states where no channel is active.\n *\n * Used for:\n *   - \"no servers\": ServerRail with no entries, no channel sidebar, empty-state content\n *   - \"no channels\": ServerRail with servers, channel sidebar (no active channel), empty-state content\n *\n * Keeps the full ServerRail + Browse/Create server modals functional so the user\n * can join or create a server without leaving the shell.\n */\n\n'use client';\n\nimport { useState, useMemo, createContext, useContext } from 'react';\nimport { useRouter } from 'next/navigation';\nimport { ServerRail } from '@/components/server-rail/ServerRail';\nimport { ChannelSidebar } from '@/components/channel/ChannelSidebar';\nimport { CreateServerModal } from '@/components/server-rail/CreateServerModal';\nimport { BrowseServersModal } from '@/components/server-rail/BrowseServersModal';\nimport { VoiceProvider } from '@/contexts/VoiceContext';\nimport { useAuth } from '@/hooks/useAuth';\nimport { useServerListSync } from '@/hooks/useServerListSync';\nimport { ChannelType, ChannelVisibility } from '@/types';\nimport type { ReactNode } from 'react';\nimport type { Server, Channel } from '@/types';\n\n// Module-internal context so NoServersContent (a child) can trigger shell-owned modals\n// without duplicating modal state or mounting duplicate modal trees.\nconst EmptyShellModalContext = createContext<{\n  openBrowseServers: () => void;\n  openCreateServer: () => void;\n} | null>(null);\n\nexport function useEmptyShellModals() {\n  return useContext(EmptyShellModalContext);\n}\n\nexport interface EmptyShellProps {\n  servers: Server[];\n  /** When provided, the channel sidebar is rendered for this server. */\n  currentServer?: Server;\n  /** Channels to display in the sidebar (pass [] for \"empty channel list\" appearance). */\n  channels?: Channel[];\n  /** All channels across every server \u2014 used by ServerRail to derive default channel per server. */\n  allChannels?: Channel[];\n  children: ReactNode;\n  basePath?: string;\n}\n\nexport function EmptyShell({\n  servers,\n  currentServer,\n  channels = [],\n  allChannels = [],\n  children,\n  basePath = '/channels',\n}: EmptyShellProps) {\n  const { user: authUser, isAuthenticated, isLoading: isAuthLoading } = useAuth();\n  const router = useRouter();\n  const [isCreateServerOpen, setIsCreateServerOpen] = useState(false);\n  const [isBrowseServersOpen, setIsBrowseServersOpen] = useState(false);\n  const [localServers, setLocalServers] = useState<Server[]>(servers);\n  const [prevServers, setPrevServers] = useState<Server[]>(servers);\n  if (prevServers !== servers) {\n    setPrevServers(servers);\n    setLocalServers(servers);\n  }\n  const { notifyServerCreated, notifyServerJoined } = useServerListSync();\n\n  const defaultChannelByServerId = useMemo(() => {\n    const map = new Map<string, string>();\n    const textOrAnn = allChannels\n      .filter(\n        c =>\n          (c.type === ChannelType.TEXT || c.type === ChannelType.ANNOUNCEMENT) &&\n          c.visibility !== ChannelVisibility.PRIVATE,\n      )\n      .sort((a, b) => a.position - b.position);\n    for (const ch of textOrAnn) {\n      if (!map.has(ch.serverId)) map.set(ch.serverId, ch.slug);\n    }\n    return map;\n  }, [allChannels]);\n\n  // Voice channel IDs for VoiceProvider \u2014 scoped to the current server's channels.\n  const voiceChannelIds = useMemo(\n    () => channels.filter(c => c.type === ChannelType.VOICE).map(c => c.id),\n    [channels],\n  );\n\n  // Fallback guest user \u2014 mirrors the pattern used in HarmonyShell.\n  const currentUser = authUser ?? {\n    id: 'guest',\n    username: 'Guest',\n    displayName: 'Guest',\n    status: 'online' as const,\n    role: 'guest' as const,\n  };\n\n  function handleServerCreated(server: Server, defaultChannel: Channel) {\n    setLocalServers(prev => [...prev, server]);\n    notifyServerCreated(server.id);\n    router.push(`${basePath}/${server.slug}/${defaultChannel.slug}`);\n  }\n\n  const content = (\n    <EmptyShellModalContext.Provider\n      value={{\n        openBrowseServers: () => setIsBrowseServersOpen(true),\n        openCreateServer: () => setIsCreateServerOpen(true),\n      }}\n    >\n      <div className='flex h-screen overflow-hidden bg-[#202225] font-sans'>\n        <ServerRail\n          servers={localServers}\n          allChannels={allChannels}\n          currentServerId={currentServer?.id ?? ''}\n          basePath={basePath}\n          onBrowseServers={isAuthenticated ? () => setIsBrowseServersOpen(true) : undefined}\n          onAddServer={\n            isAuthLoading\n              ? undefined\n              : () => {\n                  if (!isAuthenticated) {\n                    router.push('/auth/login');\n                    return;\n                  }\n                  setIsCreateServerOpen(true);\n                }\n          }\n        />\n\n        {currentServer && (\n          <ChannelSidebar\n            server={currentServer}\n            channels={channels}\n            currentChannelId=''\n            currentUser={currentUser}\n            isOpen={false}\n            onClose={() => {}}\n            basePath={basePath}\n            isAuthenticated={isAuthenticated}\n            serverId={currentServer.id}\n          />\n        )}\n\n        <main className='flex flex-1 items-center justify-center bg-[#36393f]'>\n          {children}\n        </main>\n\n        <CreateServerModal\n          isOpen={isCreateServerOpen}\n          onClose={() => setIsCreateServerOpen(false)}\n          onCreated={handleServerCreated}\n        />\n\n        <BrowseServersModal\n          isOpen={isBrowseServersOpen}\n          onClose={() => setIsBrowseServersOpen(false)}\n          joinedServerIds={new Set(localServers.map(s => s.id))}\n          defaultChannelByServerId={defaultChannelByServerId}\n          basePath={basePath}\n          onJoined={notifyServerJoined}\n        />\n      </div>\n    </EmptyShellModalContext.Provider>\n  );\n\n  // VoiceProvider is only needed when a server is active (enables voice channel joining).\n  if (currentServer) {\n    return (\n      <VoiceProvider serverId={currentServer.id} voiceChannelIds={voiceChannelIds}>\n        {content}\n      </VoiceProvider>\n    );\n  }\n  return content;\n}\n"
+}
+```
+
+## Assistant
+
+Now fix `NoServersContent.tsx` to use the shell context instead of duplicate modals:
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/NoServersContent.tsx",
+  "content": "'use client';\n\n/**\n * NoServersContent \u2014 empty-state content rendered inside EmptyShell when the\n * user has no server memberships. Offers paths to browse public servers or\n * create a new one.\n *\n * Designed to be mounted as children of EmptyShell, which provides the outer\n * 3-column layout (ServerRail + empty main area) and owns the modal state via\n * EmptyShellModalContext. Buttons delegate to those shell-owned modals so there\n * is only one modal tree on the page.\n */\n\nimport { useEmptyShellModals } from '@/components/layout/EmptyShell';\n\nexport function NoServersContent() {\n  const shellModals = useEmptyShellModals();\n\n  return (\n    <div className='text-center'>\n      <p className='text-xl font-bold text-white'>No servers yet</p>\n      <p className='mt-2 text-sm text-gray-400'>\n        You haven&apos;t joined any servers. Find a community or create your own.\n      </p>\n\n      <div className='mt-6 flex justify-center gap-3'>\n        <button\n          type='button'\n          onClick={() => shellModals?.openBrowseServers()}\n          className='rounded bg-[#3ba55c] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#2d7d46]'\n        >\n          Browse Servers\n        </button>\n        <button\n          type='button'\n          onClick={() => shellModals?.openCreateServer()}\n          className='rounded bg-[#5865f2] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#4752c4]'\n        >\n          Create a Server\n        </button>\n      </div>\n    </div>\n  );\n}\n"
+}
+```
+
+## Assistant
+
+Now fix `dev.sh` with the EXIT trap:
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/dev.sh",
+  "content": "#!/usr/bin/env bash\n# dev.sh \u2014 start Docker services, backend, and frontend for local development\nset -euo pipefail\n\nREPO_ROOT=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" && pwd)\"\nBACKEND_DIR=\"$REPO_ROOT/harmony-backend\"\nFRONTEND_DIR=\"$REPO_ROOT/harmony-frontend\"\n\n# \u2500\u2500 Docker \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\necho \"==> Checking Docker services (postgres, redis)...\"\ncd \"$BACKEND_DIR\"\n\n# Start any services that are not already running\ndocker compose up -d\n\necho \"==> Docker services ready.\"\n\n# \u2500\u2500 Prisma migrations \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\necho \"==> Applying Prisma migrations...\"\ncd \"$BACKEND_DIR\"\nnpx prisma migrate deploy\necho \"==> Migrations up to date.\"\n\n# \u2500\u2500 Backend \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\necho \"==> Starting backend (npm run dev)...\"\ncd \"$BACKEND_DIR\"\nnpm run dev &\nBACKEND_PID=$!\n\n# \u2500\u2500 Frontend \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\necho \"==> Starting frontend (npm run dev)...\"\ncd \"$FRONTEND_DIR\"\nnpm run dev &\nFRONTEND_PID=$!\n\necho \"\"\necho \"Backend PID : $BACKEND_PID\"\necho \"Frontend PID: $FRONTEND_PID\"\necho \"\"\necho \"Press Ctrl+C to stop both servers.\"\n\ncleanup() {\n  local exit_code=\"${1:-0}\"\n  trap - INT TERM EXIT\n  echo \"\"\n  echo \"Stopping...\"\n  kill \"$BACKEND_PID\" \"$FRONTEND_PID\" 2>/dev/null || true\n  wait \"$BACKEND_PID\" \"$FRONTEND_PID\" 2>/dev/null || true\n  exit \"$exit_code\"\n}\n\ntrap 'cleanup 130' INT\ntrap 'cleanup 143' TERM\ntrap 'cleanup $?' EXIT\n\nset +e\nwait -n \"$BACKEND_PID\" \"$FRONTEND_PID\"\nFIRST_EXIT_CODE=$?\nset -e\n\ncleanup \"$FIRST_EXIT_CODE\"\n"
+}
+```
+
+## Assistant
+
+Now fix type annotations and catch narrowing in the three page/component files:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels/page.tsx",
+  "old_string": "import { redirect } from 'next/navigation';\nimport { getServers } from '@/services/serverService';\nimport { EmptyShell } from '@/components/layout/EmptyShell';\nimport { NoServersContent } from '@/components/channel/NoServersContent';",
+  "new_string": "import { redirect } from 'next/navigation';\nimport { getServers } from '@/services/serverService';\nimport { TrpcHttpError } from '@/lib/trpc-client';\nimport { EmptyShell } from '@/components/layout/EmptyShell';\nimport { NoServersContent } from '@/components/channel/NoServersContent';\nimport type { Server } from '@/types';"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels/page.tsx",
+  "old_string": "  let servers;\n  try {\n    servers = await getServers();\n  } catch {\n    // Backend rejected the auth token (expired or invalid) \u2014 send to login.\n    redirect('/auth/login');\n  }",
+  "new_string": "  let servers: Server[];\n  try {\n    servers = await getServers();\n  } catch (err) {\n    // Only redirect to login for auth failures; rethrow other errors (network, 5xx) so\n    // Next.js surfaces them honestly rather than masking them as an auth problem.\n    if (err instanceof TrpcHttpError && err.status === 401) redirect('/auth/login');\n    throw err;\n  }"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels/[serverSlug]/page.tsx",
+  "old_string": "import { redirect } from 'next/navigation';\nimport { getServers } from '@/services/serverService';\nimport { getChannels } from '@/services/channelService';\nimport { publicGet } from '@/lib/trpc-client';\nimport { ChannelType, ChannelVisibility } from '@/types';",
+  "new_string": "import { redirect } from 'next/navigation';\nimport { getServers } from '@/services/serverService';\nimport { getChannels } from '@/services/channelService';\nimport { publicGet, TrpcHttpError } from '@/lib/trpc-client';\nimport { ChannelType, ChannelVisibility } from '@/types';\nimport type { Server, Channel } from '@/types';"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels/[serverSlug]/page.tsx",
+  "old_string": "  let servers;\n  try {\n    servers = await getServers();\n  } catch {\n    // Backend rejected the auth token (expired or invalid) \u2014 send to login.\n    redirect('/auth/login');\n  }",
+  "new_string": "  let servers: Server[];\n  try {\n    servers = await getServers();\n  } catch (err) {\n    // Only redirect to login for auth failures; rethrow other errors (network, 5xx) so\n    // Next.js surfaces them honestly rather than masking them as an auth problem.\n    if (err instanceof TrpcHttpError && err.status === 401) redirect('/auth/login');\n    throw err;\n  }"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels/[serverSlug]/page.tsx",
+  "old_string": "  let channels;\n  try {\n    channels = await getChannels(server.id);\n  } catch {",
+  "new_string": "  let channels: Channel[];\n  try {\n    channels = await getChannels(server.id);\n  } catch {"
+}
+```
+
+## Assistant
+
+Now fix the `channels` prop to EmptyShell to filter out PRIVATE text/announcement channels from the sidebar:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels/[serverSlug]/page.tsx",
+  "offset": 85,
+  "limit": 15
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels/[serverSlug]/page.tsx",
+  "old_string": "  return (\n    <EmptyShell\n      servers={servers}\n      currentServer={server}\n      channels={channels}\n      allChannels={allChannels}\n      basePath='/channels'\n    >\n      {showNoAccessMessage ? <NoChannelsContent /> : null}\n    </EmptyShell>",
+  "new_string": "  // Only show channels members can actually navigate to in the sidebar. Private\n  // text/announcement channels are excluded so regular members don't see links they\n  // can't open; voice channels are kept so members can still join them.\n  const sidebarChannels = showNoAccessMessage\n    ? channels.filter(\n        c =>\n          c.type === ChannelType.VOICE ||\n          c.visibility !== ChannelVisibility.PRIVATE,\n      )\n    : channels;\n\n  return (\n    <EmptyShell\n      servers={servers}\n      currentServer={server}\n      channels={sidebarChannels}\n      allChannels={allChannels}\n      basePath='/channels'\n    >\n      {showNoAccessMessage ? <NoChannelsContent /> : null}\n    </EmptyShell>"
+}
+```
+
+## Assistant
+
+Now fix `ChannelPageContent.tsx`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/ChannelPageContent.tsx",
+  "old_string": "import { redirect } from 'next/navigation';\nimport { getServers, getServerMembers } from '@/services/serverService';\nimport { getChannels } from '@/services/channelService';\nimport { getMessages } from '@/services/messageService';\nimport { getCurrentUser } from '@/services/authService';\nimport { HarmonyShell } from '@/components/layout/HarmonyShell';\nimport { VisibilityGuard } from '@/components/channel/VisibilityGuard';",
+  "new_string": "import { redirect } from 'next/navigation';\nimport { getServers, getServerMembers } from '@/services/serverService';\nimport { getChannels } from '@/services/channelService';\nimport { getMessages } from '@/services/messageService';\nimport { getCurrentUser } from '@/services/authService';\nimport { TrpcHttpError } from '@/lib/trpc-client';\nimport { HarmonyShell } from '@/components/layout/HarmonyShell';\nimport { VisibilityGuard } from '@/components/channel/VisibilityGuard';\nimport type { Server } from '@/types';"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/ChannelPageContent.tsx",
+  "old_string": "  let servers;\n  try {\n    servers = await getServers();\n  } catch {\n    // Backend rejected the auth token (expired or invalid) \u2014 send to login.\n    redirect('/auth/login');\n  }",
+  "new_string": "  let servers: Server[];\n  try {\n    servers = await getServers();\n  } catch (err) {\n    // Only redirect to login for auth failures; rethrow other errors (network, 5xx) so\n    // Next.js surfaces them honestly rather than masking them as an auth problem.\n    if (err instanceof TrpcHttpError && err.status === 401) redirect('/auth/login');\n    throw err;\n  }"
+}
+```
+
+## Assistant
+
+Now run TypeScript check and tests:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1",
+  "description": "TypeScript check after changes"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && npm run test:frontend 2>&1 | tail -30",
+  "description": "Run frontend tests"
+}
+```
+
+## Assistant
+
+All 212 tests pass. Let me also run the lint check:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npm run lint 2>&1 | tail -20",
+  "description": "Run ESLint"
+}
+```
+
+## Assistant
+
+Clean. Now commit and push:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git diff --stat && git status",
+  "description": "Show diff and status before commit"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add dev.sh harmony-frontend/src/app/channels/[serverSlug]/page.tsx harmony-frontend/src/app/channels/page.tsx harmony-frontend/src/components/channel/ChannelPageContent.tsx harmony-frontend/src/components/channel/NoServersContent.tsx harmony-frontend/src/components/layout/EmptyShell.tsx && git commit -m \"$(cat <<'EOF'\nfix: address PR review findings\n\n- EmptyShell: wrap ChannelSidebar in VoiceProvider when currentServer\n  present so voice channel joining/presence works on empty-shell paths\n- EmptyShell: add EmptyShellModalContext so NoServersContent uses\n  shell-owned modals (eliminates duplicate modal trees)\n- EmptyShell: resync localServers when servers prop changes (mirrors\n  HarmonyShell pattern)\n- EmptyShell: filter PRIVATE channels from defaultChannelByServerId to\n  avoid routing non-admin users into inaccessible channels via rail\n- NoServersContent: remove own modal state/JSX; delegate to EmptyShell\n  modals via EmptyShellModalContext\n- channels/[serverSlug]/page.tsx: exclude PRIVATE text/announcement\n  channels from sidebar in empty-shell state; keep voice channels\n- channels/page.tsx, [serverSlug]/page.tsx, ChannelPageContent.tsx:\n  add explicit Server[]/Channel[] type annotations; narrow catch to\n  TrpcHttpError 401 so network/5xx errors are not silently masked as\n  auth failures\n- dev.sh: add EXIT trap + wait -n so both child processes are always\n  terminated and the first failing exit code propagates cleanly\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit all PR review fixes"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add dev.sh 'harmony-frontend/src/app/channels/[serverSlug]/page.tsx' harmony-frontend/src/app/channels/page.tsx harmony-frontend/src/components/channel/ChannelPageContent.tsx harmony-frontend/src/components/channel/NoServersContent.tsx harmony-frontend/src/components/layout/EmptyShell.tsx && git commit -m \"$(cat <<'EOF'\nfix: address PR review findings\n\n- EmptyShell: wrap ChannelSidebar in VoiceProvider when currentServer\n  present so voice channel joining/presence works on empty-shell paths\n- EmptyShell: add EmptyShellModalContext so NoServersContent uses\n  shell-owned modals (eliminates duplicate modal trees)\n- EmptyShell: resync localServers when servers prop changes\n- EmptyShell: filter PRIVATE channels from defaultChannelByServerId\n- NoServersContent: remove own modal state/JSX; delegate to EmptyShell\n  modals via EmptyShellModalContext\n- channels/[serverSlug]/page.tsx: exclude PRIVATE text/announcement\n  channels from sidebar in empty-shell state; keep voice channels\n- channels/page.tsx, [serverSlug]/page.tsx, ChannelPageContent.tsx:\n  explicit Server[]/Channel[] types; narrow catch to TrpcHttpError 401\n- dev.sh: add EXIT trap + wait -n for clean child process teardown\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit all PR review fixes"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push 2>&1",
+  "description": "Push changes to remote"
+}
+```
+
+## Assistant
+
+Now reply to all comments:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 4122413677 \"Fixed in 991999b. EmptyShell now wraps the ChannelSidebar subtree in VoiceProvider (with the server's voice channel IDs) when currentServer is present, matching HarmonyShell's pattern. Voice channel joining and participant presence will now work correctly on the empty-shell path for voice-only servers.\" --resolve 2>&1",
+  "description": "Reply to human reviewer comment about VoiceProvider"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 3090774917 \"Fixed in 991999b. Applied the suggested cleanup() function with EXIT trap and wait -n so both child processes are always terminated when either exits early, and the first failing exit code propagates cleanly.\" --resolve 2>&1 && \\\nnpx agent-reviews --reply 3090774934 \"Fixed in 991999b. Added explicit Server[] type annotation and narrowed the catch to TrpcHttpError status 401 only \u2014 other errors (network failures, 5xx) now rethrow so they surface honestly rather than being masked as auth failures.\" --resolve 2>&1 && \\\nnpx agent-reviews --reply 3090774871 \"Fixed in 991999b. Introduced EmptyShellModalContext in EmptyShell that exposes openBrowseServers and openCreateServer handlers. NoServersContent now consumes this context and delegates to the shell-owned modals, eliminating the duplicate modal trees.\" --resolve 2>&1",
+  "description": "Reply to first three bot comments"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 3090774878 \"Fixed in 991999b. Added explicit Server[] type annotation and narrowed the catch to TrpcHttpError status 401 only \u2014 non-auth errors rethrow instead of silently redirecting to login.\" --resolve 2>&1 && \\\nnpx agent-reviews --reply 3090774890 \"Fixed in 991999b. Added explicit Server[] and Channel[] type annotations and narrowed both catches to TrpcHttpError status 401, so network/5xx errors are not masked as auth failures.\" --resolve 2>&1 && \\\nnpx agent-reviews --reply 3090774900 \"Fixed in 991999b. Added a sidebarChannels filter before passing to EmptyShell: when showNoAccessMessage is true, PRIVATE text/announcement channels are excluded from the sidebar while voice channels are preserved, so members only see channels they can interact with.\" --resolve 2>&1",
+  "description": "Reply to next three bot comments"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 3090774819 \"Won't fix: homeHref is intentionally hardcoded to /channels. The /c/ guest route has no index page \u2014 using basePath there would produce a 404. The Home button is meant to always navigate to the authenticated channels index regardless of the current route prefix. The previous DEFAULT_HOME_PATH approach was the wrong layer to put this; /channels is the correct stable target.\" --resolve 2>&1 && \\\nnpx agent-reviews --reply 3090774847 \"Fixed in 991999b. Added the prevServers/setPrevServers render-time derivation pattern (mirroring HarmonyShell lines 177-181) so localServers resets whenever the servers prop reference changes after navigation or revalidation.\" --resolve 2>&1 && \\\nnpx agent-reviews --reply 3090774859 \"Fixed in 991999b. Added c.visibility !== ChannelVisibility.PRIVATE to the defaultChannelByServerId filter in EmptyShell, matching the first-channel selection logic in [serverSlug]/page.tsx, so Browse Servers navigation won't route non-admin users into channels they cannot read.\" --resolve 2>&1",
+  "description": "Reply to last three bot comments"
+}
+```
+
+## Assistant
+
+Now starting Phase 2 - watching for new comments:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --watch 2>&1",
+  "description": "Watch for new PR comments (10 minute timeout)",
+  "timeout": 620000
+}
+```
+
+## User
+
+[Request interrupted by user for tool use]
+
+## Assistant
+
+No response requested.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "DATE=$(date +%Y-%m-%d)\nTIME=$(date +%H%M%S)\nSHORT_ID=\"15e32eb5\"\nOUTFILE=\"llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md\"\necho \"OUTFILE=$OUTFILE\"\n\npython3 - \"/Users/bigfa/.claude/projects/-Users-bigfa-Documents-GitHub-Harmony/15e32eb5-ba18-4764-ab06-31055d15eaa2.jsonl\" \"$OUTFILE\" \"$DATE\" \"$TIME\" \"$SHORT_ID\" <<'PYEOF'\nimport sys, json\n\nsession_file, outfile, date, time_str, short_id = sys.argv[1:]\nlabel = f\"{date}-{time_str}\"\n\nlines = []\nwith open(session_file) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f\"# Session Log {label}\\n\"]\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f\"## User\\n\\n{content.strip()}\\n\")\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f\"**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```\")\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f\"**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```\")\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f\"## Assistant\\n\\n{content.strip()}\\n\")\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f\"Written: {outfile}\")\nPYEOF",
+  "description": "Convert JSONL session to markdown log file"
+}
+```
+


### PR DESCRIPTION
Closes #374

## Summary

- Expired auth token in the server-side tRPC path now redirects to `/auth/login` instead of crashing the Server Component
- Stale `returnUrl` destinations (deleted server/channel after DB reset or re-seed) now redirect to `/channels` instead of showing a 404 dead-end
- Hardcoded `DEFAULT_HOME_PATH = '/harmony-hq/general'` in `ServerRail` replaced with `/channels` (dynamic resolution)
- New `EmptyShell` component provides the full 3-column layout (server rail + optional channel sidebar) for states where no channel is active
- New `NoServersContent` + `NoChannelsContent` empty-state panels rendered inside `EmptyShell`
- `/channels` now renders `EmptyShell + NoServersContent` when the user has no servers, preserving the app shell layout
- `/channels/[serverSlug]` now renders `EmptyShell + NoChannelsContent` when all text/announcement channels are PRIVATE (permission issue), shows voice channels in the sidebar and a blank main area when the server is voice-only, instead of routing the user into `VisibilityGuard`'s dead-end `NoPermissionPage`
- PRIVATE channels are excluded from the `firstChannel` auto-routing selection so non-admin members are never force-navigated into a channel they cannot read (admins can still reach private channels via the sidebar)
- `dev.sh` added: starts Docker services, runs `prisma migrate deploy`, and launches backend + frontend in parallel

## Test plan

- [ ] Log in with a seeded account — confirm landing on a valid channel
- [ ] Log in with `returnUrl` pointing to a deleted server/channel slug — confirm redirect to `/channels` instead of 404
- [ ] Let access token expire (shorten `JWT_ACCESS_EXPIRES_IN` in `.env`), navigate to `/channels` — confirm redirect to `/auth/login` rather than error page
- [ ] User with no server memberships — confirm app shell renders with empty server rail and "No servers yet" prompt; Browse Servers and Create Server modals open correctly
- [ ] Server with only PRIVATE text channels, non-admin member — confirm "No accessible channels" shown in main area with empty channel list; channel is visible in sidebar for admins
- [ ] Server with only VOICE channels — confirm voice channels appear in sidebar, main area is blank (no "no accessible channels" message)
- [ ] Click Home button in server rail — confirm navigation to `/channels` (not a hardcoded slug)
- [ ] `./dev.sh` from repo root starts Docker, runs migrations, and launches both services

🤖 Generated with [Claude Code](https://claude.com/claude-code)