### PR TITLE
feat: Railway service config and multi-origin CORS (#322)

### DIFF
--- a/harmony-backend/.env.example
+++ b/harmony-backend/.env.example
@@ -11,11 +11,22 @@ DATABASE_URL=postgresql://harmony:harmony@localhost:5432/harmony_dev
 # Redis (matches docker-compose.yml defaults)
 REDIS_URL=redis://:devsecret@localhost:6379
 
-# Frontend origin allowed by CORS
+# Frontend origins allowed by CORS — comma-separated list of allowed origins.
+# In Railway, set to the deployed Vercel URL and optionally the production domain:
+# FRONTEND_URL=https://harmony-dun-omega.vercel.app,https://harmony.chat
 FRONTEND_URL=http://localhost:3000
 
 # Canonical public frontend origin used for generated public links and sitemaps
 BASE_URL=http://localhost:3000
+
+# Railway proxy hop count — set to 1 in Railway (behind one proxy layer) so
+# express-rate-limit reads the real client IP from X-Forwarded-For.
+# Leave unset in local dev (no proxy).
+# TRUST_PROXY_HOPS=1
+
+# Railway service dispatcher — set to 'worker' on the backend-worker service,
+# omit or set to 'api' on the backend-api service. Read by start.sh.
+# SERVICE_ROLE=api
 
 # Demo-only seed gate (set true only for explicit demo seeding flows)
 HARMONY_DEMO_MODE=false

--- a/harmony-backend/railway.toml
+++ b/harmony-backend/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "NIXPACKS"
+buildCommand = "npm install && npm run build"
+
+[deploy]
+startCommand = "bash start.sh"
+healthcheckPath = "/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/harmony-backend/railway.toml
+++ b/harmony-backend/railway.toml
@@ -1,6 +1,6 @@
 [build]
 builder = "NIXPACKS"
-buildCommand = "npm install && npm run build"
+buildCommand = "npm ci && npm run build"
 
 [deploy]
 startCommand = "bash start.sh"

--- a/harmony-backend/src/middleware/cors.ts
+++ b/harmony-backend/src/middleware/cors.ts
@@ -10,12 +10,23 @@ export class CorsError extends Error {
 
 const defaultAllowedOrigins = ['http://localhost:3000'];
 
+// FRONTEND_URL may be a comma-separated list of allowed origins so that
+// preview and production frontend URLs can both be permitted without a
+// separate deployment (e.g. "https://harmony-dun-omega.vercel.app,https://harmony.chat").
+function parseFrontendOrigins(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 export const corsOptions: CorsOptions = {
   origin: (origin, callback) => {
     // Build allowed origins at request time so env-based URLs reflect current configuration
     const allowedOrigins = [
       ...defaultAllowedOrigins,
-      ...(process.env.FRONTEND_URL ? [process.env.FRONTEND_URL] : []),
+      ...parseFrontendOrigins(process.env.FRONTEND_URL),
     ];
     // Allow server-to-server requests (no Origin header) so internal callers
     // and health-check probes work without a CORS preflight.

--- a/harmony-backend/start.sh
+++ b/harmony-backend/start.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Railway service dispatcher.
+# Set SERVICE_ROLE=worker on the backend-worker Railway service;
+# omit or set SERVICE_ROLE=api on the backend-api service.
+set -e
+
+if [ "${SERVICE_ROLE}" = "worker" ]; then
+  exec node dist/worker.js
+else
+  exec node dist/index.js
+fi

--- a/harmony-backend/tests/app.test.ts
+++ b/harmony-backend/tests/app.test.ts
@@ -58,7 +58,11 @@ describe('CORS', () => {
     const originalEnv = process.env.FRONTEND_URL;
 
     afterEach(() => {
-      process.env.FRONTEND_URL = originalEnv;
+      if (originalEnv === undefined) {
+        delete process.env.FRONTEND_URL;
+      } else {
+        process.env.FRONTEND_URL = originalEnv;
+      }
     });
 
     it('allows the single URL when FRONTEND_URL has no comma', async () => {

--- a/harmony-backend/tests/app.test.ts
+++ b/harmony-backend/tests/app.test.ts
@@ -44,17 +44,50 @@ describe('404 handler', () => {
 
 describe('CORS', () => {
   it('returns 403 for disallowed origins', async () => {
-    const res = await request(app)
-      .get('/health')
-      .set('Origin', 'https://evil.example.com');
+    const res = await request(app).get('/health').set('Origin', 'https://evil.example.com');
     expect(res.status).toBe(403);
     expect(res.body).toMatchObject({ error: 'CORS: origin not allowed' });
   });
 
   it('allows requests from localhost:3000', async () => {
-    const res = await request(app)
-      .get('/health')
-      .set('Origin', 'http://localhost:3000');
+    const res = await request(app).get('/health').set('Origin', 'http://localhost:3000');
     expect(res.status).toBe(200);
+  });
+
+  describe('FRONTEND_URL comma-separated origins', () => {
+    const originalEnv = process.env.FRONTEND_URL;
+
+    afterEach(() => {
+      process.env.FRONTEND_URL = originalEnv;
+    });
+
+    it('allows the single URL when FRONTEND_URL has no comma', async () => {
+      process.env.FRONTEND_URL = 'https://harmony-dun-omega.vercel.app';
+      const res = await request(createApp())
+        .get('/health')
+        .set('Origin', 'https://harmony-dun-omega.vercel.app');
+      expect(res.status).toBe(200);
+    });
+
+    it('allows all URLs when FRONTEND_URL is comma-separated', async () => {
+      process.env.FRONTEND_URL = 'https://harmony-dun-omega.vercel.app,https://harmony.chat';
+      const freshApp = createApp();
+
+      const r1 = await request(freshApp)
+        .get('/health')
+        .set('Origin', 'https://harmony-dun-omega.vercel.app');
+      expect(r1.status).toBe(200);
+
+      const r2 = await request(freshApp).get('/health').set('Origin', 'https://harmony.chat');
+      expect(r2.status).toBe(200);
+    });
+
+    it('rejects origins not in the comma-separated list', async () => {
+      process.env.FRONTEND_URL = 'https://harmony-dun-omega.vercel.app,https://harmony.chat';
+      const res = await request(createApp())
+        .get('/health')
+        .set('Origin', 'https://evil.example.com');
+      expect(res.status).toBe(403);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #322

- **`railway.toml`** — codifies build command, health check path (`/health`), 300 s timeout, and `ON_FAILURE` restart policy; shared by both services
- **`start.sh`** — dispatcher that branches on `SERVICE_ROLE` env var so `backend-api` and `backend-worker` share one repo root without separate config files
- **CORS multi-origin** — `FRONTEND_URL` now accepts a comma-separated list (e.g. `https://harmony-dun-omega.vercel.app,https://harmony.chat`) so preview and production origins can both be allowed without a redeploy
- **`.env.example`** — documents `TRUST_PROXY_HOPS`, `SERVICE_ROLE`, and the comma-separated `FRONTEND_URL` format

## Railway Dashboard Config Required

**`backend-api`**: `SERVICE_ROLE=api`, `TRUST_PROXY_HOPS=1`, `FRONTEND_URL=https://harmony-dun-omega.vercel.app`, `NODE_ENV=production`, Railway Postgres/Redis internal URLs, JWT secrets, `BASE_URL`

**`backend-worker`**: `SERVICE_ROLE=worker`, `NODE_ENV=production`, same Postgres/Redis internal URLs

Both services use `bash start.sh` as the start command — `SERVICE_ROLE` performs the dispatch.

## Test plan

- [x] `tests/app.test.ts` — 9 tests pass (3 new multi-origin CORS cases)
- [x] `app.test|rate-limit|cors` suite — 36 tests pass, no regressions
- [ ] Verify `backend-worker` `/health` responds after Railway deploy
- [ ] Verify no CORS errors in DevTools when using Vercel frontend
- [ ] Confirm `X-Instance-Id` cycles across replicas on repeated `GET /health`