### PR TITLE
fix: remove redundant npm install from railway buildCommand

### DIFF
--- a/harmony-backend/railway.toml
+++ b/harmony-backend/railway.toml
@@ -1,6 +1,6 @@
 [build]
 builder = "NIXPACKS"
-buildCommand = "npm install && npm run build"
+buildCommand = "npm run build"
 
 [deploy]
 startCommand = "bash start.sh"


### PR DESCRIPTION
Nixpacks runs npm ci in its own install phase; a second npm install in buildCommand conflicts with the Docker cache mount on node_modules/.cache causing EBUSY (exit 240). Build command only needs npm run build.