### PR TITLE
refactor: introduce repository layer — centralize Prisma calls out of services

### DIFF
--- a/harmony-backend/src/repositories/attachment.repository.ts
+++ b/harmony-backend/src/repositories/attachment.repository.ts
@@ -1,0 +1,31 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+export const attachmentRepository = {
+  findMessageForAttachmentList(messageId: string, client: Client = prisma) {
+    return client.message.findUnique({
+      where: { id: messageId },
+      select: {
+        id: true,
+        isDeleted: true,
+        channel: { select: { serverId: true } },
+      },
+    });
+  },
+
+  findByMessageId(messageId: string, client: Client = prisma) {
+    return client.attachment.findMany({
+      where: { messageId },
+      select: {
+        id: true,
+        filename: true,
+        url: true,
+        contentType: true,
+        // sizeBytes (BigInt) intentionally excluded — tRPC default JSON
+        // transformer cannot serialize BigInt.
+      },
+    });
+  },
+};

--- a/harmony-backend/src/repositories/auditLog.repository.ts
+++ b/harmony-backend/src/repositories/auditLog.repository.ts
@@ -1,0 +1,23 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+export const auditLogRepository = {
+  create(data: Prisma.VisibilityAuditLogCreateInput, client: Client = prisma) {
+    return client.visibilityAuditLog.create({ data });
+  },
+
+  findMany(where: Prisma.VisibilityAuditLogWhereInput, skip: number, take: number, client: Client = prisma) {
+    return client.visibilityAuditLog.findMany({
+      where,
+      orderBy: { timestamp: 'desc' },
+      skip,
+      take,
+    });
+  },
+
+  count(where: Prisma.VisibilityAuditLogWhereInput, client: Client = prisma) {
+    return client.visibilityAuditLog.count({ where });
+  },
+};

--- a/harmony-backend/src/repositories/channel.repository.ts
+++ b/harmony-backend/src/repositories/channel.repository.ts
@@ -16,24 +16,6 @@ export const channelRepository = {
     return client.channel.findUnique({ where: { serverId_slug: { serverId, slug } } });
   },
 
-  findByServerSlugAndChannelSlug(serverSlug: string, channelSlug: string, client: Client = prisma) {
-    return client.server
-      .findUnique({ where: { slug: serverSlug } })
-      .then((server) => {
-        if (!server) return null;
-        return client.channel.findUnique({
-          where: { serverId_slug: { serverId: server.id, slug: channelSlug } },
-        });
-      });
-  },
-
-  findWithServerId(id: string, client: Client = prisma) {
-    return client.channel.findUnique({
-      where: { id },
-      select: { serverId: true, visibility: true },
-    });
-  },
-
   findVisibilityAndServerId(id: string, client: Client = prisma) {
     return client.channel.findUnique({
       where: { id },

--- a/harmony-backend/src/repositories/channel.repository.ts
+++ b/harmony-backend/src/repositories/channel.repository.ts
@@ -1,0 +1,73 @@
+import { ChannelVisibility, Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+export const channelRepository = {
+  findById(id: string, client: Client = prisma) {
+    return client.channel.findUnique({ where: { id } });
+  },
+
+  findByServerId(serverId: string, client: Client = prisma) {
+    return client.channel.findMany({ where: { serverId }, orderBy: { position: 'asc' } });
+  },
+
+  findByServerAndSlug(serverId: string, slug: string, client: Client = prisma) {
+    return client.channel.findUnique({ where: { serverId_slug: { serverId, slug } } });
+  },
+
+  findByServerSlugAndChannelSlug(serverSlug: string, channelSlug: string, client: Client = prisma) {
+    return client.server
+      .findUnique({ where: { slug: serverSlug } })
+      .then((server) => {
+        if (!server) return null;
+        return client.channel.findUnique({
+          where: { serverId_slug: { serverId: server.id, slug: channelSlug } },
+        });
+      });
+  },
+
+  findWithServerId(id: string, client: Client = prisma) {
+    return client.channel.findUnique({
+      where: { id },
+      select: { serverId: true, visibility: true },
+    });
+  },
+
+  findVisibilityAndServerId(id: string, client: Client = prisma) {
+    return client.channel.findUnique({
+      where: { id },
+      select: { visibility: true, serverId: true },
+    });
+  },
+
+  findForSitemap(id: string, client: Client = prisma) {
+    return client.channel.findUnique({
+      where: { id },
+      select: { serverId: true, server: { select: { slug: true } } },
+    });
+  },
+
+  findPublicIndexableByServerId(
+    serverId: string,
+    client: Client = prisma,
+  ) {
+    return client.channel.findMany({
+      where: { serverId, visibility: ChannelVisibility.PUBLIC_INDEXABLE },
+      orderBy: { position: 'asc' },
+      select: { slug: true, updatedAt: true },
+    });
+  },
+
+  create(data: Prisma.ChannelUncheckedCreateInput, client: Client = prisma) {
+    return client.channel.create({ data });
+  },
+
+  update(id: string, data: Prisma.ChannelUpdateInput, client: Client = prisma) {
+    return client.channel.update({ where: { id }, data });
+  },
+
+  delete(id: string, client: Client = prisma) {
+    return client.channel.delete({ where: { id } });
+  },
+};

--- a/harmony-backend/src/repositories/message.repository.ts
+++ b/harmony-backend/src/repositories/message.repository.ts
@@ -1,0 +1,90 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+const AUTHOR_SELECT = {
+  id: true,
+  username: true,
+  displayName: true,
+  avatarUrl: true,
+} as const;
+
+const ATTACHMENT_SELECT = {
+  id: true,
+  filename: true,
+  url: true,
+  contentType: true,
+} as const;
+
+export const MESSAGE_INCLUDE = {
+  author: { select: AUTHOR_SELECT },
+  attachments: { select: ATTACHMENT_SELECT },
+} as const;
+
+export const messageRepository = {
+  findByIdWithChannel(id: string, client: Client = prisma) {
+    return client.message.findUnique({
+      where: { id },
+      include: { channel: { select: { serverId: true } } },
+    });
+  },
+
+  findByIdWithChannelFull(id: string, client: Client = prisma) {
+    return client.message.findUnique({
+      where: { id },
+      include: { channel: { select: { id: true, serverId: true } } },
+    });
+  },
+
+  findManyPaginated(
+    where: Prisma.MessageWhereInput,
+    take: number,
+    cursor: string | undefined,
+    orderBy: Prisma.MessageOrderByWithRelationInput,
+    client: Client = prisma,
+  ) {
+    return client.message.findMany({
+      where,
+      take,
+      cursor: cursor ? { id: cursor } : undefined,
+      skip: cursor ? 1 : 0,
+      orderBy,
+      include: MESSAGE_INCLUDE,
+    });
+  },
+
+  findPinnedByChannel(channelId: string, client: Client = prisma) {
+    return client.message.findMany({
+      where: { channelId, pinned: true, isDeleted: false },
+      orderBy: { pinnedAt: 'desc' },
+      include: MESSAGE_INCLUDE,
+    });
+  },
+
+  create(data: Prisma.MessageCreateInput, client: Client = prisma) {
+    return client.message.create({ data, include: MESSAGE_INCLUDE });
+  },
+
+  update(id: string, data: Prisma.MessageUpdateInput, client: Client = prisma) {
+    return client.message.update({ where: { id }, data, include: MESSAGE_INCLUDE });
+  },
+
+  updateRaw(id: string, data: Prisma.MessageUpdateInput, client: Client = prisma) {
+    return client.message.update({ where: { id }, data });
+  },
+
+  updateMany(where: Prisma.MessageWhereInput, data: Prisma.MessageUpdateManyMutationInput, client: Client = prisma) {
+    return client.message.updateMany({ where, data });
+  },
+
+  decrementReplyCountFloored(parentId: string, client: Prisma.TransactionClient | typeof prisma = prisma) {
+    // Prisma's { decrement: 1 } has no floor; GREATEST(..., 0) guards against
+    // negative counts from concurrent races or anomalies.
+    return client.$executeRaw`
+      UPDATE "messages"
+      SET reply_count = GREATEST(reply_count - 1, 0)
+      WHERE id = ${parentId}::uuid
+    `;
+  },
+};

--- a/harmony-backend/src/repositories/reaction.repository.ts
+++ b/harmony-backend/src/repositories/reaction.repository.ts
@@ -1,0 +1,35 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+export const reactionRepository = {
+  findMessageWithChannel(messageId: string, client: Client = prisma) {
+    return client.message.findUnique({
+      where: { id: messageId },
+      include: { channel: { select: { serverId: true, id: true } } },
+    });
+  },
+
+  findByMessageId(messageId: string, client: Client = prisma) {
+    return client.messageReaction.findMany({
+      where: { messageId },
+      select: { emoji: true, userId: true },
+      orderBy: { createdAt: 'asc' },
+    });
+  },
+
+  findFirst(where: Prisma.MessageReactionWhereInput, client: Client = prisma) {
+    return client.messageReaction.findFirst({ where });
+  },
+
+  create(data: Prisma.MessageReactionCreateInput, client: Client = prisma) {
+    return client.messageReaction.create({ data });
+  },
+
+  delete(messageId: string, userId: string, emoji: string, client: Client = prisma) {
+    return client.messageReaction.delete({
+      where: { messageId_userId_emoji: { messageId, userId, emoji } },
+    });
+  },
+};

--- a/harmony-backend/src/repositories/refreshToken.repository.ts
+++ b/harmony-backend/src/repositories/refreshToken.repository.ts
@@ -1,0 +1,24 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+export const refreshTokenRepository = {
+  create(data: Prisma.RefreshTokenUncheckedCreateInput, client: Client = prisma) {
+    return client.refreshToken.create({ data });
+  },
+
+  revokeByHash(tokenHash: string, client: Client = prisma) {
+    return client.refreshToken.updateMany({
+      where: { tokenHash, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+  },
+
+  rotateByHash(tokenHash: string, client: Client = prisma) {
+    return client.refreshToken.updateMany({
+      where: { tokenHash, revokedAt: null, expiresAt: { gt: new Date() } },
+      data: { revokedAt: new Date() },
+    });
+  },
+};

--- a/harmony-backend/src/repositories/server.repository.ts
+++ b/harmony-backend/src/repositories/server.repository.ts
@@ -28,6 +28,14 @@ export const serverRepository = {
     return client.server.findMany({ orderBy: { createdAt: 'desc' }, take: limit });
   },
 
+  findAllIds(client: Client = prisma): Promise<string[]> {
+    return client.server.findMany({ select: { id: true } }).then((rs) => rs.map((r) => r.id));
+  },
+
+  findBySlugSelect<T extends Prisma.ServerSelect>(slug: string, select: T, client: Client = prisma) {
+    return client.server.findUnique({ where: { slug }, select });
+  },
+
   findPublicBySlugSelect(client: Client = prisma) {
     return client.server.findMany({
       where: { isPublic: true },

--- a/harmony-backend/src/repositories/server.repository.ts
+++ b/harmony-backend/src/repositories/server.repository.ts
@@ -1,0 +1,58 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+export const serverRepository = {
+  findBySlug(slug: string, client: Client = prisma) {
+    return client.server.findUnique({ where: { slug } });
+  },
+
+  findById(id: string, client: Client = prisma) {
+    return client.server.findUnique({ where: { id } });
+  },
+
+  findByIdSelect<T extends Prisma.ServerSelect>(id: string, select: T, client: Client = prisma) {
+    return client.server.findUnique({ where: { id }, select });
+  },
+
+  findPublic(limit: number, client: Client = prisma) {
+    return client.server.findMany({
+      where: { isPublic: true },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+  },
+
+  findAll(limit: number, client: Client = prisma) {
+    return client.server.findMany({ orderBy: { createdAt: 'desc' }, take: limit });
+  },
+
+  findPublicBySlugSelect(client: Client = prisma) {
+    return client.server.findMany({
+      where: { isPublic: true },
+      orderBy: { memberCount: 'desc' },
+      select: { slug: true },
+    });
+  },
+
+  findFirst(where: Prisma.ServerWhereInput, select: Prisma.ServerSelect, client: Client = prisma) {
+    return client.server.findFirst({ where, select });
+  },
+
+  countBySlug(slug: string, client: Client = prisma) {
+    return client.server.count({ where: { slug } });
+  },
+
+  create(data: Prisma.ServerUncheckedCreateInput, client: Client = prisma) {
+    return client.server.create({ data });
+  },
+
+  update(id: string, data: Prisma.ServerUpdateInput, client: Client = prisma) {
+    return client.server.update({ where: { id }, data });
+  },
+
+  delete(id: string, client: Client = prisma) {
+    return client.server.delete({ where: { id } });
+  },
+};

--- a/harmony-backend/src/repositories/serverMember.repository.ts
+++ b/harmony-backend/src/repositories/serverMember.repository.ts
@@ -1,0 +1,91 @@
+import { Prisma, RoleType } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+export const serverMemberRepository = {
+  findByUserAndServer(userId: string, serverId: string, client: Client = prisma) {
+    return client.serverMember.findUnique({
+      where: { userId_serverId: { userId, serverId } },
+    });
+  },
+
+  findByUserAndServerSelect(userId: string, serverId: string, client: Client = prisma) {
+    return client.serverMember.findUnique({
+      where: { userId_serverId: { userId, serverId } },
+      select: { role: true },
+    });
+  },
+
+  findByServerId(
+    serverId: string,
+    client: Client = prisma,
+  ) {
+    return client.serverMember.findMany({
+      where: { serverId },
+      include: {
+        user: {
+          select: { id: true, username: true, displayName: true, avatarUrl: true },
+        },
+      },
+      orderBy: { joinedAt: 'asc' },
+    });
+  },
+
+  findMembersByServerId(serverId: string, client: Client = prisma) {
+    return client.serverMember.findMany({
+      where: { serverId },
+      include: {
+        user: {
+          select: { id: true, username: true, displayName: true, avatarUrl: true, status: true },
+        },
+      },
+    });
+  },
+
+  findByUserIdWithServer(userId: string, take?: number, client: Client = prisma) {
+    return client.serverMember.findMany({
+      where: { userId },
+      include: { server: true },
+      orderBy: { joinedAt: 'asc' },
+      ...(take !== undefined && { take }),
+    });
+  },
+
+  findByUserIdSelect(userId: string, client: Client = prisma) {
+    return client.serverMember.findMany({
+      where: { userId },
+      select: { serverId: true },
+    });
+  },
+
+  findFirst(where: Prisma.ServerMemberWhereInput, client: Client = prisma) {
+    return client.serverMember.findFirst({ where });
+  },
+
+  create(data: Prisma.ServerMemberUncheckedCreateInput, client: Client = prisma) {
+    return client.serverMember.create({ data });
+  },
+
+  upsert(
+    where: Prisma.ServerMemberWhereUniqueInput,
+    update: Prisma.ServerMemberUpdateInput,
+    create: Prisma.ServerMemberUncheckedCreateInput,
+    client: Client = prisma,
+  ) {
+    return client.serverMember.upsert({ where, update, create });
+  },
+
+  update(userId: string, serverId: string, role: RoleType, client: Client = prisma) {
+    return client.serverMember.update({
+      where: { userId_serverId: { userId, serverId } },
+      data: { role },
+    });
+  },
+
+  delete(userId: string, serverId: string, client: Client = prisma) {
+    return client.serverMember.delete({
+      where: { userId_serverId: { userId, serverId } },
+    });
+  },
+};

--- a/harmony-backend/src/repositories/user.repository.ts
+++ b/harmony-backend/src/repositories/user.repository.ts
@@ -1,0 +1,64 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+export const PUBLIC_PROFILE_SELECT = {
+  id: true,
+  username: true,
+  displayName: true,
+  avatarUrl: true,
+  publicProfile: true,
+  status: true,
+  createdAt: true,
+} as const;
+
+export const SELF_PROFILE_SELECT = {
+  id: true,
+  email: true,
+  username: true,
+  displayName: true,
+  avatarUrl: true,
+  publicProfile: true,
+  status: true,
+  createdAt: true,
+} as const;
+
+export const userRepository = {
+  findById(id: string, client: Client = prisma) {
+    return client.user.findUnique({ where: { id }, select: PUBLIC_PROFILE_SELECT });
+  },
+
+  findSelf(id: string, client: Client = prisma) {
+    return client.user.findUnique({ where: { id }, select: SELF_PROFILE_SELECT });
+  },
+
+  findByEmail(email: string, client: Client = prisma) {
+    return client.user.findUnique({ where: { email } });
+  },
+
+  findByEmailSelect(email: string, client: Client = prisma) {
+    return client.user.findUnique({ where: { email }, select: { passwordHash: true } });
+  },
+
+  findByUsername(username: string, client: Client = prisma) {
+    return client.user.findUnique({ where: { username } });
+  },
+
+  create(data: Prisma.UserCreateInput, client: Client = prisma) {
+    return client.user.create({ data });
+  },
+
+  upsert(
+    where: Prisma.UserWhereUniqueInput,
+    update: Prisma.UserUpdateInput,
+    create: Prisma.UserCreateInput,
+    client: Client = prisma,
+  ) {
+    return client.user.upsert({ where, update, create });
+  },
+
+  update(id: string, data: Prisma.UserUpdateInput, client: Client = prisma) {
+    return client.user.update({ where: { id }, select: SELF_PROFILE_SELECT, data });
+  },
+};

--- a/harmony-backend/src/services/attachment.service.ts
+++ b/harmony-backend/src/services/attachment.service.ts
@@ -1,4 +1,4 @@
-import { prisma } from '../db/prisma';
+import { attachmentRepository } from '../repositories/attachment.repository';
 
 // ─── Validation constants ─────────────────────────────────────────────────────
 
@@ -75,14 +75,7 @@ export const attachmentService = {
    * transport-agnostic. The tRPC router maps it to TRPCError NOT_FOUND.
    */
   async listByMessage(messageId: string, serverId: string) {
-    const message = await prisma.message.findUnique({
-      where: { id: messageId },
-      select: {
-        id: true,
-        isDeleted: true,
-        channel: { select: { serverId: true } },
-      },
-    });
+    const message = await attachmentRepository.findMessageForAttachmentList(messageId);
 
     if (!message || message.isDeleted) {
       throw new AttachmentNotFoundError();
@@ -94,16 +87,6 @@ export const attachmentService = {
       throw new AttachmentNotFoundError();
     }
 
-    return prisma.attachment.findMany({
-      where: { messageId },
-      select: {
-        id: true,
-        filename: true,
-        url: true,
-        contentType: true,
-        // sizeBytes (BigInt) is intentionally excluded — tRPC's default
-        // JSON transformer cannot serialize BigInt.
-      },
-    });
+    return attachmentRepository.findByMessageId(messageId);
   },
 };

--- a/harmony-backend/src/services/auditLog.service.ts
+++ b/harmony-backend/src/services/auditLog.service.ts
@@ -14,7 +14,7 @@
  */
 
 import { Prisma, VisibilityAuditLog } from '@prisma/client';
-import { prisma } from '../db/prisma';
+import { auditLogRepository } from '../repositories/auditLog.repository';
 
 /** Max characters stored for User-Agent — matches the @db.VarChar(500) column. */
 const USER_AGENT_MAX_LEN = 500;
@@ -61,18 +61,18 @@ export const auditLogService = {
     input: LogVisibilityChangeInput,
     tx?: Prisma.TransactionClient,
   ): Promise<VisibilityAuditLog> {
-    const client = tx ?? prisma;
-    return client.visibilityAuditLog.create({
-      data: {
-        channelId: input.channelId,
-        actorId: input.actorId,
+    return auditLogRepository.create(
+      {
+        channel: { connect: { id: input.channelId } },
+        actor: { connect: { id: input.actorId } },
         action: 'VISIBILITY_CHANGED',
         oldValue: input.oldValue,
         newValue: input.newValue,
         ipAddress: input.ipAddress,
         userAgent: (input.userAgent ?? '').slice(0, USER_AGENT_MAX_LEN),
       },
-    });
+      tx,
+    );
   },
 
   /**
@@ -95,13 +95,8 @@ export const auditLogService = {
     };
 
     const [entries, total] = await Promise.all([
-      prisma.visibilityAuditLog.findMany({
-        where,
-        orderBy: { timestamp: 'desc' },
-        skip: safeOffset,
-        take: clampedLimit,
-      }),
-      prisma.visibilityAuditLog.count({ where }),
+      auditLogRepository.findMany(where, safeOffset, clampedLimit),
+      auditLogRepository.count(where),
     ]);
 
     return { entries, total };

--- a/harmony-backend/src/services/auth.service.ts
+++ b/harmony-backend/src/services/auth.service.ts
@@ -152,12 +152,12 @@ async function ensureAdminUser() {
   );
 
   // Auto-join every server as OWNER so the admin can access everything.
-  const allServers = await serverRepository.findAll(10000);
-  for (const server of allServers) {
+  const allServerIds = await serverRepository.findAllIds();
+  for (const serverId of allServerIds) {
     await serverMemberRepository.upsert(
-      { userId_serverId: { userId: admin.id, serverId: server.id } },
+      { userId_serverId: { userId: admin.id, serverId } },
       { role: 'OWNER' },
-      { userId: admin.id, serverId: server.id, role: 'OWNER' as const },
+      { userId: admin.id, serverId, role: 'OWNER' as const },
     );
   }
 

--- a/harmony-backend/src/services/auth.service.ts
+++ b/harmony-backend/src/services/auth.service.ts
@@ -2,10 +2,13 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import { Prisma } from '@prisma/client';
-import { prisma } from '../db/prisma';
 import { TRPCError } from '@trpc/server';
 import { serverMemberService } from './serverMember.service';
 import { ADMIN_EMAIL } from '../lib/admin.utils';
+import { userRepository } from '../repositories/user.repository';
+import { serverRepository } from '../repositories/server.repository';
+import { serverMemberRepository } from '../repositories/serverMember.repository';
+import { refreshTokenRepository } from '../repositories/refreshToken.repository';
 
 const BCRYPT_ROUNDS = 12;
 // Dummy hash used to equalise bcrypt timing when the email is not found
@@ -120,12 +123,10 @@ async function storeRefreshToken(userId: string, rawToken: string): Promise<void
   const expiresAt = new Date();
   expiresAt.setDate(expiresAt.getDate() + REFRESH_EXPIRES_IN_DAYS);
 
-  await prisma.refreshToken.create({
-    data: {
-      tokenHash: hashToken(rawToken),
-      userId,
-      expiresAt,
-    },
+  await refreshTokenRepository.create({
+    tokenHash: hashToken(rawToken),
+    userId,
+    expiresAt,
   });
 }
 
@@ -139,25 +140,25 @@ async function ensureAdminUser() {
   const passwordHash = await bcrypt.hash(createDevAdminPasswordVerifier(), BCRYPT_ROUNDS);
   const encodedPasswordHash = encodePasswordVerifierRecord(DEV_ADMIN_PASSWORD_SALT, passwordHash);
 
-  const admin = await prisma.user.upsert({
-    where: { email: ADMIN_EMAIL },
-    update: { passwordHash: encodedPasswordHash },
-    create: {
+  const admin = await userRepository.upsert(
+    { email: ADMIN_EMAIL },
+    { passwordHash: encodedPasswordHash },
+    {
       email: ADMIN_EMAIL,
       username: 'admin',
       displayName: 'System Admin',
       passwordHash: encodedPasswordHash,
     },
-  });
+  );
 
   // Auto-join every server as OWNER so the admin can access everything.
-  const servers = await prisma.server.findMany({ select: { id: true } });
-  for (const server of servers) {
-    await prisma.serverMember.upsert({
-      where: { userId_serverId: { userId: admin.id, serverId: server.id } },
-      update: { role: 'OWNER' },
-      create: { userId: admin.id, serverId: server.id, role: 'OWNER' },
-    });
+  const allServers = await serverRepository.findAll(10000);
+  for (const server of allServers) {
+    await serverMemberRepository.upsert(
+      { userId_serverId: { userId: admin.id, serverId: server.id } },
+      { role: 'OWNER' },
+      { userId: admin.id, serverId: server.id, role: 'OWNER' as const },
+    );
   }
 
   return admin;
@@ -175,10 +176,7 @@ export const authService = {
       return DEV_ADMIN_PASSWORD_SALT;
     }
 
-    const user = await prisma.user.findUnique({
-      where: { email },
-      select: { passwordHash: true },
-    });
+    const user = await userRepository.findByEmailSelect(email);
     const decoded = user ? decodePasswordVerifierRecord(user.passwordHash) : null;
     return decoded?.passwordSalt ?? createDummyPasswordSalt(email);
   },
@@ -189,12 +187,12 @@ export const authService = {
     passwordSalt: string,
     passwordVerifier: string,
   ): Promise<AuthTokens> {
-    const existingEmail = await prisma.user.findUnique({ where: { email } });
+    const existingEmail = await userRepository.findByEmail(email);
     if (existingEmail) {
       throw new TRPCError({ code: 'CONFLICT', message: 'Email already in use' });
     }
 
-    const existingUsername = await prisma.user.findUnique({ where: { username } });
+    const existingUsername = await userRepository.findByUsername(username);
     if (existingUsername) {
       throw new TRPCError({ code: 'CONFLICT', message: 'Username already taken' });
     }
@@ -206,15 +204,13 @@ export const authService = {
       await bcrypt.hash(passwordVerifier, BCRYPT_ROUNDS),
     );
 
-    let user: Awaited<ReturnType<typeof prisma.user.create>>;
+    let user: Awaited<ReturnType<typeof userRepository.create>>;
     try {
-      user = await prisma.user.create({
-        data: {
-          email,
-          username,
-          passwordHash,
-          displayName: username,
-        },
+      user = await userRepository.create({
+        email,
+        username,
+        passwordHash,
+        displayName: username,
       });
     } catch (err) {
       if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
@@ -224,10 +220,10 @@ export const authService = {
     }
 
     // Auto-join the default public server so new users land in a usable state.
-    const defaultServer = await prisma.server.findFirst({
-      where: { slug: 'harmony-hq', isPublic: true },
-      select: { id: true },
-    });
+    const defaultServer = await serverRepository.findFirst(
+      { slug: 'harmony-hq', isPublic: true },
+      { id: true },
+    );
     if (defaultServer) {
       try {
         await serverMemberService.joinServer(user.id, defaultServer.id);
@@ -259,7 +255,7 @@ export const authService = {
       return { accessToken, refreshToken };
     }
 
-    const user = await prisma.user.findUnique({ where: { email } });
+    const user = await userRepository.findByEmail(email);
     if (!user) {
       // Equalise timing so unknown emails are indistinguishable from wrong passwords
       await bcrypt.compare(passwordVerifier, TIMING_DUMMY_HASH);
@@ -291,10 +287,7 @@ export const authService = {
 
   async logout(rawRefreshToken: string): Promise<void> {
     const hash = hashToken(rawRefreshToken);
-    await prisma.refreshToken.updateMany({
-      where: { tokenHash: hash, revokedAt: null },
-      data: { revokedAt: new Date() },
-    });
+    await refreshTokenRepository.revokeByHash(hash);
   },
 
   async refreshTokens(rawRefreshToken: string): Promise<AuthTokens> {
@@ -309,10 +302,7 @@ export const authService = {
 
     // Atomic compare-and-revoke: succeeds only if the token exists, is not revoked, and is not expired.
     // Two concurrent requests with the same token will race; exactly one will get count === 1.
-    const revoked = await prisma.refreshToken.updateMany({
-      where: { tokenHash: hash, revokedAt: null, expiresAt: { gt: new Date() } },
-      data: { revokedAt: new Date() },
-    });
+    const revoked = await refreshTokenRepository.rotateByHash(hash);
 
     if (revoked.count === 0) {
       throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Refresh token revoked or expired' });

--- a/harmony-backend/src/services/channel.service.ts
+++ b/harmony-backend/src/services/channel.service.ts
@@ -1,9 +1,10 @@
 import { TRPCError } from '@trpc/server';
 import { ChannelType, ChannelVisibility } from '@prisma/client';
-import { prisma } from '../db/prisma';
 import { createLogger } from '../lib/logger';
 import { cacheService, CacheKeys, CacheTTL, sanitizeKeySegment } from './cache.service';
 import { eventBus, EventChannels } from '../events/eventBus';
+import { channelRepository } from '../repositories/channel.repository';
+import { serverRepository } from '../repositories/server.repository';
 
 export interface CreateChannelInput {
   serverId: string;
@@ -25,21 +26,16 @@ const logger = createLogger({ component: 'channel-service' });
 
 export const channelService = {
   async getChannels(serverId: string) {
-    return prisma.channel.findMany({
-      where: { serverId },
-      orderBy: { position: 'asc' },
-    });
+    return channelRepository.findByServerId(serverId);
   },
 
   async getChannelBySlug(serverSlug: string, channelSlug: string) {
-    const server = await prisma.server.findUnique({ where: { slug: serverSlug } });
+    const server = await serverRepository.findBySlug(serverSlug);
     if (!server) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
     }
 
-    const channel = await prisma.channel.findUnique({
-      where: { serverId_slug: { serverId: server.id, slug: channelSlug } },
-    });
+    const channel = await channelRepository.findByServerAndSlug(server.id, channelSlug);
     if (!channel) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found' });
     }
@@ -59,15 +55,13 @@ export const channelService = {
     }
 
     // Verify server exists
-    const server = await prisma.server.findUnique({ where: { id: serverId } });
+    const server = await serverRepository.findById(serverId);
     if (!server) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
     }
 
     // Check slug uniqueness per server
-    const existing = await prisma.channel.findUnique({
-      where: { serverId_slug: { serverId, slug } },
-    });
+    const existing = await channelRepository.findByServerAndSlug(serverId, slug);
     if (existing) {
       throw new TRPCError({
         code: 'CONFLICT',
@@ -75,9 +69,7 @@ export const channelService = {
       });
     }
 
-    const channel = await prisma.channel.create({
-      data: { serverId, name, slug, type, visibility, topic, position },
-    });
+    const channel = await channelRepository.create({ serverId, name, slug, type, visibility, topic, position });
 
     // Write-through: cache new visibility and invalidate server channel list (best-effort)
     cacheService
@@ -117,18 +109,15 @@ export const channelService = {
   },
 
   async updateChannel(channelId: string, serverId: string, patch: UpdateChannelInput) {
-    const channel = await prisma.channel.findUnique({ where: { id: channelId } });
+    const channel = await channelRepository.findById(channelId);
     if (!channel || channel.serverId !== serverId) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });
     }
 
-    const updated = await prisma.channel.update({
-      where: { id: channelId },
-      data: {
-        ...(patch.name !== undefined && { name: patch.name }),
-        ...(patch.topic !== undefined && { topic: patch.topic }),
-        ...(patch.position !== undefined && { position: patch.position }),
-      },
+    const updated = await channelRepository.update(channelId, {
+      ...(patch.name !== undefined && { name: patch.name }),
+      ...(patch.topic !== undefined && { topic: patch.topic }),
+      ...(patch.position !== undefined && { position: patch.position }),
     });
 
     // Write-through: invalidate message caches and server channel list (best-effort)
@@ -164,12 +153,12 @@ export const channelService = {
   },
 
   async deleteChannel(channelId: string, serverId: string) {
-    const channel = await prisma.channel.findUnique({ where: { id: channelId } });
+    const channel = await channelRepository.findById(channelId);
     if (!channel || channel.serverId !== serverId) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });
     }
 
-    await prisma.channel.delete({ where: { id: channelId } });
+    await channelRepository.delete(channelId);
 
     // Write-through: invalidate all caches for deleted channel (best-effort)
     cacheService

--- a/harmony-backend/src/services/indexing.service.ts
+++ b/harmony-backend/src/services/indexing.service.ts
@@ -69,7 +69,7 @@ export const indexingService = {
    * Uses stale-while-revalidate caching via getOrRevalidate.
    */
   async generateSitemap(serverSlug: string): Promise<string | null> {
-    const server = await serverRepository.findBySlug(serverSlug);
+    const server = await serverRepository.findBySlugSelect(serverSlug, { id: true, slug: true });
 
     if (!server) return null;
 

--- a/harmony-backend/src/services/indexing.service.ts
+++ b/harmony-backend/src/services/indexing.service.ts
@@ -10,10 +10,10 @@
  * Listens to VISIBILITY_CHANGED events to keep sitemap data in sync.
  */
 
-import { ChannelVisibility } from '@prisma/client';
-import { prisma } from '../db/prisma';
 import { cacheService, sanitizeKeySegment } from './cache.service';
 import type { VisibilityChangedPayload } from '../events/eventTypes';
+import { channelRepository } from '../repositories/channel.repository';
+import { serverRepository } from '../repositories/server.repository';
 
 const SITEMAP_CACHE_TTL = 300; // 5 minutes
 const BASE_URL = process.env.BASE_URL ?? 'https://harmony.chat';
@@ -33,11 +33,7 @@ export const indexingService = {
     return cacheService.getOrRevalidate(
       CacheKeys_Sitemap.index,
       async () => {
-        const servers = await prisma.server.findMany({
-          where: { isPublic: true },
-          orderBy: { memberCount: 'desc' },
-          select: { slug: true },
-        });
+        const servers = await serverRepository.findPublicBySlugSelect();
         return buildSitemapIndexXml(servers.map((server) => server.slug));
       },
       { ttl: SITEMAP_CACHE_TTL },
@@ -49,10 +45,7 @@ export const indexingService = {
    * appears in the next generated sitemap.
    */
   async addToSitemap(channelId: string): Promise<void> {
-    const channel = await prisma.channel.findUnique({
-      where: { id: channelId },
-      select: { serverId: true, server: { select: { slug: true } } },
-    });
+    const channel = await channelRepository.findForSitemap(channelId);
     if (!channel) return;
 
     await cacheService.invalidate(CacheKeys_Sitemap.serverSitemap(channel.server.slug));
@@ -63,16 +56,10 @@ export const indexingService = {
    * the cached sitemap so the channel no longer appears on next generation.
    */
   async removeFromSitemap(channelId: string): Promise<void> {
-    const channel = await prisma.channel.findUnique({
-      where: { id: channelId },
-      select: { serverId: true, server: { select: { slug: true } } },
-    });
+    const channel = await channelRepository.findForSitemap(channelId);
     if (!channel) return;
 
-    await prisma.channel.update({
-      where: { id: channelId },
-      data: { indexedAt: null },
-    });
+    await channelRepository.update(channelId, { indexedAt: null });
 
     await cacheService.invalidate(CacheKeys_Sitemap.serverSitemap(channel.server.slug));
   },
@@ -82,10 +69,7 @@ export const indexingService = {
    * Uses stale-while-revalidate caching via getOrRevalidate.
    */
   async generateSitemap(serverSlug: string): Promise<string | null> {
-    const server = await prisma.server.findUnique({
-      where: { slug: serverSlug },
-      select: { id: true, slug: true },
-    });
+    const server = await serverRepository.findBySlug(serverSlug);
 
     if (!server) return null;
 
@@ -94,17 +78,7 @@ export const indexingService = {
     return cacheService.getOrRevalidate(
       cacheKey,
       async () => {
-        const channels = await prisma.channel.findMany({
-          where: {
-            serverId: server.id,
-            visibility: ChannelVisibility.PUBLIC_INDEXABLE,
-          },
-          orderBy: { position: 'asc' },
-          select: {
-            slug: true,
-            updatedAt: true,
-          },
-        });
+        const channels = await channelRepository.findPublicIndexableByServerId(server.id);
         return buildSitemapXml(server.slug, channels);
       },
       { ttl: SITEMAP_CACHE_TTL },

--- a/harmony-backend/src/services/message.service.ts
+++ b/harmony-backend/src/services/message.service.ts
@@ -4,6 +4,8 @@ import { createLogger } from '../lib/logger';
 import { cacheService, CacheTTL, sanitizeKeySegment } from './cache.service';
 import { permissionService } from './permission.service';
 import { eventBus, EventChannels } from '../events/eventBus';
+import { channelRepository } from '../repositories/channel.repository';
+import { messageRepository } from '../repositories/message.repository';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -59,31 +61,6 @@ export interface DeleteMessageInput {
 
 const logger = createLogger({ component: 'message-service' });
 
-// ─── Author / attachment projections ─────────────────────────────────────────
-
-const AUTHOR_SELECT = {
-  id: true,
-  username: true,
-  displayName: true,
-  avatarUrl: true,
-} as const;
-
-// sizeBytes excluded from select — Prisma returns it as BigInt which JSON
-// cannot serialize with the default tRPC transformer. Clients that need the
-// raw byte count should read it from the HTTP Content-Length header or a
-// dedicated metadata endpoint once superjson is configured end-to-end.
-const ATTACHMENT_SELECT = {
-  id: true,
-  filename: true,
-  url: true,
-  contentType: true,
-} as const;
-
-const MESSAGE_INCLUDE = {
-  author: { select: AUTHOR_SELECT },
-  attachments: { select: ATTACHMENT_SELECT },
-} as const;
-
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
@@ -109,7 +86,7 @@ function msgCacheKey(
  * prevent callers from probing channel IDs across servers.
  */
 async function requireChannelInServer(channelId: string, serverId: string) {
-  const channel = await prisma.channel.findUnique({ where: { id: channelId } });
+  const channel = await channelRepository.findById(channelId);
   if (!channel || channel.serverId !== serverId) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });
   }
@@ -120,10 +97,7 @@ async function requireChannelInServer(channelId: string, serverId: string) {
  * Resolve a message (non-deleted) and assert its channel belongs to `serverId`.
  */
 async function requireMessageInServer(messageId: string, serverId: string) {
-  const message = await prisma.message.findUnique({
-    where: { id: messageId },
-    include: { channel: { select: { serverId: true } } },
-  });
+  const message = await messageRepository.findByIdWithChannel(messageId);
   if (!message || message.isDeleted || message.channel.serverId !== serverId) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Message not found in this server' });
   }
@@ -149,14 +123,12 @@ export const messageService = {
     return cacheService.getOrRevalidate(
       cacheKey,
       async () => {
-        const messages = await prisma.message.findMany({
-          where: { channelId, isDeleted: false },
-          take: clampedLimit + 1, // fetch one extra to determine hasMore
-          cursor: cursor ? { id: cursor } : undefined,
-          skip: cursor ? 1 : 0,
-          orderBy: { createdAt: 'asc' },
-          include: MESSAGE_INCLUDE,
-        });
+        const messages = await messageRepository.findManyPaginated(
+          { channelId, isDeleted: false },
+          clampedLimit + 1,
+          cursor,
+          { createdAt: 'asc' },
+        );
 
         const hasMore = messages.length > clampedLimit;
         const page = hasMore ? messages.slice(0, clampedLimit) : messages;
@@ -176,20 +148,17 @@ export const messageService = {
 
     await requireChannelInServer(channelId, serverId);
 
-    const message = await prisma.message.create({
-      data: {
-        channelId,
-        authorId,
-        content,
-        ...(attachments &&
-          attachments.length > 0 && {
-            attachments: {
-              // Cast number → BigInt for Prisma; sizeBytes is excluded from responses
-              create: attachments.map((a) => ({ ...a, sizeBytes: BigInt(a.sizeBytes) })),
-            },
-          }),
-      },
-      include: MESSAGE_INCLUDE,
+    const message = await messageRepository.create({
+      channel: { connect: { id: channelId } },
+      author: { connect: { id: authorId } },
+      content,
+      ...(attachments &&
+        attachments.length > 0 && {
+          attachments: {
+            // Cast number → BigInt for Prisma; sizeBytes is excluded from responses
+            create: attachments.map((a) => ({ ...a, sizeBytes: BigInt(a.sizeBytes) })),
+          },
+        }),
     });
 
     cacheService
@@ -232,11 +201,7 @@ export const messageService = {
       throw new TRPCError({ code: 'FORBIDDEN', message: 'You can only edit your own messages' });
     }
 
-    const updated = await prisma.message.update({
-      where: { id: messageId },
-      data: { content, editedAt: new Date() },
-      include: MESSAGE_INCLUDE,
-    });
+    const updated = await messageRepository.update(messageId, { content, editedAt: new Date() });
 
     cacheService
       .invalidatePattern(
@@ -291,31 +256,22 @@ export const messageService = {
 
     await prisma.$transaction(async (tx) => {
       // Soft-delete the message itself
-      await tx.message.update({
-        where: { id: messageId },
-        data: { isDeleted: true },
-      });
+      await messageRepository.updateRaw(messageId, { isDeleted: true }, tx);
 
       // If this message is a reply, decrement the parent's replyCount floored at 0.
       // Prisma's { decrement: 1 } maps to raw subtraction with no floor; use
       // GREATEST(..., 0) to guard against negative counts from races or anomalies.
       if (message.parentMessageId) {
-        await tx.$executeRaw`
-          UPDATE "messages"
-          SET reply_count = GREATEST(reply_count - 1, 0)
-          WHERE id = ${message.parentMessageId}::uuid
-        `;
+        await messageRepository.decrementReplyCountFloored(message.parentMessageId, tx);
       }
 
       // Cascade soft-delete any non-deleted replies and reset the denormalised counter
-      await tx.message.updateMany({
-        where: { parentMessageId: messageId, isDeleted: false },
-        data: { isDeleted: true },
-      });
-      await tx.message.update({
-        where: { id: messageId },
-        data: { replyCount: 0 },
-      });
+      await messageRepository.updateMany(
+        { parentMessageId: messageId, isDeleted: false },
+        { isDeleted: true },
+        tx,
+      );
+      await messageRepository.updateRaw(messageId, { replyCount: 0 }, tx);
     });
 
     // If this message is a reply, its thread cache lives under the parent's id.
@@ -359,10 +315,7 @@ export const messageService = {
    */
   async pinMessage(messageId: string, serverId: string) {
     const updated = await prisma.$transaction(async (tx) => {
-      const msg = await tx.message.findUnique({
-        where: { id: messageId },
-        include: { channel: { select: { serverId: true } } },
-      });
+      const msg = await messageRepository.findByIdWithChannel(messageId, tx);
 
       if (!msg || msg.isDeleted || msg.channel.serverId !== serverId) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Message not found in this server' });
@@ -371,11 +324,7 @@ export const messageService = {
         throw new TRPCError({ code: 'CONFLICT', message: 'Message is already pinned' });
       }
 
-      return tx.message.update({
-        where: { id: messageId },
-        data: { pinned: true, pinnedAt: new Date() },
-        include: MESSAGE_INCLUDE,
-      });
+      return messageRepository.update(messageId, { pinned: true, pinnedAt: new Date() }, tx);
     });
 
     cacheService
@@ -398,10 +347,7 @@ export const messageService = {
    */
   async unpinMessage(messageId: string, serverId: string) {
     const updated = await prisma.$transaction(async (tx) => {
-      const msg = await tx.message.findUnique({
-        where: { id: messageId },
-        include: { channel: { select: { serverId: true } } },
-      });
+      const msg = await messageRepository.findByIdWithChannel(messageId, tx);
 
       if (!msg || msg.isDeleted || msg.channel.serverId !== serverId) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Message not found in this server' });
@@ -410,11 +356,7 @@ export const messageService = {
         throw new TRPCError({ code: 'CONFLICT', message: 'Message is not pinned' });
       }
 
-      return tx.message.update({
-        where: { id: messageId },
-        data: { pinned: false, pinnedAt: null },
-        include: MESSAGE_INCLUDE,
-      });
+      return messageRepository.update(messageId, { pinned: false, pinnedAt: null }, tx);
     });
 
     cacheService
@@ -436,12 +378,7 @@ export const messageService = {
    */
   async getPinnedMessages(channelId: string, serverId: string) {
     await requireChannelInServer(channelId, serverId);
-
-    return prisma.message.findMany({
-      where: { channelId, pinned: true, isDeleted: false },
-      orderBy: { pinnedAt: 'desc' },
-      include: MESSAGE_INCLUDE,
-    });
+    return messageRepository.findPinnedByChannel(channelId);
   },
 
   /**
@@ -455,10 +392,7 @@ export const messageService = {
     await requireChannelInServer(channelId, serverId);
 
     const reply = await prisma.$transaction(async (tx) => {
-      const parent = await tx.message.findUnique({
-        where: { id: parentMessageId },
-        include: { channel: { select: { id: true, serverId: true } } },
-      });
+      const parent = await messageRepository.findByIdWithChannelFull(parentMessageId, tx);
 
       if (
         !parent ||
@@ -480,15 +414,21 @@ export const messageService = {
         });
       }
 
-      const created = await tx.message.create({
-        data: { channelId, authorId, content, parentMessageId },
-        include: MESSAGE_INCLUDE,
-      });
+      const created = await messageRepository.create(
+        {
+          channel: { connect: { id: channelId } },
+          author: { connect: { id: authorId } },
+          content,
+          parent: { connect: { id: parentMessageId } },
+        },
+        tx,
+      );
 
-      await tx.message.update({
-        where: { id: parentMessageId },
-        data: { replyCount: { increment: 1 } },
-      });
+      await messageRepository.updateRaw(
+        parentMessageId,
+        { replyCount: { increment: 1 } },
+        tx,
+      );
 
       return created;
     });
@@ -549,10 +489,7 @@ export const messageService = {
         // soft-deleted parent's cache entries are always busted before this guard could
         // serve a stale thread. The check is therefore redundant in the happy path and
         // only fires for genuinely invalid requests.
-        const parent = await prisma.message.findUnique({
-          where: { id: parentMessageId },
-          include: { channel: { select: { id: true, serverId: true } } },
-        });
+        const parent = await messageRepository.findByIdWithChannelFull(parentMessageId);
 
         if (
           !parent ||
@@ -574,14 +511,12 @@ export const messageService = {
           });
         }
 
-        const replies = await prisma.message.findMany({
-          where: { parentMessageId, isDeleted: false },
-          take: clampedLimit + 1,
-          cursor: cursor ? { id: cursor } : undefined,
-          skip: cursor ? 1 : 0,
-          orderBy: { createdAt: 'asc' },
-          include: MESSAGE_INCLUDE,
-        });
+        const replies = await messageRepository.findManyPaginated(
+          { parentMessageId, isDeleted: false },
+          clampedLimit + 1,
+          cursor,
+          { createdAt: 'asc' },
+        );
 
         const hasMore = replies.length > clampedLimit;
         const page = hasMore ? replies.slice(0, clampedLimit) : replies;

--- a/harmony-backend/src/services/permission.service.ts
+++ b/harmony-backend/src/services/permission.service.ts
@@ -1,7 +1,8 @@
 import { RoleType } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
-import { prisma } from '../db/prisma';
 import { isSystemAdmin } from '../lib/admin.utils';
+import { serverRepository } from '../repositories/server.repository';
+import { serverMemberRepository } from '../repositories/serverMember.repository';
 
 // ─── Action types ─────────────────────────────────────────────────────────────
 
@@ -82,10 +83,7 @@ export const permissionService = {
    * the user is not a member.
    */
   async getMemberRole(userId: string, serverId: string): Promise<RoleType | null> {
-    const membership = await prisma.serverMember.findUnique({
-      where: { userId_serverId: { userId, serverId } },
-      select: { role: true },
-    });
+    const membership = await serverMemberRepository.findByUserAndServerSelect(userId, serverId);
     return membership?.role ?? null;
   },
 
@@ -99,10 +97,7 @@ export const permissionService = {
     // Dev admin bypass — remove before production
     if (await isSystemAdmin(userId)) return true;
 
-    const server = await prisma.server.findUnique({
-      where: { id: serverId },
-      select: { id: true },
-    });
+    const server = await serverRepository.findByIdSelect(serverId, { id: true });
     if (!server) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
     }

--- a/harmony-backend/src/services/reaction.service.ts
+++ b/harmony-backend/src/services/reaction.service.ts
@@ -1,8 +1,8 @@
 import { TRPCError } from '@trpc/server';
-import { prisma } from '../db/prisma';
 import { createLogger } from '../lib/logger';
 import { cacheService, sanitizeKeySegment } from './cache.service';
 import { eventBus, EventChannels } from '../events/eventBus';
+import { reactionRepository } from '../repositories/reaction.repository';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -44,10 +44,7 @@ const logger = createLogger({ component: 'reaction-service' });
  * from probing channel or server IDs across boundaries.
  */
 async function requireMessageInChannel(messageId: string, channelId: string, serverId: string) {
-  const message = await prisma.message.findUnique({
-    where: { id: messageId },
-    include: { channel: { select: { serverId: true, id: true } } },
-  });
+  const message = await reactionRepository.findMessageWithChannel(messageId);
   if (
     !message ||
     message.isDeleted ||
@@ -78,9 +75,7 @@ export const reactionService = {
     const message = await requireMessageInChannel(messageId, channelId, serverId);
 
     try {
-      const reaction = await prisma.messageReaction.create({
-        data: { messageId, userId, emoji },
-      });
+      const reaction = await reactionRepository.create({ message: { connect: { id: messageId } }, user: { connect: { id: userId } }, emoji });
 
       cacheService
         .invalidatePattern(reactionCacheKey(serverId, messageId))
@@ -140,9 +135,7 @@ export const reactionService = {
 
     try {
       // Attempt delete atomically — no separate pre-check needed
-      await prisma.messageReaction.delete({
-        where: { messageId_userId_emoji: { messageId, userId, emoji } },
-      });
+      await reactionRepository.delete(messageId, userId, emoji);
     } catch (err: unknown) {
       // P2025: the caller's reaction did not exist
       if (
@@ -152,9 +145,7 @@ export const reactionService = {
         (err as { code: string }).code === 'P2025'
       ) {
         // Distinguish: does this emoji exist on the message for someone else?
-        const anyReaction = await prisma.messageReaction.findFirst({
-          where: { messageId, emoji },
-        });
+        const anyReaction = await reactionRepository.findFirst({ messageId, emoji });
         if (anyReaction) {
           throw new TRPCError({
             code: 'FORBIDDEN',
@@ -201,11 +192,7 @@ export const reactionService = {
 
     await requireMessageInChannel(messageId, channelId, serverId);
 
-    const reactions = await prisma.messageReaction.findMany({
-      where: { messageId },
-      select: { emoji: true, userId: true },
-      orderBy: { createdAt: 'asc' },
-    });
+    const reactions = await reactionRepository.findByMessageId(messageId);
 
     // Group by emoji
     const grouped = new Map<string, string[]>();

--- a/harmony-backend/src/services/server.service.ts
+++ b/harmony-backend/src/services/server.service.ts
@@ -1,10 +1,11 @@
 import { Server, Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
-import { prisma } from '../db/prisma';
 import { channelService } from './channel.service';
 import { serverMemberService } from './serverMember.service';
 import { isSystemAdmin } from '../lib/admin.utils';
 import { eventBus, EventChannels } from '../events/eventBus';
+import { serverRepository } from '../repositories/server.repository';
+import { serverMemberRepository } from '../repositories/serverMember.repository';
 
 // Role hierarchy for sorting: lower rank = higher privilege
 const ROLE_RANK: Record<string, number> = {
@@ -47,7 +48,7 @@ async function generateUniqueSlug(name: string): Promise<string> {
   const MAX_ATTEMPTS = 10;
   let candidate = base;
   for (let suffix = 1; suffix <= MAX_ATTEMPTS; suffix++) {
-    if ((await prisma.server.count({ where: { slug: candidate } })) === 0) return candidate;
+    if ((await serverRepository.countBySlug(candidate)) === 0) return candidate;
     candidate = `${base}-${suffix}`;
   }
   throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });
@@ -84,34 +85,22 @@ async function withSlugRetry(
 
 export const serverService = {
   async getPublicServers(limit = 50): Promise<Server[]> {
-    return prisma.server.findMany({
-      where: { isPublic: true },
-      orderBy: { createdAt: 'desc' },
-      take: Math.min(limit, 100),
-    });
+    return serverRepository.findPublic(Math.min(limit, 100));
   },
 
   /** Dev admin: returns all servers regardless of visibility. */
   async getAllServers(limit = 50): Promise<Server[]> {
-    return prisma.server.findMany({
-      orderBy: { createdAt: 'desc' },
-      take: Math.min(limit, 100),
-    });
+    return serverRepository.findAll(Math.min(limit, 100));
   },
 
   /** Returns only the servers the given user is a member of. */
   async getMemberServers(userId: string, limit = 50): Promise<Server[]> {
-    const memberships = await prisma.serverMember.findMany({
-      where: { userId },
-      include: { server: true },
-      orderBy: { joinedAt: 'asc' },
-      take: Math.min(limit, 100),
-    });
+    const memberships = await serverMemberRepository.findByUserIdWithServer(userId, Math.min(limit, 100));
     return memberships.map((m) => m.server);
   },
 
   async getServer(slug: string): Promise<Server | null> {
-    return prisma.server.findUnique({ where: { slug } });
+    return serverRepository.findBySlug(slug);
   },
 
   async createServer(input: {
@@ -123,7 +112,7 @@ export const serverService = {
   }): Promise<Server> {
     const slug = await generateUniqueSlug(input.name);
     const server = await withSlugRetry(input.name, slug, (s) =>
-      prisma.server.create({ data: { ...input, slug: s } }),
+      serverRepository.create({ ...input, slug: s }),
     );
     await channelService.createDefaultChannel(server.id);
     await serverMemberService.addOwner(input.ownerId, server.id);
@@ -135,7 +124,7 @@ export const serverService = {
     actorId: string,
     data: { name?: string; description?: string; iconUrl?: string; isPublic?: boolean },
   ): Promise<Server> {
-    const server = await prisma.server.findUnique({ where: { id } });
+    const server = await serverRepository.findById(id);
     if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
     if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))
       throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can update' });
@@ -144,10 +133,10 @@ export const serverService = {
     if (data.name && data.name !== server.name) {
       const slug = await generateUniqueSlug(data.name);
       updated = await withSlugRetry(data.name, slug, (s) =>
-        prisma.server.update({ where: { id }, data: { ...data, slug: s } }),
+        serverRepository.update(id, { ...data, slug: s }),
       );
     } else {
-      updated = await prisma.server.update({ where: { id }, data });
+      updated = await serverRepository.update(id, data);
     }
 
     void eventBus.publish(EventChannels.SERVER_UPDATED, {
@@ -162,40 +151,27 @@ export const serverService = {
   },
 
   async deleteServer(id: string, actorId: string): Promise<Server> {
-    const server = await prisma.server.findUnique({ where: { id } });
+    const server = await serverRepository.findById(id);
     if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
     if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))
       throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can delete' });
-    return prisma.server.delete({ where: { id } });
+    return serverRepository.delete(id);
   },
 
   async incrementMemberCount(id: string): Promise<Server> {
-    return prisma.server.update({
-      where: { id },
-      data: { memberCount: { increment: 1 } },
-    });
+    return serverRepository.update(id, { memberCount: { increment: 1 } });
   },
 
   async decrementMemberCount(id: string): Promise<Server> {
-    const server = await prisma.server.findUnique({ where: { id } });
+    const server = await serverRepository.findById(id);
     if (!server || server.memberCount <= 0) {
       throw new TRPCError({ code: 'BAD_REQUEST', message: 'Member count is already zero' });
     }
-    return prisma.server.update({
-      where: { id },
-      data: { memberCount: { decrement: 1 } },
-    });
+    return serverRepository.update(id, { memberCount: { decrement: 1 } });
   },
 
   async getMembers(serverId: string): Promise<ServerMemberWithUser[]> {
-    const members = await prisma.serverMember.findMany({
-      where: { serverId },
-      include: {
-        user: {
-          select: { id: true, username: true, displayName: true, avatarUrl: true, status: true },
-        },
-      },
-    });
+    const members = await serverMemberRepository.findMembersByServerId(serverId);
     return members
       .map((m) => ({ ...m, role: m.role as string }))
       .sort(

--- a/harmony-backend/src/services/serverMember.service.ts
+++ b/harmony-backend/src/services/serverMember.service.ts
@@ -2,6 +2,8 @@ import { Prisma, RoleType, ServerMember } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import { prisma } from '../db/prisma';
 import { eventBus, EventChannels } from '../events/eventBus';
+import { serverRepository } from '../repositories/server.repository';
+import { serverMemberRepository } from '../repositories/serverMember.repository';
 
 export interface ServerMemberWithUser {
   userId: string;
@@ -29,13 +31,11 @@ export const serverMemberService = {
    */
   async addOwner(userId: string, serverId: string): Promise<ServerMember> {
     return prisma.$transaction(async (tx) => {
-      const member = await tx.serverMember.create({
-        data: { userId, serverId, role: 'OWNER' },
-      });
-      await tx.server.update({
-        where: { id: serverId },
-        data: { memberCount: { increment: 1 } },
-      });
+      const member = await serverMemberRepository.create(
+        { userId, serverId, role: 'OWNER' },
+        tx,
+      );
+      await serverRepository.update(serverId, { memberCount: { increment: 1 } }, tx);
       return member;
     });
   },
@@ -45,7 +45,7 @@ export const serverMemberService = {
    * Throws CONFLICT if already a member. Rejects private servers.
    */
   async joinServer(userId: string, serverId: string): Promise<ServerMember> {
-    const server = await prisma.server.findUnique({ where: { id: serverId } });
+    const server = await serverRepository.findById(serverId);
     if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
     if (!server.isPublic) {
       throw new TRPCError({ code: 'FORBIDDEN', message: 'This server is private' });
@@ -53,13 +53,11 @@ export const serverMemberService = {
 
     try {
       const member = await prisma.$transaction(async (tx) => {
-        const created = await tx.serverMember.create({
-          data: { userId, serverId, role: 'MEMBER' },
-        });
-        await tx.server.update({
-          where: { id: serverId },
-          data: { memberCount: { increment: 1 } },
-        });
+        const created = await serverMemberRepository.create(
+          { userId, serverId, role: 'MEMBER' },
+          tx,
+        );
+        await serverRepository.update(serverId, { memberCount: { increment: 1 } }, tx);
         return created;
       });
 
@@ -83,22 +81,15 @@ export const serverMemberService = {
    * Leave a server. Owners cannot leave — they must transfer ownership or delete.
    */
   async leaveServer(userId: string, serverId: string): Promise<void> {
-    const membership = await prisma.serverMember.findUnique({
-      where: { userId_serverId: { userId, serverId } },
-    });
+    const membership = await serverMemberRepository.findByUserAndServer(userId, serverId);
     if (!membership) throw new TRPCError({ code: 'NOT_FOUND', message: 'Not a member of this server' });
     if (membership.role === 'OWNER') {
       throw new TRPCError({ code: 'BAD_REQUEST', message: 'Server owner cannot leave. Transfer ownership or delete the server.' });
     }
 
     await prisma.$transaction(async (tx) => {
-      await tx.serverMember.delete({
-        where: { userId_serverId: { userId, serverId } },
-      });
-      await tx.server.update({
-        where: { id: serverId },
-        data: { memberCount: { decrement: 1 } },
-      });
+      await serverMemberRepository.delete(userId, serverId, tx);
+      await serverRepository.update(serverId, { memberCount: { decrement: 1 } }, tx);
     });
 
     void eventBus.publish(EventChannels.MEMBER_LEFT, {
@@ -114,18 +105,10 @@ export const serverMemberService = {
    * Sorted by role hierarchy (OWNER first) then join date.
    */
   async getServerMembers(serverId: string): Promise<ServerMemberWithUser[]> {
-    const server = await prisma.server.findUnique({ where: { id: serverId }, select: { id: true } });
+    const server = await serverRepository.findByIdSelect(serverId, { id: true });
     if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
 
-    const members = await prisma.serverMember.findMany({
-      where: { serverId },
-      include: {
-        user: {
-          select: { id: true, username: true, displayName: true, avatarUrl: true },
-        },
-      },
-      orderBy: { joinedAt: 'asc' },
-    });
+    const members = await serverMemberRepository.findByServerId(serverId);
 
     // Sort by role hierarchy (Prisma enum ordering is alphabetical, not semantic)
     return members.sort((a, b) => roleRank(a.role) - roleRank(b.role));
@@ -146,8 +129,8 @@ export const serverMemberService = {
     }
 
     const [actorMembership, targetMembership] = await Promise.all([
-      prisma.serverMember.findUnique({ where: { userId_serverId: { userId: actorId, serverId } } }),
-      prisma.serverMember.findUnique({ where: { userId_serverId: { userId: targetUserId, serverId } } }),
+      serverMemberRepository.findByUserAndServer(actorId, serverId),
+      serverMemberRepository.findByUserAndServer(targetUserId, serverId),
     ]);
 
     if (!actorMembership) throw new TRPCError({ code: 'FORBIDDEN', message: 'You are not a member of this server' });
@@ -164,10 +147,7 @@ export const serverMemberService = {
       throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot assign a role equal to or higher than your own' });
     }
 
-    return prisma.serverMember.update({
-      where: { userId_serverId: { userId: targetUserId, serverId } },
-      data: { role: newRole },
-    });
+    return serverMemberRepository.update(targetUserId, serverId, newRole);
   },
 
   /**
@@ -176,8 +156,8 @@ export const serverMemberService = {
    */
   async removeMember(targetUserId: string, serverId: string, actorId: string): Promise<void> {
     const [actorMembership, targetMembership] = await Promise.all([
-      prisma.serverMember.findUnique({ where: { userId_serverId: { userId: actorId, serverId } } }),
-      prisma.serverMember.findUnique({ where: { userId_serverId: { userId: targetUserId, serverId } } }),
+      serverMemberRepository.findByUserAndServer(actorId, serverId),
+      serverMemberRepository.findByUserAndServer(targetUserId, serverId),
     ]);
 
     if (!actorMembership) throw new TRPCError({ code: 'FORBIDDEN', message: 'You are not a member of this server' });
@@ -190,13 +170,8 @@ export const serverMemberService = {
     }
 
     await prisma.$transaction(async (tx) => {
-      await tx.serverMember.delete({
-        where: { userId_serverId: { userId: targetUserId, serverId } },
-      });
-      await tx.server.update({
-        where: { id: serverId },
-        data: { memberCount: { decrement: 1 } },
-      });
+      await serverMemberRepository.delete(targetUserId, serverId, tx);
+      await serverRepository.update(serverId, { memberCount: { decrement: 1 } }, tx);
     });
 
     void eventBus.publish(EventChannels.MEMBER_LEFT, {

--- a/harmony-backend/src/services/user.service.ts
+++ b/harmony-backend/src/services/user.service.ts
@@ -1,8 +1,9 @@
 import { TRPCError } from '@trpc/server';
 import { Prisma, UserStatus } from '@prisma/client';
-import { prisma } from '../db/prisma';
 import { isSystemAdmin } from '../lib/admin.utils';
 import { eventBus, EventChannels } from '../events/eventBus';
+import { userRepository } from '../repositories/user.repository';
+import { serverMemberRepository } from '../repositories/serverMember.repository';
 
 export interface UpdateUserInput {
   displayName?: string;
@@ -10,35 +11,6 @@ export interface UpdateUserInput {
   publicProfile?: boolean;
   status?: UserStatus;
 }
-
-/**
- * Fields returned when viewing another user's profile.
- * Excludes all credential fields (passwordHash, email).
- */
-const PUBLIC_PROFILE_SELECT = {
-  id: true,
-  username: true,
-  displayName: true,
-  avatarUrl: true,
-  publicProfile: true,
-  status: true,
-  createdAt: true,
-} as const;
-
-/**
- * Fields returned for the authenticated user's own profile.
- * Includes email (visible to self) but never passwordHash.
- */
-const SELF_PROFILE_SELECT = {
-  id: true,
-  email: true,
-  username: true,
-  displayName: true,
-  avatarUrl: true,
-  publicProfile: true,
-  status: true,
-  createdAt: true,
-} as const;
 
 export const userService = {
   /**
@@ -50,10 +22,7 @@ export const userService = {
    * Credential fields (passwordHash, email) are never returned.
    */
   async getUser(userId: string) {
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: PUBLIC_PROFILE_SELECT,
-    });
+    const user = await userRepository.findById(userId);
     if (!user) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
     }
@@ -76,10 +45,7 @@ export const userService = {
    * Never returns passwordHash.
    */
   async getCurrentUser(userId: string) {
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: SELF_PROFILE_SELECT,
-    });
+    const user = await userRepository.findSelf(userId);
     if (!user) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
     }
@@ -91,15 +57,11 @@ export const userService = {
 
   async updateUser(userId: string, patch: UpdateUserInput) {
     try {
-      const updated = await prisma.user.update({
-        where: { id: userId },
-        select: SELF_PROFILE_SELECT,
-        data: {
-          ...(patch.displayName !== undefined && { displayName: patch.displayName }),
-          ...(patch.avatarUrl !== undefined && { avatarUrl: patch.avatarUrl }),
-          ...(patch.publicProfile !== undefined && { publicProfile: patch.publicProfile }),
-          ...(patch.status !== undefined && { status: patch.status }),
-        },
+      const updated = await userRepository.update(userId, {
+        ...(patch.displayName !== undefined && { displayName: patch.displayName }),
+        ...(patch.avatarUrl !== undefined && { avatarUrl: patch.avatarUrl }),
+        ...(patch.publicProfile !== undefined && { publicProfile: patch.publicProfile }),
+        ...(patch.status !== undefined && { status: patch.status }),
       });
 
       // When status changes, publish one event per server the user belongs to so
@@ -107,10 +69,7 @@ export const userService = {
       // Status reflects presence only (not identity), so we publish for all servers
       // regardless of the user's publicProfile setting.
       if (patch.status !== undefined) {
-        const memberships = await prisma.serverMember.findMany({
-          where: { userId },
-          select: { serverId: true },
-        });
+        const memberships = await serverMemberRepository.findByUserIdSelect(userId);
         for (const { serverId } of memberships) {
           void eventBus.publish(EventChannels.USER_STATUS_CHANGED, {
             userId,

--- a/harmony-backend/src/services/visibility.service.ts
+++ b/harmony-backend/src/services/visibility.service.ts
@@ -17,6 +17,7 @@ import { ChannelType, ChannelVisibility } from '@prisma/client';
 import { prisma } from '../db/prisma';
 import { eventBus, EventChannels } from '../events/eventBus';
 import { auditLogService } from './auditLog.service';
+import { channelRepository } from '../repositories/channel.repository';
 
 export interface SetVisibilityInput {
   channelId: string;
@@ -44,10 +45,7 @@ export const visibilityService = {
    * cross-server channel probing.
    */
   async getVisibility(channelId: string, serverId: string): Promise<ChannelVisibility> {
-    const channel = await prisma.channel.findUnique({
-      where: { id: channelId },
-      select: { visibility: true, serverId: true },
-    });
+    const channel = await channelRepository.findVisibilityAndServerId(channelId);
     if (!channel || channel.serverId !== serverId) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });
     }
@@ -68,7 +66,7 @@ export const visibilityService = {
     // Atomic DB write: read current state inside the transaction to avoid a
     // race where two concurrent calls record stale oldVisibility.
     const result = await prisma.$transaction(async (tx) => {
-      const current = await tx.channel.findUnique({ where: { id: channelId } });
+      const current = await channelRepository.findById(channelId, tx);
       if (!current || current.serverId !== serverId) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });
       }
@@ -86,9 +84,9 @@ export const visibilityService = {
         });
       }
 
-      const updated = await tx.channel.update({
-        where: { id: channelId },
-        data: {
+      const updated = await channelRepository.update(
+        channelId,
+        {
           visibility,
           // §6.3: set indexedAt only when transitioning TO PUBLIC_INDEXABLE (not on no-op updates)
           ...(visibility === ChannelVisibility.PUBLIC_INDEXABLE &&
@@ -97,7 +95,8 @@ export const visibilityService = {
           ...(visibility === ChannelVisibility.PRIVATE &&
             current.visibility !== ChannelVisibility.PRIVATE && { indexedAt: null }),
         },
-      });
+        tx,
+      );
 
       const audit = await auditLogService.logVisibilityChange(
         {

--- a/llm-logs/2026-04-16-192011-session-c477791c.md
+++ b/llm-logs/2026-04-16-192011-session-c477791c.md
@@ -1,0 +1,1302 @@
+# Session Log 2026-04-16-192011
+
+## User
+
+complete https://github.com/CS485-Harmony/Harmony/issues/227 in a new branch
+
+## Assistant
+
+**Tool call: `ToolSearch`**
+```json
+{
+  "query": "select:WebFetch",
+  "max_results": 1
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 227 --repo CS485-Harmony/Harmony"
+}
+```
+
+## Assistant
+
+Let me explore the codebase structure before planning.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src -type f -name \"*.ts\" | sort"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /Users/bigfa/Documents/GitHub/Harmony/docs/architecture.md 2>/dev/null | head -100 || ls /Users/bigfa/Documents/GitHub/Harmony/docs/"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/docs/"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"M-D1\\|repository\\|Repository\\|6\\.8\" /Users/bigfa/Documents/GitHub/Harmony/docs/unified-backend-architecture.md | head -50"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -rn \"prisma\\.\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/ --include=\"*.ts\" -l"
+}
+```
+
+## Assistant
+
+Let me read the main service files to understand the scope.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat -n /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/message.service.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat -n /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/channel.service.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "for f in /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/{server.service.ts,user.service.ts,auth.service.ts,permission.service.ts,reaction.service.ts,auditLog.service.ts,attachment.service.ts,serverMember.service.ts,visibility.service.ts,indexing.service.ts}; do echo \"=== $f ===\"; cat -n \"$f\"; done"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/.claude/projects/-Users-bigfa-Documents-GitHub-Harmony/c477791c-9a77-4535-8b26-56857c2a1db0/tool-results/bfzcrilxy.txt"
+}
+```
+
+## Assistant
+
+Now let me call advisor before planning the implementation.
+
+## Assistant
+
+Good guidance. Let me check the tests first before coding.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -rn \"jest.mock.*prisma\\|prisma\\.\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/ --include=\"*.ts\" | head -50"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/server.service.test.ts",
+  "limit": 80
+}
+```
+
+## Assistant
+
+Good. Scope: full implementation (all services) since partial doesn't achieve the architectural goal. Now creating the branch.
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b feature/issue-227-repository-layer"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 227 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Starting]**\n\nIntroducing a repository layer to centralize all Prisma calls out of services, as specified in \u00a76.8 M-D1 of the architecture doc.\n\n**Scope**: Full implementation \u2014 all services (message, channel, server, user, auth, permission, reaction, auditLog, attachment, serverMember, visibility, indexing). Going beyond the six \u00a76.8 named repositories to fully satisfy the principle that services must not call prisma.* directly.\n\n**Approach**: Create \\`src/repositories/\\` with one repository per domain entity. Each repository method is a thin wrapper accepting an optional \\`client?: Prisma.TransactionClient\\` for use inside existing \\`\\$transaction\\` blocks. Transaction boundaries remain in services; error handling (P2002/P2025 catch blocks) remains in services. Pure refactor \u2014 zero behavior changes.\""
+}
+```
+
+## Assistant
+
+Now I'll create all repositories and then update the services. Let me start with the repositories:
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "mkdir -p /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/channel.repository.ts",
+  "content": "import { ChannelVisibility, Prisma } from '@prisma/client';\nimport { prisma } from '../db/prisma';\n\ntype Client = Prisma.TransactionClient | typeof prisma;\n\nexport const channelRepository = {\n  findById(id: string, client: Client = prisma) {\n    return client.channel.findUnique({ where: { id } });\n  },\n\n  findByServerId(serverId: string, client: Client = prisma) {\n    return client.channel.findMany({ where: { serverId }, orderBy: { position: 'asc' } });\n  },\n\n  findByServerAndSlug(serverId: string, slug: string, client: Client = prisma) {\n    return client.channel.findUnique({ where: { serverId_slug: { serverId, slug } } });\n  },\n\n  findByServerSlugAndChannelSlug(serverSlug: string, channelSlug: string, client: Client = prisma) {\n    return client.server\n      .findUnique({ where: { slug: serverSlug } })\n      .then((server) => {\n        if (!server) return null;\n        return client.channel.findUnique({\n          where: { serverId_slug: { serverId: server.id, slug: channelSlug } },\n        });\n      });\n  },\n\n  findWithServerId(id: string, client: Client = prisma) {\n    return client.channel.findUnique({\n      where: { id },\n      select: { serverId: true, visibility: true },\n    });\n  },\n\n  findVisibilityAndServerId(id: string, client: Client = prisma) {\n    return client.channel.findUnique({\n      where: { id },\n      select: { visibility: true, serverId: true },\n    });\n  },\n\n  findForSitemap(id: string, client: Client = prisma) {\n    return client.channel.findUnique({\n      where: { id },\n      select: { serverId: true, server: { select: { slug: true } } },\n    });\n  },\n\n  findPublicIndexableByServerId(\n    serverId: string,\n    client: Client = prisma,\n  ) {\n    return client.channel.findMany({\n      where: { serverId, visibility: ChannelVisibility.PUBLIC_INDEXABLE },\n      orderBy: { position: 'asc' },\n      select: { slug: true, updatedAt: true },\n    });\n  },\n\n  create(data: Prisma.ChannelCreateInput, client: Client = prisma) {\n    return client.channel.create({ data });\n  },\n\n  update(id: string, data: Prisma.ChannelUpdateInput, client: Client = prisma) {\n    return client.channel.update({ where: { id }, data });\n  },\n\n  delete(id: string, client: Client = prisma) {\n    return client.channel.delete({ where: { id } });\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/message.repository.ts",
+  "content": "import { Prisma } from '@prisma/client';\nimport { prisma } from '../db/prisma';\n\ntype Client = Prisma.TransactionClient | typeof prisma;\n\nconst AUTHOR_SELECT = {\n  id: true,\n  username: true,\n  displayName: true,\n  avatarUrl: true,\n} as const;\n\nconst ATTACHMENT_SELECT = {\n  id: true,\n  filename: true,\n  url: true,\n  contentType: true,\n} as const;\n\nexport const MESSAGE_INCLUDE = {\n  author: { select: AUTHOR_SELECT },\n  attachments: { select: ATTACHMENT_SELECT },\n} as const;\n\nexport const messageRepository = {\n  findByIdWithChannel(id: string, client: Client = prisma) {\n    return client.message.findUnique({\n      where: { id },\n      include: { channel: { select: { serverId: true } } },\n    });\n  },\n\n  findByIdWithChannelFull(id: string, client: Client = prisma) {\n    return client.message.findUnique({\n      where: { id },\n      include: { channel: { select: { id: true, serverId: true } } },\n    });\n  },\n\n  findManyPaginated(\n    where: Prisma.MessageWhereInput,\n    take: number,\n    cursor: string | undefined,\n    orderBy: Prisma.MessageOrderByWithRelationInput,\n    client: Client = prisma,\n  ) {\n    return client.message.findMany({\n      where,\n      take,\n      cursor: cursor ? { id: cursor } : undefined,\n      skip: cursor ? 1 : 0,\n      orderBy,\n      include: MESSAGE_INCLUDE,\n    });\n  },\n\n  findPinnedByChannel(channelId: string, client: Client = prisma) {\n    return client.message.findMany({\n      where: { channelId, pinned: true, isDeleted: false },\n      orderBy: { pinnedAt: 'desc' },\n      include: MESSAGE_INCLUDE,\n    });\n  },\n\n  create(data: Prisma.MessageCreateInput, client: Client = prisma) {\n    return client.message.create({ data, include: MESSAGE_INCLUDE });\n  },\n\n  update(id: string, data: Prisma.MessageUpdateInput, client: Client = prisma) {\n    return client.message.update({ where: { id }, data, include: MESSAGE_INCLUDE });\n  },\n\n  updateRaw(id: string, data: Prisma.MessageUpdateInput, client: Client = prisma) {\n    return client.message.update({ where: { id }, data });\n  },\n\n  updateMany(where: Prisma.MessageWhereInput, data: Prisma.MessageUpdateManyMutationInput, client: Client = prisma) {\n    return client.message.updateMany({ where, data });\n  },\n\n  decrementReplyCountFloored(parentId: string, client: Client = prisma) {\n    // Prisma's { decrement: 1 } has no floor; GREATEST(..., 0) guards against\n    // negative counts from concurrent races or anomalies.\n    return (client as typeof prisma).$executeRaw`\n      UPDATE \"messages\"\n      SET reply_count = GREATEST(reply_count - 1, 0)\n      WHERE id = ${parentId}::uuid\n    `;\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/message.repository.ts",
+  "old_string": "  decrementReplyCountFloored(parentId: string, client: Client = prisma) {\n    // Prisma's { decrement: 1 } has no floor; GREATEST(..., 0) guards against\n    // negative counts from concurrent races or anomalies.\n    return (client as typeof prisma).$executeRaw`\n      UPDATE \"messages\"\n      SET reply_count = GREATEST(reply_count - 1, 0)\n      WHERE id = ${parentId}::uuid\n    `;\n  },",
+  "new_string": "  decrementReplyCountFloored(parentId: string, client: Prisma.TransactionClient | typeof prisma = prisma) {\n    // Prisma's { decrement: 1 } has no floor; GREATEST(..., 0) guards against\n    // negative counts from concurrent races or anomalies.\n    return client.$executeRaw`\n      UPDATE \"messages\"\n      SET reply_count = GREATEST(reply_count - 1, 0)\n      WHERE id = ${parentId}::uuid\n    `;\n  },"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/server.repository.ts",
+  "content": "import { Prisma } from '@prisma/client';\nimport { prisma } from '../db/prisma';\n\ntype Client = Prisma.TransactionClient | typeof prisma;\n\nexport const serverRepository = {\n  findBySlug(slug: string, client: Client = prisma) {\n    return client.server.findUnique({ where: { slug } });\n  },\n\n  findById(id: string, client: Client = prisma) {\n    return client.server.findUnique({ where: { id } });\n  },\n\n  findByIdSelect<T extends Prisma.ServerSelect>(id: string, select: T, client: Client = prisma) {\n    return client.server.findUnique({ where: { id }, select });\n  },\n\n  findPublic(limit: number, client: Client = prisma) {\n    return client.server.findMany({\n      where: { isPublic: true },\n      orderBy: { createdAt: 'desc' },\n      take: limit,\n    });\n  },\n\n  findAll(limit: number, client: Client = prisma) {\n    return client.server.findMany({ orderBy: { createdAt: 'desc' }, take: limit });\n  },\n\n  findPublicBySlugSelect(client: Client = prisma) {\n    return client.server.findMany({\n      where: { isPublic: true },\n      orderBy: { memberCount: 'desc' },\n      select: { slug: true },\n    });\n  },\n\n  findFirst(where: Prisma.ServerWhereInput, select: Prisma.ServerSelect, client: Client = prisma) {\n    return client.server.findFirst({ where, select });\n  },\n\n  countBySlug(slug: string, client: Client = prisma) {\n    return client.server.count({ where: { slug } });\n  },\n\n  create(data: Prisma.ServerCreateInput, client: Client = prisma) {\n    return client.server.create({ data });\n  },\n\n  update(id: string, data: Prisma.ServerUpdateInput, client: Client = prisma) {\n    return client.server.update({ where: { id }, data });\n  },\n\n  delete(id: string, client: Client = prisma) {\n    return client.server.delete({ where: { id } });\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/user.repository.ts",
+  "content": "import { Prisma } from '@prisma/client';\nimport { prisma } from '../db/prisma';\n\ntype Client = Prisma.TransactionClient | typeof prisma;\n\nexport const PUBLIC_PROFILE_SELECT = {\n  id: true,\n  username: true,\n  displayName: true,\n  avatarUrl: true,\n  publicProfile: true,\n  status: true,\n  createdAt: true,\n} as const;\n\nexport const SELF_PROFILE_SELECT = {\n  id: true,\n  email: true,\n  username: true,\n  displayName: true,\n  avatarUrl: true,\n  publicProfile: true,\n  status: true,\n  createdAt: true,\n} as const;\n\nexport const userRepository = {\n  findById(id: string, client: Client = prisma) {\n    return client.user.findUnique({ where: { id }, select: PUBLIC_PROFILE_SELECT });\n  },\n\n  findSelf(id: string, client: Client = prisma) {\n    return client.user.findUnique({ where: { id }, select: SELF_PROFILE_SELECT });\n  },\n\n  findByEmail(email: string, client: Client = prisma) {\n    return client.user.findUnique({ where: { email } });\n  },\n\n  findByEmailSelect(email: string, client: Client = prisma) {\n    return client.user.findUnique({ where: { email }, select: { passwordHash: true } });\n  },\n\n  findByUsername(username: string, client: Client = prisma) {\n    return client.user.findUnique({ where: { username } });\n  },\n\n  create(data: Prisma.UserCreateInput, client: Client = prisma) {\n    return client.user.create({ data });\n  },\n\n  upsert(\n    where: Prisma.UserWhereUniqueInput,\n    update: Prisma.UserUpdateInput,\n    create: Prisma.UserCreateInput,\n    client: Client = prisma,\n  ) {\n    return client.user.upsert({ where, update, create });\n  },\n\n  update(id: string, data: Prisma.UserUpdateInput, client: Client = prisma) {\n    return client.user.update({ where: { id }, select: SELF_PROFILE_SELECT, data });\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/auditLog.repository.ts",
+  "content": "import { Prisma } from '@prisma/client';\nimport { prisma } from '../db/prisma';\n\ntype Client = Prisma.TransactionClient | typeof prisma;\n\nexport const auditLogRepository = {\n  create(data: Prisma.VisibilityAuditLogCreateInput, client: Client = prisma) {\n    return client.visibilityAuditLog.create({ data });\n  },\n\n  findMany(where: Prisma.VisibilityAuditLogWhereInput, skip: number, take: number, client: Client = prisma) {\n    return client.visibilityAuditLog.findMany({\n      where,\n      orderBy: { timestamp: 'desc' },\n      skip,\n      take,\n    });\n  },\n\n  count(where: Prisma.VisibilityAuditLogWhereInput, client: Client = prisma) {\n    return client.visibilityAuditLog.count({ where });\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/serverMember.repository.ts",
+  "content": "import { Prisma, RoleType } from '@prisma/client';\nimport { prisma } from '../db/prisma';\n\ntype Client = Prisma.TransactionClient | typeof prisma;\n\nexport const serverMemberRepository = {\n  findByUserAndServer(userId: string, serverId: string, client: Client = prisma) {\n    return client.serverMember.findUnique({\n      where: { userId_serverId: { userId, serverId } },\n    });\n  },\n\n  findByUserAndServerSelect(userId: string, serverId: string, client: Client = prisma) {\n    return client.serverMember.findUnique({\n      where: { userId_serverId: { userId, serverId } },\n      select: { role: true },\n    });\n  },\n\n  findByServerId(\n    serverId: string,\n    client: Client = prisma,\n  ) {\n    return client.serverMember.findMany({\n      where: { serverId },\n      include: {\n        user: {\n          select: { id: true, username: true, displayName: true, avatarUrl: true },\n        },\n      },\n      orderBy: { joinedAt: 'asc' },\n    });\n  },\n\n  findMembersByServerId(serverId: string, client: Client = prisma) {\n    return client.serverMember.findMany({\n      where: { serverId },\n      include: {\n        user: {\n          select: { id: true, username: true, displayName: true, avatarUrl: true, status: true },\n        },\n      },\n    });\n  },\n\n  findByUserIdWithServer(userId: string, client: Client = prisma) {\n    return client.serverMember.findMany({\n      where: { userId },\n      include: { server: true },\n      orderBy: { joinedAt: 'asc' },\n    });\n  },\n\n  findByUserIdSelect(userId: string, client: Client = prisma) {\n    return client.serverMember.findMany({\n      where: { userId },\n      select: { serverId: true },\n    });\n  },\n\n  findFirst(where: Prisma.ServerMemberWhereInput, client: Client = prisma) {\n    return client.serverMember.findFirst({ where });\n  },\n\n  create(data: Prisma.ServerMemberCreateInput, client: Client = prisma) {\n    return client.serverMember.create({ data });\n  },\n\n  upsert(\n    where: Prisma.ServerMemberWhereUniqueInput,\n    update: Prisma.ServerMemberUpdateInput,\n    create: Prisma.ServerMemberCreateInput,\n    client: Client = prisma,\n  ) {\n    return client.serverMember.upsert({ where, update, create });\n  },\n\n  update(userId: string, serverId: string, role: RoleType, client: Client = prisma) {\n    return client.serverMember.update({\n      where: { userId_serverId: { userId, serverId } },\n      data: { role },\n    });\n  },\n\n  delete(userId: string, serverId: string, client: Client = prisma) {\n    return client.serverMember.delete({\n      where: { userId_serverId: { userId, serverId } },\n    });\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/reaction.repository.ts",
+  "content": "import { Prisma } from '@prisma/client';\nimport { prisma } from '../db/prisma';\n\ntype Client = Prisma.TransactionClient | typeof prisma;\n\nexport const reactionRepository = {\n  findMessageWithChannel(messageId: string, client: Client = prisma) {\n    return client.message.findUnique({\n      where: { id: messageId },\n      include: { channel: { select: { serverId: true, id: true } } },\n    });\n  },\n\n  findByMessageId(messageId: string, client: Client = prisma) {\n    return client.messageReaction.findMany({\n      where: { messageId },\n      select: { emoji: true, userId: true },\n      orderBy: { createdAt: 'asc' },\n    });\n  },\n\n  findFirst(where: Prisma.MessageReactionWhereInput, client: Client = prisma) {\n    return client.messageReaction.findFirst({ where });\n  },\n\n  create(data: Prisma.MessageReactionCreateInput, client: Client = prisma) {\n    return client.messageReaction.create({ data });\n  },\n\n  delete(messageId: string, userId: string, emoji: string, client: Client = prisma) {\n    return client.messageReaction.delete({\n      where: { messageId_userId_emoji: { messageId, userId, emoji } },\n    });\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/attachment.repository.ts",
+  "content": "import { Prisma } from '@prisma/client';\nimport { prisma } from '../db/prisma';\n\ntype Client = Prisma.TransactionClient | typeof prisma;\n\nexport const attachmentRepository = {\n  findMessageForAttachmentList(messageId: string, client: Client = prisma) {\n    return client.message.findUnique({\n      where: { id: messageId },\n      select: {\n        id: true,\n        isDeleted: true,\n        channel: { select: { serverId: true } },\n      },\n    });\n  },\n\n  findByMessageId(messageId: string, client: Client = prisma) {\n    return client.attachment.findMany({\n      where: { messageId },\n      select: {\n        id: true,\n        filename: true,\n        url: true,\n        contentType: true,\n        // sizeBytes (BigInt) intentionally excluded \u2014 tRPC default JSON\n        // transformer cannot serialize BigInt.\n      },\n    });\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/refreshToken.repository.ts",
+  "content": "import { Prisma } from '@prisma/client';\nimport { prisma } from '../db/prisma';\n\ntype Client = Prisma.TransactionClient | typeof prisma;\n\nexport const refreshTokenRepository = {\n  create(data: Prisma.RefreshTokenCreateInput, client: Client = prisma) {\n    return client.refreshToken.create({ data });\n  },\n\n  revokeByHash(tokenHash: string, client: Client = prisma) {\n    return client.refreshToken.updateMany({\n      where: { tokenHash, revokedAt: null },\n      data: { revokedAt: new Date() },\n    });\n  },\n\n  rotateByHash(tokenHash: string, client: Client = prisma) {\n    return client.refreshToken.updateMany({\n      where: { tokenHash, revokedAt: null, expiresAt: { gt: new Date() } },\n      data: { revokedAt: new Date() },\n    });\n  },\n};\n"
+}
+```
+
+## Assistant
+
+Now update each service to use repositories instead of direct prisma calls:
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/channel.service.ts",
+  "content": "import { TRPCError } from '@trpc/server';\nimport { ChannelType, ChannelVisibility } from '@prisma/client';\nimport { createLogger } from '../lib/logger';\nimport { cacheService, CacheKeys, CacheTTL, sanitizeKeySegment } from './cache.service';\nimport { eventBus, EventChannels } from '../events/eventBus';\nimport { channelRepository } from '../repositories/channel.repository';\nimport { serverRepository } from '../repositories/server.repository';\n\nexport interface CreateChannelInput {\n  serverId: string;\n  name: string;\n  slug: string;\n  type: ChannelType;\n  visibility: ChannelVisibility;\n  topic?: string;\n  position?: number;\n}\n\nexport interface UpdateChannelInput {\n  name?: string;\n  topic?: string;\n  position?: number;\n}\n\nconst logger = createLogger({ component: 'channel-service' });\n\nexport const channelService = {\n  async getChannels(serverId: string) {\n    return channelRepository.findByServerId(serverId);\n  },\n\n  async getChannelBySlug(serverSlug: string, channelSlug: string) {\n    const server = await serverRepository.findBySlug(serverSlug);\n    if (!server) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n    }\n\n    const channel = await channelRepository.findByServerAndSlug(server.id, channelSlug);\n    if (!channel) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found' });\n    }\n\n    return channel;\n  },\n\n  async createChannel(input: CreateChannelInput) {\n    const { serverId, name, slug, type, visibility, topic, position = 0 } = input;\n\n    // VOICE channels cannot be PUBLIC_INDEXABLE\n    if (type === ChannelType.VOICE && visibility === ChannelVisibility.PUBLIC_INDEXABLE) {\n      throw new TRPCError({\n        code: 'BAD_REQUEST',\n        message: 'VOICE channels cannot have PUBLIC_INDEXABLE visibility',\n      });\n    }\n\n    // Verify server exists\n    const server = await serverRepository.findById(serverId);\n    if (!server) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n    }\n\n    // Check slug uniqueness per server\n    const existing = await channelRepository.findByServerAndSlug(serverId, slug);\n    if (existing) {\n      throw new TRPCError({\n        code: 'CONFLICT',\n        message: 'Channel slug already exists in this server',\n      });\n    }\n\n    const channel = await channelRepository.create({ serverId, name, slug, type, visibility, topic, position });\n\n    // Write-through: cache new visibility and invalidate server channel list (best-effort)\n    cacheService\n      .set(CacheKeys.channelVisibility(channel.id), channel.visibility, {\n        ttl: CacheTTL.channelVisibility,\n      })\n      .catch((err) =>\n        logger.warn(\n          { err, channelId: channel.id },\n          'Failed to cache channel visibility after creation',\n        ),\n      );\n    cacheService\n      .invalidate(`server:${sanitizeKeySegment(serverId)}:public_channels`)\n      .catch((err) =>\n        logger.warn(\n          { err, serverId },\n          'Failed to invalidate public channel cache after channel creation',\n        ),\n      );\n\n    // Notify connected clients (fire-and-forget)\n    eventBus\n      .publish(EventChannels.CHANNEL_CREATED, {\n        channelId: channel.id,\n        serverId: channel.serverId,\n        timestamp: new Date().toISOString(),\n      })\n      .catch((err) =>\n        logger.warn(\n          { err, channelId: channel.id, serverId },\n          'Failed to publish channel created event',\n        ),\n      );\n\n    return channel;\n  },\n\n  async updateChannel(channelId: string, serverId: string, patch: UpdateChannelInput) {\n    const channel = await channelRepository.findById(channelId);\n    if (!channel || channel.serverId !== serverId) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });\n    }\n\n    const updated = await channelRepository.update(channelId, {\n      ...(patch.name !== undefined && { name: patch.name }),\n      ...(patch.topic !== undefined && { topic: patch.topic }),\n      ...(patch.position !== undefined && { position: patch.position }),\n    });\n\n    // Write-through: invalidate message caches and server channel list (best-effort)\n    cacheService\n      .invalidatePattern(`channel:msgs:${sanitizeKeySegment(channelId)}:*`)\n      .catch((err) =>\n        logger.warn({ err, channelId }, 'Failed to invalidate channel message cache after update'),\n      );\n    cacheService\n      .invalidate(`server:${sanitizeKeySegment(channel.serverId)}:public_channels`)\n      .catch((err) =>\n        logger.warn(\n          { err, serverId: channel.serverId },\n          'Failed to invalidate public channel cache after channel update',\n        ),\n      );\n\n    // Notify connected clients (fire-and-forget)\n    eventBus\n      .publish(EventChannels.CHANNEL_UPDATED, {\n        channelId: updated.id,\n        serverId: updated.serverId,\n        timestamp: new Date().toISOString(),\n      })\n      .catch((err) =>\n        logger.warn(\n          { err, channelId: updated.id, serverId },\n          'Failed to publish channel updated event',\n        ),\n      );\n\n    return updated;\n  },\n\n  async deleteChannel(channelId: string, serverId: string) {\n    const channel = await channelRepository.findById(channelId);\n    if (!channel || channel.serverId !== serverId) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });\n    }\n\n    await channelRepository.delete(channelId);\n\n    // Write-through: invalidate all caches for deleted channel (best-effort)\n    cacheService\n      .invalidate(CacheKeys.channelVisibility(channelId))\n      .catch((err) =>\n        logger.warn(\n          { err, channelId },\n          'Failed to invalidate channel visibility cache after deletion',\n        ),\n      );\n    cacheService\n      .invalidatePattern(`channel:msgs:${sanitizeKeySegment(channelId)}:*`)\n      .catch((err) =>\n        logger.warn(\n          { err, channelId },\n          'Failed to invalidate channel message cache after deletion',\n        ),\n      );\n    cacheService\n      .invalidate(`server:${sanitizeKeySegment(channel.serverId)}:public_channels`)\n      .catch((err) =>\n        logger.warn(\n          { err, serverId: channel.serverId },\n          'Failed to invalidate public channel cache after channel deletion',\n        ),\n      );\n\n    // Notify connected clients (fire-and-forget)\n    eventBus\n      .publish(EventChannels.CHANNEL_DELETED, {\n        channelId: channel.id,\n        serverId: channel.serverId,\n        timestamp: new Date().toISOString(),\n      })\n      .catch((err) =>\n        logger.warn(\n          { err, channelId: channel.id, serverId },\n          'Failed to publish channel deleted event',\n        ),\n      );\n  },\n\n  async createDefaultChannel(serverId: string) {\n    return channelService.createChannel({\n      serverId,\n      name: 'general',\n      slug: 'general',\n      type: ChannelType.TEXT,\n      visibility: ChannelVisibility.PRIVATE,\n      position: 0,\n    });\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/message.service.ts",
+  "content": "import { TRPCError } from '@trpc/server';\nimport { prisma } from '../db/prisma';\nimport { createLogger } from '../lib/logger';\nimport { cacheService, CacheTTL, sanitizeKeySegment } from './cache.service';\nimport { permissionService } from './permission.service';\nimport { eventBus, EventChannels } from '../events/eventBus';\nimport { channelRepository } from '../repositories/channel.repository';\nimport { messageRepository } from '../repositories/message.repository';\n\n// \u2500\u2500\u2500 Types \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nexport interface GetMessagesInput {\n  serverId: string;\n  channelId: string;\n  cursor?: string; // messageId to paginate from (exclusive)\n  limit?: number; // default 20\n}\n\nexport interface CreateReplyInput {\n  parentMessageId: string;\n  channelId: string;\n  serverId: string;\n  authorId: string;\n  content: string;\n}\n\nexport interface GetThreadMessagesInput {\n  parentMessageId: string;\n  channelId: string;\n  serverId: string;\n  cursor?: string;\n  limit?: number;\n}\n\nexport interface SendMessageInput {\n  serverId: string;\n  channelId: string;\n  authorId: string;\n  content: string;\n  // sizeBytes is number on the wire (JSON-safe); cast to BigInt for Prisma\n  attachments?: Array<{\n    filename: string;\n    url: string;\n    contentType: string;\n    sizeBytes: number;\n  }>;\n}\n\nexport interface EditMessageInput {\n  serverId: string;\n  messageId: string;\n  authorId: string;\n  content: string;\n}\n\nexport interface DeleteMessageInput {\n  messageId: string;\n  actorId: string;\n  serverId: string;\n}\n\nconst logger = createLogger({ component: 'message-service' });\n\n// \u2500\u2500\u2500 Helpers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n/**\n * Cache key scoped to both server and channel so that private-channel entries\n * cannot be hit by users authorized on a different server.\n */\nfunction msgCacheKey(\n  serverId: string,\n  channelId: string,\n  cursor: string | undefined,\n  limit: number,\n): string {\n  const c = sanitizeKeySegment(cursor ?? 'start');\n  return (\n    `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)}` +\n    `:cursor:${c}:limit:${limit}`\n  );\n}\n\n/**\n * Resolve a channel and assert it belongs to the given server.\n * Throws NOT_FOUND (collapsed from both \"no channel\" and \"wrong server\") to\n * prevent callers from probing channel IDs across servers.\n */\nasync function requireChannelInServer(channelId: string, serverId: string) {\n  const channel = await channelRepository.findById(channelId);\n  if (!channel || channel.serverId !== serverId) {\n    throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });\n  }\n  return channel;\n}\n\n/**\n * Resolve a message (non-deleted) and assert its channel belongs to `serverId`.\n */\nasync function requireMessageInServer(messageId: string, serverId: string) {\n  const message = await messageRepository.findByIdWithChannel(messageId);\n  if (!message || message.isDeleted || message.channel.serverId !== serverId) {\n    throw new TRPCError({ code: 'NOT_FOUND', message: 'Message not found in this server' });\n  }\n  return message;\n}\n\n// \u2500\u2500\u2500 Service \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nexport const messageService = {\n  /**\n   * Retrieve messages for a channel using cursor-based pagination.\n   * Messages are returned in ascending chronological order (oldest first).\n   * Pass the last returned message's id as `cursor` to get the next page.\n   */\n  async getMessages(input: GetMessagesInput) {\n    const { serverId, channelId, cursor, limit = 20 } = input;\n    const clampedLimit = Math.min(Math.max(1, limit), 100);\n\n    await requireChannelInServer(channelId, serverId);\n\n    const cacheKey = msgCacheKey(serverId, channelId, cursor, clampedLimit);\n\n    return cacheService.getOrRevalidate(\n      cacheKey,\n      async () => {\n        const messages = await messageRepository.findManyPaginated(\n          { channelId, isDeleted: false },\n          clampedLimit + 1,\n          cursor,\n          { createdAt: 'asc' },\n        );\n\n        const hasMore = messages.length > clampedLimit;\n        const page = hasMore ? messages.slice(0, clampedLimit) : messages;\n        const nextCursor = hasMore ? page[page.length - 1].id : null;\n\n        return { messages: page, nextCursor, hasMore };\n      },\n      { ttl: CacheTTL.channelMessages },\n    );\n  },\n\n  /**\n   * Send a new message to a channel, optionally with attachment metadata.\n   */\n  async sendMessage(input: SendMessageInput) {\n    const { serverId, channelId, authorId, content, attachments } = input;\n\n    await requireChannelInServer(channelId, serverId);\n\n    const message = await messageRepository.create({\n      channel: { connect: { id: channelId } },\n      author: { connect: { id: authorId } },\n      content,\n      ...(attachments &&\n        attachments.length > 0 && {\n          attachments: {\n            // Cast number \u2192 BigInt for Prisma; sizeBytes is excluded from responses\n            create: attachments.map((a) => ({ ...a, sizeBytes: BigInt(a.sizeBytes) })),\n          },\n        }),\n    });\n\n    cacheService\n      .invalidatePattern(\n        `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)}:*`,\n      )\n      .catch((err) =>\n        logger.warn(\n          { err, channelId, serverId },\n          'Failed to invalidate channel message cache after send',\n        ),\n      );\n\n    eventBus\n      .publish(EventChannels.MESSAGE_CREATED, {\n        messageId: message.id,\n        channelId,\n        authorId,\n        timestamp: message.createdAt.toISOString(),\n      })\n      .catch((err) =>\n        logger.warn(\n          { err, messageId: message.id, channelId, serverId },\n          'Failed to publish message created event',\n        ),\n      );\n\n    return message;\n  },\n\n  /**\n   * Edit a message's content. Only the message author may edit.\n   */\n  async editMessage(input: EditMessageInput) {\n    const { serverId, messageId, authorId, content } = input;\n\n    const message = await requireMessageInServer(messageId, serverId);\n\n    if (message.authorId !== authorId) {\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'You can only edit your own messages' });\n    }\n\n    const updated = await messageRepository.update(messageId, { content, editedAt: new Date() });\n\n    cacheService\n      .invalidatePattern(\n        `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(message.channelId)}:*`,\n      )\n      .catch((err) =>\n        logger.warn(\n          { err, channelId: message.channelId, serverId },\n          'Failed to invalidate channel message cache after edit',\n        ),\n      );\n\n    eventBus\n      .publish(EventChannels.MESSAGE_EDITED, {\n        messageId,\n        channelId: message.channelId,\n        timestamp: updated.editedAt!.toISOString(),\n      })\n      .catch((err) =>\n        logger.warn(\n          { err, messageId, channelId: message.channelId, serverId },\n          'Failed to publish message edited event',\n        ),\n      );\n\n    return updated;\n  },\n\n  /**\n   * Soft-delete a message.\n   * - Own messages: requires message:delete_own (checked via router RBAC).\n   * - Other users' messages: additionally requires message:delete_any.\n   */\n  async deleteMessage(input: DeleteMessageInput) {\n    const { messageId, actorId, serverId } = input;\n\n    const message = await requireMessageInServer(messageId, serverId);\n\n    if (message.authorId !== actorId) {\n      const canDeleteAny = await permissionService.checkPermission(\n        actorId,\n        serverId,\n        'message:delete_any',\n      );\n      if (!canDeleteAny) {\n        throw new TRPCError({\n          code: 'FORBIDDEN',\n          message: 'You do not have permission to delete this message',\n        });\n      }\n    }\n\n    await prisma.$transaction(async (tx) => {\n      // Soft-delete the message itself\n      await messageRepository.updateRaw(messageId, { isDeleted: true }, tx);\n\n      // If this message is a reply, decrement the parent's replyCount floored at 0.\n      // Prisma's { decrement: 1 } maps to raw subtraction with no floor; use\n      // GREATEST(..., 0) to guard against negative counts from races or anomalies.\n      if (message.parentMessageId) {\n        await messageRepository.decrementReplyCountFloored(message.parentMessageId, tx);\n      }\n\n      // Cascade soft-delete any non-deleted replies and reset the denormalised counter\n      await messageRepository.updateMany(\n        { parentMessageId: messageId, isDeleted: false },\n        { isDeleted: true },\n        tx,\n      );\n      await messageRepository.updateRaw(messageId, { replyCount: 0 }, tx);\n    });\n\n    // If this message is a reply, its thread cache lives under the parent's id.\n    // If it's a parent, the thread cache lives under its own id.\n    const threadCacheId = message.parentMessageId ?? messageId;\n\n    cacheService\n      .invalidatePattern(\n        `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(message.channelId)}:*`,\n      )\n      .catch((err) =>\n        logger.warn(\n          { err, channelId: message.channelId, serverId },\n          'Failed to invalidate channel message cache after delete',\n        ),\n      );\n    cacheService\n      .invalidatePattern(`thread:msgs:${sanitizeKeySegment(threadCacheId)}:*`)\n      .catch((err) =>\n        logger.warn({ err, threadCacheId }, 'Failed to invalidate thread cache after delete'),\n      );\n\n    eventBus\n      .publish(EventChannels.MESSAGE_DELETED, {\n        messageId,\n        channelId: message.channelId,\n        timestamp: new Date().toISOString(),\n      })\n      .catch((err) =>\n        logger.warn(\n          { err, messageId, channelId: message.channelId, serverId },\n          'Failed to publish message deleted event',\n        ),\n      );\n  },\n\n  /**\n   * Pin a message. Requires message:pin (MODERATOR+), checked via router RBAC.\n   * Uses a transaction to atomically check-and-set, preventing concurrent\n   * double-pin races.\n   */\n  async pinMessage(messageId: string, serverId: string) {\n    const updated = await prisma.$transaction(async (tx) => {\n      const msg = await messageRepository.findByIdWithChannel(messageId, tx);\n\n      if (!msg || msg.isDeleted || msg.channel.serverId !== serverId) {\n        throw new TRPCError({ code: 'NOT_FOUND', message: 'Message not found in this server' });\n      }\n      if (msg.pinned) {\n        throw new TRPCError({ code: 'CONFLICT', message: 'Message is already pinned' });\n      }\n\n      return messageRepository.update(messageId, { pinned: true, pinnedAt: new Date() }, tx);\n    });\n\n    cacheService\n      .invalidatePattern(\n        `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(updated.channelId)}:*`,\n      )\n      .catch((err) =>\n        logger.warn(\n          { err, channelId: updated.channelId, serverId },\n          'Failed to invalidate channel message cache after pin',\n        ),\n      );\n\n    return updated;\n  },\n\n  /**\n   * Unpin a message. Requires message:pin (MODERATOR+), checked via router RBAC.\n   * Uses a transaction to atomically check-and-clear.\n   */\n  async unpinMessage(messageId: string, serverId: string) {\n    const updated = await prisma.$transaction(async (tx) => {\n      const msg = await messageRepository.findByIdWithChannel(messageId, tx);\n\n      if (!msg || msg.isDeleted || msg.channel.serverId !== serverId) {\n        throw new TRPCError({ code: 'NOT_FOUND', message: 'Message not found in this server' });\n      }\n      if (!msg.pinned) {\n        throw new TRPCError({ code: 'CONFLICT', message: 'Message is not pinned' });\n      }\n\n      return messageRepository.update(messageId, { pinned: false, pinnedAt: null }, tx);\n    });\n\n    cacheService\n      .invalidatePattern(\n        `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(updated.channelId)}:*`,\n      )\n      .catch((err) =>\n        logger.warn(\n          { err, channelId: updated.channelId, serverId },\n          'Failed to invalidate channel message cache after unpin',\n        ),\n      );\n\n    return updated;\n  },\n\n  /**\n   * Retrieve all pinned messages for a channel in pin order (pinnedAt DESC).\n   */\n  async getPinnedMessages(channelId: string, serverId: string) {\n    await requireChannelInServer(channelId, serverId);\n    return messageRepository.findPinnedByChannel(channelId);\n  },\n\n  /**\n   * Create a reply to an existing, non-deleted message.\n   * - Validates the parent belongs to the given channel/server.\n   * - Atomically creates the reply and increments parent.replyCount.\n   */\n  async createReply(input: CreateReplyInput) {\n    const { parentMessageId, channelId, serverId, authorId, content } = input;\n\n    await requireChannelInServer(channelId, serverId);\n\n    const reply = await prisma.$transaction(async (tx) => {\n      const parent = await messageRepository.findByIdWithChannelFull(parentMessageId, tx);\n\n      if (\n        !parent ||\n        parent.isDeleted ||\n        parent.channel.id !== channelId ||\n        parent.channel.serverId !== serverId\n      ) {\n        throw new TRPCError({\n          code: 'NOT_FOUND',\n          message: 'Parent message not found in this channel',\n        });\n      }\n\n      // Replies cannot themselves be parents (one level of threading)\n      if (parent.parentMessageId !== null) {\n        throw new TRPCError({\n          code: 'BAD_REQUEST',\n          message: 'Cannot reply to a reply \u2014 only top-level messages can be threaded',\n        });\n      }\n\n      const created = await messageRepository.create(\n        {\n          channel: { connect: { id: channelId } },\n          author: { connect: { id: authorId } },\n          content,\n          parent: { connect: { id: parentMessageId } },\n        },\n        tx,\n      );\n\n      await messageRepository.updateRaw(\n        parentMessageId,\n        { replyCount: { increment: 1 } },\n        tx,\n      );\n\n      return created;\n    });\n\n    // Invalidate channel-level and thread-level caches\n    cacheService\n      .invalidatePattern(\n        `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)}:*`,\n      )\n      .catch((err) =>\n        logger.warn(\n          { err, channelId, serverId },\n          'Failed to invalidate channel message cache after reply',\n        ),\n      );\n    cacheService\n      .invalidatePattern(`thread:msgs:${sanitizeKeySegment(parentMessageId)}:*`)\n      .catch((err) =>\n        logger.warn({ err, parentMessageId }, 'Failed to invalidate thread cache after reply'),\n      );\n\n    eventBus\n      .publish(EventChannels.MESSAGE_CREATED, {\n        messageId: reply.id,\n        channelId,\n        authorId,\n        parentMessageId,\n        timestamp: reply.createdAt.toISOString(),\n      })\n      .catch((err) =>\n        logger.warn(\n          { err, messageId: reply.id, channelId, serverId },\n          'Failed to publish reply created event',\n        ),\n      );\n\n    return reply;\n  },\n\n  /**\n   * Retrieve paginated replies for a parent message, ordered chronologically (ASC).\n   */\n  async getThreadMessages(input: GetThreadMessagesInput) {\n    const { parentMessageId, channelId, serverId, cursor, limit = 20 } = input;\n    const clampedLimit = Math.min(Math.max(1, limit), 100);\n\n    await requireChannelInServer(channelId, serverId);\n\n    const cacheKey =\n      `thread:msgs:${sanitizeKeySegment(parentMessageId)}` +\n      `:cursor:${sanitizeKeySegment(cursor ?? 'start')}:limit:${clampedLimit}`;\n\n    return cacheService.getOrRevalidate(\n      cacheKey,\n      async () => {\n        // Validate the parent on every cache miss. This costs a serial DB round-trip,\n        // but it is sound: deleteMessage invalidates `thread:msgs:<messageId>:*`, so a\n        // soft-deleted parent's cache entries are always busted before this guard could\n        // serve a stale thread. The check is therefore redundant in the happy path and\n        // only fires for genuinely invalid requests.\n        const parent = await messageRepository.findByIdWithChannelFull(parentMessageId);\n\n        if (\n          !parent ||\n          parent.isDeleted ||\n          parent.channel.id !== channelId ||\n          parent.channel.serverId !== serverId\n        ) {\n          throw new TRPCError({\n            code: 'NOT_FOUND',\n            message: 'Parent message not found in this channel',\n          });\n        }\n\n        // Enforce one-level threading: only top-level messages have threads\n        if (parent.parentMessageId !== null) {\n          throw new TRPCError({\n            code: 'BAD_REQUEST',\n            message: 'Cannot fetch thread for a reply \u2014 only top-level messages have threads',\n          });\n        }\n\n        const replies = await messageRepository.findManyPaginated(\n          { parentMessageId, isDeleted: false },\n          clampedLimit + 1,\n          cursor,\n          { createdAt: 'asc' },\n        );\n\n        const hasMore = replies.length > clampedLimit;\n        const page = hasMore ? replies.slice(0, clampedLimit) : replies;\n        const nextCursor = hasMore ? page[page.length - 1].id : null;\n\n        return { replies: page, nextCursor, hasMore };\n      },\n      { ttl: CacheTTL.channelMessages },\n    );\n  },\n};\n"
+}
+```
+
+## Assistant
+
+Now update server.service.ts:
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/server.service.ts",
+  "content": "import { Server, Prisma } from '@prisma/client';\nimport { TRPCError } from '@trpc/server';\nimport { channelService } from './channel.service';\nimport { serverMemberService } from './serverMember.service';\nimport { isSystemAdmin } from '../lib/admin.utils';\nimport { eventBus, EventChannels } from '../events/eventBus';\nimport { serverRepository } from '../repositories/server.repository';\nimport { serverMemberRepository } from '../repositories/serverMember.repository';\n\n// Role hierarchy for sorting: lower rank = higher privilege\nconst ROLE_RANK: Record<string, number> = {\n  OWNER: 0,\n  ADMIN: 1,\n  MODERATOR: 2,\n  MEMBER: 3,\n  GUEST: 4,\n};\n\nexport interface ServerMemberWithUser {\n  userId: string;\n  serverId: string;\n  role: string;\n  joinedAt: Date;\n  user: {\n    id: string;\n    username: string;\n    displayName: string;\n    avatarUrl: string | null;\n    status: string;\n  };\n}\n\nexport function generateSlug(name: string): string {\n  return name\n    .toLowerCase()\n    .trim()\n    .replace(/[^a-z0-9\\s-]/g, '')\n    .replace(/[\\s]+/g, '-')\n    .replace(/-+/g, '-')\n    .replace(/^-|-$/g, '');\n}\n\nasync function generateUniqueSlug(name: string): Promise<string> {\n  const base = generateSlug(name);\n  if (!base)\n    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot generate slug from name' });\n\n  const MAX_ATTEMPTS = 10;\n  let candidate = base;\n  for (let suffix = 1; suffix <= MAX_ATTEMPTS; suffix++) {\n    if ((await serverRepository.countBySlug(candidate)) === 0) return candidate;\n    candidate = `${base}-${suffix}`;\n  }\n  throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });\n}\n\n/**\n * Generic slug-collision retry helper.\n * Calls fn(slug) up to maxRetries times, regenerating the slug on a P2002 unique violation.\n */\nasync function withSlugRetry(\n  name: string,\n  initialSlug: string,\n  fn: (slug: string) => Promise<Server>,\n  maxRetries = 3,\n): Promise<Server> {\n  let slug = initialSlug;\n  for (let attempt = 0; attempt < maxRetries; attempt++) {\n    if (attempt > 0) slug = await generateUniqueSlug(name);\n    try {\n      return await fn(slug);\n    } catch (err) {\n      if (\n        err instanceof Prisma.PrismaClientKnownRequestError &&\n        err.code === 'P2002' &&\n        attempt < maxRetries - 1\n      ) {\n        continue;\n      }\n      throw err;\n    }\n  }\n  throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });\n}\n\nexport const serverService = {\n  async getPublicServers(limit = 50): Promise<Server[]> {\n    return serverRepository.findPublic(Math.min(limit, 100));\n  },\n\n  /** Dev admin: returns all servers regardless of visibility. */\n  async getAllServers(limit = 50): Promise<Server[]> {\n    return serverRepository.findAll(Math.min(limit, 100));\n  },\n\n  /** Returns only the servers the given user is a member of. */\n  async getMemberServers(userId: string, limit = 50): Promise<Server[]> {\n    const memberships = await serverMemberRepository.findByUserIdWithServer(userId);\n    return memberships.slice(0, Math.min(limit, 100)).map((m) => m.server);\n  },\n\n  async getServer(slug: string): Promise<Server | null> {\n    return serverRepository.findBySlug(slug);\n  },\n\n  async createServer(input: {\n    name: string;\n    description?: string;\n    iconUrl?: string;\n    isPublic?: boolean;\n    ownerId: string;\n  }): Promise<Server> {\n    const slug = await generateUniqueSlug(input.name);\n    const server = await withSlugRetry(input.name, slug, (s) =>\n      serverRepository.create({ ...input, slug: s }),\n    );\n    await channelService.createDefaultChannel(server.id);\n    await serverMemberService.addOwner(input.ownerId, server.id);\n    return server;\n  },\n\n  async updateServer(\n    id: string,\n    actorId: string,\n    data: { name?: string; description?: string; iconUrl?: string; isPublic?: boolean },\n  ): Promise<Server> {\n    const server = await serverRepository.findById(id);\n    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can update' });\n\n    let updated: Server;\n    if (data.name && data.name !== server.name) {\n      const slug = await generateUniqueSlug(data.name);\n      updated = await withSlugRetry(data.name, slug, (s) =>\n        serverRepository.update(id, { ...data, slug: s }),\n      );\n    } else {\n      updated = await serverRepository.update(id, data);\n    }\n\n    void eventBus.publish(EventChannels.SERVER_UPDATED, {\n      serverId: id,\n      name: updated.name,\n      iconUrl: updated.iconUrl ?? null,\n      description: updated.description ?? null,\n      timestamp: new Date().toISOString(),\n    });\n\n    return updated;\n  },\n\n  async deleteServer(id: string, actorId: string): Promise<Server> {\n    const server = await serverRepository.findById(id);\n    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can delete' });\n    return serverRepository.delete(id);\n  },\n\n  async incrementMemberCount(id: string): Promise<Server> {\n    return serverRepository.update(id, { memberCount: { increment: 1 } });\n  },\n\n  async decrementMemberCount(id: string): Promise<Server> {\n    const server = await serverRepository.findById(id);\n    if (!server || server.memberCount <= 0) {\n      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Member count is already zero' });\n    }\n    return serverRepository.update(id, { memberCount: { decrement: 1 } });\n  },\n\n  async getMembers(serverId: string): Promise<ServerMemberWithUser[]> {\n    const members = await serverMemberRepository.findMembersByServerId(serverId);\n    return members\n      .map((m) => ({ ...m, role: m.role as string }))\n      .sort(\n        (a, b) =>\n          (ROLE_RANK[a.role] ?? 99) - (ROLE_RANK[b.role] ?? 99) ||\n          a.joinedAt.getTime() - b.joinedAt.getTime(),\n      );\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/server.service.ts",
+  "limit": 5
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/server.service.ts",
+  "content": "import { Server, Prisma } from '@prisma/client';\nimport { TRPCError } from '@trpc/server';\nimport { channelService } from './channel.service';\nimport { serverMemberService } from './serverMember.service';\nimport { isSystemAdmin } from '../lib/admin.utils';\nimport { eventBus, EventChannels } from '../events/eventBus';\nimport { serverRepository } from '../repositories/server.repository';\nimport { serverMemberRepository } from '../repositories/serverMember.repository';\n\n// Role hierarchy for sorting: lower rank = higher privilege\nconst ROLE_RANK: Record<string, number> = {\n  OWNER: 0,\n  ADMIN: 1,\n  MODERATOR: 2,\n  MEMBER: 3,\n  GUEST: 4,\n};\n\nexport interface ServerMemberWithUser {\n  userId: string;\n  serverId: string;\n  role: string;\n  joinedAt: Date;\n  user: {\n    id: string;\n    username: string;\n    displayName: string;\n    avatarUrl: string | null;\n    status: string;\n  };\n}\n\nexport function generateSlug(name: string): string {\n  return name\n    .toLowerCase()\n    .trim()\n    .replace(/[^a-z0-9\\s-]/g, '')\n    .replace(/[\\s]+/g, '-')\n    .replace(/-+/g, '-')\n    .replace(/^-|-$/g, '');\n}\n\nasync function generateUniqueSlug(name: string): Promise<string> {\n  const base = generateSlug(name);\n  if (!base)\n    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot generate slug from name' });\n\n  const MAX_ATTEMPTS = 10;\n  let candidate = base;\n  for (let suffix = 1; suffix <= MAX_ATTEMPTS; suffix++) {\n    if ((await serverRepository.countBySlug(candidate)) === 0) return candidate;\n    candidate = `${base}-${suffix}`;\n  }\n  throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });\n}\n\n/**\n * Generic slug-collision retry helper.\n * Calls fn(slug) up to maxRetries times, regenerating the slug on a P2002 unique violation.\n */\nasync function withSlugRetry(\n  name: string,\n  initialSlug: string,\n  fn: (slug: string) => Promise<Server>,\n  maxRetries = 3,\n): Promise<Server> {\n  let slug = initialSlug;\n  for (let attempt = 0; attempt < maxRetries; attempt++) {\n    if (attempt > 0) slug = await generateUniqueSlug(name);\n    try {\n      return await fn(slug);\n    } catch (err) {\n      if (\n        err instanceof Prisma.PrismaClientKnownRequestError &&\n        err.code === 'P2002' &&\n        attempt < maxRetries - 1\n      ) {\n        continue;\n      }\n      throw err;\n    }\n  }\n  throw new TRPCError({ code: 'CONFLICT', message: 'Unable to generate a unique slug' });\n}\n\nexport const serverService = {\n  async getPublicServers(limit = 50): Promise<Server[]> {\n    return serverRepository.findPublic(Math.min(limit, 100));\n  },\n\n  /** Dev admin: returns all servers regardless of visibility. */\n  async getAllServers(limit = 50): Promise<Server[]> {\n    return serverRepository.findAll(Math.min(limit, 100));\n  },\n\n  /** Returns only the servers the given user is a member of. */\n  async getMemberServers(userId: string, limit = 50): Promise<Server[]> {\n    const memberships = await serverMemberRepository.findByUserIdWithServer(userId);\n    return memberships.slice(0, Math.min(limit, 100)).map((m) => m.server);\n  },\n\n  async getServer(slug: string): Promise<Server | null> {\n    return serverRepository.findBySlug(slug);\n  },\n\n  async createServer(input: {\n    name: string;\n    description?: string;\n    iconUrl?: string;\n    isPublic?: boolean;\n    ownerId: string;\n  }): Promise<Server> {\n    const slug = await generateUniqueSlug(input.name);\n    const server = await withSlugRetry(input.name, slug, (s) =>\n      serverRepository.create({ ...input, slug: s }),\n    );\n    await channelService.createDefaultChannel(server.id);\n    await serverMemberService.addOwner(input.ownerId, server.id);\n    return server;\n  },\n\n  async updateServer(\n    id: string,\n    actorId: string,\n    data: { name?: string; description?: string; iconUrl?: string; isPublic?: boolean },\n  ): Promise<Server> {\n    const server = await serverRepository.findById(id);\n    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can update' });\n\n    let updated: Server;\n    if (data.name && data.name !== server.name) {\n      const slug = await generateUniqueSlug(data.name);\n      updated = await withSlugRetry(data.name, slug, (s) =>\n        serverRepository.update(id, { ...data, slug: s }),\n      );\n    } else {\n      updated = await serverRepository.update(id, data);\n    }\n\n    void eventBus.publish(EventChannels.SERVER_UPDATED, {\n      serverId: id,\n      name: updated.name,\n      iconUrl: updated.iconUrl ?? null,\n      description: updated.description ?? null,\n      timestamp: new Date().toISOString(),\n    });\n\n    return updated;\n  },\n\n  async deleteServer(id: string, actorId: string): Promise<Server> {\n    const server = await serverRepository.findById(id);\n    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can delete' });\n    return serverRepository.delete(id);\n  },\n\n  async incrementMemberCount(id: string): Promise<Server> {\n    return serverRepository.update(id, { memberCount: { increment: 1 } });\n  },\n\n  async decrementMemberCount(id: string): Promise<Server> {\n    const server = await serverRepository.findById(id);\n    if (!server || server.memberCount <= 0) {\n      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Member count is already zero' });\n    }\n    return serverRepository.update(id, { memberCount: { decrement: 1 } });\n  },\n\n  async getMembers(serverId: string): Promise<ServerMemberWithUser[]> {\n    const members = await serverMemberRepository.findMembersByServerId(serverId);\n    return members\n      .map((m) => ({ ...m, role: m.role as string }))\n      .sort(\n        (a, b) =>\n          (ROLE_RANK[a.role] ?? 99) - (ROLE_RANK[b.role] ?? 99) ||\n          a.joinedAt.getTime() - b.joinedAt.getTime(),\n      );\n  },\n};\n"
+}
+```
+
+## Assistant
+
+Now update user.service.ts, auth.service.ts, permission.service.ts, reaction.service.ts, auditLog.service.ts, attachment.service.ts, serverMember.service.ts, visibility.service.ts, and indexing.service.ts:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/user.service.ts",
+  "limit": 5
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/user.service.ts",
+  "content": "import { TRPCError } from '@trpc/server';\nimport { Prisma, UserStatus } from '@prisma/client';\nimport { isSystemAdmin } from '../lib/admin.utils';\nimport { eventBus, EventChannels } from '../events/eventBus';\nimport { userRepository } from '../repositories/user.repository';\nimport { serverMemberRepository } from '../repositories/serverMember.repository';\n\nexport interface UpdateUserInput {\n  displayName?: string;\n  avatarUrl?: string | null;\n  publicProfile?: boolean;\n  status?: UserStatus;\n}\n\nexport const userService = {\n  /**\n   * Returns a user's profile by ID, respecting the publicProfile privacy flag.\n   * Users with publicProfile=false are returned anonymised \u2014 per architecture \u00a74.1:\n   * \"Users with public_profile = false are displayed as 'Anonymous' with no avatar.\"\n   * The publicProfile flag itself is also masked (returned as true) so callers\n   * cannot infer whether a user has a private profile.\n   * Credential fields (passwordHash, email) are never returned.\n   */\n  async getUser(userId: string) {\n    const user = await userRepository.findById(userId);\n    if (!user) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });\n    }\n    if (!user.publicProfile) {\n      return {\n        ...user,\n        username: 'anonymous',\n        displayName: 'Anonymous',\n        avatarUrl: null,\n        publicProfile: true, // mask the flag \u2014 callers cannot infer private status\n        status: UserStatus.OFFLINE,\n      };\n    }\n    return user;\n  },\n\n  /**\n   * Returns the full safe profile for the currently authenticated user.\n   * Bypasses the publicProfile privacy filter \u2014 a user always sees their own data.\n   * Never returns passwordHash.\n   */\n  async getCurrentUser(userId: string) {\n    const user = await userRepository.findSelf(userId);\n    if (!user) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });\n    }\n    return {\n      ...user,\n      isSystemAdmin: await isSystemAdmin(userId),\n    };\n  },\n\n  async updateUser(userId: string, patch: UpdateUserInput) {\n    try {\n      const updated = await userRepository.update(userId, {\n        ...(patch.displayName !== undefined && { displayName: patch.displayName }),\n        ...(patch.avatarUrl !== undefined && { avatarUrl: patch.avatarUrl }),\n        ...(patch.publicProfile !== undefined && { publicProfile: patch.publicProfile }),\n        ...(patch.status !== undefined && { status: patch.status }),\n      });\n\n      // When status changes, publish one event per server the user belongs to so\n      // all connected members of those servers can update their member sidebar in real time.\n      // Status reflects presence only (not identity), so we publish for all servers\n      // regardless of the user's publicProfile setting.\n      if (patch.status !== undefined) {\n        const memberships = await serverMemberRepository.findByUserIdSelect(userId);\n        for (const { serverId } of memberships) {\n          void eventBus.publish(EventChannels.USER_STATUS_CHANGED, {\n            userId,\n            serverId,\n            status: patch.status,\n          });\n        }\n      }\n\n      return updated;\n    } catch (e) {\n      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {\n        throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });\n      }\n      throw e;\n    }\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auth.service.ts",
+  "limit": 5
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auth.service.ts",
+  "content": "import bcrypt from 'bcryptjs';\nimport jwt from 'jsonwebtoken';\nimport crypto from 'crypto';\nimport { Prisma } from '@prisma/client';\nimport { TRPCError } from '@trpc/server';\nimport { serverMemberService } from './serverMember.service';\nimport { ADMIN_EMAIL } from '../lib/admin.utils';\nimport { userRepository } from '../repositories/user.repository';\nimport { serverRepository } from '../repositories/server.repository';\nimport { serverMemberRepository } from '../repositories/serverMember.repository';\nimport { refreshTokenRepository } from '../repositories/refreshToken.repository';\n\nconst BCRYPT_ROUNDS = 12;\n// Dummy hash used to equalise bcrypt timing when the email is not found\nconst TIMING_DUMMY_HASH = '$2a$12$invalidhashfortimingequalizerXXXXXXXXXXXXXXXXXXXXXXXX';\nconst PASSWORD_VERIFIER_PREFIX = 'v1';\nconst PASSWORD_SALT_BYTES = 16;\nconst DEV_ADMIN_PASSWORD_SALT = 'f6f0e4f9f5f841caa4dd4ac4ef0bf9e8';\n\nconst ACCESS_SECRET = (() => {\n  const value = process.env.JWT_ACCESS_SECRET;\n  // istanbul ignore next -- NODE_ENV guard makes this unreachable in Jest (ts-jest transform cache)\n  if (!value && process.env.NODE_ENV !== 'test') {\n    throw new Error('JWT_ACCESS_SECRET environment variable is not set');\n  }\n  return value ?? 'dev-access-secret-change-in-prod';\n})();\n\nconst REFRESH_SECRET = (() => {\n  const value = process.env.JWT_REFRESH_SECRET;\n  // istanbul ignore next -- NODE_ENV guard makes this unreachable in Jest (ts-jest transform cache)\n  if (!value && process.env.NODE_ENV !== 'test') {\n    throw new Error('JWT_REFRESH_SECRET environment variable is not set');\n  }\n  return value ?? 'dev-refresh-secret-change-in-prod';\n})();\n\nconst ACCESS_EXPIRES_IN = process.env.JWT_ACCESS_EXPIRES_IN ?? '15m';\n\nconst REFRESH_EXPIRES_IN_DAYS: number = (() => {\n  const raw = process.env.JWT_REFRESH_EXPIRES_DAYS;\n  if (raw === undefined) return 7;\n  const parsed = Number(raw);\n  if (!Number.isFinite(parsed) || parsed <= 0) {\n    throw new Error(`Invalid JWT_REFRESH_EXPIRES_DAYS value \"${raw}\". Expected a positive number.`);\n  }\n  return parsed;\n})();\n\nexport interface AuthTokens {\n  accessToken: string;\n  refreshToken: string;\n}\n\nexport interface JwtPayload {\n  sub: string; // userId\n  jti?: string; // unique token ID (present on refresh tokens)\n}\n\nfunction encodePasswordVerifierRecord(passwordSalt: string, bcryptHash: string): string {\n  return `${PASSWORD_VERIFIER_PREFIX}$${passwordSalt}$${bcryptHash}`;\n}\n\nfunction decodePasswordVerifierRecord(\n  record: string,\n): { passwordSalt: string; bcryptHash: string } | null {\n  const prefix = `${PASSWORD_VERIFIER_PREFIX}$`;\n  if (!record.startsWith(prefix)) {\n    return null;\n  }\n\n  const firstSeparator = record.indexOf('$', prefix.length);\n  if (firstSeparator === -1) {\n    return null;\n  }\n\n  const passwordSalt = record.slice(prefix.length, firstSeparator);\n  const bcryptHash = record.slice(firstSeparator + 1);\n  if (!passwordSalt || !bcryptHash) {\n    return null;\n  }\n\n  return { passwordSalt, bcryptHash };\n}\n\nfunction createDummyPasswordSalt(email: string): string {\n  return crypto\n    .createHash('sha256')\n    .update(`missing-user:${email.toLowerCase()}`)\n    .digest('hex')\n    .slice(0, PASSWORD_SALT_BYTES * 2);\n}\n\nfunction decodePasswordSalt(passwordSalt: string): Buffer {\n  return Buffer.from(passwordSalt, 'hex');\n}\n\nfunction createDevAdminPasswordVerifier(): string {\n  return crypto\n    .pbkdf2Sync('admin', decodePasswordSalt(DEV_ADMIN_PASSWORD_SALT), 310000, 32, 'sha256')\n    .toString('base64');\n}\n\n// \u2500\u2500\u2500 Token helpers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nfunction signAccessToken(userId: string): string {\n  return jwt.sign({ sub: userId } as JwtPayload, ACCESS_SECRET, {\n    expiresIn: ACCESS_EXPIRES_IN as jwt.SignOptions['expiresIn'],\n  });\n}\n\nfunction signRefreshToken(userId: string): string {\n  return jwt.sign({ sub: userId, jti: crypto.randomUUID() } as JwtPayload, REFRESH_SECRET, {\n    expiresIn: `${REFRESH_EXPIRES_IN_DAYS}d` as jwt.SignOptions['expiresIn'],\n  });\n}\n\nfunction hashToken(token: string): string {\n  return crypto.createHash('sha256').update(token).digest('hex');\n}\n\nasync function storeRefreshToken(userId: string, rawToken: string): Promise<void> {\n  const expiresAt = new Date();\n  expiresAt.setDate(expiresAt.getDate() + REFRESH_EXPIRES_IN_DAYS);\n\n  await refreshTokenRepository.create({\n    tokenHash: hashToken(rawToken),\n    user: { connect: { id: userId } },\n    expiresAt,\n  });\n}\n\n// \u2500\u2500\u2500 Dev admin bootstrap \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n/**\n * Upserts the dev admin user and ensures they are an OWNER member of every\n * existing server. Called on admin login only.\n */\nasync function ensureAdminUser() {\n  const passwordHash = await bcrypt.hash(createDevAdminPasswordVerifier(), BCRYPT_ROUNDS);\n  const encodedPasswordHash = encodePasswordVerifierRecord(DEV_ADMIN_PASSWORD_SALT, passwordHash);\n\n  const admin = await userRepository.upsert(\n    { email: ADMIN_EMAIL },\n    { passwordHash: encodedPasswordHash },\n    {\n      email: ADMIN_EMAIL,\n      username: 'admin',\n      displayName: 'System Admin',\n      passwordHash: encodedPasswordHash,\n    },\n  );\n\n  // Auto-join every server as OWNER so the admin can access everything.\n  const servers = await serverRepository.findPublicBySlugSelect();\n  // findPublicBySlugSelect returns only public servers; we need all servers for admin\n  // Use findAll with a high limit to get all servers\n  const allServers = await serverRepository.findAll(10000);\n  for (const server of allServers) {\n    await serverMemberRepository.upsert(\n      { userId_serverId: { userId: admin.id, serverId: server.id } },\n      { role: 'OWNER' },\n      { userId: admin.id, serverId: server.id, role: 'OWNER' },\n    );\n  }\n\n  return admin;\n}\n\n// \u2500\u2500\u2500 Auth service \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nexport const authService = {\n  generatePasswordSalt(): string {\n    return crypto.randomBytes(PASSWORD_SALT_BYTES).toString('hex');\n  },\n\n  async getLoginPasswordSalt(email: string): Promise<string> {\n    if (process.env.NODE_ENV !== 'production' && email === ADMIN_EMAIL) {\n      return DEV_ADMIN_PASSWORD_SALT;\n    }\n\n    const user = await userRepository.findByEmailSelect(email);\n    const decoded = user ? decodePasswordVerifierRecord(user.passwordHash) : null;\n    return decoded?.passwordSalt ?? createDummyPasswordSalt(email);\n  },\n\n  async register(\n    email: string,\n    username: string,\n    passwordSalt: string,\n    passwordVerifier: string,\n  ): Promise<AuthTokens> {\n    const existingEmail = await userRepository.findByEmail(email);\n    if (existingEmail) {\n      throw new TRPCError({ code: 'CONFLICT', message: 'Email already in use' });\n    }\n\n    const existingUsername = await userRepository.findByUsername(username);\n    if (existingUsername) {\n      throw new TRPCError({ code: 'CONFLICT', message: 'Username already taken' });\n    }\n\n    // Store a bcrypt hash of the client-derived verifier so the raw password\n    // never traverses the wire or lands in request-body logs.\n    const passwordHash = encodePasswordVerifierRecord(\n      passwordSalt,\n      await bcrypt.hash(passwordVerifier, BCRYPT_ROUNDS),\n    );\n\n    let user: Awaited<ReturnType<typeof userRepository.create>>;\n    try {\n      user = await userRepository.create({\n        email,\n        username,\n        passwordHash,\n        displayName: username,\n      });\n    } catch (err) {\n      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {\n        throw new TRPCError({ code: 'CONFLICT', message: 'Email or username already in use' });\n      }\n      throw err;\n    }\n\n    // Auto-join the default public server so new users land in a usable state.\n    const defaultServer = await serverRepository.findFirst(\n      { slug: 'harmony-hq', isPublic: true },\n      { id: true },\n    );\n    if (defaultServer) {\n      try {\n        await serverMemberService.joinServer(user.id, defaultServer.id);\n      } catch {\n        // Best-effort: don't block registration if the join fails\n      }\n    }\n\n    const accessToken = signAccessToken(user.id);\n    const refreshToken = signRefreshToken(user.id);\n    await storeRefreshToken(user.id, refreshToken);\n\n    return { accessToken, refreshToken };\n  },\n\n  async login(email: string, passwordVerifier: string): Promise<AuthTokens> {\n    // \u2500\u2500 Dev-only admin override \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n    // Login as admin@harmony.dev / admin to get a system-admin account that\n    // bypasses all permission and ownership checks. Remove before production.\n    if (\n      process.env.NODE_ENV !== 'production' &&\n      email === ADMIN_EMAIL &&\n      passwordVerifier === createDevAdminPasswordVerifier()\n    ) {\n      const admin = await ensureAdminUser();\n      const accessToken = signAccessToken(admin.id);\n      const refreshToken = signRefreshToken(admin.id);\n      await storeRefreshToken(admin.id, refreshToken);\n      return { accessToken, refreshToken };\n    }\n\n    const user = await userRepository.findByEmail(email);\n    if (!user) {\n      // Equalise timing so unknown emails are indistinguishable from wrong passwords\n      await bcrypt.compare(passwordVerifier, TIMING_DUMMY_HASH);\n      throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Invalid credentials' });\n    }\n\n    const decoded = decodePasswordVerifierRecord(user.passwordHash);\n    if (!decoded) {\n      await bcrypt.compare(passwordVerifier, TIMING_DUMMY_HASH);\n      throw new TRPCError({\n        code: 'UNAUTHORIZED',\n        message: 'This account must reset its password before signing in.',\n      });\n    }\n\n    // This protects request bodies and logs from raw-password exposure, but a\n    // captured verifier is still replayable. HTTPS remains load-bearing here.\n    const valid = await bcrypt.compare(passwordVerifier, decoded.bcryptHash);\n    if (!valid) {\n      throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Invalid credentials' });\n    }\n\n    const accessToken = signAccessToken(user.id);\n    const refreshToken = signRefreshToken(user.id);\n    await storeRefreshToken(user.id, refreshToken);\n\n    return { accessToken, refreshToken };\n  },\n\n  async logout(rawRefreshToken: string): Promise<void> {\n    const hash = hashToken(rawRefreshToken);\n    await refreshTokenRepository.revokeByHash(hash);\n  },\n\n  async refreshTokens(rawRefreshToken: string): Promise<AuthTokens> {\n    let payload: JwtPayload;\n    try {\n      payload = jwt.verify(rawRefreshToken, REFRESH_SECRET) as JwtPayload;\n    } catch {\n      throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Invalid refresh token' });\n    }\n\n    const hash = hashToken(rawRefreshToken);\n\n    // Atomic compare-and-revoke: succeeds only if the token exists, is not revoked, and is not expired.\n    // Two concurrent requests with the same token will race; exactly one will get count === 1.\n    const revoked = await refreshTokenRepository.rotateByHash(hash);\n\n    if (revoked.count === 0) {\n      throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Refresh token revoked or expired' });\n    }\n\n    const accessToken = signAccessToken(payload.sub);\n    const newRefreshToken = signRefreshToken(payload.sub);\n    await storeRefreshToken(payload.sub, newRefreshToken);\n\n    return { accessToken, refreshToken: newRefreshToken };\n  },\n\n  verifyAccessToken(token: string): JwtPayload {\n    try {\n      return jwt.verify(token, ACCESS_SECRET) as JwtPayload;\n    } catch {\n      throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Invalid or expired access token' });\n    }\n  },\n};\n"
+}
+```
+
+## Assistant
+
+I introduced a bug in `ensureAdminUser` — let me fix that now:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auth.service.ts",
+  "old_string": "  // Auto-join every server as OWNER so the admin can access everything.\n  const servers = await serverRepository.findPublicBySlugSelect();\n  // findPublicBySlugSelect returns only public servers; we need all servers for admin\n  // Use findAll with a high limit to get all servers\n  const allServers = await serverRepository.findAll(10000);\n  for (const server of allServers) {",
+  "new_string": "  // Auto-join every server as OWNER so the admin can access everything.\n  const allServers = await serverRepository.findAll(10000);\n  for (const server of allServers) {"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/permission.service.ts",
+  "limit": 5
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/permission.service.ts",
+  "content": "import { RoleType } from '@prisma/client';\nimport { TRPCError } from '@trpc/server';\nimport { isSystemAdmin } from '../lib/admin.utils';\nimport { serverRepository } from '../repositories/server.repository';\nimport { serverMemberRepository } from '../repositories/serverMember.repository';\n\n// \u2500\u2500\u2500 Action types \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nexport type ServerAction =\n  | 'server:read'\n  | 'server:update'\n  | 'server:delete'\n  | 'server:manage_members';\n\nexport type ChannelAction =\n  | 'channel:read'\n  | 'channel:create'\n  | 'channel:update'\n  | 'channel:delete'\n  | 'channel:manage_visibility';\n\nexport type MessageAction =\n  | 'message:read'\n  | 'message:create'\n  | 'message:update_own'\n  | 'message:delete_own'\n  | 'message:delete_any'\n  | 'message:pin'\n  | 'message:react';\n\nexport type SettingsAction = 'settings:read' | 'settings:update';\n\nexport type Action = ServerAction | ChannelAction | MessageAction | SettingsAction;\n\n// \u2500\u2500\u2500 Permission matrix \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n// Maps each role to the set of actions it may perform.\n// Higher-privilege roles include all permissions of lower-privilege roles plus\n// their own additions (accumulated below).\n\nconst GUEST_PERMISSIONS = new Set<Action>(['server:read', 'channel:read', 'message:read']);\n\nconst MEMBER_PERMISSIONS = new Set<Action>([\n  ...GUEST_PERMISSIONS,\n  'message:create',\n  'message:update_own',\n  'message:delete_own',\n  'message:react',\n]);\n\nconst MODERATOR_PERMISSIONS = new Set<Action>([\n  ...MEMBER_PERMISSIONS,\n  'message:delete_any',\n  'message:pin',\n]);\n\nconst ADMIN_PERMISSIONS = new Set<Action>([\n  ...MODERATOR_PERMISSIONS,\n  'channel:create',\n  'channel:update',\n  'channel:delete',\n  'channel:manage_visibility',\n  'settings:read',\n  'settings:update',\n  'server:update',\n  'server:manage_members',\n]);\n\nconst OWNER_PERMISSIONS = new Set<Action>([...ADMIN_PERMISSIONS, 'server:delete']);\n\nconst ROLE_PERMISSIONS: Record<RoleType, Set<Action>> = {\n  OWNER: OWNER_PERMISSIONS,\n  ADMIN: ADMIN_PERMISSIONS,\n  MODERATOR: MODERATOR_PERMISSIONS,\n  MEMBER: MEMBER_PERMISSIONS,\n  GUEST: GUEST_PERMISSIONS,\n};\n\n// \u2500\u2500\u2500 Permission service \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nexport const permissionService = {\n  /**\n   * Returns the RoleType for the given user in the given server, or null if\n   * the user is not a member.\n   */\n  async getMemberRole(userId: string, serverId: string): Promise<RoleType | null> {\n    const membership = await serverMemberRepository.findByUserAndServerSelect(userId, serverId);\n    return membership?.role ?? null;\n  },\n\n  /**\n   * Checks whether `userId` is permitted to perform `action` in `serverId`.\n   *\n   * Throws `NOT_FOUND` when the server does not exist.\n   * Returns `false` (does not throw) when the user is not a member at all.\n   */\n  async checkPermission(userId: string, serverId: string, action: Action): Promise<boolean> {\n    // Dev admin bypass \u2014 remove before production\n    if (await isSystemAdmin(userId)) return true;\n\n    const server = await serverRepository.findByIdSelect(serverId, { id: true });\n    if (!server) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n    }\n\n    const role = await permissionService.getMemberRole(userId, serverId);\n    if (role === null) return false;\n\n    return ROLE_PERMISSIONS[role].has(action);\n  },\n\n  /**\n   * Like `checkPermission` but throws `FORBIDDEN` instead of returning false.\n   * Use this inside tRPC procedures that should reject unauthorized callers.\n   */\n  async requirePermission(userId: string, serverId: string, action: Action): Promise<void> {\n    const allowed = await permissionService.checkPermission(userId, serverId, action);\n    if (!allowed) {\n      throw new TRPCError({\n        code: 'FORBIDDEN',\n        message: `You do not have permission to perform '${action}' in this server`,\n      });\n    }\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/reaction.service.ts",
+  "limit": 5
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/reaction.service.ts",
+  "content": "import { TRPCError } from '@trpc/server';\nimport { createLogger } from '../lib/logger';\nimport { cacheService, sanitizeKeySegment } from './cache.service';\nimport { eventBus, EventChannels } from '../events/eventBus';\nimport { reactionRepository } from '../repositories/reaction.repository';\n\n// \u2500\u2500\u2500 Types \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nexport interface AddReactionInput {\n  messageId: string;\n  channelId: string;\n  userId: string;\n  emoji: string;\n  serverId: string;\n}\n\nexport interface RemoveReactionInput {\n  messageId: string;\n  channelId: string;\n  userId: string;\n  emoji: string;\n  serverId: string;\n}\n\nexport interface GetMessageReactionsInput {\n  messageId: string;\n  channelId: string;\n  serverId: string;\n}\n\nexport interface ReactionGroup {\n  emoji: string;\n  count: number;\n  userIds: string[];\n}\n\nconst logger = createLogger({ component: 'reaction-service' });\n\n// \u2500\u2500\u2500 Helpers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n/**\n * Resolve a message (non-deleted) and assert it belongs to both the given\n * channel and server. Throws NOT_FOUND for any mismatch to prevent callers\n * from probing channel or server IDs across boundaries.\n */\nasync function requireMessageInChannel(messageId: string, channelId: string, serverId: string) {\n  const message = await reactionRepository.findMessageWithChannel(messageId);\n  if (\n    !message ||\n    message.isDeleted ||\n    message.channelId !== channelId ||\n    message.channel.serverId !== serverId\n  ) {\n    throw new TRPCError({ code: 'NOT_FOUND', message: 'Message not found in this channel' });\n  }\n  return message;\n}\n\n/** Cache key for all reactions on a message, scoped to server to prevent cross-server probing. */\nfunction reactionCacheKey(serverId: string, messageId: string): string {\n  return `reactions:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(messageId)}`;\n}\n\n// \u2500\u2500\u2500 Service \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nexport const reactionService = {\n  /**\n   * Add an emoji reaction to a message.\n   * Validates the message exists in the server; throws CONFLICT if the user\n   * has already reacted with the same emoji.\n   */\n  async addReaction(input: AddReactionInput) {\n    const { messageId, channelId, userId, emoji, serverId } = input;\n\n    const message = await requireMessageInChannel(messageId, channelId, serverId);\n\n    try {\n      const reaction = await reactionRepository.create({ message: { connect: { id: messageId } }, user: { connect: { id: userId } }, emoji });\n\n      cacheService\n        .invalidatePattern(reactionCacheKey(serverId, messageId))\n        .catch((err) =>\n          logger.warn(\n            { err, messageId, serverId },\n            'Failed to invalidate reaction cache after add',\n          ),\n        );\n\n      eventBus\n        .publish(EventChannels.REACTION_ADDED, {\n          messageId,\n          channelId: message.channel.id,\n          userId,\n          emoji,\n          timestamp: reaction.createdAt.toISOString(),\n        })\n        .catch((err) =>\n          logger.warn(\n            { err, messageId, channelId, serverId },\n            'Failed to publish reaction added event',\n          ),\n        );\n\n      return reaction;\n    } catch (err: unknown) {\n      // Prisma unique constraint violation \u2014 P2002\n      if (\n        typeof err === 'object' &&\n        err !== null &&\n        'code' in err &&\n        (err as { code: string }).code === 'P2002'\n      ) {\n        throw new TRPCError({\n          code: 'CONFLICT',\n          message: 'You have already reacted with this emoji',\n        });\n      }\n      throw err;\n    }\n  },\n\n  /**\n   * Remove an emoji reaction from a message.\n   * Only the reaction owner may remove it; throws FORBIDDEN otherwise.\n   *\n   * Uses an atomic delete-first pattern to avoid the TOCTOU race between a\n   * findUnique check and the subsequent delete. If Prisma returns P2025\n   * (record not found), we do a single findFirst to decide FORBIDDEN vs\n   * NOT_FOUND.\n   */\n  async removeReaction(input: RemoveReactionInput) {\n    const { messageId, channelId, userId, emoji, serverId } = input;\n\n    const message = await requireMessageInChannel(messageId, channelId, serverId);\n\n    try {\n      // Attempt delete atomically \u2014 no separate pre-check needed\n      await reactionRepository.delete(messageId, userId, emoji);\n    } catch (err: unknown) {\n      // P2025: the caller's reaction did not exist\n      if (\n        typeof err === 'object' &&\n        err !== null &&\n        'code' in err &&\n        (err as { code: string }).code === 'P2025'\n      ) {\n        // Distinguish: does this emoji exist on the message for someone else?\n        const anyReaction = await reactionRepository.findFirst({ messageId, emoji });\n        if (anyReaction) {\n          throw new TRPCError({\n            code: 'FORBIDDEN',\n            message: 'You can only remove your own reactions',\n          });\n        }\n        throw new TRPCError({ code: 'NOT_FOUND', message: 'Reaction not found' });\n      }\n      throw err;\n    }\n\n    cacheService\n      .invalidatePattern(reactionCacheKey(serverId, messageId))\n      .catch((err) =>\n        logger.warn(\n          { err, messageId, serverId },\n          'Failed to invalidate reaction cache after removal',\n        ),\n      );\n\n    eventBus\n      .publish(EventChannels.REACTION_REMOVED, {\n        messageId,\n        channelId: message.channel.id,\n        userId,\n        emoji,\n        timestamp: new Date().toISOString(),\n      })\n      .catch((err) =>\n        logger.warn(\n          { err, messageId, channelId, serverId },\n          'Failed to publish reaction removed event',\n        ),\n      );\n  },\n\n  /**\n   * Return all reactions for a message, grouped by emoji with counts and\n   * the list of user IDs who reacted.\n   * Shape: `{ emoji, count, userIds[] }[]`\n   */\n  async getMessageReactions(input: GetMessageReactionsInput): Promise<ReactionGroup[]> {\n    const { messageId, channelId, serverId } = input;\n\n    await requireMessageInChannel(messageId, channelId, serverId);\n\n    const reactions = await reactionRepository.findByMessageId(messageId);\n\n    // Group by emoji\n    const grouped = new Map<string, string[]>();\n    for (const r of reactions) {\n      const existing = grouped.get(r.emoji);\n      if (existing) {\n        existing.push(r.userId);\n      } else {\n        grouped.set(r.emoji, [r.userId]);\n      }\n    }\n\n    return Array.from(grouped.entries()).map(([emoji, userIds]) => ({\n      emoji,\n      count: userIds.length,\n      userIds,\n    }));\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auditLog.service.ts",
+  "limit": 5
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auditLog.service.ts",
+  "content": "/**\n * AuditLogService (M-B3 sub-module) \u2014 dedicated service for visibility\n * audit log operations.\n *\n * Provides:\n *   - logVisibilityChange  \u2014 create a single audit entry, callable inside\n *     an existing Prisma transaction or standalone.\n *   - getVisibilityAuditLog \u2014 paginated read of audit entries for a channel,\n *     with optional date filtering.\n *\n * Retention policy: records must be kept for a minimum of 7 years per\n * compliance requirements. Automated purge jobs must not delete entries\n * whose `timestamp` falls within the 7-year window.\n */\n\nimport { Prisma, VisibilityAuditLog } from '@prisma/client';\nimport { auditLogRepository } from '../repositories/auditLog.repository';\n\n/** Max characters stored for User-Agent \u2014 matches the @db.VarChar(500) column. */\nconst USER_AGENT_MAX_LEN = 500;\n\n/** Hard cap on `limit` to prevent unbounded queries (matches messageService pattern). */\nconst AUDIT_LOG_MAX_LIMIT = 500;\n\nexport interface LogVisibilityChangeInput {\n  channelId: string;\n  actorId: string;\n  /** JSON snapshot of the old visibility state, e.g. `{ visibility: 'PRIVATE' }` */\n  oldValue: Prisma.InputJsonObject;\n  /** JSON snapshot of the new visibility state, e.g. `{ visibility: 'PUBLIC_INDEXABLE' }` */\n  newValue: Prisma.InputJsonObject;\n  /** Caller's IP address \u2014 stored for compliance (IPv4 or IPv6). */\n  ipAddress: string;\n  /** HTTP User-Agent header value; defaults to empty string if not provided. */\n  userAgent?: string;\n}\n\nexport interface AuditLogPage {\n  entries: VisibilityAuditLog[];\n  /** Total number of matching records (before pagination). */\n  total: number;\n}\n\nexport interface GetAuditLogOptions {\n  /** Maximum number of entries to return (default: 20). */\n  limit?: number;\n  /** Number of entries to skip (default: 0). */\n  offset?: number;\n  /** If provided, only entries at or after this timestamp are returned. */\n  startDate?: Date;\n}\n\nexport const auditLogService = {\n  /**\n   * Record a VISIBILITY_CHANGED audit event.\n   *\n   * Pass `tx` to run this inside an existing `prisma.$transaction` so the\n   * insert is part of the same atomic unit as the channel UPDATE.\n   */\n  async logVisibilityChange(\n    input: LogVisibilityChangeInput,\n    tx?: Prisma.TransactionClient,\n  ): Promise<VisibilityAuditLog> {\n    return auditLogRepository.create(\n      {\n        channel: { connect: { id: input.channelId } },\n        actor: { connect: { id: input.actorId } },\n        action: 'VISIBILITY_CHANGED',\n        oldValue: input.oldValue,\n        newValue: input.newValue,\n        ipAddress: input.ipAddress,\n        userAgent: (input.userAgent ?? '').slice(0, USER_AGENT_MAX_LEN),\n      },\n      tx,\n    );\n  },\n\n  /**\n   * Retrieve paginated audit log entries for a channel.\n   *\n   * Results are ordered by `timestamp DESC` (most recent first).\n   * Returns both the page of entries and the total count for cursor/offset UI.\n   */\n  async getVisibilityAuditLog(\n    channelId: string,\n    options: GetAuditLogOptions = {},\n  ): Promise<AuditLogPage> {\n    const { limit, offset, startDate } = options;\n    const clampedLimit = Math.min(Math.max(1, limit ?? 20), AUDIT_LOG_MAX_LIMIT);\n    const safeOffset = Math.max(0, Math.floor(offset ?? 0));\n\n    const where: Prisma.VisibilityAuditLogWhereInput = {\n      channelId,\n      ...(startDate !== undefined && { timestamp: { gte: startDate } }),\n    };\n\n    const [entries, total] = await Promise.all([\n      auditLogRepository.findMany(where, safeOffset, clampedLimit),\n      auditLogRepository.count(where),\n    ]);\n\n    return { entries, total };\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/attachment.service.ts",
+  "limit": 5
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/attachment.service.ts",
+  "content": "import { attachmentRepository } from '../repositories/attachment.repository';\n\n// \u2500\u2500\u2500 Validation constants \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nexport const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25 MB\n\n/**\n * Whitelist of accepted MIME types.\n * Add new types here \u2014 rejection is the secure default.\n */\nexport const ALLOWED_CONTENT_TYPES = new Set([\n  // Images\n  'image/jpeg',\n  'image/png',\n  'image/gif',\n  'image/webp',\n  // Documents\n  'application/pdf',\n  'text/plain',\n  // Common office formats\n  'application/msword',\n  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',\n]);\n\n// \u2500\u2500\u2500 Domain errors \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n/**\n * Thrown by validateUpload. Plain Error keeps the service transport-agnostic \u2014\n * REST routes catch and map to 400; tRPC callers can re-throw as TRPCError.\n */\nexport class AttachmentValidationError extends Error {\n  constructor(message: string) {\n    super(message);\n    this.name = 'AttachmentValidationError';\n  }\n}\n\n/**\n * Thrown by listByMessage when the message is not found, is deleted, or\n * belongs to a different server. Plain Error \u2014 callers map to their transport's\n * not-found response (TRPCError NOT_FOUND for tRPC, 404 for REST).\n */\nexport class AttachmentNotFoundError extends Error {\n  constructor(message = 'Message not found') {\n    super(message);\n    this.name = 'AttachmentNotFoundError';\n  }\n}\n\n// \u2500\u2500\u2500 Service \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nexport const attachmentService = {\n  /**\n   * Validate that a file upload is within accepted type and size limits.\n   * Throws AttachmentValidationError on failure.\n   */\n  validateUpload(contentType: string, sizeBytes: number): void {\n    if (!ALLOWED_CONTENT_TYPES.has(contentType)) {\n      throw new AttachmentValidationError(`Unsupported content type: ${contentType}`);\n    }\n    if (sizeBytes > MAX_FILE_SIZE_BYTES) {\n      throw new AttachmentValidationError(\n        `File exceeds the 25 MB limit (received ${sizeBytes} bytes)`,\n      );\n    }\n  },\n\n  /**\n   * Return all attachments for a given message, scoped to a server.\n   * Verifies the message belongs to the given server to prevent cross-server\n   * probing (a caller with message:read on server A cannot fetch attachments\n   * from a message in server B by passing server A's ID).\n   *\n   * Throws AttachmentNotFoundError (a plain Error) so this service stays\n   * transport-agnostic. The tRPC router maps it to TRPCError NOT_FOUND.\n   */\n  async listByMessage(messageId: string, serverId: string) {\n    const message = await attachmentRepository.findMessageForAttachmentList(messageId);\n\n    if (!message || message.isDeleted) {\n      throw new AttachmentNotFoundError();\n    }\n\n    // Collapse ownership mismatch to the same error as not-found to prevent\n    // callers from probing message IDs across servers.\n    if (message.channel.serverId !== serverId) {\n      throw new AttachmentNotFoundError();\n    }\n\n    return attachmentRepository.findByMessageId(messageId);\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/serverMember.service.ts",
+  "limit": 5
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/serverMember.service.ts",
+  "content": "import { Prisma, RoleType, ServerMember } from '@prisma/client';\nimport { TRPCError } from '@trpc/server';\nimport { prisma } from '../db/prisma';\nimport { eventBus, EventChannels } from '../events/eventBus';\nimport { serverRepository } from '../repositories/server.repository';\nimport { serverMemberRepository } from '../repositories/serverMember.repository';\n\nexport interface ServerMemberWithUser {\n  userId: string;\n  serverId: string;\n  role: RoleType;\n  joinedAt: Date;\n  user: {\n    id: string;\n    username: string;\n    displayName: string;\n    avatarUrl: string | null;\n  };\n}\n\n/** Role hierarchy \u2014 lower index = higher privilege. */\nconst ROLE_HIERARCHY: RoleType[] = ['OWNER', 'ADMIN', 'MODERATOR', 'MEMBER', 'GUEST'];\n\nfunction roleRank(role: RoleType): number {\n  return ROLE_HIERARCHY.indexOf(role);\n}\n\nexport const serverMemberService = {\n  /**\n   * Add the server owner as an OWNER member. Called when a server is created.\n   */\n  async addOwner(userId: string, serverId: string): Promise<ServerMember> {\n    return prisma.$transaction(async (tx) => {\n      const member = await serverMemberRepository.create(\n        { userId, serverId, role: 'OWNER' },\n        tx,\n      );\n      await serverRepository.update(serverId, { memberCount: { increment: 1 } }, tx);\n      return member;\n    });\n  },\n\n  /**\n   * Join a server as a MEMBER (default role).\n   * Throws CONFLICT if already a member. Rejects private servers.\n   */\n  async joinServer(userId: string, serverId: string): Promise<ServerMember> {\n    const server = await serverRepository.findById(serverId);\n    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n    if (!server.isPublic) {\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'This server is private' });\n    }\n\n    try {\n      const member = await prisma.$transaction(async (tx) => {\n        const created = await serverMemberRepository.create(\n          { userId, serverId, role: 'MEMBER' },\n          tx,\n        );\n        await serverRepository.update(serverId, { memberCount: { increment: 1 } }, tx);\n        return created;\n      });\n\n      void eventBus.publish(EventChannels.MEMBER_JOINED, {\n        userId,\n        serverId,\n        role: 'MEMBER' as RoleType,\n        timestamp: new Date().toISOString(),\n      });\n\n      return member;\n    } catch (err) {\n      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {\n        throw new TRPCError({ code: 'CONFLICT', message: 'Already a member of this server' });\n      }\n      throw err;\n    }\n  },\n\n  /**\n   * Leave a server. Owners cannot leave \u2014 they must transfer ownership or delete.\n   */\n  async leaveServer(userId: string, serverId: string): Promise<void> {\n    const membership = await serverMemberRepository.findByUserAndServer(userId, serverId);\n    if (!membership) throw new TRPCError({ code: 'NOT_FOUND', message: 'Not a member of this server' });\n    if (membership.role === 'OWNER') {\n      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Server owner cannot leave. Transfer ownership or delete the server.' });\n    }\n\n    await prisma.$transaction(async (tx) => {\n      await serverMemberRepository.delete(userId, serverId, tx);\n      await serverRepository.update(serverId, { memberCount: { decrement: 1 } }, tx);\n    });\n\n    void eventBus.publish(EventChannels.MEMBER_LEFT, {\n      userId,\n      serverId,\n      reason: 'LEFT',\n      timestamp: new Date().toISOString(),\n    });\n  },\n\n  /**\n   * List all members of a server with user profile info.\n   * Sorted by role hierarchy (OWNER first) then join date.\n   */\n  async getServerMembers(serverId: string): Promise<ServerMemberWithUser[]> {\n    const server = await serverRepository.findByIdSelect(serverId, { id: true });\n    if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n\n    const members = await serverMemberRepository.findByServerId(serverId);\n\n    // Sort by role hierarchy (Prisma enum ordering is alphabetical, not semantic)\n    return members.sort((a, b) => roleRank(a.role) - roleRank(b.role));\n  },\n\n  /**\n   * Change a member's role. Only ADMIN+ can change roles, and only for members\n   * with lower privilege than the actor. Cannot change OWNER role.\n   */\n  async changeRole(\n    targetUserId: string,\n    serverId: string,\n    newRole: RoleType,\n    actorId: string,\n  ): Promise<ServerMember> {\n    if (newRole === 'OWNER') {\n      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot assign OWNER role. Use ownership transfer.' });\n    }\n\n    const [actorMembership, targetMembership] = await Promise.all([\n      serverMemberRepository.findByUserAndServer(actorId, serverId),\n      serverMemberRepository.findByUserAndServer(targetUserId, serverId),\n    ]);\n\n    if (!actorMembership) throw new TRPCError({ code: 'FORBIDDEN', message: 'You are not a member of this server' });\n    if (!targetMembership) throw new TRPCError({ code: 'NOT_FOUND', message: 'Target user is not a member of this server' });\n    if (targetMembership.role === 'OWNER') {\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot change the role of the server owner' });\n    }\n\n    // Actor must outrank the target's current role and the new role\n    if (roleRank(actorMembership.role) >= roleRank(targetMembership.role)) {\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot change role of a member with equal or higher privilege' });\n    }\n    if (roleRank(actorMembership.role) >= roleRank(newRole)) {\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot assign a role equal to or higher than your own' });\n    }\n\n    return serverMemberRepository.update(targetUserId, serverId, newRole);\n  },\n\n  /**\n   * Remove a member from the server. Actor must outrank the target.\n   * Cannot kick the owner.\n   */\n  async removeMember(targetUserId: string, serverId: string, actorId: string): Promise<void> {\n    const [actorMembership, targetMembership] = await Promise.all([\n      serverMemberRepository.findByUserAndServer(actorId, serverId),\n      serverMemberRepository.findByUserAndServer(targetUserId, serverId),\n    ]);\n\n    if (!actorMembership) throw new TRPCError({ code: 'FORBIDDEN', message: 'You are not a member of this server' });\n    if (!targetMembership) throw new TRPCError({ code: 'NOT_FOUND', message: 'Target user is not a member of this server' });\n    if (targetMembership.role === 'OWNER') {\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot remove the server owner' });\n    }\n    if (roleRank(actorMembership.role) >= roleRank(targetMembership.role)) {\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot remove a member with equal or higher privilege' });\n    }\n\n    await prisma.$transaction(async (tx) => {\n      await serverMemberRepository.delete(targetUserId, serverId, tx);\n      await serverRepository.update(serverId, { memberCount: { decrement: 1 } }, tx);\n    });\n\n    void eventBus.publish(EventChannels.MEMBER_LEFT, {\n      userId: targetUserId,\n      serverId,\n      reason: 'KICKED',\n      timestamp: new Date().toISOString(),\n    });\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/visibility.service.ts",
+  "limit": 5
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/visibility.service.ts",
+  "content": "/**\n * ChannelVisibilityService (M-B3) \u2014 owns the visibility state machine\n * and audit logging for channel visibility changes.\n *\n * Authorization is handled at the router level via `withPermission`\n * middleware (RBAC from PR #141). This service no longer performs its\n * own permission checks.\n *\n * Per \u00a76.3: the channel UPDATE and audit log INSERT are wrapped in a single\n * Prisma $transaction. After a successful commit, a VISIBILITY_CHANGED event\n * is published fire-and-forget so downstream consumers (CacheInvalidator,\n * IndexingService, MetaTagService) can react without blocking this call.\n */\n\nimport { TRPCError } from '@trpc/server';\nimport { ChannelType, ChannelVisibility } from '@prisma/client';\nimport { prisma } from '../db/prisma';\nimport { eventBus, EventChannels } from '../events/eventBus';\nimport { auditLogService } from './auditLog.service';\nimport { channelRepository } from '../repositories/channel.repository';\n\nexport interface SetVisibilityInput {\n  channelId: string;\n  serverId: string;\n  visibility: ChannelVisibility;\n  actorId: string;\n  ip: string;\n  userAgent?: string;\n}\n\nexport interface VisibilityChangeResult {\n  success: boolean;\n  channelId: string;\n  oldVisibility: ChannelVisibility;\n  newVisibility: ChannelVisibility;\n  /** Null when the request was a no-op (visibility unchanged \u2014 no audit entry created). */\n  auditLogId: string | null;\n}\n\nexport const visibilityService = {\n  /**\n   * Get the current visibility of a channel.\n   *\n   * Validates that the channel belongs to the given server to prevent\n   * cross-server channel probing.\n   */\n  async getVisibility(channelId: string, serverId: string): Promise<ChannelVisibility> {\n    const channel = await channelRepository.findVisibilityAndServerId(channelId);\n    if (!channel || channel.serverId !== serverId) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });\n    }\n    return channel.visibility;\n  },\n\n  /**\n   * Change a channel's visibility.\n   *\n   * Verifies the channel belongs to `serverId` before applying the change,\n   * preventing cross-server authorization bypass. The VOICE type check,\n   * channel UPDATE, and audit log INSERT are all performed inside a single\n   * $transaction to ensure consistency.\n   */\n  async setVisibility(input: SetVisibilityInput): Promise<VisibilityChangeResult> {\n    const { channelId, serverId, visibility, actorId, ip, userAgent = '' } = input;\n\n    // Atomic DB write: read current state inside the transaction to avoid a\n    // race where two concurrent calls record stale oldVisibility.\n    const result = await prisma.$transaction(async (tx) => {\n      const current = await channelRepository.findById(channelId, tx);\n      if (!current || current.serverId !== serverId) {\n        throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });\n      }\n\n      // No-op guard: skip DB write, audit log, and event emission if visibility is unchanged.\n      if (current.visibility === visibility) {\n        return { isNoOp: true as const, oldVisibility: current.visibility };\n      }\n\n      // VOICE channels cannot be made PUBLIC_INDEXABLE\n      if (current.type === ChannelType.VOICE && visibility === ChannelVisibility.PUBLIC_INDEXABLE) {\n        throw new TRPCError({\n          code: 'BAD_REQUEST',\n          message: 'VOICE channels cannot have PUBLIC_INDEXABLE visibility',\n        });\n      }\n\n      const updated = await channelRepository.update(\n        channelId,\n        {\n          visibility,\n          // \u00a76.3: set indexedAt only when transitioning TO PUBLIC_INDEXABLE (not on no-op updates)\n          ...(visibility === ChannelVisibility.PUBLIC_INDEXABLE &&\n            current.visibility !== ChannelVisibility.PUBLIC_INDEXABLE && { indexedAt: new Date() }),\n          // \u00a75.2: clear indexedAt when transitioning TO PRIVATE\n          ...(visibility === ChannelVisibility.PRIVATE &&\n            current.visibility !== ChannelVisibility.PRIVATE && { indexedAt: null }),\n        },\n        tx,\n      );\n\n      const audit = await auditLogService.logVisibilityChange(\n        {\n          channelId,\n          actorId,\n          oldValue: { visibility: current.visibility },\n          newValue: { visibility },\n          ipAddress: ip,\n          userAgent,\n        },\n        tx,\n      );\n\n      return { isNoOp: false as const, updatedChannel: updated, auditEntry: audit, oldVisibility: current.visibility };\n    });\n\n    if (result.isNoOp) {\n      return {\n        success: true,\n        channelId,\n        oldVisibility: result.oldVisibility,\n        newVisibility: visibility,\n        auditLogId: null,\n      };\n    }\n\n    // Publish event after successful commit (fire-and-forget)\n    void eventBus.publish(EventChannels.VISIBILITY_CHANGED, {\n      channelId: result.updatedChannel.id,\n      serverId: result.updatedChannel.serverId,\n      oldVisibility: result.oldVisibility,\n      newVisibility: visibility,\n      actorId,\n      timestamp: new Date().toISOString(),\n    });\n\n    return {\n      success: true,\n      channelId,\n      oldVisibility: result.oldVisibility,\n      newVisibility: visibility,\n      auditLogId: result.auditEntry.id,\n    };\n  },\n};\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/indexing.service.ts",
+  "limit": 5
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/indexing.service.ts",
+  "content": "/**\n * IndexingService \u2014 manages sitemap data for PUBLIC_INDEXABLE channels.\n *\n * Provides:\n *   - addToSitemap(channelId)   \u2014 marks a channel for sitemap inclusion\n *   - removeFromSitemap(channelId) \u2014 removes a channel from sitemap\n *   - generateSitemapIndex() \u2014 builds the sitemap index consumed by the frontend\n *   - generateSitemap(serverSlug)  \u2014 builds XML sitemap for a server\n *\n * Listens to VISIBILITY_CHANGED events to keep sitemap data in sync.\n */\n\nimport { cacheService, sanitizeKeySegment } from './cache.service';\nimport type { VisibilityChangedPayload } from '../events/eventTypes';\nimport { channelRepository } from '../repositories/channel.repository';\nimport { serverRepository } from '../repositories/server.repository';\n\nconst SITEMAP_CACHE_TTL = 300; // 5 minutes\nconst BASE_URL = process.env.BASE_URL ?? 'https://harmony.chat';\n\nexport const CacheKeys_Sitemap = {\n  index: 'sitemap:index',\n  serverSitemap: (serverSlug: string) => `sitemap:${sanitizeKeySegment(serverSlug)}`,\n};\n\nexport const indexingService = {\n  /**\n   * Generate the sitemap index consumed by the frontend apex-domain route\n   * handler. The backend remains the XML producer, while the frontend owns the\n   * crawler-facing hostname in production.\n   */\n  async generateSitemapIndex(): Promise<string> {\n    return cacheService.getOrRevalidate(\n      CacheKeys_Sitemap.index,\n      async () => {\n        const servers = await serverRepository.findPublicBySlugSelect();\n        return buildSitemapIndexXml(servers.map((server) => server.slug));\n      },\n      { ttl: SITEMAP_CACHE_TTL },\n    );\n  },\n\n  /**\n   * Invalidate the sitemap cache for the channel's server so the channel\n   * appears in the next generated sitemap.\n   */\n  async addToSitemap(channelId: string): Promise<void> {\n    const channel = await channelRepository.findForSitemap(channelId);\n    if (!channel) return;\n\n    await cacheService.invalidate(CacheKeys_Sitemap.serverSitemap(channel.server.slug));\n  },\n\n  /**\n   * Remove a channel from the sitemap. Clears indexed_at and invalidates\n   * the cached sitemap so the channel no longer appears on next generation.\n   */\n  async removeFromSitemap(channelId: string): Promise<void> {\n    const channel = await channelRepository.findForSitemap(channelId);\n    if (!channel) return;\n\n    await channelRepository.update(channelId, { indexedAt: null });\n\n    await cacheService.invalidate(CacheKeys_Sitemap.serverSitemap(channel.server.slug));\n  },\n\n  /**\n   * Generate a sitemap XML string for all PUBLIC_INDEXABLE channels in a server.\n   * Uses stale-while-revalidate caching via getOrRevalidate.\n   */\n  async generateSitemap(serverSlug: string): Promise<string | null> {\n    const server = await serverRepository.findBySlug(serverSlug);\n\n    if (!server) return null;\n\n    const cacheKey = CacheKeys_Sitemap.serverSitemap(serverSlug);\n\n    return cacheService.getOrRevalidate(\n      cacheKey,\n      async () => {\n        const channels = await channelRepository.findPublicIndexableByServerId(server.id);\n        return buildSitemapXml(server.slug, channels);\n      },\n      { ttl: SITEMAP_CACHE_TTL },\n    );\n  },\n\n  /**\n   * Handle a visibility change event \u2014 update sitemap accordingly.\n   */\n  async onVisibilityChanged(\n    payload: Pick<VisibilityChangedPayload, 'channelId' | 'oldVisibility' | 'newVisibility'>,\n  ): Promise<void> {\n    if (payload.newVisibility === 'PUBLIC_INDEXABLE') {\n      await this.addToSitemap(payload.channelId);\n    } else if (payload.oldVisibility === 'PUBLIC_INDEXABLE') {\n      await this.removeFromSitemap(payload.channelId);\n    }\n  },\n};\n\nfunction buildSitemapXml(\n  serverSlug: string,\n  channels: { slug: string; updatedAt: Date }[],\n): string {\n  const urls = channels\n    .map(\n      (ch) =>\n        `  <url>\\n    <loc>${escapeXml(BASE_URL)}/c/${encodeURIComponent(serverSlug)}/${encodeURIComponent(ch.slug)}</loc>\\n    <lastmod>${ch.updatedAt.toISOString()}</lastmod>\\n    <changefreq>daily</changefreq>\\n    <priority>0.7</priority>\\n  </url>`,\n    )\n    .join('\\n');\n\n  return `<?xml version=\"1.0\" encoding=\"UTF-8\"?>\\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\\n${urls}\\n</urlset>`;\n}\n\nfunction buildSitemapIndexXml(serverSlugs: string[]): string {\n  const sitemaps = serverSlugs\n    .map(\n      (serverSlug) =>\n        `  <sitemap>\\n    <loc>${escapeXml(BASE_URL)}/sitemap/${encodeURIComponent(serverSlug)}</loc>\\n  </sitemap>`,\n    )\n    .join('\\n');\n\n  return `<?xml version=\"1.0\" encoding=\"UTF-8\"?>\\n<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\\n${sitemaps}\\n</sitemapindex>`;\n}\n\nfunction escapeXml(str: string): string {\n  return str\n    .replace(/&/g, '&amp;')\n    .replace(/</g, '&lt;')\n    .replace(/>/g, '&gt;')\n    .replace(/\"/g, '&quot;')\n    .replace(/'/g, '&apos;');\n}\n"
+}
+```
+
+## Assistant
+
+Now let's do a TypeScript build check to see if there are any errors:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npx tsc --noEmit 2>&1",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+TypeScript errors because Prisma's checked `CreateInput` requires relation objects. Need to use `UncheckedCreateInput` for scalar ID forms. Let me fix the affected repositories:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/serverMember.repository.ts",
+  "old_string": "  create(data: Prisma.ServerMemberCreateInput, client: Client = prisma) {\n    return client.serverMember.create({ data });\n  },\n\n  upsert(\n    where: Prisma.ServerMemberWhereUniqueInput,\n    update: Prisma.ServerMemberUpdateInput,\n    create: Prisma.ServerMemberCreateInput,\n    client: Client = prisma,\n  ) {\n    return client.serverMember.upsert({ where, update, create });\n  },",
+  "new_string": "  create(data: Prisma.ServerMemberUncheckedCreateInput, client: Client = prisma) {\n    return client.serverMember.create({ data });\n  },\n\n  upsert(\n    where: Prisma.ServerMemberWhereUniqueInput,\n    update: Prisma.ServerMemberUpdateInput,\n    create: Prisma.ServerMemberUncheckedCreateInput,\n    client: Client = prisma,\n  ) {\n    return client.serverMember.upsert({ where, update, create });\n  },"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/channel.repository.ts",
+  "old_string": "  create(data: Prisma.ChannelCreateInput, client: Client = prisma) {\n    return client.channel.create({ data });\n  },",
+  "new_string": "  create(data: Prisma.ChannelUncheckedCreateInput, client: Client = prisma) {\n    return client.channel.create({ data });\n  },"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/server.repository.ts",
+  "old_string": "  create(data: Prisma.ServerCreateInput, client: Client = prisma) {\n    return client.server.create({ data });\n  },",
+  "new_string": "  create(data: Prisma.ServerUncheckedCreateInput, client: Client = prisma) {\n    return client.server.create({ data });\n  },"
+}
+```
+
+## Assistant
+
+Now update auth.service.ts `ensureAdminUser` to fix the upsert call:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auth.service.ts",
+  "old_string": "  for (const server of allServers) {\n    await serverMemberRepository.upsert(\n      { userId_serverId: { userId: admin.id, serverId: server.id } },\n      { role: 'OWNER' },\n      { userId: admin.id, serverId: server.id, role: 'OWNER' },\n    );\n  }",
+  "new_string": "  for (const server of allServers) {\n    await serverMemberRepository.upsert(\n      { userId_serverId: { userId: admin.id, serverId: server.id } },\n      { role: 'OWNER' },\n      { userId: admin.id, serverId: server.id, role: 'OWNER' } as { userId: string; serverId: string; role: string },\n    );\n  }"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npx tsc --noEmit 2>&1",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auth.service.ts",
+  "old_string": "      { userId: admin.id, serverId: server.id, role: 'OWNER' } as { userId: string; serverId: string; role: string },",
+  "new_string": "      { userId: admin.id, serverId: server.id, role: 'OWNER' as const },"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npx tsc --noEmit 2>&1",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+TypeScript compiles clean. Now let's run the tests:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test 2>&1 | tail -80",
+  "timeout": 120000
+}
+```
+
+## Assistant
+
+Two test failures to fix:
+
+1. `serverMember.findByUserIdWithServer` needs a `take` param
+2. `refreshToken.create` needs to use unchecked input (scalar `userId`)
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/serverMember.repository.ts",
+  "old_string": "  findByUserIdWithServer(userId: string, client: Client = prisma) {\n    return client.serverMember.findMany({\n      where: { userId },\n      include: { server: true },\n      orderBy: { joinedAt: 'asc' },\n    });\n  },",
+  "new_string": "  findByUserIdWithServer(userId: string, take?: number, client: Client = prisma) {\n    return client.serverMember.findMany({\n      where: { userId },\n      include: { server: true },\n      orderBy: { joinedAt: 'asc' },\n      ...(take !== undefined && { take }),\n    });\n  },"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/server.service.ts",
+  "old_string": "  /** Returns only the servers the given user is a member of. */\n  async getMemberServers(userId: string, limit = 50): Promise<Server[]> {\n    const memberships = await serverMemberRepository.findByUserIdWithServer(userId);\n    return memberships.slice(0, Math.min(limit, 100)).map((m) => m.server);\n  },",
+  "new_string": "  /** Returns only the servers the given user is a member of. */\n  async getMemberServers(userId: string, limit = 50): Promise<Server[]> {\n    const memberships = await serverMemberRepository.findByUserIdWithServer(userId, Math.min(limit, 100));\n    return memberships.map((m) => m.server);\n  },"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/refreshToken.repository.ts",
+  "old_string": "  create(data: Prisma.RefreshTokenCreateInput, client: Client = prisma) {\n    return client.refreshToken.create({ data });\n  },",
+  "new_string": "  create(data: Prisma.RefreshTokenUncheckedCreateInput, client: Client = prisma) {\n    return client.refreshToken.create({ data });\n  },"
+}
+```
+
+## Assistant
+
+Now update auth.service.ts `storeRefreshToken` to use scalar `userId`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auth.service.ts",
+  "old_string": "  await refreshTokenRepository.create({\n    tokenHash: hashToken(rawToken),\n    user: { connect: { id: userId } },\n    expiresAt,\n  });",
+  "new_string": "  await refreshTokenRepository.create({\n    tokenHash: hashToken(rawToken),\n    userId,\n    expiresAt,\n  });"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test 2>&1 | tail -30",
+  "timeout": 120000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test 2>&1 | grep -A 30 \"indexing.service.test.ts\"",
+  "timeout": 120000
+}
+```
+
+## Assistant
+
+Let me look at the indexing test to understand what's happening:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/indexing.service.test.ts",
+  "limit": 120
+}
+```
+
+## Assistant
+
+Let me verify if these indexing tests were passing on main before my changes:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git stash && npm run test:backend -- tests/indexing.service.test.ts 2>&1 | tail -20",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+I stashed my changes to check if the indexing test was already failing on main. Let me wait for the result and restore:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /private/tmp/claude-501/-Users-bigfa-Documents-GitHub-Harmony/c477791c-9a77-4535-8b26-56857c2a1db0/tasks/bk1g0k41m.output 2>/dev/null | tail -20"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && npm run test:backend -- tests/indexing.service.test.ts 2>&1 | tail -15",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git stash pop"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /private/tmp/claude-501/-Users-bigfa-Documents-GitHub-Harmony/c477791c-9a77-4535-8b26-56857c2a1db0/tasks/bpi16rkz2.output 2>/dev/null | grep -E \"PASS|FAIL|Tests:\" | tail -10"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /private/tmp/claude-501/-Users-bigfa-Documents-GitHub-Harmony/c477791c-9a77-4535-8b26-56857c2a1db0/tasks/bpi16rkz2.output 2>/dev/null | tail -15; echo \"---DONE---\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm run test:backend -- tests/indexing.service.test.ts 2>&1 | tail -15",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npm test -- tests/indexing.service.test.ts 2>&1 | tail -15",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "sleep 20 && cat /private/tmp/claude-501/-Users-bigfa-Documents-GitHub-Harmony/c477791c-9a77-4535-8b26-56857c2a1db0/tasks/b3ogrv2o6.output | tail -20",
+  "timeout": 40000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npx jest tests/indexing.service.test.ts --forceExit 2>&1 | tail -20",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+Let me verify these indexing failures exist on main too (quick check):
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git stash && cd harmony-backend && npx jest tests/indexing.service.test.ts --forceExit 2>&1 | tail -10",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+Pre-existing failure confirmed — same 2 tests fail on `main`. Restoring my changes:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git stash pop"
+}
+```
+
+## Assistant
+
+All test failures are pre-existing (same on `main`). Now let's run the full suite one more time to confirm my branch is at parity:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npm test 2>&1 | tail -10",
+  "timeout": 120000
+}
+```
+
+## Assistant
+
+Only the 2 pre-existing indexing failures. Now let me do a final check to verify no service still directly imports `prisma` for data access:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"import.*prisma.*from.*db/prisma\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/*.ts"
+}
+```
+
+## Assistant
+
+These 3 services import `prisma` only for `prisma.$transaction()` (they own transaction boundaries). Let me verify there are no direct data calls remaining:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"prisma\\.\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/message.service.ts /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/serverMember.service.ts /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/visibility.service.ts"
+}
+```
+
+## Assistant
+
+Only `prisma.$transaction` — no direct data access. Now commit and push:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-backend/src/repositories/ harmony-backend/src/services/"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git commit -m \"$(cat <<'EOF'\nrefactor: introduce repository layer \u2014 centralize Prisma calls out of services (issue #227)\n\nCreates src/repositories/ with one repository per domain entity:\nChannelRepository, MessageRepository, ServerRepository, UserRepository,\nAuditLogRepository, ServerMemberRepository, ReactionRepository,\nAttachmentRepository, RefreshTokenRepository.\n\nAll direct `prisma.*` data-access calls are moved out of services into\nrepository methods. Services retain `prisma.$transaction()` boundaries;\nrepository methods accept an optional `client?: Prisma.TransactionClient`\nparameter so they compose correctly inside transactions. Error handling\n(P2002/P2025) remains in the service layer. Zero behavior changes.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin feature/issue-227-repository-layer"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --repo CS485-Harmony/Harmony --title \"refactor: introduce repository layer \u2014 centralize Prisma calls out of services\" --body \"$(cat <<'EOF'\nCloses #227\n\n## Summary\n\n- Created `src/repositories/` with 9 repository files: `ChannelRepository`, `MessageRepository`, `ServerRepository`, `UserRepository`, `AuditLogRepository`, `ServerMemberRepository`, `ReactionRepository`, `AttachmentRepository`, `RefreshTokenRepository`\n- All direct `prisma.*` data-access calls removed from every service; services now delegate to repository methods\n- Services retain `prisma.$transaction()` boundaries \u2014 repository methods accept optional `client?: Prisma.TransactionClient` to compose inside transactions\n- Error handling (P2002/P2025 catch blocks) and business logic remain in services\n- Zero behavior changes \u2014 pure structural refactor aligning with \u00a76.8 M-D1\n\n## Test plan\n\n- [ ] `npm run test:backend` passes (only pre-existing 2 Redis-cache flaky tests in `indexing.service.test.ts` fail \u2014 confirmed same failures on `main`)\n- [ ] `npx tsc --noEmit` passes clean\n- [ ] No service file directly calls `prisma.model.find/create/update/delete` anymore\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 227 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Complete]**\n\nPR #385 implements the full repository layer.\n\n**What was done:**\n- Created \\`src/repositories/\\` with 9 repository files covering all domains: Channel, Message, Server, User, AuditLog, ServerMember, Reaction, Attachment, RefreshToken\n- Removed all direct \\`prisma.*\\` data-access calls from every service (12 files updated)\n- Repository methods accept optional \\`client?: Prisma.TransactionClient\\` so they compose inside existing \\`prisma.\\$transaction()\\` blocks (services still own transaction boundaries)\n- Error handling (P2002/P2025) and business logic remain in services\n- Zero behavior changes \u2014 pure structural refactor\n\n**Test results:** 635/637 tests pass. The 2 failing tests (\\`indexing.service.test.ts\\`) are pre-existing Redis-cache flakiness that also fails on \\`main\\` \u2014 not introduced by this PR.\""
+}
+```
+
+## Assistant
+
+PR #385 is open at https://github.com/CS485-Harmony/Harmony/pull/385.
+
+**Summary:** Created `src/repositories/` with 9 repository classes (Channel, Message, Server, User, AuditLog, ServerMember, Reaction, Attachment, RefreshToken) and updated all 12 service files to use them. Services no longer call `prisma.*` directly — only `prisma.$transaction()` remains in 3 services that own atomic boundaries. Repository methods accept an optional `client?: Prisma.TransactionClient` to compose inside those transactions. TypeScript clean, 635/637 tests pass (the 2 failures are pre-existing Redis cache flakiness confirmed on `main`).
+
+## User
+
+<local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.</local-command-caveat>
+
+## User
+
+<bash-input>git pull</bash-input>
+
+## User
+
+<bash-stdout>From https://github.com/CS485-Harmony/Harmony
+ * [new branch]      fix/skeleton-misalignment -> origin/fix/skeleton-misalignment
+   9b452a9..3b1069e  main       -> origin/main
+Already up to date.</bash-stdout><bash-stderr></bash-stderr>
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Skill`**
+```json
+{
+  "skill": "export-logs"
+}
+```
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF"
+}
+```
+


### PR DESCRIPTION
Closes #227

## Summary

- Created `src/repositories/` with 9 repository files: `ChannelRepository`, `MessageRepository`, `ServerRepository`, `UserRepository`, `AuditLogRepository`, `ServerMemberRepository`, `ReactionRepository`, `AttachmentRepository`, `RefreshTokenRepository`
- All direct `prisma.*` data-access calls removed from every service; services now delegate to repository methods
- Services retain `prisma.$transaction()` boundaries — repository methods accept optional `client?: Prisma.TransactionClient` to compose inside transactions
- Error handling (P2002/P2025 catch blocks) and business logic remain in services
- Zero behavior changes — pure structural refactor aligning with §6.8 M-D1

## Test plan

- [ ] `npm run test:backend` passes (only pre-existing 2 Redis-cache flaky tests in `indexing.service.test.ts` fail — confirmed same failures on `main`)
- [ ] `npx tsc --noEmit` passes clean
- [ ] No service file directly calls `prisma.model.find/create/update/delete` anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)