### PR TITLE
feat: wire up frontend file attachment upload UI

### DIFF
--- a/harmony-backend/src/trpc/routers/message.router.ts
+++ b/harmony-backend/src/trpc/routers/message.router.ts
@@ -37,7 +37,7 @@ export const messageRouter = router({
       z.object({
         serverId: z.string().uuid(),
         channelId: z.string().uuid(),
-        content: z.string().min(1).max(4000),
+        content: z.string().max(4000),
         attachments: z.array(AttachmentInputSchema).max(10).optional(),
       }),
     )

--- a/harmony-backend/src/trpc/routers/message.router.ts
+++ b/harmony-backend/src/trpc/routers/message.router.ts
@@ -39,7 +39,10 @@ export const messageRouter = router({
         channelId: z.string().uuid(),
         content: z.string().max(4000),
         attachments: z.array(AttachmentInputSchema).max(10).optional(),
-      }),
+      }).refine(
+        data => data.content.trim().length > 0 || (data.attachments?.length ?? 0) > 0,
+        { message: 'Message must have content or at least one attachment.' },
+      ),
     )
     .mutation(({ input, ctx }) =>
       messageService.sendMessage({

--- a/harmony-frontend/src/app/actions/sendMessage.ts
+++ b/harmony-frontend/src/app/actions/sendMessage.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import type { Message } from '@/types';
+import type { Message, AttachmentInput } from '@/types';
 import { sendMessage as sendMessageService } from '@/services/messageService';
 
 /**
@@ -12,6 +12,7 @@ export async function sendMessageAction(
   channelId: string,
   content: string,
   serverId: string,
+  attachments?: AttachmentInput[],
 ): Promise<Message> {
-  return sendMessageService(channelId, content, serverId);
+  return sendMessageService(channelId, content, serverId, attachments);
 }

--- a/harmony-frontend/src/app/api/attachments/upload/route.ts
+++ b/harmony-frontend/src/app/api/attachments/upload/route.ts
@@ -17,6 +17,11 @@ export async function POST(request: NextRequest) {
     body: formData,
   });
 
-  const data = await res.json();
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch {
+    data = { error: 'Upload failed.' };
+  }
   return NextResponse.json(data, { status: res.status });
 }

--- a/harmony-frontend/src/app/api/attachments/upload/route.ts
+++ b/harmony-frontend/src/app/api/attachments/upload/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { getApiBaseUrl } from '@/lib/runtime-config';
+
+export async function POST(request: NextRequest) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('auth_token')?.value;
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const formData = await request.formData();
+
+  const res = await fetch(`${getApiBaseUrl()}/api/attachments/upload`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData,
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/harmony-frontend/src/components/channel/MessageInput.tsx
+++ b/harmony-frontend/src/components/channel/MessageInput.tsx
@@ -118,7 +118,7 @@ export function MessageInput({
 
   const handleSend = useCallback(async () => {
     const trimmed = value.trim();
-    if (!trimmed || isSending || isUploading || isReadOnly) return;
+    if ((!trimmed && !pendingAttachments.length) || isSending || isUploading || isReadOnly) return;
     setIsSending(true);
     setSendError(null);
     try {

--- a/harmony-frontend/src/components/channel/MessageInput.tsx
+++ b/harmony-frontend/src/components/channel/MessageInput.tsx
@@ -1,7 +1,8 @@
 /**
  * Channel Component: MessageInput
  * Message composition bar at the bottom of the channel view.
- * Supports multi-line input, Enter-to-send, character limit, and read-only guest state.
+ * Supports multi-line input, Enter-to-send, character limit, file attachments,
+ * and read-only guest state.
  * Ref: dev-spec-guest-public-channel-view.md — M3, CL-C3
  */
 
@@ -10,7 +11,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { cn } from '@/lib/utils';
 import { sendMessageAction } from '@/app/actions/sendMessage';
-import type { Message } from '@/types';
+import type { Message, AttachmentInput } from '@/types';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -40,13 +41,16 @@ export function MessageInput({
   const [value, setValue] = useState('');
   const [isSending, setIsSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
+  const [pendingAttachments, setPendingAttachments] = useState<AttachmentInput[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // On channel switch: clear draft, clear any send error, and autofocus the
-  // textarea so the user can start typing without clicking the input first
+  // On channel switch: clear draft, clear attachments, clear any send error, and autofocus
   useEffect(() => {
     setValue('');
     setSendError(null);
+    setPendingAttachments([]);
     textareaRef.current?.focus();
   }, [channelId]);
 
@@ -58,23 +62,82 @@ export function MessageInput({
     el.style.height = `${Math.min(el.scrollHeight, 240)}px`;
   }, [value]);
 
+  const handleAttachClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      // Reset the input so selecting the same file again triggers onChange
+      e.target.value = '';
+
+      setIsUploading(true);
+      setSendError(null);
+
+      try {
+        const formData = new FormData();
+        formData.append('file', file);
+
+        const res = await fetch('/api/attachments/upload', {
+          method: 'POST',
+          body: formData,
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          const msg =
+            typeof body?.error === 'string'
+              ? body.error
+              : res.status === 401
+                ? 'You must be logged in to upload files.'
+                : res.status === 413
+                  ? 'File is too large (max 25 MB).'
+                  : 'Upload failed. Unsupported file type or server error.';
+          setSendError(msg);
+          return;
+        }
+
+        const attachment = (await res.json()) as AttachmentInput;
+        setPendingAttachments(prev => [...prev, attachment]);
+      } catch {
+        setSendError('Upload failed. Please try again.');
+      } finally {
+        setIsUploading(false);
+        textareaRef.current?.focus();
+      }
+    },
+    [],
+  );
+
+  const removeAttachment = (index: number) => {
+    setPendingAttachments(prev => prev.filter((_, i) => i !== index));
+  };
+
   const handleSend = useCallback(async () => {
     const trimmed = value.trim();
-    if (!trimmed || isSending || isReadOnly) return;
+    if (!trimmed || isSending || isUploading || isReadOnly) return;
     setIsSending(true);
     setSendError(null);
     try {
-      const msg = await sendMessageAction(channelId, trimmed, serverId);
+      const msg = await sendMessageAction(
+        channelId,
+        trimmed,
+        serverId,
+        pendingAttachments.length ? pendingAttachments : undefined,
+      );
       setValue('');
+      setPendingAttachments([]);
       onMessageSent?.(msg);
     } catch {
       setSendError('Failed to send message. Please try again.');
     } finally {
       setIsSending(false);
-      // Return focus to textarea after send
       textareaRef.current?.focus();
     }
-  }, [value, isSending, isReadOnly, channelId, serverId, onMessageSent]);
+  }, [value, isSending, isUploading, isReadOnly, channelId, serverId, onMessageSent, pendingAttachments]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Enter sends; Shift+Enter inserts a newline
@@ -114,22 +177,75 @@ export function MessageInput({
           {sendError}
         </p>
       )}
+
+      {/* Pending attachment chips */}
+      {pendingAttachments.length > 0 && (
+        <div className='mb-1 flex flex-wrap gap-1 px-1' aria-label='Pending attachments'>
+          {pendingAttachments.map((att, i) => (
+            <span
+              key={`${att.url}-${i}`}
+              className='flex items-center gap-1 rounded bg-[#36393f] px-2 py-1 text-xs text-gray-300'
+            >
+              <svg className='h-3 w-3 flex-shrink-0' viewBox='0 0 24 24' fill='currentColor'>
+                <path d='M16.5 6v11.5c0 2.21-1.79 4-4 4s-4-1.79-4-4V5a2.5 2.5 0 0 1 5 0v10.5c0 .55-.45 1-1 1s-1-.45-1-1V6H10v9.5a2.5 2.5 0 0 0 5 0V5c0-2.21-1.79-4-4-4S7 2.79 7 5v12.5c0 3.04 2.46 5.5 5.5 5.5s5.5-2.46 5.5-5.5V6h-1.5z' />
+              </svg>
+              <span className='max-w-[120px] truncate'>{att.filename}</span>
+              <button
+                type='button'
+                aria-label={`Remove attachment ${att.filename}`}
+                onClick={() => removeAttachment(i)}
+                className='ml-0.5 text-gray-400 hover:text-gray-100'
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
       <div
         className={cn(
           'flex items-end gap-1 rounded-lg bg-[#40444b] px-2 py-2',
           isAtLimit && 'ring-1 ring-red-500/60',
         )}
       >
+        {/* Hidden file input */}
+        <input
+          ref={fileInputRef}
+          type='file'
+          className='hidden'
+          aria-hidden='true'
+          onChange={handleFileChange}
+          accept='image/jpeg,image/png,image/gif,image/webp,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        />
+
         {/* Attachment button */}
         <button
           type='button'
-          title='Attach file (coming soon)'
-          aria-label='Attach file'
-          className='flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-white/10 hover:text-gray-200'
+          title={isUploading ? 'Uploading…' : 'Attach file'}
+          aria-label={isUploading ? 'Uploading file' : 'Attach file'}
+          aria-busy={isUploading}
+          disabled={isUploading || isSending}
+          onClick={handleAttachClick}
+          className='flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-white/10 hover:text-gray-200 disabled:cursor-not-allowed disabled:opacity-50'
         >
-          <svg className='h-5 w-5' viewBox='0 0 24 24' fill='currentColor'>
-            <path d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z' />
-          </svg>
+          {isUploading ? (
+            /* Spinner while uploading */
+            <svg
+              className='h-4 w-4 animate-spin'
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+              strokeWidth={2}
+            >
+              <circle cx='12' cy='12' r='10' strokeOpacity={0.25} />
+              <path d='M12 2a10 10 0 0 1 10 10' />
+            </svg>
+          ) : (
+            <svg className='h-5 w-5' viewBox='0 0 24 24' fill='currentColor'>
+              <path d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z' />
+            </svg>
+          )}
         </button>
 
         {/* Textarea */}

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -17,6 +17,41 @@ import { formatMessageTimestamp, formatTimeOnly } from '@/lib/utils';
 import { pinMessageAction, unpinMessageAction } from '@/app/actions/pinMessage';
 import type { Message, Reaction } from '@/types';
 
+// ─── AttachmentList ───────────────────────────────────────────────────────────
+
+function AttachmentList({ attachments }: { attachments: Message['attachments'] }) {
+  if (!attachments || attachments.length === 0) return null;
+  return (
+    <div className='mt-1.5 flex flex-col gap-2'>
+      {attachments.map(a => {
+        const isImage = a.type?.startsWith('image/');
+        if (isImage) {
+          return (
+            <a key={a.id} href={a.url} target='_blank' rel='noopener noreferrer' className='inline-block max-w-sm'>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={a.url} alt={a.filename} className='max-h-64 rounded-md object-contain' />
+            </a>
+          );
+        }
+        return (
+          <a
+            key={a.id}
+            href={a.url}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='flex items-center gap-1.5 rounded-md border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-blue-400 hover:bg-white/10 hover:text-blue-300 transition-colors w-fit'
+          >
+            <svg className='h-4 w-4 flex-shrink-0' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth={2} aria-hidden='true'>
+              <path d='M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48' />
+            </svg>
+            <span className='truncate max-w-xs'>{a.filename}</span>
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+
 // ─── ReactionList ─────────────────────────────────────────────────────────────
 
 function ReactionList({ reactions, messageId }: { reactions: Reaction[]; messageId: string }) {
@@ -259,6 +294,7 @@ export function MessageItem({
             {message.content}
             {message.editedAt && <span className='ml-1 text-[10px] text-gray-500'>(edited)</span>}
           </p>
+          <AttachmentList attachments={message.attachments} />
           <ReactionList reactions={message.reactions ?? []} messageId={message.id} />
         </div>
       </div>
@@ -300,6 +336,7 @@ export function MessageItem({
         <p className='mt-0.5 whitespace-pre-line text-sm leading-relaxed text-[#dcddde]'>
           {message.content}
         </p>
+        <AttachmentList attachments={message.attachments} />
         <ReactionList reactions={message.reactions ?? []} messageId={message.id} />
       </div>
     </div>

--- a/harmony-frontend/src/services/messageService.ts
+++ b/harmony-frontend/src/services/messageService.ts
@@ -4,12 +4,8 @@
  * References: dev-spec-guest-public-channel-view.md
  */
 
-import { createFrontendLogger } from '@/lib/frontend-logger';
-import type { Message } from '@/types';
+import type { Message, AttachmentInput } from '@/types';
 import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
-import type { AttachmentInput } from '@/types';
-
-const logger = createFrontendLogger({ component: 'message-service' });
 
 // ─── Type adapters ────────────────────────────────────────────────────────────
 
@@ -51,8 +47,11 @@ function toFrontendMessage(raw: Record<string, unknown>, fallbackChannelId = '')
 
 /**
  * Returns a page of messages for a channel.
- * Uses the public REST endpoint for PUBLIC_INDEXABLE channels.
- * Falls back to tRPC for authenticated access (pass options.serverId).
+ *
+ * When serverId is provided (authenticated context), fetches via tRPC so that
+ * responses are always fresh and include attachment data. The public REST
+ * endpoint is ISR-cached and omits attachments, so it is only used for
+ * unauthenticated / SEO access when no serverId is available.
  *
  * Errors propagate to the caller — the UI is responsible for rendering
  * failure state so users can distinguish a fetch error from an empty channel.
@@ -62,42 +61,8 @@ export async function getMessages(
   page = 1,
   options?: { serverId?: string },
 ): Promise<{ messages: Message[]; hasMore: boolean }> {
-  // Try public endpoint first (works for PUBLIC_INDEXABLE channels).
-  // A non-2xx response throws, which we catch only to attempt the tRPC fallback.
-  try {
-    const data = await publicGet<{
-      messages: Record<string, unknown>[];
-      page: number;
-      pageSize: number;
-    }>(`/channels/${encodeURIComponent(channelId)}/messages?page=${page}`);
-
-    // null means HTTP 404 — channel not found on public API. Throw so the catch
-    // block can attempt the tRPC fallback (or re-throw if no serverId).
-    if (data === null)
-      throw new Error(`getMessages: public channel not found for channelId=${channelId}`);
-
-    return {
-      // Public endpoint returns newest-first; populate channelId from param since
-      // the backend select does not include it.
-      messages: data.messages.map(m => toFrontendMessage(m, channelId)),
-      hasMore: data.messages.length >= (data.pageSize ?? 50),
-    };
-  } catch (err) {
-    // Public endpoint unavailable or channel is not PUBLIC_INDEXABLE — try tRPC.
-    logger.warn('Public message fetch failed; falling back to tRPC', {
-      feature: 'message-service',
-      event: 'public_fetch_failed',
-      procedure: 'publicGet',
-      route: '/channels/[channelId]/messages',
-      error: err,
-    });
-    // If serverId is not provided we cannot authenticate, so re-throw.
-    if (!options?.serverId)
-      throw new Error(
-        'getMessages: channel is not publicly accessible and no serverId was provided',
-      );
-
-    // tRPC errors propagate to the caller.
+  // Authenticated path: tRPC returns fresh data and includes attachments.
+  if (options?.serverId) {
     const data = await trpcQuery<{
       messages: Record<string, unknown>[];
       nextCursor?: string;
@@ -108,14 +73,27 @@ export async function getMessages(
     });
     if (data === null)
       throw new Error(`getMessages: tRPC returned no data for channelId=${channelId}`);
-    // tRPC backend returns oldest-first (orderBy createdAt: 'asc'); reverse to
-    // match the public endpoint's newest-first ordering so callers get a
-    // consistent contract regardless of which path was taken.
+    // tRPC returns oldest-first; reverse so callers get newest-first.
     return {
       messages: [...data.messages].reverse().map(m => toFrontendMessage(m, channelId)),
       hasMore: !!data.nextCursor,
     };
   }
+
+  // Unauthenticated path: public REST endpoint (ISR-cached, SEO-friendly).
+  const data = await publicGet<{
+    messages: Record<string, unknown>[];
+    page: number;
+    pageSize: number;
+  }>(`/channels/${encodeURIComponent(channelId)}/messages?page=${page}`);
+
+  if (data === null)
+    throw new Error(`getMessages: public channel not found for channelId=${channelId}`);
+
+  return {
+    messages: data.messages.map(m => toFrontendMessage(m, channelId)),
+    hasMore: data.messages.length >= (data.pageSize ?? 50),
+  };
 }
 
 /**

--- a/harmony-frontend/src/services/messageService.ts
+++ b/harmony-frontend/src/services/messageService.ts
@@ -34,6 +34,16 @@ function toFrontendMessage(raw: Record<string, unknown>, fallbackChannelId = '')
     },
     content: raw.content as string,
     timestamp: (raw.createdAt ?? raw.created_at ?? raw.timestamp) as string,
+    attachments: Array.isArray(raw.attachments)
+      ? (raw.attachments as Array<Record<string, unknown>>).map(a => ({
+          id: a.id as string,
+          messageId: raw.id as string,
+          url: a.url as string,
+          filename: (a.filename ?? '') as string,
+          type: (a.contentType ?? a.type ?? '') as string,
+          size: typeof a.sizeBytes === 'number' ? a.sizeBytes : 0,
+        }))
+      : undefined,
   };
 }
 

--- a/harmony-frontend/src/services/messageService.ts
+++ b/harmony-frontend/src/services/messageService.ts
@@ -7,6 +7,7 @@
 import { createFrontendLogger } from '@/lib/frontend-logger';
 import type { Message } from '@/types';
 import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+import type { AttachmentInput } from '@/types';
 
 const logger = createFrontendLogger({ component: 'message-service' });
 
@@ -114,6 +115,7 @@ export async function sendMessage(
   channelId: string,
   content: string,
   serverId?: string,
+  attachments?: AttachmentInput[],
 ): Promise<Message> {
   if (!serverId) {
     throw new Error('serverId is required for sendMessage');
@@ -122,6 +124,7 @@ export async function sendMessage(
     serverId,
     channelId,
     content,
+    ...(attachments?.length ? { attachments } : {}),
   });
   return toFrontendMessage(data);
 }

--- a/harmony-frontend/src/types/message.ts
+++ b/harmony-frontend/src/types/message.ts
@@ -45,6 +45,14 @@ export interface Attachment {
   size: number;
 }
 
+/** Attachment data returned by the upload endpoint, ready to attach to a message. */
+export interface AttachmentInput {
+  url: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+}
+
 export interface MessageDTO {
   id: string;
   channelId: string;

--- a/llm-logs/2026-04-16-204149-session-0b1db006.md
+++ b/llm-logs/2026-04-16-204149-session-0b1db006.md
@@ -1,0 +1,278 @@
+# Session Log 2026-04-16-204149
+
+## User
+
+<command-message>review</command-message>
+<command-name>/review</command-name>
+<command-args>387 and post approval or request changes</command-args>
+
+## User
+
+You are an expert code reviewer. Follow these steps:
+
+      1. If no PR number is provided in the args, run `gh pr list` to show open PRs
+      2. If a PR number is provided, run `gh pr view <number>` to get PR details
+      3. Run `gh pr diff <number>` to get the diff
+      4. Analyze the changes and provide a thorough code review that includes:
+         - Overview of what the PR does
+         - Analysis of code quality and style
+         - Specific suggestions for improvements
+         - Any potential issues or risks
+
+      Keep your review concise but thorough. Focus on:
+      - Code correctness
+      - Following project conventions
+      - Performance implications
+      - Test coverage
+      - Security considerations
+
+      Format your review with clear sections and bullet points.
+
+      PR number: 387 and post approval or request changes
+
+## Assistant
+
+I'll fetch the PR details and diff for review.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 387 2>&1",
+  "description": "Get PR 387 details"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr diff 387 2>&1",
+  "description": "Get PR 387 diff"
+}
+```
+
+## Assistant
+
+Now let me check the PR review guidelines and look at the existing tests.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /Users/bigfa/Documents/GitHub/Harmony/.github/PR_REVIEW.md 2>&1",
+  "description": "Read PR review guidelines"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr checks 387 2>&1 | head -40",
+  "description": "Check CI status for PR 387"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 386 2>&1 | head -80",
+  "description": "View issue 386 to check acceptance criteria"
+}
+```
+
+## Assistant
+
+Now I have everything I need. Let me post the review.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr review 387 --request-changes --body \"$(cat <<'EOF'\n## PR Review Guidelines Checklist\n\n- [x] **Prioritize Logic over Style** \u2014 Code is DRY and logically sound. The `getMessages` refactor from try/catch fallback to explicit branching is cleaner and intentional.\n- [ ] **Security First** \u2014 One unguarded `res.json()` call in the proxy route (see below).\n- [x] **Architectural Alignment** \u2014 Proxy pattern for httpOnly cookie forwarding is the correct approach; tRPC mutation extension follows existing patterns.\n- [x] **Issue Completion** \u2014 All five acceptance criteria from #386 are satisfied.\n- [x] **No Nitpicking** \u2014 Only critical logic and correctness issues raised.\n- [x] **Avoid Repetition** \u2014 First review on this PR.\n- [x] **Iterative Reviews** \u2014 N/A (first review).\n- [x] **Prevent CI Failures** \u2014 All 6 CI checks pass. TypeScript compiles cleanly.\n\n---\n\n## Review\n\nThe overall implementation is solid \u2014 the proxy pattern, state management, and UX flow are all well-reasoned. Two issues need to be addressed before merge.\n\n### Issue 1 \u2014 Unguarded `res.json()` in proxy route (Bug)\n\n**`harmony-frontend/src/app/api/attachments/upload/route.ts`, line 17:**\n\n```ts\nconst data = await res.json();\nreturn NextResponse.json(data, { status: res.status });\n```\n\nIf the Express backend (or an intermediary like nginx) returns a non-JSON body \u2014 for example a plain-text `413 Request Entity Too Large` from nginx before the request reaches Express \u2014 `res.json()` throws, which propagates as an unhandled 500 to the client. The client-side error handler in `MessageInput` then shows \"Upload failed. Please try again.\" instead of the more helpful \"File is too large\" message.\n\nFix:\n\n```ts\nlet data: unknown;\ntry {\n  data = await res.json();\n} catch {\n  data = { error: 'Upload failed.' };\n}\nreturn NextResponse.json(data, { status: res.status });\n```\n\n### Issue 2 \u2014 Server-side validation gap after removing `content: z.string().min(1)` (Logic)\n\n**`harmony-backend/src/trpc/routers/message.router.ts`, line 40:**\n\n```ts\n- content: z.string().min(1).max(4000),\n+ content: z.string().max(4000),\n```\n\nRemoving `min(1)` is required to support attachment-only messages \u2014 correct. However, the schema now accepts `{ content: \"\", attachments: undefined }` (empty message, no attachments), which the frontend guards against in `handleSend` but the backend does not. A malformed or replayed request could create a blank message with no attachments.\n\nAdd a `.superRefine` or a `.refine` to enforce that at least one of `content` or `attachments` is non-empty at the schema level:\n\n```ts\nz.object({\n  serverId: z.string().uuid(),\n  channelId: z.string().uuid(),\n  content: z.string().max(4000),\n  attachments: z.array(AttachmentInputSchema).max(10).optional(),\n}).refine(\n  data => data.content.trim().length > 0 || (data.attachments?.length ?? 0) > 0,\n  { message: 'Message must have content or at least one attachment.' },\n)\n```\n\n---\n\nBoth issues are straightforward fixes. Everything else \u2014 the `AttachmentList` component, chip UI, channel-switch clearing, spinner state, and `getMessages` branching refactor \u2014 looks correct and well-implemented.\nEOF\n)\"\n",
+  "description": "Post review requesting changes on PR 387"
+}
+```
+
+## Assistant
+
+Review posted requesting changes. Two issues flagged:
+
+1. **Unguarded `res.json()` in the proxy route** — if the backend or nginx returns a non-JSON 413, the call throws and the client gets a generic 500 instead of the meaningful "file too large" error message.
+
+2. **Missing server-side validation** — removing `content: z.string().min(1)` opens a gap where a blank message with no attachments passes schema validation. A `.refine()` check ensuring either `content` or `attachments` is non-empty would close it.
+
+Everything else is solid — CI passes, all five acceptance criteria from #386 are met, and the proxy pattern/UX implementation is well done.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "DATE=$(date +%Y-%m-%d)\nTIME=$(date +%H%M%S)\nSESSION_ID=\"0b1db006-f016-42d2-9f7b-090a7dfdce0d\"\nSHORT_ID=\"${SESSION_ID:0:8}\"\nOUTFILE=\"llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md\"\necho \"OUTFILE=$OUTFILE\"\necho \"DATE=$DATE\"\necho \"TIME=$TIME\"\necho \"SHORT_ID=$SHORT_ID\"",
+  "description": "Determine output filename"
+}
+```
+

--- a/llm-logs/2026-04-16-205200-session-0b1db006.md
+++ b/llm-logs/2026-04-16-205200-session-0b1db006.md
@@ -1,0 +1,525 @@
+# Session Log 2026-04-16-205200
+
+## User
+
+<command-message>review</command-message>
+<command-name>/review</command-name>
+<command-args>387 and post approval or request changes</command-args>
+
+## User
+
+You are an expert code reviewer. Follow these steps:
+
+      1. If no PR number is provided in the args, run `gh pr list` to show open PRs
+      2. If a PR number is provided, run `gh pr view <number>` to get PR details
+      3. Run `gh pr diff <number>` to get the diff
+      4. Analyze the changes and provide a thorough code review that includes:
+         - Overview of what the PR does
+         - Analysis of code quality and style
+         - Specific suggestions for improvements
+         - Any potential issues or risks
+
+      Keep your review concise but thorough. Focus on:
+      - Code correctness
+      - Following project conventions
+      - Performance implications
+      - Test coverage
+      - Security considerations
+
+      Format your review with clear sections and bullet points.
+
+      PR number: 387 and post approval or request changes
+
+## Assistant
+
+I'll fetch the PR details and diff for review.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 387 2>&1",
+  "description": "Get PR 387 details"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr diff 387 2>&1",
+  "description": "Get PR 387 diff"
+}
+```
+
+## Assistant
+
+Now let me check the PR review guidelines and look at the existing tests.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /Users/bigfa/Documents/GitHub/Harmony/.github/PR_REVIEW.md 2>&1",
+  "description": "Read PR review guidelines"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr checks 387 2>&1 | head -40",
+  "description": "Check CI status for PR 387"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 386 2>&1 | head -80",
+  "description": "View issue 386 to check acceptance criteria"
+}
+```
+
+## Assistant
+
+Now I have everything I need. Let me post the review.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr review 387 --request-changes --body \"$(cat <<'EOF'\n## PR Review Guidelines Checklist\n\n- [x] **Prioritize Logic over Style** \u2014 Code is DRY and logically sound. The `getMessages` refactor from try/catch fallback to explicit branching is cleaner and intentional.\n- [ ] **Security First** \u2014 One unguarded `res.json()` call in the proxy route (see below).\n- [x] **Architectural Alignment** \u2014 Proxy pattern for httpOnly cookie forwarding is the correct approach; tRPC mutation extension follows existing patterns.\n- [x] **Issue Completion** \u2014 All five acceptance criteria from #386 are satisfied.\n- [x] **No Nitpicking** \u2014 Only critical logic and correctness issues raised.\n- [x] **Avoid Repetition** \u2014 First review on this PR.\n- [x] **Iterative Reviews** \u2014 N/A (first review).\n- [x] **Prevent CI Failures** \u2014 All 6 CI checks pass. TypeScript compiles cleanly.\n\n---\n\n## Review\n\nThe overall implementation is solid \u2014 the proxy pattern, state management, and UX flow are all well-reasoned. Two issues need to be addressed before merge.\n\n### Issue 1 \u2014 Unguarded `res.json()` in proxy route (Bug)\n\n**`harmony-frontend/src/app/api/attachments/upload/route.ts`, line 17:**\n\n```ts\nconst data = await res.json();\nreturn NextResponse.json(data, { status: res.status });\n```\n\nIf the Express backend (or an intermediary like nginx) returns a non-JSON body \u2014 for example a plain-text `413 Request Entity Too Large` from nginx before the request reaches Express \u2014 `res.json()` throws, which propagates as an unhandled 500 to the client. The client-side error handler in `MessageInput` then shows \"Upload failed. Please try again.\" instead of the more helpful \"File is too large\" message.\n\nFix:\n\n```ts\nlet data: unknown;\ntry {\n  data = await res.json();\n} catch {\n  data = { error: 'Upload failed.' };\n}\nreturn NextResponse.json(data, { status: res.status });\n```\n\n### Issue 2 \u2014 Server-side validation gap after removing `content: z.string().min(1)` (Logic)\n\n**`harmony-backend/src/trpc/routers/message.router.ts`, line 40:**\n\n```ts\n- content: z.string().min(1).max(4000),\n+ content: z.string().max(4000),\n```\n\nRemoving `min(1)` is required to support attachment-only messages \u2014 correct. However, the schema now accepts `{ content: \"\", attachments: undefined }` (empty message, no attachments), which the frontend guards against in `handleSend` but the backend does not. A malformed or replayed request could create a blank message with no attachments.\n\nAdd a `.superRefine` or a `.refine` to enforce that at least one of `content` or `attachments` is non-empty at the schema level:\n\n```ts\nz.object({\n  serverId: z.string().uuid(),\n  channelId: z.string().uuid(),\n  content: z.string().max(4000),\n  attachments: z.array(AttachmentInputSchema).max(10).optional(),\n}).refine(\n  data => data.content.trim().length > 0 || (data.attachments?.length ?? 0) > 0,\n  { message: 'Message must have content or at least one attachment.' },\n)\n```\n\n---\n\nBoth issues are straightforward fixes. Everything else \u2014 the `AttachmentList` component, chip UI, channel-switch clearing, spinner state, and `getMessages` branching refactor \u2014 looks correct and well-implemented.\nEOF\n)\"\n",
+  "description": "Post review requesting changes on PR 387"
+}
+```
+
+## Assistant
+
+Review posted requesting changes. Two issues flagged:
+
+1. **Unguarded `res.json()` in the proxy route** — if the backend or nginx returns a non-JSON 413, the call throws and the client gets a generic 500 instead of the meaningful "file too large" error message.
+
+2. **Missing server-side validation** — removing `content: z.string().min(1)` opens a gap where a blank message with no attachments passes schema validation. A `.refine()` check ensuring either `content` or `attachments` is non-empty would close it.
+
+Everything else is solid — CI passes, all five acceptance criteria from #386 are met, and the proxy pattern/UX implementation is well done.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "DATE=$(date +%Y-%m-%d)\nTIME=$(date +%H%M%S)\nSESSION_ID=\"0b1db006-f016-42d2-9f7b-090a7dfdce0d\"\nSHORT_ID=\"${SESSION_ID:0:8}\"\nOUTFILE=\"llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md\"\necho \"OUTFILE=$OUTFILE\"\necho \"DATE=$DATE\"\necho \"TIME=$TIME\"\necho \"SHORT_ID=$SHORT_ID\"",
+  "description": "Determine output filename"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - \"/Users/bigfa/.claude/projects/-Users-bigfa-Documents-GitHub-Harmony/0b1db006-f016-42d2-9f7b-090a7dfdce0d.jsonl\" \"llm-logs/2026-04-16-204149-session-0b1db006.md\" \"2026-04-16\" \"204149\" \"0b1db006\" <<'PYEOF'\nimport sys, json\n\nsession_file, outfile, date, time_str, short_id = sys.argv[1:]\nlabel = f\"{date}-{time_str}\"\n\nlines = []\nwith open(session_file) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f\"# Session Log {label}\\n\"]\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f\"## User\\n\\n{content.strip()}\\n\")\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f\"**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```\")\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f\"**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```\")\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f\"## Assistant\\n\\n{content.strip()}\\n\")\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f\"Written: {outfile}\")\nPYEOF",
+  "description": "Convert JSONL to markdown log file"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add \"llm-logs/2026-04-16-204149-session-0b1db006.md\" && git commit -m \"chore: add llm logs\" && git push",
+  "description": "Commit and push log file"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git pull --rebase && git push",
+  "description": "Pull with rebase then push"
+}
+```
+
+## Assistant
+
+Done. Log exported and pushed:
+
+- **File:** `llm-logs/2026-04-16-204149-session-0b1db006.md`
+- **Commit:** `f1e2062`
+- **Push:** succeeded (rebased over remote changes first)
+
+## User
+
+check if latest changes fixed issues and approve if they have
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr diff 387 2>&1",
+  "description": "Get latest PR 387 diff"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 387 --json commits 2>&1",
+  "description": "Get PR 387 commits"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/.claude/projects/-Users-bigfa-Documents-GitHub-Harmony/0b1db006-f016-42d2-9f7b-090a7dfdce0d/tool-results/bsb3v80gz.txt",
+  "limit": 80
+}
+```
+
+## Assistant
+
+Both fixes are confirmed in the diff. Approving now.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr review 387 --approve --body \"$(cat <<'EOF'\nBoth issues from my previous review have been addressed in the latest commit (`f48dfc8`):\n\n- **Proxy JSON parse guard**: `res.json()` is now wrapped in try/catch in `route.ts`, with a fallback `{ error: 'Upload failed.' }` for non-JSON responses (e.g. nginx 413).\n- **Server-side validation**: `.refine()` added to the `sendMessage` input schema, rejecting requests with empty content and no attachments at the tRPC layer.\n\nApproved.\nEOF\n)\"\n",
+  "description": "Approve PR 387"
+}
+```
+
+## Assistant
+
+PR #387 is approved. Both issues were fixed in commit `f48dfc8`:
+
+- `route.ts` now wraps `res.json()` in try/catch to handle non-JSON error responses
+- `message.router.ts` has the `.refine()` guard rejecting empty-content, no-attachment requests at the schema level
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL"
+}
+```
+


### PR DESCRIPTION
## Summary

Closes #386

- Added `AttachmentInput` type to the frontend types barrel for the upload response shape
- Created a Next.js route handler at `/api/attachments/upload` to proxy multipart POSTs server-side — necessary because the auth token lives in an httpOnly cookie that can't be read client-side, so the handler reads it via `cookies()` and forwards it as a Bearer header to the Express backend
- Extended `messageService.sendMessage` and `sendMessageAction` to accept and forward an optional `AttachmentInput[]` to the tRPC `message.sendMessage` mutation (which already supports attachments)
- Wired the attachment button in `MessageInput.tsx` with the full upload UX

## Behavior

1. Clicking the attachment button opens a native file picker (filtered to allowed MIME types)
2. Selecting a file immediately POSTs it to `/api/attachments/upload`; the button shows a spinner while the upload is in flight
3. On success, a dismissible filename chip appears above the input
4. On error (401, 413, unsupported type, network failure), a message appears in the existing error area
5. On send, pending attachments are forwarded to the backend and cleared after the message is created

## Test plan

- [ ] All 214 existing frontend tests pass (`npm test` in `harmony-frontend/`)
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Attach a supported file (image/PDF) → chip appears, message sends with attachment
- [ ] Attach an oversized or unsupported file → error message shown, no chip added
- [ ] Dismiss a chip via × → chip removed, not sent
- [ ] Send without attaching anything → works as before (no regression)
- [ ] Switch channels mid-compose → pending chips cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)