### PR TITLE
fix: public server default #general channel should be PUBLIC_INDEXABLE

### DIFF
--- a/harmony-backend/src/services/channel.service.ts
+++ b/harmony-backend/src/services/channel.service.ts
@@ -43,7 +43,7 @@ export const channelService = {
     return channel;
   },
 
-  async createChannel(input: CreateChannelInput) {
+  async createChannel(input: CreateChannelInput, _tx?: Prisma.TransactionClient) {
     const { serverId, name, slug, type, visibility, topic, position = 0 } = input;
 
     // VOICE channels cannot be PUBLIC_INDEXABLE
@@ -201,7 +201,7 @@ export const channelService = {
       );
   },
 
-  async createDefaultChannel(serverId: string, isPublic = false, _tx?: Prisma.TransactionClient) {
+  async createDefaultChannel(serverId: string, isPublic = false, tx?: Prisma.TransactionClient) {
     return channelService.createChannel({
       serverId,
       name: 'general',
@@ -209,6 +209,6 @@ export const channelService = {
       type: ChannelType.TEXT,
       visibility: isPublic ? ChannelVisibility.PUBLIC_INDEXABLE : ChannelVisibility.PRIVATE,
       position: 0,
-    });
+    }, tx);
   },
 };

--- a/harmony-backend/src/services/channel.service.ts
+++ b/harmony-backend/src/services/channel.service.ts
@@ -201,13 +201,13 @@ export const channelService = {
       );
   },
 
-  async createDefaultChannel(serverId: string) {
+  async createDefaultChannel(serverId: string, isPublic = false) {
     return channelService.createChannel({
       serverId,
       name: 'general',
       slug: 'general',
       type: ChannelType.TEXT,
-      visibility: ChannelVisibility.PRIVATE,
+      visibility: isPublic ? ChannelVisibility.PUBLIC_INDEXABLE : ChannelVisibility.PRIVATE,
       position: 0,
     });
   },

--- a/harmony-backend/src/services/channel.service.ts
+++ b/harmony-backend/src/services/channel.service.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from '@trpc/server';
-import { ChannelType, ChannelVisibility } from '@prisma/client';
+import { ChannelType, ChannelVisibility, Prisma } from '@prisma/client';
 import { createLogger } from '../lib/logger';
 import { cacheService, CacheKeys, CacheTTL, sanitizeKeySegment } from './cache.service';
 import { eventBus, EventChannels } from '../events/eventBus';
@@ -201,7 +201,7 @@ export const channelService = {
       );
   },
 
-  async createDefaultChannel(serverId: string, isPublic = false) {
+  async createDefaultChannel(serverId: string, isPublic = false, _tx?: Prisma.TransactionClient) {
     return channelService.createChannel({
       serverId,
       name: 'general',

--- a/harmony-backend/src/services/server.service.ts
+++ b/harmony-backend/src/services/server.service.ts
@@ -114,7 +114,7 @@ export const serverService = {
     const server = await withSlugRetry(input.name, slug, (s) =>
       serverRepository.create({ ...input, slug: s }),
     );
-    await channelService.createDefaultChannel(server.id);
+    await channelService.createDefaultChannel(server.id, input.isPublic ?? false);
     await serverMemberService.addOwner(input.ownerId, server.id);
     return server;
   },

--- a/harmony-backend/tests/channel.service.test.ts
+++ b/harmony-backend/tests/channel.service.test.ts
@@ -546,7 +546,7 @@ describe('channelService.createDefaultChannel', () => {
       type: 'TEXT',
       visibility: 'PRIVATE',
       position: 0,
-    });
+    }, undefined);
     expect(result.name).toBe('general');
     expect(result.slug).toBe('general');
 
@@ -560,6 +560,7 @@ describe('channelService.createDefaultChannel', () => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({ visibility: 'PUBLIC_INDEXABLE' }),
+      undefined,
     );
     expect(result.visibility).toBe('PUBLIC_INDEXABLE');
 

--- a/harmony-backend/tests/channel.service.test.ts
+++ b/harmony-backend/tests/channel.service.test.ts
@@ -526,8 +526,11 @@ describe('channelService.createDefaultChannel', () => {
     defaultChannelServerId = server.id;
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await prisma.channel.deleteMany({ where: { serverId: defaultChannelServerId } }).catch(() => {});
+  });
+
+  afterAll(async () => {
     await prisma.server.delete({ where: { id: defaultChannelServerId } }).catch(() => {});
   });
 
@@ -546,6 +549,19 @@ describe('channelService.createDefaultChannel', () => {
     });
     expect(result.name).toBe('general');
     expect(result.slug).toBe('general');
+
+    spy.mockRestore();
+  });
+
+  it('CS-26b: creates PUBLIC_INDEXABLE channel when isPublic=true', async () => {
+    const spy = jest.spyOn(channelService, 'createChannel');
+
+    const result = await channelService.createDefaultChannel(defaultChannelServerId, true);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ visibility: 'PUBLIC_INDEXABLE' }),
+    );
+    expect(result.visibility).toBe('PUBLIC_INDEXABLE');
 
     spy.mockRestore();
   });

--- a/harmony-backend/tests/server.flow.integration.test.ts
+++ b/harmony-backend/tests/server.flow.integration.test.ts
@@ -195,7 +195,7 @@ describe('server flow integration', () => {
       name: 'general',
       slug: 'general',
       type: ChannelType.TEXT,
-      visibility: ChannelVisibility.PRIVATE,
+      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
       position: 0,
     });
 

--- a/harmony-backend/tests/server.service.test.ts
+++ b/harmony-backend/tests/server.service.test.ts
@@ -311,7 +311,7 @@ describe('serverService.createServer', () => {
     });
 
     expect(result).toEqual(created);
-    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('new-id');
+    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('new-id', true);
     expect(serverMemberService.addOwner).toHaveBeenCalledWith('owner-1', 'new-id');
     // createDefaultChannel must be called before addOwner
     const createOrder = (channelService.createDefaultChannel as jest.Mock).mock.invocationCallOrder[0];
@@ -326,7 +326,7 @@ describe('serverService.createServer', () => {
 
     const result = await serverService.createServer({ name: 'Minimal', ownerId: 'owner-1' });
     expect(result).toEqual(created);
-    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('min-id');
+    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('min-id', false);
     expect(serverMemberService.addOwner).toHaveBeenCalledWith('owner-1', 'min-id');
   });
 
@@ -422,7 +422,7 @@ describe('serverService.createServer', () => {
     await expect(serverService.createServer({ name: 'New Server', ownerId: 'owner-1' }))
       .rejects.toThrow('addOwner failed');
     // createDefaultChannel was called and completed before addOwner threw.
-    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('new-id');
+    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('new-id', false);
   });
 });
 

--- a/llm-logs/2026-04-16-203538-session-a8d233db.md
+++ b/llm-logs/2026-04-16-203538-session-a8d233db.md
@@ -1,0 +1,437 @@
+# Session Log 2026-04-16-203538
+
+## User
+
+fix https://github.com/CS485-Harmony/Harmony/issues/337 in a new branch
+
+## Assistant
+
+**Tool call: `ToolSearch`**
+```json
+{
+  "query": "select:WebFetch",
+  "max_results": 1
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 337 --repo CS485-Harmony/Harmony"
+}
+```
+
+## Assistant
+
+Let me read the relevant files before planning.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/channel.service.ts",
+  "offset": 155,
+  "limit": 30
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/server.service.ts",
+  "offset": 110,
+  "limit": 30
+}
+```
+
+## Assistant
+
+**Tool call: `Grep`**
+```json
+{
+  "pattern": "createDefaultChannel",
+  "path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/channel.service.ts",
+  "output_mode": "content",
+  "context": 10
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/server.flow.integration.test.ts",
+  "offset": 160,
+  "limit": 40
+}
+```
+
+## Assistant
+
+Now I have the full picture. The fix is clear. Let me create the branch and implement it.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b fix/issue-337-public-server-default-channel-visibility"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/channel.service.ts",
+  "old_string": "  async createDefaultChannel(serverId: string) {\n    return channelService.createChannel({\n      serverId,\n      name: 'general',\n      slug: 'general',\n      type: ChannelType.TEXT,\n      visibility: ChannelVisibility.PRIVATE,\n      position: 0,\n    });\n  },",
+  "new_string": "  async createDefaultChannel(serverId: string, isPublic = false) {\n    return channelService.createChannel({\n      serverId,\n      name: 'general',\n      slug: 'general',\n      type: ChannelType.TEXT,\n      visibility: isPublic ? ChannelVisibility.PUBLIC_INDEXABLE : ChannelVisibility.PRIVATE,\n      position: 0,\n    });\n  },"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/server.service.ts",
+  "old_string": "    await channelService.createDefaultChannel(server.id);",
+  "new_string": "    await channelService.createDefaultChannel(server.id, input.isPublic ?? false);"
+}
+```
+
+## Assistant
+
+Now fix the integration test to assert the correct behavior (public server → `PUBLIC_INDEXABLE` channel):
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/server.flow.integration.test.ts",
+  "old_string": "      visibility: ChannelVisibility.PRIVATE,",
+  "new_string": "      visibility: ChannelVisibility.PUBLIC_INDEXABLE,"
+}
+```
+
+## Assistant
+
+Now let me check if there are any other tests referencing the default channel visibility that need updating, and run a lint check:
+
+## Assistant
+
+**Tool call: `Grep`**
+```json
+{
+  "pattern": "createDefaultChannel",
+  "path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend",
+  "output_mode": "content",
+  "context": 3
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npm run lint 2>&1 | tail -20"
+}
+```
+
+## Assistant
+
+I need to update the `server.service.test.ts` assertions that check `createDefaultChannel` call args — they now need to include the `isPublic` parameter.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/server.service.test.ts",
+  "offset": 299,
+  "limit": 135
+}
+```
+
+## Assistant
+
+Now update the three `createDefaultChannel` call assertions in `server.service.test.ts`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/server.service.test.ts",
+  "old_string": "    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('new-id');\n    expect(serverMemberService.addOwner).toHaveBeenCalledWith('owner-1', 'new-id');\n    // createDefaultChannel must be called before addOwner",
+  "new_string": "    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('new-id', true);\n    expect(serverMemberService.addOwner).toHaveBeenCalledWith('owner-1', 'new-id');\n    // createDefaultChannel must be called before addOwner"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/server.service.test.ts",
+  "old_string": "    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('min-id');",
+  "new_string": "    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('min-id', false);"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/server.service.test.ts",
+  "old_string": "    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('new-id');\n  });\n});",
+  "new_string": "    expect(channelService.createDefaultChannel).toHaveBeenCalledWith('new-id', false);\n  });\n});"
+}
+```
+
+## Assistant
+
+Now check the `channel.service.test.ts` CS-26 test — it calls `createDefaultChannel` with no args and checks the spy for `PRIVATE`:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/channel.service.test.ts",
+  "offset": 512,
+  "limit": 50
+}
+```
+
+## Assistant
+
+CS-26 is fine — it uses `isPublic: false` server and no arg (defaults to `false`) → `PRIVATE` is still correct. Let me run the tests:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test -- tests/server.service.test.ts tests/channel.service.test.ts 2>&1 | tail -30",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All tests pass. Now commit and push:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-backend/src/services/channel.service.ts harmony-backend/src/services/server.service.ts harmony-backend/tests/server.service.test.ts harmony-backend/tests/server.flow.integration.test.ts && git commit -m \"$(cat <<'EOF'\nfix: public server creation now creates default #general channel as PUBLIC_INDEXABLE\n\nCloses #337\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/issue-337-public-server-default-channel-visibility 2>&1"
+}
+```
+
+## Assistant
+
+Branch pushed. The fix was two small changes:
+
+1. **`channel.service.ts:204`** — `createDefaultChannel` now accepts `isPublic = false` and sets visibility to `PUBLIC_INDEXABLE` when true, `PRIVATE` otherwise.
+2. **`server.service.ts:117`** — passes `input.isPublic ?? false` to `createDefaultChannel`.
+3. Updated 4 test assertions (`server.service.test.ts` ×3, `server.flow.integration.test.ts` ×1) to match the corrected behavior.
+
+## User
+
+create a PR
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --title \"fix: public server default #general channel should be PUBLIC_INDEXABLE\" --body \"$(cat <<'EOF'\n## Summary\n- `createDefaultChannel` hardcoded `PRIVATE` visibility regardless of server visibility\n- Pass `isPublic` from `createServer` into `createDefaultChannel` and set visibility to `PUBLIC_INDEXABLE` for public servers\n- Updated 4 test assertions to reflect correct behavior\n\nCloses #337\n\n## Test plan\n- [ ] `npm test -- tests/server.service.test.ts tests/channel.service.test.ts` passes (82 tests)\n- [ ] Integration: create a public server, verify `GET /api/public/servers/:slug/channels` returns the `#general` channel\n- [ ] Integration: create a private server, verify `#general` channel remains `PRIVATE`\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\""
+}
+```
+
+## Assistant
+
+PR created: https://github.com/CS485-Harmony/Harmony/pull/389
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+


### PR DESCRIPTION
## Summary
- `createDefaultChannel` hardcoded `PRIVATE` visibility regardless of server visibility
- Pass `isPublic` from `createServer` into `createDefaultChannel` and set visibility to `PUBLIC_INDEXABLE` for public servers
- Updated 4 test assertions to reflect correct behavior

Closes #337

## Test plan
- [ ] `npm test -- tests/server.service.test.ts tests/channel.service.test.ts` passes (82 tests)
- [ ] Integration: create a public server, verify `GET /api/public/servers/:slug/channels` returns the `#general` channel
- [ ] Integration: create a private server, verify `#general` channel remains `PRIVATE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)