### PR TITLE
fix: redirect guests to login when clicking Reply (#367)

### DIFF
--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -13,8 +13,10 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import Image from 'next/image';
+import { useRouter, usePathname } from 'next/navigation';
 import { formatMessageTimestamp, formatTimeOnly } from '@/lib/utils';
 import { pinMessageAction, unpinMessageAction } from '@/app/actions/pinMessage';
+import { useAuth } from '@/hooks/useAuth';
 import type { Message, Reaction } from '@/types';
 
 // ─── ReactionList ─────────────────────────────────────────────────────────────
@@ -70,6 +72,9 @@ function ActionBar({
   canPin?: boolean;
   initialPinned?: boolean;
 }) {
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
   const [isMoreOpen, setIsMoreOpen] = useState(false);
   const [isPinned, setIsPinned] = useState(initialPinned ?? false);
   const [pinState, setPinState] = useState<PinState>('idle');
@@ -139,11 +144,12 @@ function ActionBar({
         <span className='px-2 text-xs text-red-400'>{pinErrorMsg}</span>
       )}
 
-      {/* Reply (stub) */}
+      {/* Reply — redirects guests to login; stub for authenticated users */}
       <button
         type='button'
         aria-label='Reply'
         title='Reply'
+        onClick={!isAuthenticated ? () => router.push(`/auth/login?returnUrl=${encodeURIComponent(pathname)}`) : undefined}
         className='flex h-8 w-8 items-center justify-center text-gray-400 hover:text-white hover:bg-white/10 rounded-md transition-colors'
       >
         <svg className='h-4 w-4' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true' focusable='false'>

--- a/llm-logs/2026-04-16-203917-session-01adcf39.md
+++ b/llm-logs/2026-04-16-203917-session-01adcf39.md
@@ -1,0 +1,469 @@
+# Session Log 2026-04-16-203917
+
+## User
+
+fix https://github.com/CS485-Harmony/Harmony/issues/367 on a new branch and open a PR
+
+## Assistant
+
+**Tool call: `ToolSearch`**
+```json
+{
+  "query": "select:WebFetch",
+  "max_results": 1
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 367 --repo CS485-Harmony/Harmony",
+  "description": "View GitHub issue 367"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 367 --repo CS485-Harmony/Harmony --comments",
+  "description": "View issue comments"
+}
+```
+
+## Assistant
+
+Now let me find the Reply button implementation in the frontend.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"Reply\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src --include=\"*.tsx\" -l",
+  "description": "Find files with Reply button"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"guest\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src --include=\"*.tsx\" -l -i",
+  "description": "Find files with guest mode handling"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/message/MessageItem.tsx"
+}
+```
+
+## Assistant
+
+Now let me look at how guest detection works and how other components handle auth redirects.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/AuthRedirect.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestPromoBanner.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/MessageList.tsx"
+}
+```
+
+## Assistant
+
+Let me check the `useAuth` hook to understand what it returns.
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "**/useAuth*",
+  "path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/hooks/useAuth.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"isAuthenticated\\|AuthContextValue\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/context/AuthContext.tsx | head -30",
+  "description": "Check AuthContext for isAuthenticated"
+}
+```
+
+## Assistant
+
+Let me check if the guest view has an AuthProvider wrapper.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"AuthProvider\\|AuthContext\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app --include=\"*.tsx\" -l",
+  "description": "Find AuthProvider usage"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"AuthProvider\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/layout.tsx /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/providers.tsx 2>/dev/null",
+  "description": "Check if AuthProvider is in root layout"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"Providers\\|providers\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/layout.tsx | head -10",
+  "description": "Check root layout for Providers"
+}
+```
+
+## Assistant
+
+`AuthProvider` wraps the root layout, so `useAuth()` is safe everywhere. Now I'll create the branch and fix the Reply button.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b fix/issue-367-guest-reply-auth-prompt",
+  "description": "Create new branch for issue 367"
+}
+```
+
+## Assistant
+
+Now I'll update `ActionBar` to redirect guests to login when they click Reply.
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/message/MessageItem.tsx",
+  "old_string": "import { useState, useRef, useEffect, useCallback } from 'react';\nimport Image from 'next/image';\nimport { formatMessageTimestamp, formatTimeOnly } from '@/lib/utils';\nimport { pinMessageAction, unpinMessageAction } from '@/app/actions/pinMessage';\nimport type { Message, Reaction } from '@/types';",
+  "new_string": "import { useState, useRef, useEffect, useCallback } from 'react';\nimport Image from 'next/image';\nimport { useRouter, usePathname } from 'next/navigation';\nimport { formatMessageTimestamp, formatTimeOnly } from '@/lib/utils';\nimport { pinMessageAction, unpinMessageAction } from '@/app/actions/pinMessage';\nimport { useAuth } from '@/hooks/useAuth';\nimport type { Message, Reaction } from '@/types';"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/message/MessageItem.tsx",
+  "old_string": "  const [isMoreOpen, setIsMoreOpen] = useState(false);\n  const [isPinned, setIsPinned] = useState(initialPinned ?? false);\n  const [pinState, setPinState] = useState<PinState>('idle');\n  const [pinErrorMsg, setPinErrorMsg] = useState('');\n  const moreRef = useRef<HTMLDivElement>(null);\n  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);\n  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);",
+  "new_string": "  const { isAuthenticated } = useAuth();\n  const router = useRouter();\n  const pathname = usePathname();\n  const [isMoreOpen, setIsMoreOpen] = useState(false);\n  const [isPinned, setIsPinned] = useState(initialPinned ?? false);\n  const [pinState, setPinState] = useState<PinState>('idle');\n  const [pinErrorMsg, setPinErrorMsg] = useState('');\n  const moreRef = useRef<HTMLDivElement>(null);\n  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);\n  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/message/MessageItem.tsx",
+  "old_string": "      {/* Reply (stub) */}\n      <button\n        type='button'\n        aria-label='Reply'\n        title='Reply'\n        className='flex h-8 w-8 items-center justify-center text-gray-400 hover:text-white hover:bg-white/10 rounded-md transition-colors'\n      >",
+  "new_string": "      {/* Reply \u2014 redirects guests to login; stub for authenticated users */}\n      <button\n        type='button'\n        aria-label='Reply'\n        title='Reply'\n        onClick={!isAuthenticated ? () => router.push(`/auth/login?returnUrl=${encodeURIComponent(pathname)}`) : undefined}\n        className='flex h-8 w-8 items-center justify-center text-gray-400 hover:text-white hover:bg-white/10 rounded-md transition-colors'\n      >"
+}
+```
+
+## Assistant
+
+Now let me verify the final state of the file looks correct:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/message/MessageItem.tsx",
+  "offset": 62,
+  "limit": 100
+}
+```
+
+## Assistant
+
+Good. Now let me run the frontend tests to verify nothing is broken:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npm test -- --passWithNoTests 2>&1 | tail -30",
+  "description": "Run frontend tests",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All 214 tests pass. Now let me check for TypeScript/build errors:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1 | head -20",
+  "description": "TypeScript type check",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+No type errors. Now let me commit and push, then open the PR.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-frontend/src/components/message/MessageItem.tsx && git commit -m \"$(cat <<'EOF'\nfix: redirect guests to login when clicking Reply on a message\n\nCloses #367\n\nThe Reply button in the message action bar was a stub with no onClick\nhandler, so guest users received no feedback when clicking it. Guest\nusers (unauthenticated) are now redirected to /auth/login?returnUrl=<current-path>\nwhen they click Reply; authenticated users retain the existing stub\nbehavior (reply/thread UI is a future feature).\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit the fix"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/issue-367-guest-reply-auth-prompt",
+  "description": "Push branch to remote"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --repo CS485-Harmony/Harmony --title \"fix: redirect guests to login when clicking Reply (#367)\" --body \"$(cat <<'EOF'\n## Summary\n\n- Closes #367\n- The `Reply` button in the message action bar had no `onClick` handler, so guest (unauthenticated) users received no feedback when clicking it\n- Guests are now redirected to `/auth/login?returnUrl=<current-path>` on click, matching how other auth-gated actions work in the app\n- Authenticated users retain the existing no-op stub behavior (reply/thread UI is a planned future feature)\n\n## Changes\n\n- `harmony-frontend/src/components/message/MessageItem.tsx`: Added `useAuth`, `useRouter`, and `usePathname` hooks inside `ActionBar`; wired `onClick` on the Reply button to redirect unauthenticated users to the login page with a `returnUrl`\n\n## Test plan\n\n- [ ] Open a public channel as a guest (`/c/<server>/<channel>`)\n- [ ] Hover a message \u2014 Reply button appears in the action bar\n- [ ] Click Reply \u2014 browser navigates to `/auth/login?returnUrl=<channel-path>`\n- [ ] Log in \u2014 `returnUrl` returns you to the channel\n- [ ] As an authenticated user, hover a message and click Reply \u2014 no navigation occurs (stub behavior unchanged)\n- [ ] All 214 frontend unit tests pass (`npm test` in `harmony-frontend/`)\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\"",
+  "description": "Create PR"
+}
+```
+
+## Assistant
+
+PR is open: **https://github.com/CS485-Harmony/Harmony/pull/390**
+
+The fix adds a single `onClick` handler to the Reply button in `ActionBar` (`MessageItem.tsx`). When an unauthenticated guest clicks Reply, they're redirected to `/auth/login?returnUrl=<current-path>`. Authenticated users see no change (Reply remains a stub pending the thread/reply feature). All 214 frontend tests pass.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+


### PR DESCRIPTION
## Summary

- Closes #367
- The `Reply` button in the message action bar had no `onClick` handler, so guest (unauthenticated) users received no feedback when clicking it
- Guests are now redirected to `/auth/login?returnUrl=<current-path>` on click, matching how other auth-gated actions work in the app
- Authenticated users retain the existing no-op stub behavior (reply/thread UI is a planned future feature)

## Changes

- `harmony-frontend/src/components/message/MessageItem.tsx`: Added `useAuth`, `useRouter`, and `usePathname` hooks inside `ActionBar`; wired `onClick` on the Reply button to redirect unauthenticated users to the login page with a `returnUrl`

## Test plan

- [ ] Open a public channel as a guest (`/c/<server>/<channel>`)
- [ ] Hover a message — Reply button appears in the action bar
- [ ] Click Reply — browser navigates to `/auth/login?returnUrl=<channel-path>`
- [ ] Log in — `returnUrl` returns you to the channel
- [ ] As an authenticated user, hover a message and click Reply — no navigation occurs (stub behavior unchanged)
- [ ] All 214 frontend unit tests pass (`npm test` in `harmony-frontend/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)