### PR TITLE
fix: redirect guests to login when clicking Add Reaction (#368)

### DIFF
--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -192,11 +192,12 @@ function ActionBar({
         </svg>
       </button>
 
-      {/* Add Reaction (stub) */}
+      {/* Add Reaction — redirects guests to login; stub for authenticated users */}
       <button
         type='button'
         aria-label='Add Reaction'
         title='Add Reaction'
+        onClick={!isAuthenticated ? () => router.push(`/auth/login?returnUrl=${encodeURIComponent(pathname)}`) : undefined}
         className='flex h-8 w-8 items-center justify-center text-gray-400 hover:text-white hover:bg-white/10 rounded-md transition-colors'
       >
         <svg className='h-4 w-4' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true' focusable='false'>

--- a/llm-logs/2026-04-16-210235-session-f17588ab.md
+++ b/llm-logs/2026-04-16-210235-session-f17588ab.md
@@ -1,0 +1,290 @@
+# Session Log 2026-04-16-210235
+
+## User
+
+complete issue 368 in a new branch if not already complete
+
+## Assistant
+
+Let me look up issue 368 first.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 368 --repo CS485-Harmony/Harmony"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr list --repo CS485-Harmony/Harmony --search \"368\" --state all"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 390 --repo CS485-Harmony/Harmony 2>/dev/null || gh pr view 390 --repo CS485-Harmony/Harmony 2>/dev/null | head -30"
+}
+```
+
+## Assistant
+
+Now let me find the Add Reaction button implementation.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"Add Reaction\\|AddReaction\\|addReaction\\|reaction\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/message/MessageItem.tsx | head -40"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/message/MessageItem.tsx",
+  "offset": 85,
+  "limit": 130
+}
+```
+
+## Assistant
+
+Now I have a clear picture. The fix is straightforward — mirror the Reply button pattern for Add Reaction. Let me create the branch and fix it.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b fix/issue-368-guest-reaction-auth-prompt"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/message/MessageItem.tsx",
+  "old_string": "      {/* Add Reaction (stub) */}\n      <button\n        type='button'\n        aria-label='Add Reaction'\n        title='Add Reaction'\n        className='flex h-8 w-8 items-center justify-center text-gray-400 hover:text-white hover:bg-white/10 rounded-md transition-colors'\n      >",
+  "new_string": "      {/* Add Reaction \u2014 redirects guests to login; stub for authenticated users */}\n      <button\n        type='button'\n        aria-label='Add Reaction'\n        title='Add Reaction'\n        onClick={!isAuthenticated ? () => router.push(`/auth/login?returnUrl=${encodeURIComponent(pathname)}`) : undefined}\n        className='flex h-8 w-8 items-center justify-center text-gray-400 hover:text-white hover:bg-white/10 rounded-md transition-colors'\n      >"
+}
+```
+
+## Assistant
+
+Now run the frontend tests to verify nothing broke.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npm test -- --passWithNoTests 2>&1 | tail -20",
+  "timeout": 120000
+}
+```
+
+## Assistant
+
+All 214 tests pass. Now commit and push.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-frontend/src/components/message/MessageItem.tsx && git commit -m \"$(cat <<'EOF'\nfix: redirect guests to login when clicking Add Reaction (#368)\n\nClicking Add Reaction as a guest now navigates to /auth/login?returnUrl=<current-path>,\nmatching the existing behavior of the Reply button. Authenticated users retain the\nno-op stub (reaction picker is a future feature).\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/issue-368-guest-reaction-auth-prompt"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --repo CS485-Harmony/Harmony --title \"fix: redirect guests to login when clicking Add Reaction (#368)\" --body \"$(cat <<'EOF'\n## Summary\n\n- Closes #368\n- The `Add Reaction` button in the message action bar had no `onClick` handler, so guest (unauthenticated) users received no feedback when clicking it\n- Guests are now redirected to `/auth/login?returnUrl=<current-path>` on click, matching the existing behavior of the Reply button (fixed in #390)\n- Authenticated users retain the existing no-op stub behavior (reaction picker UI is a planned future feature)\n\n## Changes\n\n- `harmony-frontend/src/components/message/MessageItem.tsx`: Wired `onClick` on the Add Reaction button to redirect unauthenticated users to the login page with a `returnUrl` (reuses the `isAuthenticated`, `router`, and `pathname` hooks already present in `ActionBar`)\n\n## Test plan\n\n- [ ] Open a public channel as a guest (`/channels/<server>/<channel>`)\n- [ ] Hover a message \u2014 Add Reaction button appears in the action bar\n- [ ] Click Add Reaction \u2014 browser navigates to `/auth/login?returnUrl=<channel-path>`\n- [ ] Log in \u2014 `returnUrl` returns you to the channel\n- [ ] As an authenticated user, hover a message and click Add Reaction \u2014 no navigation occurs (stub behavior unchanged)\n- [ ] All 214 frontend unit tests pass (`npm test` in `harmony-frontend/`)\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\""
+}
+```
+
+## Assistant
+
+PR #391 is open: https://github.com/CS485-Harmony/Harmony/pull/391
+
+The fix adds an `onClick` to the Add Reaction button that redirects guests to `/auth/login?returnUrl=<current-path>`, identical to the Reply button fix from #390. One line changed in `MessageItem.tsx:200`, all 214 tests still pass.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF"
+}
+```
+


### PR DESCRIPTION
## Summary

- Closes #368
- The `Add Reaction` button in the message action bar had no `onClick` handler, so guest (unauthenticated) users received no feedback when clicking it
- Guests are now redirected to `/auth/login?returnUrl=<current-path>` on click, matching the existing behavior of the Reply button (fixed in #390)
- Authenticated users retain the existing no-op stub behavior (reaction picker UI is a planned future feature)

## Changes

- `harmony-frontend/src/components/message/MessageItem.tsx`: Wired `onClick` on the Add Reaction button to redirect unauthenticated users to the login page with a `returnUrl` (reuses the `isAuthenticated`, `router`, and `pathname` hooks already present in `ActionBar`)

## Test plan

- [ ] Open a public channel as a guest (`/channels/<server>/<channel>`)
- [ ] Hover a message — Add Reaction button appears in the action bar
- [ ] Click Add Reaction — browser navigates to `/auth/login?returnUrl=<channel-path>`
- [ ] Log in — `returnUrl` returns you to the channel
- [ ] As an authenticated user, hover a message and click Add Reaction — no navigation occurs (stub behavior unchanged)
- [ ] All 214 frontend unit tests pass (`npm test` in `harmony-frontend/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)