### PR TITLE
fix: enable Browse Public Servers CTA for guests (#369)

### DIFF
--- a/harmony-frontend/src/components/layout/EmptyShell.tsx
+++ b/harmony-frontend/src/components/layout/EmptyShell.tsx
@@ -116,7 +116,7 @@ export function EmptyShell({
           allChannels={allChannels}
           currentServerId={currentServer?.id ?? ''}
           basePath={basePath}
-          onBrowseServers={isAuthenticated ? () => setIsBrowseServersOpen(true) : undefined}
+          onBrowseServers={() => setIsBrowseServersOpen(true)}
           onAddServer={
             isAuthLoading
               ? undefined

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -396,7 +396,7 @@ export function HarmonyShell({
           currentServerId={currentServer.id}
           basePath={basePath}
           isMobileVisible={isMenuOpen}
-          onBrowseServers={isAuthenticated ? () => setIsBrowseServersOpen(true) : undefined}
+          onBrowseServers={() => setIsBrowseServersOpen(true)}
           onAddServer={
             isAuthLoading
               ? undefined

--- a/llm-logs/2026-04-16-210439-session-474b0897.md
+++ b/llm-logs/2026-04-16-210439-session-474b0897.md
@@ -1,0 +1,402 @@
+# Session Log 2026-04-16-210439
+
+## User
+
+complete 369 in a new branch and open a PR
+
+## Assistant
+
+Let me fetch issue 369 first.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 369 --repo CS485-Harmony/Harmony"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 369 --repo CS485-Harmony/Harmony --comments"
+}
+```
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "harmony-frontend/src/**/*Server*Nav*"
+}
+```
+
+## Assistant
+
+**Tool call: `Grep`**
+```json
+{
+  "pattern": "Browse Public Servers",
+  "path": "harmony-frontend/src",
+  "output_mode": "content"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/server-rail/ServerRail.tsx",
+  "offset": 160,
+  "limit": 40
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/server-rail/ServerRail.tsx",
+  "offset": 90,
+  "limit": 70
+}
+```
+
+## Assistant
+
+Now let me find where `ServerRail` is used and how `onBrowseServers` is passed.
+
+## Assistant
+
+**Tool call: `Grep`**
+```json
+{
+  "pattern": "onBrowseServers",
+  "path": "harmony-frontend/src",
+  "output_mode": "content"
+}
+```
+
+## Assistant
+
+Found it. The issue is clear — `onBrowseServers` is only passed when `isAuthenticated`, so guests get `undefined` and the button is disabled. Let me check the `BrowseServersModal` to confirm guests can use it.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/HarmonyShell.tsx",
+  "offset": 385,
+  "limit": 30
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/EmptyShell.tsx",
+  "offset": 105,
+  "limit": 30
+}
+```
+
+## Assistant
+
+Now let me check if `BrowseServersModal` has any auth requirements.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"isAuthenticated\\|guest\\|auth\\|login\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/server-rail/BrowseServersModal.tsx | head -30"
+}
+```
+
+## Assistant
+
+The modal itself has no auth gate — only the caller restricts it. The fix is to pass `onBrowseServers` unconditionally (for both guests and authenticated users) in both `HarmonyShell.tsx` and `EmptyShell.tsx`.
+
+Let me create the branch and make the fix.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout main && git pull && git checkout -b fix/issue-369-guest-browse-servers"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/HarmonyShell.tsx",
+  "old_string": "          onBrowseServers={isAuthenticated ? () => setIsBrowseServersOpen(true) : undefined}",
+  "new_string": "          onBrowseServers={() => setIsBrowseServersOpen(true)}"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/EmptyShell.tsx",
+  "old_string": "          onBrowseServers={isAuthenticated ? () => setIsBrowseServersOpen(true) : undefined}",
+  "new_string": "          onBrowseServers={() => setIsBrowseServersOpen(true)}"
+}
+```
+
+## Assistant
+
+Now let me verify no type errors and run tests.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd harmony-frontend && npx tsc --noEmit 2>&1 | tail -20"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd harmony-frontend && npm test -- --passWithNoTests 2>&1 | tail -20"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test 2>&1 | tail -20"
+}
+```
+
+## Assistant
+
+All 214 tests pass. Now commit and open the PR.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add harmony-frontend/src/components/layout/HarmonyShell.tsx harmony-frontend/src/components/layout/EmptyShell.tsx && git commit -m \"$(cat <<'EOF'\nfix: enable Browse Public Servers for guests (#369)\n\nRemove the isAuthenticated guard on onBrowseServers so guests can\nopen the public server discovery modal from the server rail.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "pwd && git status"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-frontend/src/components/layout/HarmonyShell.tsx harmony-frontend/src/components/layout/EmptyShell.tsx && git commit -m \"$(cat <<'EOF'\nfix: enable Browse Public Servers for guests (#369)\n\nRemove the isAuthenticated guard on onBrowseServers so guests can\nopen the public server discovery modal from the server rail.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/issue-369-guest-browse-servers && gh pr create --repo CS485-Harmony/Harmony --title \"fix: enable Browse Public Servers CTA for guests (#369)\" --body \"$(cat <<'EOF'\n## Summary\n- Removes the `isAuthenticated` guard on `onBrowseServers` in `HarmonyShell.tsx` and `EmptyShell.tsx`\n- Guests can now click **Browse Public Servers** in the server rail and open the discovery modal\n- Fixes #369\n\n## Test plan\n- [ ] Open a public channel page as a guest (e.g. `/channels/harmony-hq/general`)\n- [ ] Confirm **Browse Public Servers** button in the left nav is clickable\n- [ ] Confirm the Browse Public Servers modal opens correctly\n- [ ] Confirm authenticated users still see the modal open as before\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\""
+}
+```
+
+## Assistant
+
+PR is open: https://github.com/CS485-Harmony/Harmony/pull/392
+
+The fix was a two-line change — both `HarmonyShell.tsx` and `EmptyShell.tsx` were gating `onBrowseServers` behind `isAuthenticated`, causing the button to receive `undefined` and render as `disabled`. Removing that guard lets guests open the Browse Public Servers modal directly.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "DATE=$(date +%Y-%m-%d)\nTIME=$(date +%H%M%S)\nSESSION_ID=\"474b0897-8f7d-461d-81ce-297b8d3e889b\"\nSHORT_ID=\"${SESSION_ID:0:8}\"\nOUTFILE=\"llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md\"\n\npython3 - \"/Users/bigfa/.claude/projects/-Users-bigfa-Documents-GitHub-Harmony/474b0897-8f7d-461d-81ce-297b8d3e889b.jsonl\" \"$OUTFILE\" \"$DATE\" \"$TIME\" \"$SHORT_ID\" <<'PYEOF'\nimport sys, json\n\nsession_file, outfile, date, time_str, short_id = sys.argv[1:]\nlabel = f\"{date}-{time_str}\"\n\nlines = []\nwith open(session_file) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f\"# Session Log {label}\\n\"]\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f\"## User\\n\\n{content.strip()}\\n\")\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f\"**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```\")\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f\"**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```\")\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f\"## Assistant\\n\\n{content.strip()}\\n\")\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f\"Written: {outfile}\")\nPYEOF"
+}
+```
+


### PR DESCRIPTION
## Summary
- Removes the `isAuthenticated` guard on `onBrowseServers` in `HarmonyShell.tsx` and `EmptyShell.tsx`
- Guests can now click **Browse Public Servers** in the server rail and open the discovery modal
- Fixes #369

## Test plan
- [ ] Open a public channel page as a guest (e.g. `/channels/harmony-hq/general`)
- [ ] Confirm **Browse Public Servers** button in the left nav is clickable
- [ ] Confirm the Browse Public Servers modal opens correctly
- [ ] Confirm authenticated users still see the modal open as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)