### PR TITLE
fix: add persistent auth CTAs to guest header (closes #370)

### DIFF
--- a/harmony-frontend/src/components/channel/GuestChannelView.tsx
+++ b/harmony-frontend/src/components/channel/GuestChannelView.tsx
@@ -6,7 +6,6 @@
  */
 
 import { notFound } from 'next/navigation';
-import Link from 'next/link';
 import {
   fetchPublicServer,
   fetchPublicChannel,
@@ -18,46 +17,9 @@ import { AuthRedirect } from '@/components/channel/AuthRedirect';
 import { VisibilityGuard } from '@/components/channel/VisibilityGuard';
 import { MessageList } from '@/components/channel/MessageList';
 import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+import { GuestHeader } from '@/components/channel/GuestHeader';
 import { PrivateChannelLockedPane } from '@/components/channel/PrivateChannelLockedPane';
-import type { Server, Channel } from '@/types';
-
-type PublicServer = Omit<Server, 'ownerId'>;
-
-// ─── Guest Header ─────────────────────────────────────────────────────────────
-
-function GuestHeader({ server }: { server: PublicServer }) {
-  return (
-    <header className='flex h-14 shrink-0 items-center gap-3 border-b border-black/20 bg-[#2f3136] px-4'>
-      {/* Harmony logo wordmark */}
-      <span className='text-lg font-bold text-[#5865f2]'>Harmony</span>
-
-      {/* Divider */}
-      <span className='text-gray-600' aria-hidden='true'>
-        /
-      </span>
-
-      {/* Server name */}
-      <span className='text-sm font-semibold text-white'>{server.name}</span>
-
-      {/* Persistent auth CTAs — always visible so guests retain a login path after dismissing the promo banner */}
-      <div className='ml-auto flex shrink-0 items-center gap-2'>
-        <Link
-          href='/auth/signup'
-          className='inline-flex h-7 items-center justify-center rounded-md bg-[#5865f2] px-3 text-xs font-medium text-white transition-colors hover:bg-[#4752c4]'
-        >
-          <span className='hidden sm:inline'>Create Account</span>
-          <span className='sm:hidden'>Join</span>
-        </Link>
-        <Link
-          href='/auth/login'
-          className='inline-flex h-7 items-center justify-center rounded-md border border-white/20 bg-[#40444b] px-3 text-xs font-medium text-gray-200 transition-colors hover:bg-[#3d4148]'
-        >
-          Log In
-        </Link>
-      </div>
-    </header>
-  );
-}
+import type { Channel } from '@/types';
 
 // ─── Channel Header ───────────────────────────────────────────────────────────
 

--- a/harmony-frontend/src/components/channel/GuestChannelView.tsx
+++ b/harmony-frontend/src/components/channel/GuestChannelView.tsx
@@ -6,6 +6,7 @@
  */
 
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import {
   fetchPublicServer,
   fetchPublicChannel,
@@ -24,7 +25,7 @@ type PublicServer = Omit<Server, 'ownerId'>;
 
 // ─── Guest Header ─────────────────────────────────────────────────────────────
 
-function GuestHeader({ server, memberCount }: { server: PublicServer; memberCount: number }) {
+function GuestHeader({ server }: { server: PublicServer }) {
   return (
     <header className='flex h-14 shrink-0 items-center gap-3 border-b border-black/20 bg-[#2f3136] px-4'>
       {/* Harmony logo wordmark */}
@@ -38,19 +39,22 @@ function GuestHeader({ server, memberCount }: { server: PublicServer; memberCoun
       {/* Server name */}
       <span className='text-sm font-semibold text-white'>{server.name}</span>
 
-      {/* Member count */}
-      <span className='ml-auto flex items-center gap-1.5 text-xs text-gray-400'>
-        <svg
-          className='h-3.5 w-3.5'
-          viewBox='0 0 24 24'
-          fill='currentColor'
-          aria-hidden='true'
-          focusable='false'
+      {/* Persistent auth CTAs — always visible so guests retain a login path after dismissing the promo banner */}
+      <div className='ml-auto flex shrink-0 items-center gap-2'>
+        <Link
+          href='/auth/signup'
+          className='inline-flex h-7 items-center justify-center rounded-md bg-[#5865f2] px-3 text-xs font-medium text-white transition-colors hover:bg-[#4752c4]'
         >
-          <path d='M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z' />
-        </svg>
-        {memberCount.toLocaleString()} members
-      </span>
+          <span className='hidden sm:inline'>Create Account</span>
+          <span className='sm:hidden'>Join</span>
+        </Link>
+        <Link
+          href='/auth/login'
+          className='inline-flex h-7 items-center justify-center rounded-md border border-white/20 bg-[#40444b] px-3 text-xs font-medium text-gray-200 transition-colors hover:bg-[#3d4148]'
+        >
+          Log In
+        </Link>
+      </div>
     </header>
   );
 }
@@ -122,7 +126,7 @@ export async function GuestChannelView({ serverSlug, channelSlug }: GuestChannel
     return (
       <div className='flex h-screen flex-col overflow-hidden bg-[#36393f] font-sans'>
         {isMember && <AuthRedirect to={`/channels/${serverSlug}/${channelSlug}`} />}
-        <GuestHeader server={server} memberCount={server.memberCount ?? 0} />
+        <GuestHeader server={server} />
         <PrivateChannelLockedPane mode='guest' />
       </div>
     );
@@ -136,7 +140,7 @@ export async function GuestChannelView({ serverSlug, channelSlug }: GuestChannel
   return (
     <div className='flex h-screen flex-col overflow-hidden bg-[#36393f] font-sans'>
       {isMember && <AuthRedirect to={`/channels/${serverSlug}/${channelSlug}`} />}
-      <GuestHeader server={server} memberCount={memberCount} />
+      <GuestHeader server={server} />
 
       <VisibilityGuard visibility={channel.visibility} isLoading={false}>
         <div className='flex flex-1 flex-col overflow-hidden'>

--- a/harmony-frontend/src/components/channel/GuestHeader.tsx
+++ b/harmony-frontend/src/components/channel/GuestHeader.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth';
+import type { Server } from '@/types';
+
+type PublicServer = Omit<Server, 'ownerId'>;
+
+export function GuestHeader({ server }: { server: PublicServer }) {
+  const { isAuthenticated } = useAuth();
+  const pathname = usePathname();
+  const returnUrl = encodeURIComponent(pathname);
+
+  return (
+    <header className='flex h-14 shrink-0 items-center gap-3 border-b border-black/20 bg-[#2f3136] px-4'>
+      {/* Harmony logo wordmark */}
+      <span className='text-lg font-bold text-[#5865f2]'>Harmony</span>
+
+      {/* Divider */}
+      <span className='text-gray-600' aria-hidden='true'>
+        /
+      </span>
+
+      {/* Server name — min-w-0 flex-1 prevents overflow when CTAs are present */}
+      <span className='min-w-0 flex-1 truncate text-sm font-semibold text-white'>{server.name}</span>
+
+      {/* Auth CTAs — hidden for authenticated users (e.g. non-member 403 path) */}
+      {!isAuthenticated && (
+        <div className='flex shrink-0 items-center gap-2'>
+          <Link
+            href={`/auth/signup?returnUrl=${returnUrl}`}
+            className='inline-flex h-7 items-center justify-center rounded-md bg-[#5865f2] px-3 text-xs font-medium text-white transition-colors hover:bg-[#4752c4]'
+          >
+            <span className='hidden sm:inline'>Create Account</span>
+            <span className='sm:hidden'>Join</span>
+          </Link>
+          <Link
+            href={`/auth/login?returnUrl=${returnUrl}`}
+            className='inline-flex h-7 items-center justify-center rounded-md border border-white/20 bg-[#40444b] px-3 text-xs font-medium text-gray-200 transition-colors hover:bg-[#3d4148]'
+          >
+            Log In
+          </Link>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/harmony-frontend/tests/e2e/auth.spec.ts
+++ b/harmony-frontend/tests/e2e/auth.spec.ts
@@ -79,12 +79,12 @@ test.describe('True E2E auth and access flows', () => {
     );
 
     await expect(page.getByRole('heading', { name: 'This channel is private' })).toBeVisible();
-    // The header also renders auth CTAs (no returnUrl); narrow to the locked-pane links that carry returnUrl.
+    // Both the guest header and the locked-pane now render returnUrl auth CTAs; use .first() to avoid strict-mode violation.
     await expect(
-      page.getByRole('link', { name: 'Create Account' }).and(page.locator('[href*="returnUrl"]')),
+      page.getByRole('link', { name: 'Create Account' }).and(page.locator('[href*="returnUrl"]')).first(),
     ).toBeVisible();
     await expect(
-      page.getByRole('link', { name: 'Log In' }).and(page.locator('[href*="returnUrl"]')),
+      page.getByRole('link', { name: 'Log In' }).and(page.locator('[href*="returnUrl"]')).first(),
     ).toHaveAttribute(
       'href',
       new RegExp(

--- a/harmony-frontend/tests/e2e/auth.spec.ts
+++ b/harmony-frontend/tests/e2e/auth.spec.ts
@@ -79,8 +79,13 @@ test.describe('True E2E auth and access flows', () => {
     );
 
     await expect(page.getByRole('heading', { name: 'This channel is private' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Create Account' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Log In' })).toHaveAttribute(
+    // The header also renders auth CTAs (no returnUrl); narrow to the locked-pane links that carry returnUrl.
+    await expect(
+      page.getByRole('link', { name: 'Create Account' }).and(page.locator('[href*="returnUrl"]')),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Log In' }).and(page.locator('[href*="returnUrl"]')),
+    ).toHaveAttribute(
       'href',
       new RegExp(
         `returnUrl=%2Fc%2F${SEEDED_PRIVATE_CHANNEL.serverSlug}%2F${SEEDED_PRIVATE_CHANNEL.channelSlug}$`,
@@ -164,10 +169,6 @@ test.describe('True E2E auth and access flows', () => {
       timeout: NAVIGATION_TIMEOUT_MS,
     });
     await expect(page.getByLabel('Join server promotion')).toBeVisible();
-    await expect(
-      page.getByRole('link', {
-        name: 'Log In',
-      }),
-    ).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Log In' }).first()).toBeVisible();
   });
 });

--- a/llm-logs/2026-04-16-210816-session-58ce89e9.md
+++ b/llm-logs/2026-04-16-210816-session-58ce89e9.md
@@ -1,0 +1,478 @@
+# Session Log 2026-04-16-210816
+
+## User
+
+complete 370 in a new branch and create a PR, if not already done
+
+## Assistant
+
+Let me look up issue #370 and check for existing branches/PRs.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 370 --repo CS485-Harmony/Harmony 2>/dev/null || gh issue view 370",
+  "description": "View issue #370"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr list --search \"370\" --state all 2>/dev/null | head -20",
+  "description": "Check for existing PRs related to issue 370"
+}
+```
+
+## Assistant
+
+No existing PR. Let me explore the codebase to find the guest promo banner implementation.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git branch -a | grep -i \"370\\|guest\\|promo\\|banner\" 2>/dev/null",
+  "description": "Check for existing branches related to issue 370"
+}
+```
+
+## Assistant
+
+**Tool call: `Grep`**
+```json
+{
+  "pattern": "promo|guest.*banner|banner.*guest|dismiss.*banner|banner.*dismiss",
+  "path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src",
+  "output_mode": "files_with_matches",
+  "-i": true
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestPromoBanner.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx"
+}
+```
+
+## Assistant
+
+Let me check the similar fixes from issues 367-369 for pattern consistency.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git log --oneline origin/fix/issue-367-guest-reply-auth-prompt | head -5",
+  "description": "Check commits on 367 branch"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git show origin/fix/issue-367-guest-reply-auth-prompt --name-only | head -20",
+  "description": "See files changed in 367 fix"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git diff main origin/fix/issue-367-guest-reply-auth-prompt -- harmony-frontend/src/ 2>/dev/null | head -80",
+  "description": "Diff 367 fix against main"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/docs/ | grep -i guest",
+  "description": "Find guest-related spec docs"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"header\\|banner\\|dismiss\\|auth\\|CTA\\|login\\|signup\" /Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-guest-public-channel-view.md -i | head -40",
+  "description": "Check spec for header/banner/auth guidance"
+}
+```
+
+## Assistant
+
+The fix is clear: add persistent auth links to `GuestHeader` so they're always visible regardless of banner state. Let me create the branch and implement it.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout main && git pull origin main && git checkout -b fix/issue-370-guest-banner-dismiss-auth-path",
+  "description": "Create new branch for issue 370"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx",
+  "old_string": "import { notFound } from 'next/navigation';\nimport {\n  fetchPublicServer,\n  fetchPublicChannel,\n  fetchPublicMessages,\n} from '@/services/publicApiService';\nimport { getChannels } from '@/services/channelService';\nimport { TrpcHttpError } from '@/lib/trpc-errors';\nimport { AuthRedirect } from '@/components/channel/AuthRedirect';\nimport { VisibilityGuard } from '@/components/channel/VisibilityGuard';\nimport { MessageList } from '@/components/channel/MessageList';\nimport { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';\nimport { PrivateChannelLockedPane } from '@/components/channel/PrivateChannelLockedPane';\nimport type { Server, Channel } from '@/types';",
+  "new_string": "import { notFound } from 'next/navigation';\nimport Link from 'next/link';\nimport {\n  fetchPublicServer,\n  fetchPublicChannel,\n  fetchPublicMessages,\n} from '@/services/publicApiService';\nimport { getChannels } from '@/services/channelService';\nimport { TrpcHttpError } from '@/lib/trpc-errors';\nimport { AuthRedirect } from '@/components/channel/AuthRedirect';\nimport { VisibilityGuard } from '@/components/channel/VisibilityGuard';\nimport { MessageList } from '@/components/channel/MessageList';\nimport { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';\nimport { PrivateChannelLockedPane } from '@/components/channel/PrivateChannelLockedPane';\nimport type { Server, Channel } from '@/types';"
+}
+```
+
+## Assistant
+
+Now add persistent auth links to `GuestHeader`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx",
+  "old_string": "      {/* Member count */}\n      <span className='ml-auto flex items-center gap-1.5 text-xs text-gray-400'>\n        <svg\n          className='h-3.5 w-3.5'\n          viewBox='0 0 24 24'\n          fill='currentColor'\n          aria-hidden='true'\n          focusable='false'\n        >\n          <path d='M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z' />\n        </svg>\n        {memberCount.toLocaleString()} members\n      </span>\n    </header>",
+  "new_string": "      {/* Persistent auth CTAs \u2014 always visible so guests retain a login path after dismissing the promo banner */}\n      <div className='ml-auto flex shrink-0 items-center gap-2'>\n        <Link\n          href='/auth/signup'\n          className='inline-flex h-7 items-center justify-center rounded-md bg-[#5865f2] px-3 text-xs font-medium text-white transition-colors hover:bg-[#4752c4]'\n        >\n          <span className='hidden sm:inline'>Create Account</span>\n          <span className='sm:hidden'>Join</span>\n        </Link>\n        <Link\n          href='/auth/login'\n          className='inline-flex h-7 items-center justify-center rounded-md border border-white/20 bg-[#40444b] px-3 text-xs font-medium text-gray-200 transition-colors hover:bg-[#3d4148]'\n        >\n          Log In\n        </Link>\n      </div>\n    </header>"
+}
+```
+
+## Assistant
+
+Now let me verify the change and run linting/tests:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npm run lint 2>&1 | tail -20",
+  "description": "Run frontend lint"
+}
+```
+
+## Assistant
+
+The `memberCount` prop is now unused in `GuestHeader` since I replaced it with auth links. Let me clean that up:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx",
+  "limit": 35,
+  "offset": 25
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx",
+  "old_string": "function GuestHeader({ server, memberCount }: { server: PublicServer; memberCount: number }) {",
+  "new_string": "function GuestHeader({ server }: { server: PublicServer }) {"
+}
+```
+
+## Assistant
+
+Now fix the two call sites that pass `memberCount` to `GuestHeader`:
+
+## Assistant
+
+**Tool call: `Grep`**
+```json
+{
+  "pattern": "GuestHeader server=",
+  "path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx",
+  "output_mode": "content"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": true,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx",
+  "old_string": "        <GuestHeader server={server} memberCount={server.memberCount ?? 0} />",
+  "new_string": "        <GuestHeader server={server} />"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx",
+  "old_string": "      <GuestHeader server={server} memberCount={memberCount} />",
+  "new_string": "      <GuestHeader server={server} />"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm run lint 2>&1 | tail -10",
+  "description": "Re-run lint"
+}
+```
+
+## Assistant
+
+Clean. Now run the tests:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && npm run test:frontend 2>&1 | tail -20",
+  "description": "Run frontend tests"
+}
+```
+
+## Assistant
+
+All 214 tests pass. Now commit and create the PR:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add harmony-frontend/src/components/channel/GuestChannelView.tsx && git diff --staged",
+  "description": "Stage changes and verify diff"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git commit -m \"$(cat <<'EOF'\nfix: add persistent auth CTAs to guest header so login path survives banner dismiss\n\nCloses #370\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit the fix"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/issue-370-guest-banner-dismiss-auth-path",
+  "description": "Push branch to remote"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --title \"fix: add persistent auth CTAs to guest header (closes #370)\" --body \"$(cat <<'EOF'\n## Summary\n- Replaces the member count in `GuestHeader` with persistent **Create Account** / **Log In** links\n- These links are always visible in the header regardless of whether the promo banner has been dismissed\n- The promo banner still shows the full join CTA with server name/member count; the header provides a permanent fallback\n\n## Root Cause\n`GuestPromoBanner` was the only in-page auth entry point. After dismissal, guests had no visible path to log in or sign up.\n\n## Test Plan\n- [ ] Open `/c/<server>/<channel>` as a guest \u2014 verify Create Account and Log In links appear in the header\n- [ ] Dismiss the promo banner \u2014 verify header auth links remain visible\n- [ ] Click Log In \u2014 verify redirect to `/auth/login`\n- [ ] Click Create Account \u2014 verify redirect to `/auth/signup`\n- [ ] Verify all 214 frontend tests pass (`npm run test:frontend`)\n- [ ] Verify lint is clean (`npm run lint`)\n\nCloses #370\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\"",
+  "description": "Create pull request"
+}
+```
+
+## Assistant
+
+PR created: https://github.com/CS485-Harmony/Harmony/pull/393
+
+The fix adds persistent **Create Account** / **Log In** links to `GuestHeader` in `GuestChannelView.tsx`, replacing the member count display. These are always visible regardless of banner state, so guests retain an auth path after dismissing the promo banner. All 214 frontend tests pass and lint is clean.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+

--- a/llm-logs/2026-04-17-084441-session-1e50aad9.md
+++ b/llm-logs/2026-04-17-084441-session-1e50aad9.md
@@ -1,0 +1,677 @@
+# Session Log 2026-04-17-084441
+
+## User
+
+<command-message>resolve-reviews</command-message>
+<command-name>/resolve-reviews</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/resolve-reviews
+
+Automatically resolve all review comments (both human and bot) on the current PR. Uses a two-phase workflow: fix all existing issues, then poll for new ones until quiet.
+
+## Prerequisites
+
+All commands below use `npx agent-reviews`. If the project uses a different package manager, substitute the appropriate runner (e.g., `pnpm dlx agent-reviews` for pnpm, `yarn dlx agent-reviews` for Yarn, `bunx agent-reviews` for Bun). Honor the user's package manager preference throughout.
+
+**Cloud environments only** (e.g., Codespaces, remote agents): verify git author identity so CI checks can map commits to the user. Run `git config --global --get user.email` and if empty or a placeholder, set it manually. Skip this check in local environments.
+
+## Phase 1: FETCH & FIX (synchronous)
+
+### Step 1: Fetch All Comments (Expanded)
+
+Run `npx agent-reviews --unanswered --expanded`
+
+The CLI auto-detects the current branch, finds the associated PR, and authenticates via `gh` CLI or environment variables. If anything fails (no token, no PR, CLI not installed), it exits with a clear error message.
+
+This shows all unanswered comments (both human and bot) with full detail: complete comment body (no truncation), diff hunk (code context), and all replies. Each comment shows its ID in brackets (e.g., `[12345678]`).
+
+If zero comments are returned, print "No unanswered comments found" and skip to Phase 2.
+
+### Step 3: Process Each Unanswered Comment
+
+For each comment from the expanded output, apply the appropriate evaluation based on whether the author is a bot or a human.
+
+#### For Bot Comments
+
+Read the referenced code and determine:
+
+1. **TRUE POSITIVE** - A real bug that needs fixing
+2. **FALSE POSITIVE** - Not actually a bug (intentional behavior, bot misunderstanding)
+3. **UNCERTAIN** - Not sure; ask the user
+
+**Likely TRUE POSITIVE:**
+- Code obviously violates stated behavior
+- Missing null checks on potentially undefined values
+- Type mismatches or incorrect function signatures
+- Logic errors in conditionals
+- Missing error handling for documented failure cases
+
+**Likely FALSE POSITIVE:**
+- Bot doesn't understand the framework/library patterns
+- Code is intentionally structured that way (with comments explaining why)
+- Bot is flagging style preferences, not bugs
+- The "bug" is actually a feature or intentional behavior
+- Bot misread the code flow
+
+#### For Human Comments
+
+Read the referenced code and the reviewer's comment. Human reviewers are generally more accurate and context-aware than bots. Determine:
+
+1. **ACTIONABLE** - The reviewer identified a real issue or requested a concrete change
+2. **DISCUSSION** - The comment raises a valid point but the right approach is unclear
+3. **ALREADY ADDRESSED** - The concern has already been fixed or is no longer relevant
+
+**Likely ACTIONABLE:**
+- Reviewer points out a bug or logic error
+- Reviewer requests a specific code change
+- Reviewer identifies missing edge cases or error handling
+
+**Likely DISCUSSION -- ask the user:**
+- Reviewer suggests an architectural change you're unsure about
+- Comment involves a tradeoff (performance vs readability, etc.)
+- The feedback is subjective without team consensus
+
+#### When UNCERTAIN -- ask the user
+
+For both bot and human comments:
+- The fix would require architectural changes
+- You're genuinely unsure if the behavior is intentional
+- Multiple valid interpretations exist
+- The fix could have unintended side effects
+
+#### Act on Evaluation
+
+**If TRUE POSITIVE / ACTIONABLE:** Fix the code. Track the comment ID and a brief description of the fix.
+
+**If FALSE POSITIVE:** Do NOT change the code. Track the comment ID and the reason it's not a real bug.
+
+**If DISCUSSION:** Ask the user to consult the PR author. Apply their decision and track it.
+
+**If ALREADY ADDRESSED:** Track the comment ID and note why.
+
+**If UNCERTAIN:** Ask the user. If they say skip, track it as skipped.
+
+Do NOT reply to comments yet. Replies happen after the commit (Step 5).
+
+### Step 4: Commit and Push
+
+After evaluating and fixing ALL unanswered comments:
+
+1. Run your project's lint and type-check
+2. Stage, commit, and push:
+   ```bash
+   git add -A
+   git commit -m "fix: address PR review findings
+
+   {List of changes made, grouped by reviewer/bot}"
+   git push
+   ```
+3. Capture the commit hash from the output.
+
+### Step 5: Reply to All Comments
+
+Now that the commit hash exists, reply to every processed comment. The `--resolve` flag marks the review thread as resolved on GitHub.
+
+**For each TRUE POSITIVE / ACTIONABLE:**
+
+Run `npx agent-reviews --reply <comment_id> "Fixed in {hash}. {Brief description of the fix}" --resolve`
+
+**For each FALSE POSITIVE:**
+
+Run `npx agent-reviews --reply <comment_id> "Won't fix: {reason}. {Explanation of why this is intentional or not applicable}" --resolve`
+
+**For each DISCUSSION (after user decision):**
+
+Run `npx agent-reviews --reply <comment_id> "{Outcome}. {Explanation of the decision and any changes made}" --resolve`
+
+**For each ALREADY ADDRESSED:**
+
+Run `npx agent-reviews --reply <comment_id> "Already addressed. {Explanation of when/how this was fixed}" --resolve`
+
+**For each SKIPPED:**
+
+Run `npx agent-reviews --reply <comment_id> "Skipped per user request" --resolve`
+
+**DO NOT start Phase 2 until all replies are posted.**
+
+---
+
+## Phase 2: POLL FOR NEW COMMENTS (loop until quiet)
+
+The watcher exits immediately when new comments are found (after a 5s grace period to catch batch posts). This means you run it in a loop: start watcher, process any comments it returns, restart watcher, repeat until the watcher times out with no new comments.
+
+### Step 6: Start Watcher Loop
+
+Repeat the following until the watcher exits with no new comments:
+
+**6a.** Launch the watcher in the background:
+
+Run `npx agent-reviews --watch` as a background task.
+
+**6b.** Wait for the background command to complete (default 10 minutes; override with `--timeout`).
+
+**6c.** Check the output:
+
+- **If new comments were found** (output contains `EXITING WITH NEW COMMENTS`):
+  1. Use `--detail <id>` to read each new comment's full detail
+  2. Process them exactly as in Phase 1, Steps 3-5 (evaluate, fix, commit, push, reply)
+  3. **Go back to Step 6a** to restart the watcher
+
+- **If no new comments** (output contains `WATCH COMPLETE`):
+  Stop looping and move to the Summary Report.
+
+---
+
+## Summary Report
+
+After both phases complete, provide a summary:
+
+```text
+## PR Review Resolution Summary
+
+### Results
+- Fixed: X issues
+- Already addressed: X
+- Won't fix (false positives): X
+- Discussion resolved: X
+- Skipped per user: X
+
+### By Reviewer/Bot
+#### cursor[bot]
+- {description} - Fixed in {commit}
+- {description} - Won't fix: {reason}
+
+#### @reviewer-name
+- {description} - Fixed in {commit}
+
+### Status
+All findings addressed. Watch completed.
+```
+
+## Important Notes
+
+### Response Policy
+- **Every comment gets a response** - No silent ignores
+- For bots: responses help train them and prevent re-raised false positives
+- For humans: replies keep reviewers informed and unblock approvals
+
+### User Interaction
+- Ask the user when uncertain about a finding
+- Don't guess on architectural or business logic questions
+- It's better to ask than to make a wrong fix or wrong dismissal
+- Human reviewers often have context you don't - defer to the author when unsure
+
+### Best Practices
+- Verify findings before fixing - bots have false positives, humans rarely do
+- Keep fixes minimal and focused - don't refactor unrelated code
+- Ensure type-check and lint pass before committing
+- Group related fixes into a single commit
+- Copilot `suggestion` blocks often contain ready-to-use fixes
+- If a human reviewer suggests a specific code change, prefer their version unless it introduces issues
+
+## Assistant
+
+I'll fetch all unanswered PR review comments to get started.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --unanswered --expanded 2>&1",
+  "description": "Fetch all unanswered PR review comments"
+}
+```
+
+## Assistant
+
+Let me read the current file and related auth components to understand the context.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git log --oneline -10 2>&1",
+  "description": "Show recent commits"
+}
+```
+
+## Assistant
+
+Let me look at GuestPromoBanner and PrivateChannelLockedPane to understand the established auth pattern.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat -n /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestPromoBanner.tsx 2>&1",
+  "description": "Read GuestPromoBanner component"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat -n /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/PrivateChannelLockedPane.tsx 2>&1",
+  "description": "Read PrivateChannelLockedPane component"
+}
+```
+
+## Assistant
+
+Now I have a clear picture. Let me call advisor before making changes.
+
+## Assistant
+
+Let me check the tests and E2E specs before writing code.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"GuestHeader\\|GuestChannelView\\|guest.*header\\|header.*CTA\\|auth.*link.*guest\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/ 2>&1 | head -60",
+  "description": "Search for GuestHeader and related test references"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/ 2>&1",
+  "description": "List test files"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"Log In\\|Create Account\\|signup\\|login\\|auth.*link\\|returnUrl\\|GuestHeader\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/ 2>&1 | grep -v \"node_modules\" | head -40",
+  "description": "Search for auth link tests"
+}
+```
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "**/*.spec.ts",
+  "path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat -n /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/tests/e2e/auth.spec.ts 2>&1 | grep -A5 -B5 \"header\\|GuestHeader\\|Log In\\|Create Account\\|returnUrl\" | head -80",
+  "description": "Search E2E spec for auth/header references"
+}
+```
+
+## Assistant
+
+The E2E tests already handle duplicates via `[href*="returnUrl"]`. Now I'll create the client `GuestHeader` component, then update `GuestChannelView`.
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestHeader.tsx",
+  "content": "'use client';\n\nimport Link from 'next/link';\nimport { usePathname } from 'next/navigation';\nimport { useAuth } from '@/hooks/useAuth';\nimport type { Server } from '@/types';\n\ntype PublicServer = Omit<Server, 'ownerId'>;\n\nexport function GuestHeader({ server }: { server: PublicServer }) {\n  const { isAuthenticated } = useAuth();\n  const pathname = usePathname();\n  const returnUrl = encodeURIComponent(pathname);\n\n  return (\n    <header className='flex h-14 shrink-0 items-center gap-3 border-b border-black/20 bg-[#2f3136] px-4'>\n      {/* Harmony logo wordmark */}\n      <span className='text-lg font-bold text-[#5865f2]'>Harmony</span>\n\n      {/* Divider */}\n      <span className='text-gray-600' aria-hidden='true'>\n        /\n      </span>\n\n      {/* Server name \u2014 min-w-0 flex-1 prevents overflow when CTAs are present */}\n      <span className='min-w-0 flex-1 truncate text-sm font-semibold text-white'>{server.name}</span>\n\n      {/* Auth CTAs \u2014 hidden for authenticated users (e.g. non-member 403 path) */}\n      {!isAuthenticated && (\n        <div className='flex shrink-0 items-center gap-2'>\n          <Link\n            href={`/auth/signup?returnUrl=${returnUrl}`}\n            className='inline-flex h-7 items-center justify-center rounded-md bg-[#5865f2] px-3 text-xs font-medium text-white transition-colors hover:bg-[#4752c4]'\n          >\n            <span className='hidden sm:inline'>Create Account</span>\n            <span className='sm:hidden'>Join</span>\n          </Link>\n          <Link\n            href={`/auth/login?returnUrl=${returnUrl}`}\n            className='inline-flex h-7 items-center justify-center rounded-md border border-white/20 bg-[#40444b] px-3 text-xs font-medium text-gray-200 transition-colors hover:bg-[#3d4148]'\n          >\n            Log In\n          </Link>\n        </div>\n      )}\n    </header>\n  );\n}\n"
+}
+```
+
+## Assistant
+
+Now update `GuestChannelView.tsx` to import the new client component and remove the old `GuestHeader`.
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx",
+  "old_string": "import { AuthRedirect } from '@/components/channel/AuthRedirect';\nimport { VisibilityGuard } from '@/components/channel/VisibilityGuard';\nimport { MessageList } from '@/components/channel/MessageList';\nimport { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';\nimport { PrivateChannelLockedPane } from '@/components/channel/PrivateChannelLockedPane';\nimport type { Server, Channel } from '@/types';\n\ntype PublicServer = Omit<Server, 'ownerId'>;\n\n// \u2500\u2500\u2500 Guest Header \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nfunction GuestHeader({ server }: { server: PublicServer }) {\n  return (\n    <header className='flex h-14 shrink-0 items-center gap-3 border-b border-black/20 bg-[#2f3136] px-4'>\n      {/* Harmony logo wordmark */}\n      <span className='text-lg font-bold text-[#5865f2]'>Harmony</span>\n\n      {/* Divider */}\n      <span className='text-gray-600' aria-hidden='true'>\n        /\n      </span>\n\n      {/* Server name */}\n      <span className='text-sm font-semibold text-white'>{server.name}</span>\n\n      {/* Persistent auth CTAs \u2014 always visible so guests retain a login path after dismissing the promo banner */}\n      <div className='ml-auto flex shrink-0 items-center gap-2'>\n        <Link\n          href='/auth/signup'\n          className='inline-flex h-7 items-center justify-center rounded-md bg-[#5865f2] px-3 text-xs font-medium text-white transition-colors hover:bg-[#4752c4]'\n        >\n          <span className='hidden sm:inline'>Create Account</span>\n          <span className='sm:hidden'>Join</span>\n        </Link>\n        <Link\n          href='/auth/login'\n          className='inline-flex h-7 items-center justify-center rounded-md border border-white/20 bg-[#40444b] px-3 text-xs font-medium text-gray-200 transition-colors hover:bg-[#3d4148]'\n        >\n          Log In\n        </Link>\n      </div>\n    </header>\n  );\n}",
+  "new_string": "import { AuthRedirect } from '@/components/channel/AuthRedirect';\nimport { VisibilityGuard } from '@/components/channel/VisibilityGuard';\nimport { MessageList } from '@/components/channel/MessageList';\nimport { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';\nimport { GuestHeader } from '@/components/channel/GuestHeader';\nimport { PrivateChannelLockedPane } from '@/components/channel/PrivateChannelLockedPane';\nimport type { Channel } from '@/types';"
+}
+```
+
+## Assistant
+
+Now remove the unused `Link` import and `PublicServer` type alias from the top of the file.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx",
+  "old_string": "import { notFound } from 'next/navigation';\nimport Link from 'next/link';\nimport {",
+  "new_string": "import { notFound } from 'next/navigation';\nimport {"
+}
+```
+
+## Assistant
+
+Now run lint and type-check to verify:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npx tsc --noEmit 2>&1 | head -40",
+  "description": "Run TypeScript type check"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm run lint 2>&1 | tail -20",
+  "description": "Run ESLint"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test -- --passWithNoTests 2>&1 | tail -20",
+  "description": "Run frontend tests",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All 214 tests pass. Now commit and push.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-frontend/src/components/channel/GuestHeader.tsx harmony-frontend/src/components/channel/GuestChannelView.tsx && git diff --staged --stat",
+  "description": "Stage changed files and show diff stat"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git commit -m \"$(cat <<'EOF'\nfix: hide guest header CTAs for authed users and add returnUrl\n\n- Extract GuestHeader into a 'use client' component so it can read\n  auth state via useAuth and current path via usePathname\n- Hide Create Account / Log In links when isAuthenticated (fixes\n  authenticated non-member users seeing irrelevant CTAs on 403 path)\n- Append returnUrl to both auth links, matching GuestPromoBanner and\n  PrivateChannelLockedPane behavior\n- Wrap server name in min-w-0 flex-1 + truncate to prevent overflow\n  when CTA buttons are present\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit the GuestHeader fixes"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push 2>&1",
+  "description": "Push to remote"
+}
+```
+
+## Assistant
+
+Now reply to all comments.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 3097334033 \"Fixed in e3eb6e2. Both auth links now append \\`?returnUrl=\\` using \\`usePathname()\\`, matching the established pattern from \\`GuestPromoBanner\\` and \\`PrivateChannelLockedPane\\`.\" --resolve 2>&1",
+  "description": "Reply to returnUrl comment"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 3097334050 \"Fixed in e3eb6e2. \\`GuestHeader\\` is now a \\`'use client'\\` component that calls \\`useAuth()\\` and hides both CTAs when \\`isAuthenticated\\` is true, so authenticated non-member users on the 403 path no longer see Create Account / Log In.\" --resolve 2>&1",
+  "description": "Reply to authenticated user CTA visibility comment"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 3097334071 \"Fixed in e3eb6e2. The server name \\`<span>\\` now carries \\`min-w-0 flex-1 truncate\\` classes so it shrinks and ellipsis-clips before the CTA buttons are pushed off-screen.\" --resolve 2>&1",
+  "description": "Reply to overflow comment"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 4125970847 \"Fixed in e3eb6e2. \\`GuestHeader\\` is now a \\`'use client'\\` component that: (1) hides auth CTAs when \\`isAuthenticated\\` (fixing the authed non-member regression), (2) appends \\`returnUrl\\` to both links (matching the \\`GuestPromoBanner\\`/\\`PrivateChannelLockedPane\\` established pattern), and (3) fixes server-name overflow. These three changes bring the header CTA flow into alignment with the rest of the guest auth surface.\" --resolve 2>&1",
+  "description": "Reply to human reviewer comment"
+}
+```
+
+## Assistant
+
+Now start the Phase 2 watcher.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --watch 2>&1",
+  "description": "Watch for new PR comments (10 min timeout)",
+  "timeout": 620000
+}
+```
+
+## User
+
+[Request interrupted by user for tool use]
+
+## Assistant
+
+No response requested.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+


### PR DESCRIPTION
## Summary
- Replaces the member count in `GuestHeader` with persistent **Create Account** / **Log In** links
- These links are always visible in the header regardless of whether the promo banner has been dismissed
- The promo banner still shows the full join CTA with server name/member count; the header provides a permanent fallback

## Root Cause
`GuestPromoBanner` was the only in-page auth entry point. After dismissal, guests had no visible path to log in or sign up.

## Test Plan
- [ ] Open `/c/<server>/<channel>` as a guest — verify Create Account and Log In links appear in the header
- [ ] Dismiss the promo banner — verify header auth links remain visible
- [ ] Click Log In — verify redirect to `/auth/login`
- [ ] Click Create Account — verify redirect to `/auth/signup`
- [ ] Verify all 214 frontend tests pass (`npm run test:frontend`)
- [ ] Verify lint is clean (`npm run lint`)

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)