### PR TITLE
[codex] Add signup empty-data regression coverage

### DIFF
--- a/harmony-backend/tests/auth.service.test.ts
+++ b/harmony-backend/tests/auth.service.test.ts
@@ -249,6 +249,21 @@ describe('authService.register', () => {
     expect(mockJoinServer).toHaveBeenCalledWith(mockUserId, 'server-001');
   });
 
+  it('still returns tokens when no default server exists in an empty-data environment', async () => {
+    mockPrisma.server.findFirst.mockResolvedValue(null);
+
+    const result = await authService.register(
+      'user@example.com',
+      'testuser',
+      PASSWORD_SALT,
+      derivePasswordVerifier('SecurePass123!'),
+    );
+
+    expect(result.accessToken).toBeTruthy();
+    expect(result.refreshToken).toBeTruthy();
+    expect(mockJoinServer).not.toHaveBeenCalled();
+  });
+
   it('continues registration when joinServer fails', async () => {
     mockPrisma.server.findFirst.mockResolvedValue({ id: 'server-001' });
     mockJoinServer.mockRejectedValue(new Error('Server join failed'));

--- a/harmony-backend/tests/auth.service.test.ts
+++ b/harmony-backend/tests/auth.service.test.ts
@@ -249,7 +249,7 @@ describe('authService.register', () => {
     expect(mockJoinServer).toHaveBeenCalledWith(mockUserId, 'server-001');
   });
 
-  it('still returns tokens when no default server exists in an empty-data environment', async () => {
+  it('returns tokens when no default server exists and skips joinServer', async () => {
     mockPrisma.server.findFirst.mockResolvedValue(null);
 
     const result = await authService.register(


### PR DESCRIPTION
## Summary
- add backend regression coverage for signup when no default server exists
- document the actual root cause behind issue #376: the attached repro left the required password field blank, so the browser never submitted the form
- keep the fix surface limited to test coverage because the product path already behaves correctly

## Root cause
Issue #376 reported signup as a no-op in an empty-data environment, but the attached screenshots show native browser validation blocking submit on an empty password field. No registration request fired because the form was invalid before submit.

## Impact
This locks down the real empty-data behavior on the backend so registration still succeeds even when there is no default server to auto-join.

## Validation
- `npm test -- --runInBand tests/auth.service.test.ts`
- `npx eslint tests/auth.service.test.ts`

Closes #376.
