### PR TITLE
[codex] Fix server settings authorization bypass

### DIFF
--- a/harmony-frontend/src/__tests__/server-settings-access.test.ts
+++ b/harmony-frontend/src/__tests__/server-settings-access.test.ts
@@ -1,6 +1,6 @@
 import { requireServerSettingsAccess } from '@/app/settings/[serverSlug]/settings-access';
 import { getCurrentUser } from '@/services/authService';
-import { getServerAuthenticated } from '@/services/serverService';
+import { getServerAuthenticated, getServerMembersWithRole } from '@/services/serverService';
 
 const mockRedirect = jest.fn((path: string) => {
   throw new Error(`REDIRECT:${path}`);
@@ -20,11 +20,15 @@ jest.mock('@/services/authService', () => ({
 
 jest.mock('@/services/serverService', () => ({
   getServerAuthenticated: jest.fn(),
+  getServerMembersWithRole: jest.fn(),
 }));
 
 const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
 const mockGetServerAuthenticated = getServerAuthenticated as jest.MockedFunction<
   typeof getServerAuthenticated
+>;
+const mockGetServerMembersWithRole = getServerMembersWithRole as jest.MockedFunction<
+  typeof getServerMembersWithRole
 >;
 
 describe('requireServerSettingsAccess', () => {
@@ -37,6 +41,7 @@ describe('requireServerSettingsAccess', () => {
       ReturnType<typeof getServerAuthenticated>
     >;
     mockGetServerAuthenticated.mockResolvedValue(server);
+    mockGetServerMembersWithRole.mockResolvedValue([]);
     mockGetCurrentUser.mockResolvedValue({
       id: 'owner-1',
       username: 'owner',
@@ -55,6 +60,7 @@ describe('requireServerSettingsAccess', () => {
       ReturnType<typeof getServerAuthenticated>
     >;
     mockGetServerAuthenticated.mockResolvedValue(server);
+    mockGetServerMembersWithRole.mockResolvedValue([]);
     mockGetCurrentUser.mockResolvedValue({
       id: 'admin-1',
       username: 'admin',
@@ -67,11 +73,48 @@ describe('requireServerSettingsAccess', () => {
     await expect(requireServerSettingsAccess('test-server')).resolves.toBe(server);
   });
 
+  it('returns the server for a server admin', async () => {
+    const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
+      ReturnType<typeof getServerAuthenticated>
+    >;
+    mockGetServerAuthenticated.mockResolvedValue(server);
+    mockGetServerMembersWithRole.mockResolvedValue([
+      {
+        userId: 'admin-member-1',
+        username: 'admin-member',
+        displayName: 'Admin Member',
+        avatarUrl: null,
+        role: 'admin',
+        joinedAt: '2026-04-17T00:00:00.000Z',
+      },
+    ]);
+    mockGetCurrentUser.mockResolvedValue({
+      id: 'admin-member-1',
+      username: 'admin-member',
+      displayName: 'Admin Member',
+      role: 'member',
+      status: 'online',
+      isSystemAdmin: false,
+    });
+
+    await expect(requireServerSettingsAccess('test-server')).resolves.toBe(server);
+  });
+
   it('redirects unauthorized users to the channel view', async () => {
     const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
       ReturnType<typeof getServerAuthenticated>
     >;
     mockGetServerAuthenticated.mockResolvedValue(server);
+    mockGetServerMembersWithRole.mockResolvedValue([
+      {
+        userId: 'member-1',
+        username: 'member',
+        displayName: 'Member',
+        avatarUrl: null,
+        role: 'member',
+        joinedAt: '2026-04-17T00:00:00.000Z',
+      },
+    ]);
     mockGetCurrentUser.mockResolvedValue({
       id: 'member-1',
       username: 'member',
@@ -91,6 +134,16 @@ describe('requireServerSettingsAccess', () => {
       ReturnType<typeof getServerAuthenticated>
     >;
     mockGetServerAuthenticated.mockResolvedValue(server);
+    mockGetServerMembersWithRole.mockResolvedValue([
+      {
+        userId: 'member-1',
+        username: 'member',
+        displayName: 'Member',
+        avatarUrl: null,
+        role: 'member',
+        joinedAt: '2026-04-17T00:00:00.000Z',
+      },
+    ]);
     mockGetCurrentUser.mockResolvedValue({
       id: 'member-1',
       username: 'member',

--- a/harmony-frontend/src/__tests__/server-settings-access.test.ts
+++ b/harmony-frontend/src/__tests__/server-settings-access.test.ts
@@ -1,0 +1,112 @@
+import { requireServerSettingsAccess } from '@/app/settings/[serverSlug]/settings-access';
+import { getCurrentUser } from '@/services/authService';
+import { getServerAuthenticated } from '@/services/serverService';
+
+const mockRedirect = jest.fn((path: string) => {
+  throw new Error(`REDIRECT:${path}`);
+});
+const mockNotFound = jest.fn(() => {
+  throw new Error('NOT_FOUND');
+});
+
+jest.mock('next/navigation', () => ({
+  redirect: (path: string) => mockRedirect(path),
+  notFound: () => mockNotFound(),
+}));
+
+jest.mock('@/services/authService', () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock('@/services/serverService', () => ({
+  getServerAuthenticated: jest.fn(),
+}));
+
+const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
+const mockGetServerAuthenticated = getServerAuthenticated as jest.MockedFunction<
+  typeof getServerAuthenticated
+>;
+
+describe('requireServerSettingsAccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the server for the owner', async () => {
+    const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
+      ReturnType<typeof getServerAuthenticated>
+    >;
+    mockGetServerAuthenticated.mockResolvedValue(server);
+    mockGetCurrentUser.mockResolvedValue({
+      id: 'owner-1',
+      username: 'owner',
+      displayName: 'Owner',
+      role: 'member',
+      status: 'online',
+      isSystemAdmin: false,
+    });
+
+    await expect(requireServerSettingsAccess('test-server')).resolves.toBe(server);
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('returns the server for a system admin', async () => {
+    const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
+      ReturnType<typeof getServerAuthenticated>
+    >;
+    mockGetServerAuthenticated.mockResolvedValue(server);
+    mockGetCurrentUser.mockResolvedValue({
+      id: 'admin-1',
+      username: 'admin',
+      displayName: 'Admin',
+      role: 'member',
+      status: 'online',
+      isSystemAdmin: true,
+    });
+
+    await expect(requireServerSettingsAccess('test-server')).resolves.toBe(server);
+  });
+
+  it('redirects unauthorized users to the channel view', async () => {
+    const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
+      ReturnType<typeof getServerAuthenticated>
+    >;
+    mockGetServerAuthenticated.mockResolvedValue(server);
+    mockGetCurrentUser.mockResolvedValue({
+      id: 'member-1',
+      username: 'member',
+      displayName: 'Member',
+      role: 'member',
+      status: 'online',
+      isSystemAdmin: false,
+    });
+
+    await expect(requireServerSettingsAccess('test-server')).rejects.toThrow(
+      'REDIRECT:/channels/test-server',
+    );
+  });
+
+  it('throws in server-action mode for unauthorized users', async () => {
+    const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
+      ReturnType<typeof getServerAuthenticated>
+    >;
+    mockGetServerAuthenticated.mockResolvedValue(server);
+    mockGetCurrentUser.mockResolvedValue({
+      id: 'member-1',
+      username: 'member',
+      displayName: 'Member',
+      role: 'member',
+      status: 'online',
+      isSystemAdmin: false,
+    });
+
+    await expect(requireServerSettingsAccess('test-server', 'throw')).rejects.toThrow('Forbidden');
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('delegates missing servers to notFound', async () => {
+    mockGetServerAuthenticated.mockResolvedValue(null);
+
+    await expect(requireServerSettingsAccess('missing-server')).rejects.toThrow('NOT_FOUND');
+  });
+});

--- a/harmony-frontend/src/app/settings/[serverSlug]/actions.ts
+++ b/harmony-frontend/src/app/settings/[serverSlug]/actions.ts
@@ -12,22 +12,18 @@ import { revalidatePath } from 'next/cache';
 import {
   updateServer,
   deleteServer,
-  getServerAuthenticated,
   getServerMembersWithRole,
   changeMemberRole,
   removeMember,
 } from '@/services/serverService';
 import type { Server, ServerMemberInfo } from '@/types';
+import { requireServerSettingsAccess } from './settings-access';
 
 export async function saveServerSettings(
   serverSlug: string,
   patch: Partial<Pick<Server, 'name' | 'description' | 'icon' | 'isPublic'>>,
 ): Promise<void> {
-  // Resolve server by route param (don't trust a raw serverId from the client)
-  const server = await getServerAuthenticated(serverSlug);
-  if (!server) {
-    throw new Error('Server not found');
-  }
+  const server = await requireServerSettingsAccess(serverSlug, 'throw');
 
   // Build an explicit whitelist so callers cannot sneak in extra fields
   const sanitizedPatch: Partial<Pick<Server, 'name' | 'description' | 'icon' | 'isPublic'>> = {};
@@ -61,11 +57,7 @@ export async function saveServerSettings(
 }
 
 export async function deleteServerAction(serverSlug: string): Promise<void> {
-  // Resolve server first to confirm it exists
-  const server = await getServerAuthenticated(serverSlug);
-  if (!server) {
-    throw new Error('Server not found');
-  }
+  const server = await requireServerSettingsAccess(serverSlug, 'throw');
 
   // The backend deleteServer takes the server ID and handles cascade deletion
   await deleteServer(server.id);
@@ -78,8 +70,9 @@ export async function deleteServerAction(serverSlug: string): Promise<void> {
   redirect('/');
 }
 
-export async function getServerMembersAction(serverId: string): Promise<ServerMemberInfo[]> {
-  return getServerMembersWithRole(serverId);
+export async function getServerMembersAction(serverSlug: string): Promise<ServerMemberInfo[]> {
+  const server = await requireServerSettingsAccess(serverSlug, 'throw');
+  return getServerMembersWithRole(server.id);
 }
 
 export async function changeMemberRoleAction(
@@ -87,18 +80,13 @@ export async function changeMemberRoleAction(
   targetUserId: string,
   newRole: 'ADMIN' | 'MODERATOR' | 'MEMBER',
 ): Promise<void> {
-  const server = await getServerAuthenticated(serverSlug);
-  if (!server) throw new Error('Server not found');
+  const server = await requireServerSettingsAccess(serverSlug, 'throw');
   await changeMemberRole(server.id, targetUserId, newRole);
   revalidatePath(`/settings/${serverSlug}`);
 }
 
-export async function removeMemberAction(
-  serverSlug: string,
-  targetUserId: string,
-): Promise<void> {
-  const server = await getServerAuthenticated(serverSlug);
-  if (!server) throw new Error('Server not found');
+export async function removeMemberAction(serverSlug: string, targetUserId: string): Promise<void> {
+  const server = await requireServerSettingsAccess(serverSlug, 'throw');
   await removeMember(server.id, targetUserId);
   revalidatePath(`/settings/${serverSlug}`);
 }

--- a/harmony-frontend/src/app/settings/[serverSlug]/page.tsx
+++ b/harmony-frontend/src/app/settings/[serverSlug]/page.tsx
@@ -1,4 +1,3 @@
-import { notFound } from 'next/navigation';
 import { ServerSettingsPage } from '@/components/settings/ServerSettingsPage';
 import { requireServerSettingsAccess } from './settings-access';
 
@@ -9,7 +8,6 @@ interface PageProps {
 export default async function ServerSettingsRoute({ params }: PageProps) {
   const { serverSlug } = await params;
   const server = await requireServerSettingsAccess(serverSlug);
-  if (!server) notFound();
 
   return <ServerSettingsPage server={server} serverSlug={serverSlug} />;
 }

--- a/harmony-frontend/src/app/settings/[serverSlug]/page.tsx
+++ b/harmony-frontend/src/app/settings/[serverSlug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
-import { getServerAuthenticated } from '@/services/serverService';
 import { ServerSettingsPage } from '@/components/settings/ServerSettingsPage';
+import { requireServerSettingsAccess } from './settings-access';
 
 interface PageProps {
   params: Promise<{ serverSlug: string }>;
@@ -8,7 +8,7 @@ interface PageProps {
 
 export default async function ServerSettingsRoute({ params }: PageProps) {
   const { serverSlug } = await params;
-  const server = await getServerAuthenticated(serverSlug);
+  const server = await requireServerSettingsAccess(serverSlug);
   if (!server) notFound();
 
   return <ServerSettingsPage server={server} serverSlug={serverSlug} />;

--- a/harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts
+++ b/harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts
@@ -1,6 +1,6 @@
 import { notFound, redirect } from 'next/navigation';
 import { getCurrentUser } from '@/services/authService';
-import { getServerAuthenticated } from '@/services/serverService';
+import { getServerAuthenticated, getServerMembersWithRole } from '@/services/serverService';
 
 type UnauthorizedMode = 'redirect' | 'throw';
 
@@ -9,6 +9,16 @@ function isSettingsAdmin(
   ownerId: string,
 ): boolean {
   return Boolean(user && (user.isSystemAdmin || user.id === ownerId));
+}
+
+async function hasServerAdminAccess(userId: string, serverId: string): Promise<boolean> {
+  try {
+    const members = await getServerMembersWithRole(serverId);
+    const currentMembership = members.find(member => member.userId === userId);
+    return currentMembership?.role === 'owner' || currentMembership?.role === 'admin';
+  } catch {
+    return false;
+  }
 }
 
 export async function requireServerSettingsAccess(
@@ -20,6 +30,10 @@ export async function requireServerSettingsAccess(
 
   const user = await getCurrentUser();
   if (isSettingsAdmin(user, server.ownerId)) {
+    return server;
+  }
+
+  if (user && (await hasServerAdminAccess(user.id, server.id))) {
     return server;
   }
 

--- a/harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts
+++ b/harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts
@@ -1,0 +1,31 @@
+import { notFound, redirect } from 'next/navigation';
+import { getCurrentUser } from '@/services/authService';
+import { getServerAuthenticated } from '@/services/serverService';
+
+type UnauthorizedMode = 'redirect' | 'throw';
+
+function isSettingsAdmin(
+  user: Awaited<ReturnType<typeof getCurrentUser>>,
+  ownerId: string,
+): boolean {
+  return Boolean(user && (user.isSystemAdmin || user.id === ownerId));
+}
+
+export async function requireServerSettingsAccess(
+  serverSlug: string,
+  mode: UnauthorizedMode = 'redirect',
+) {
+  const server = await getServerAuthenticated(serverSlug);
+  if (!server) notFound();
+
+  const user = await getCurrentUser();
+  if (isSettingsAdmin(user, server.ownerId)) {
+    return server;
+  }
+
+  if (mode === 'throw') {
+    throw new Error('Forbidden');
+  }
+
+  redirect(`/channels/${serverSlug}`);
+}

--- a/harmony-frontend/src/components/settings/MembersSection.tsx
+++ b/harmony-frontend/src/components/settings/MembersSection.tsx
@@ -98,7 +98,14 @@ interface MemberRowProps {
   onRemoved: (userId: string) => void;
 }
 
-function MemberRow({ member, serverSlug, isCurrentUser, canCurrentUserManage, onRoleChanged, onRemoved }: MemberRowProps) {
+function MemberRow({
+  member,
+  serverSlug,
+  isCurrentUser,
+  canCurrentUserManage,
+  onRoleChanged,
+  onRemoved,
+}: MemberRowProps) {
   const [state, setState] = useState<MemberRowState>({
     changingRole: false,
     kickConfirm: false,
@@ -156,9 +163,7 @@ function MemberRow({ member, serverSlug, isCurrentUser, canCurrentUserManage, on
             >
               {ROLE_LABEL[member.role]}
             </span>
-            {isCurrentUser && (
-              <span className='text-xs text-gray-500'>(you)</span>
-            )}
+            {isCurrentUser && <span className='text-xs text-gray-500'>(you)</span>}
           </div>
           <p className='truncate text-xs text-gray-500'>@{member.username}</p>
         </div>
@@ -232,11 +237,10 @@ function MemberRow({ member, serverSlug, isCurrentUser, canCurrentUserManage, on
 // ─── Main component ───────────────────────────────────────────────────────────
 
 interface MembersSectionProps {
-  serverId: string;
   serverSlug: string;
 }
 
-export function MembersSection({ serverId, serverSlug }: MembersSectionProps) {
+export function MembersSection({ serverSlug }: MembersSectionProps) {
   const { user } = useAuth();
   const [members, setMembers] = useState<ServerMemberInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -244,7 +248,7 @@ export function MembersSection({ serverId, serverSlug }: MembersSectionProps) {
 
   useEffect(() => {
     let cancelled = false;
-    getServerMembersAction(serverId)
+    getServerMembersAction(serverSlug)
       .then(data => {
         if (!cancelled) {
           setMembers(data);
@@ -258,11 +262,13 @@ export function MembersSection({ serverId, serverSlug }: MembersSectionProps) {
           setLoading(false);
         }
       });
-    return () => { cancelled = true; };
-  }, [serverId]);
+    return () => {
+      cancelled = true;
+    };
+  }, [serverSlug]);
 
   function handleRoleChanged(userId: string, newRole: ServerMemberInfo['role']) {
-    setMembers(prev => prev.map(m => m.userId === userId ? { ...m, role: newRole } : m));
+    setMembers(prev => prev.map(m => (m.userId === userId ? { ...m, role: newRole } : m)));
   }
 
   function handleRemoved(userId: string) {

--- a/harmony-frontend/src/components/settings/ServerSettingsPage.tsx
+++ b/harmony-frontend/src/components/settings/ServerSettingsPage.tsx
@@ -98,10 +98,7 @@ function OverviewSection({
         return;
       setSaveError(getUserErrorMessage(err, 'Failed to save changes.'));
     } finally {
-      if (
-        currentServerIdRef.current === savedForServerId &&
-        saveCounterRef.current === thisToken
-      ) {
+      if (currentServerIdRef.current === savedForServerId && saveCounterRef.current === thisToken) {
         isSavingRef.current = false;
         setSaving(false);
       }
@@ -220,9 +217,7 @@ function DangerZoneSection({ server }: { server: Server }) {
           </button>
         ) : (
           <div className='space-y-3'>
-            <p className='text-sm font-medium text-red-300'>
-              Are you sure? This cannot be undone.
-            </p>
+            <p className='text-sm font-medium text-red-300'>Are you sure? This cannot be undone.</p>
             <div className='flex gap-2'>
               <button
                 type='button'
@@ -343,7 +338,9 @@ export function ServerSettingsPage({ server, serverSlug }: ServerSettingsPagePro
                 activeSection === id
                   ? cn(BG.active, 'font-medium text-white')
                   : 'text-gray-400 hover:bg-[#393c43] hover:text-gray-200',
-                id === 'danger-zone' && activeSection !== 'danger-zone' && 'text-red-400 hover:text-red-300',
+                id === 'danger-zone' &&
+                  activeSection !== 'danger-zone' &&
+                  'text-red-400 hover:text-red-300',
               )}
             >
               {label}
@@ -365,8 +362,18 @@ export function ServerSettingsPage({ server, serverSlug }: ServerSettingsPagePro
             aria-expanded={isSidebarOpen}
             aria-controls='settings-sidebar'
           >
-            <svg className='h-5 w-5' viewBox='0 0 20 20' fill='currentColor' aria-hidden='true' focusable='false'>
-              <path fillRule='evenodd' d='M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z' clipRule='evenodd' />
+            <svg
+              className='h-5 w-5'
+              viewBox='0 0 20 20'
+              fill='currentColor'
+              aria-hidden='true'
+              focusable='false'
+            >
+              <path
+                fillRule='evenodd'
+                d='M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z'
+                clipRule='evenodd'
+              />
             </svg>
           </button>
           <button
@@ -394,13 +401,9 @@ export function ServerSettingsPage({ server, serverSlug }: ServerSettingsPagePro
         {/* Section content */}
         <div className='px-4 py-6 sm:px-10 sm:py-8'>
           {activeSection === 'overview' && (
-            <OverviewSection key={server.id}
-            server={server}
-            onSave={setDisplayName} />
+            <OverviewSection key={server.id} server={server} onSave={setDisplayName} />
           )}
-          {activeSection === 'members' && (
-            <MembersSection serverId={server.id} serverSlug={serverSlug} />
-          )}
+          {activeSection === 'members' && <MembersSection serverSlug={serverSlug} />}
           {activeSection === 'privacy' && (
             <VisibilitySection server={server} serverSlug={serverSlug} />
           )}


### PR DESCRIPTION
## Summary
- move server settings authorization into a shared server-side helper
- enforce that helper in the settings route and related server actions
- preserve access for server owners, system admins, and server admins
- add regression coverage for unauthorized and admin settings access

## Root Cause
The `/settings/[serverSlug]` flow server-rendered for any authenticated user and then relied on a client-side redirect that trusted the frontend `user.isSystemAdmin` state. A tampered `user.getCurrentUser` response could therefore suppress the redirect and expose privileged settings UI.

The concrete impact was privileged UI exposure and missing server-side enforcement for the settings page flow, not a backend mutation privilege escalation: the backend already enforced ownership and permission checks on the underlying mutations.

## Fix
This change introduces a server-side settings access guard that resolves the server and verifies the current user is allowed to manage settings before rendering the page or running the related settings actions. The guard now preserves the intended behavior for:
- server owners
- real system admins
- server admins

It also removes the unreachable null check in the settings page route and adds regression coverage for the admin path.

## Verification
- `npx jest --runInBand src/__tests__/server-settings-access.test.ts src/__tests__/authService.test.ts src/__tests__/VisibilityGuard.test.tsx`
- `npx eslint src/app/settings/[serverSlug]/settings-access.ts src/app/settings/[serverSlug]/page.tsx src/app/settings/[serverSlug]/actions.ts src/components/settings/MembersSection.tsx src/components/settings/ServerSettingsPage.tsx src/__tests__/server-settings-access.test.ts`
- `npx tsc --noEmit`

Closes #400.
