### PR TITLE
fix: eliminate MaxListenersExceededWarning in eventBus (#396)

### DIFF
--- a/harmony-backend/src/events/eventBus.ts
+++ b/harmony-backend/src/events/eventBus.ts
@@ -30,10 +30,12 @@ export type {
 let subscriberClient: Redis | null = null;
 const logger = createLogger({ component: 'event-bus' });
 
-// Per-channel handler count — tracks how many JS handlers are registered for
-// each Redis channel so we can unsubscribe at the Redis level precisely when
-// the last handler for a given channel is removed.
-const channelHandlerCounts = new Map<string, number>();
+// Central handler registry — maps each Redis channel to its active JS handlers.
+// A single 'message' listener on the ioredis client dispatches to these sets,
+// avoiding per-subscription client.on() calls that accumulate and trigger
+// MaxListenersExceededWarning under concurrent SSE connections.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const channelHandlers = new Map<string, Set<(payload: any) => void>>();
 
 // Per-channel ready promise — resolves when Redis confirms the subscription.
 // All subscribers on the same channel share this promise so latecomers don't
@@ -45,6 +47,28 @@ function getSubscriberClient(): Redis {
     subscriberClient = new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379', {
       maxRetriesPerRequest: null, // subscriber clients must not timeout on blocked commands
       lazyConnect: true,
+    });
+
+    // Single dispatcher — routes all incoming Redis messages to registered JS handlers.
+    // This replaces per-subscription client.on('message', ...) calls, keeping the
+    // ioredis emitter's listener count at 1 regardless of how many SSE connections exist.
+    subscriberClient.on('message', (ch: string, rawMessage: string) => {
+      const handlers = channelHandlers.get(ch);
+      if (!handlers) return;
+      let payload: unknown;
+      try {
+        payload = JSON.parse(rawMessage);
+      } catch (err) {
+        logger.error({ err, channel: ch }, 'Failed to parse event payload');
+        return;
+      }
+      for (const handler of handlers) {
+        try {
+          handler(payload);
+        } catch (err) {
+          logger.error({ err, channel: ch }, 'Event handler threw synchronously');
+        }
+      }
     });
   }
   return subscriberClient;
@@ -81,31 +105,21 @@ export const eventBus = {
   ): { unsubscribe: () => void; ready: Promise<void> } {
     const client = getSubscriberClient();
 
-    const messageListener = (ch: string, message: string) => {
-      if (ch !== channel) return;
-      let payload: EventPayloadMap[C];
-      try {
-        payload = JSON.parse(message) as EventPayloadMap[C];
-      } catch (err) {
-        logger.error({ err, channel: ch }, 'Failed to parse event payload');
-        return;
-      }
-      try {
-        handler(payload);
-      } catch (err) {
-        logger.error({ err, channel: ch }, 'Event handler threw synchronously');
-      }
-    };
-
-    const prevCount = channelHandlerCounts.get(channel) ?? 0;
-    channelHandlerCounts.set(channel, prevCount + 1);
+    // Register the typed handler in the central registry.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let handlers = channelHandlers.get(channel) as Set<(p: any) => void> | undefined;
+    const isFirstSubscriber = !handlers || handlers.size === 0;
+    if (!handlers) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handlers = new Set<(p: any) => void>();
+      channelHandlers.set(channel, handlers);
+    }
+    handlers.add(handler);
 
     let ready: Promise<void>;
-    if (prevCount === 0) {
+    if (isFirstSubscriber) {
       // First subscriber — issue SUBSCRIBE and store the in-flight handshake promise
       // so subsequent subscribers on the same channel wait for the same confirmation.
-      // ioredis queues the SUBSCRIBE command and fires the callback once Redis
-      // confirms — this resolves even on error so callers never hang.
       const handshake = new Promise<void>((resolve, reject) => {
         client.subscribe(channel, (err) => {
           if (err) {
@@ -123,23 +137,21 @@ export const eventBus = {
       // Redis actually confirms the subscription rather than resolving immediately.
       ready = channelReadyPromises.get(channel) ?? Promise.resolve();
     }
-    client.on('message', messageListener);
 
     return {
       unsubscribe: () => {
-        client.removeListener('message', messageListener);
-
-        const count = (channelHandlerCounts.get(channel) ?? 1) - 1;
-        if (count <= 0) {
-          channelHandlerCounts.delete(channel);
-          channelReadyPromises.delete(channel);
-          client
-            .unsubscribe(channel)
-            .catch((err) =>
-              logger.warn({ err, channel }, 'Failed to unsubscribe from event channel'),
-            );
-        } else {
-          channelHandlerCounts.set(channel, count);
+        const set = channelHandlers.get(channel);
+        if (set) {
+          set.delete(handler);
+          if (set.size === 0) {
+            channelHandlers.delete(channel);
+            channelReadyPromises.delete(channel);
+            client
+              .unsubscribe(channel)
+              .catch((err) =>
+                logger.warn({ err, channel }, 'Failed to unsubscribe from event channel'),
+              );
+          }
         }
       },
       ready,
@@ -153,7 +165,7 @@ export const eventBus = {
         .quit()
         .catch((err) => logger.warn({ err }, 'Failed to close event subscriber client cleanly'));
       subscriberClient = null;
-      channelHandlerCounts.clear();
+      channelHandlers.clear();
       channelReadyPromises.clear();
     }
   },

--- a/llm-logs/2026-04-18-010249-session-e104c77d.md
+++ b/llm-logs/2026-04-18-010249-session-e104c77d.md
@@ -1,0 +1,364 @@
+# Session Log 2026-04-18-010249
+
+## User
+
+https://github.com/CS485-Harmony/Harmony/issues/396 complete in a new branch and open PR
+
+## Assistant
+
+Let me fetch the issue details first.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 396 --repo CS485-Harmony/Harmony"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 396 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Starting]**\n\nInvestigating the MaxListenersExceededWarning in backend-api. Will trace Commander usage and event listener accumulation, then apply a targeted fix.\n\nNext steps: audit listener registration in backend startup code, identify where Commander accumulates listeners under horizontal scaling.\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"Commander\\|commander\\|MaxListeners\\|setMaxListeners\\|EventEmitter\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src --include=\"*.ts\" -l"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"on\\(\\|addListener\\|process\\.on\\|emitter\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src --include=\"*.ts\" -l 2>/dev/null | head -20"
+}
+```
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "harmony-backend/src/**/*.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/events/eventBus.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/routes/events.router.ts"
+}
+```
+
+## Assistant
+
+Now I understand the root cause. Each SSE connection calls `client.on('message', messageListener)` on the shared ioredis subscriber client — so N concurrent connections = N listeners. With 11+ connections, Node's default MaxListeners of 10 is exceeded.
+
+The elegant fix: replace per-subscription `client.on('message', ...)` with a single internal dispatcher that routes to a `Map<channel, Set<handler>>`.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b fix/issue-396-max-listeners-warning"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/events/eventBus.ts",
+  "old_string": "let subscriberClient: Redis | null = null;\nconst logger = createLogger({ component: 'event-bus' });\n\n// Per-channel handler count \u2014 tracks how many JS handlers are registered for\n// each Redis channel so we can unsubscribe at the Redis level precisely when\n// the last handler for a given channel is removed.\nconst channelHandlerCounts = new Map<string, number>();\n\n// Per-channel ready promise \u2014 resolves when Redis confirms the subscription.\n// All subscribers on the same channel share this promise so latecomers don't\n// get a false-immediate-ready before the handshake completes.\nconst channelReadyPromises = new Map<string, Promise<void>>();\n\nfunction getSubscriberClient(): Redis {\n  if (!subscriberClient) {\n    subscriberClient = new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379', {\n      maxRetriesPerRequest: null, // subscriber clients must not timeout on blocked commands\n      lazyConnect: true,\n    });\n  }\n  return subscriberClient;\n}",
+  "new_string": "let subscriberClient: Redis | null = null;\nconst logger = createLogger({ component: 'event-bus' });\n\n// Central handler registry \u2014 maps each Redis channel to its active JS handlers.\n// A single 'message' listener on the ioredis client dispatches to these sets,\n// avoiding per-subscription client.on() calls that accumulate and trigger\n// MaxListenersExceededWarning under concurrent SSE connections.\n// eslint-disable-next-line @typescript-eslint/no-explicit-any\nconst channelHandlers = new Map<string, Set<(payload: any) => void>>();\n\n// Per-channel ready promise \u2014 resolves when Redis confirms the subscription.\n// All subscribers on the same channel share this promise so latecomers don't\n// get a false-immediate-ready before the handshake completes.\nconst channelReadyPromises = new Map<string, Promise<void>>();\n\nfunction getSubscriberClient(): Redis {\n  if (!subscriberClient) {\n    subscriberClient = new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379', {\n      maxRetriesPerRequest: null, // subscriber clients must not timeout on blocked commands\n      lazyConnect: true,\n    });\n\n    // Single dispatcher \u2014 routes all incoming Redis messages to registered JS handlers.\n    // This replaces per-subscription client.on('message', ...) calls, keeping the\n    // ioredis emitter's listener count at 1 regardless of how many SSE connections exist.\n    subscriberClient.on('message', (ch: string, rawMessage: string) => {\n      const handlers = channelHandlers.get(ch);\n      if (!handlers) return;\n      let payload: unknown;\n      try {\n        payload = JSON.parse(rawMessage);\n      } catch (err) {\n        logger.error({ err, channel: ch }, 'Failed to parse event payload');\n        return;\n      }\n      for (const handler of handlers) {\n        try {\n          handler(payload);\n        } catch (err) {\n          logger.error({ err, channel: ch }, 'Event handler threw synchronously');\n        }\n      }\n    });\n  }\n  return subscriberClient;\n}"
+}
+```
+
+## Assistant
+
+Now update the `subscribe` method to use the registry instead of `client.on`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/events/eventBus.ts",
+  "old_string": "  subscribe<C extends EventChannelName>(\n    channel: C,\n    handler: EventHandler<C>,\n  ): { unsubscribe: () => void; ready: Promise<void> } {\n    const client = getSubscriberClient();\n\n    const messageListener = (ch: string, message: string) => {\n      if (ch !== channel) return;\n      let payload: EventPayloadMap[C];\n      try {\n        payload = JSON.parse(message) as EventPayloadMap[C];\n      } catch (err) {\n        logger.error({ err, channel: ch }, 'Failed to parse event payload');\n        return;\n      }\n      try {\n        handler(payload);\n      } catch (err) {\n        logger.error({ err, channel: ch }, 'Event handler threw synchronously');\n      }\n    };\n\n    const prevCount = channelHandlerCounts.get(channel) ?? 0;\n    channelHandlerCounts.set(channel, prevCount + 1);\n\n    let ready: Promise<void>;\n    if (prevCount === 0) {\n      // First subscriber \u2014 issue SUBSCRIBE and store the in-flight handshake promise\n      // so subsequent subscribers on the same channel wait for the same confirmation.\n      // ioredis queues the SUBSCRIBE command and fires the callback once Redis\n      // confirms \u2014 this resolves even on error so callers never hang.\n      const handshake = new Promise<void>((resolve, reject) => {\n        client.subscribe(channel, (err) => {\n          if (err) {\n            logger.error({ err, channel }, 'Failed to subscribe to event channel');\n            reject(err);\n          } else {\n            resolve();\n          }\n        });\n      });\n      ready = handshake;\n      channelReadyPromises.set(channel, handshake);\n    } else {\n      // Subsequent subscribers share the same in-flight promise so they wait until\n      // Redis actually confirms the subscription rather than resolving immediately.\n      ready = channelReadyPromises.get(channel) ?? Promise.resolve();\n    }\n    client.on('message', messageListener);\n\n    return {\n      unsubscribe: () => {\n        client.removeListener('message', messageListener);\n\n        const count = (channelHandlerCounts.get(channel) ?? 1) - 1;\n        if (count <= 0) {\n          channelHandlerCounts.delete(channel);\n          channelReadyPromises.delete(channel);\n          client\n            .unsubscribe(channel)\n            .catch((err) =>\n              logger.warn({ err, channel }, 'Failed to unsubscribe from event channel'),\n            );\n        } else {\n          channelHandlerCounts.set(channel, count);\n        }\n      },\n      ready,\n    };\n  },",
+  "new_string": "  subscribe<C extends EventChannelName>(\n    channel: C,\n    handler: EventHandler<C>,\n  ): { unsubscribe: () => void; ready: Promise<void> } {\n    const client = getSubscriberClient();\n\n    // Register the typed handler in the central registry.\n    // eslint-disable-next-line @typescript-eslint/no-explicit-any\n    let handlers = channelHandlers.get(channel) as Set<(p: any) => void> | undefined;\n    const isFirstSubscriber = !handlers || handlers.size === 0;\n    if (!handlers) {\n      // eslint-disable-next-line @typescript-eslint/no-explicit-any\n      handlers = new Set<(p: any) => void>();\n      channelHandlers.set(channel, handlers);\n    }\n    handlers.add(handler);\n\n    let ready: Promise<void>;\n    if (isFirstSubscriber) {\n      // First subscriber \u2014 issue SUBSCRIBE and store the in-flight handshake promise\n      // so subsequent subscribers on the same channel wait for the same confirmation.\n      const handshake = new Promise<void>((resolve, reject) => {\n        client.subscribe(channel, (err) => {\n          if (err) {\n            logger.error({ err, channel }, 'Failed to subscribe to event channel');\n            reject(err);\n          } else {\n            resolve();\n          }\n        });\n      });\n      ready = handshake;\n      channelReadyPromises.set(channel, handshake);\n    } else {\n      // Subsequent subscribers share the same in-flight promise so they wait until\n      // Redis actually confirms the subscription rather than resolving immediately.\n      ready = channelReadyPromises.get(channel) ?? Promise.resolve();\n    }\n\n    return {\n      unsubscribe: () => {\n        const set = channelHandlers.get(channel);\n        if (set) {\n          set.delete(handler);\n          if (set.size === 0) {\n            channelHandlers.delete(channel);\n            channelReadyPromises.delete(channel);\n            client\n              .unsubscribe(channel)\n              .catch((err) =>\n                logger.warn({ err, channel }, 'Failed to unsubscribe from event channel'),\n              );\n          }\n        }\n      },\n      ready,\n    };\n  },"
+}
+```
+
+## Assistant
+
+Now update the `disconnect` method to clear `channelHandlers` instead of `channelHandlerCounts`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/events/eventBus.ts",
+  "old_string": "      subscriberClient = null;\n      channelHandlerCounts.clear();\n      channelReadyPromises.clear();",
+  "new_string": "      subscriberClient = null;\n      channelHandlers.clear();\n      channelReadyPromises.clear();"
+}
+```
+
+## Assistant
+
+Now let me verify the final file looks correct:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/events/eventBus.ts"
+}
+```
+
+## Assistant
+
+Good. Now let me run the backend tests to verify nothing is broken:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npm test -- --testPathPattern=\"eventBus|events|sse\" 2>&1 | tail -30"
+}
+```
+
+## Assistant
+
+All 74 event-related tests pass. Let me run the full backend suite quickly:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test 2>&1 | tail -15"
+}
+```
+
+## Assistant
+
+641/641 tests pass. The worker force-exit warning is pre-existing (unrelated to this change). Now commit and open the PR:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-backend/src/events/eventBus.ts && git commit -m \"$(cat <<'EOF'\nfix: replace per-subscription client.on() with single dispatcher in eventBus\n\nEach SSE connection was calling client.on('message', ...) on the shared\nioredis subscriber, accumulating one listener per active connection and\ntriggering MaxListenersExceededWarning after 10+ concurrent connections.\n\nReplace with a central Map<channel, Set<handler>> registry and a single\n'message' listener on the ioredis client that dispatches to registered\nhandlers, keeping the emitter's listener count at 1 regardless of scale.\n\nCloses #396\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/issue-396-max-listeners-warning && gh pr create --repo CS485-Harmony/Harmony --title \"fix: eliminate MaxListenersExceededWarning in eventBus (#396)\" --body \"$(cat <<'EOF'\n## Summary\n\n- Each SSE connection called `client.on('message', messageListener)` on the shared ioredis subscriber client \u2014 adding one listener per active connection per subscribed channel\n- With 11+ concurrent SSE connections the default Node.js MaxListeners limit (10) was exceeded, producing `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added to [Commander]`\n- Replace per-subscription `client.on()` calls with a single internal dispatcher: a `Map<channel, Set<handler>>` registry + one permanent `'message'` listener on the ioredis client that routes to registered handlers\n- The emitter's listener count is now permanently **1** regardless of how many SSE connections or replicas are active\n\nCloses #396\n\n## Test plan\n\n- [x] All 74 event-bus / SSE tests pass (`npm test -- --testPathPattern=\"eventBus|events|sse\"`)\n- [x] Full backend suite: 641/641 tests pass\n- [x] `unsubscribe()` still removes only the target handler and issues Redis UNSUBSCRIBE only when the last handler for a channel is removed\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 396 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Complete]**\n\nRoot cause: each SSE connection called \\`client.on('message', ...)\\` on the shared ioredis subscriber, accumulating one listener per connection and exceeding Node's default MaxListeners limit of 10.\n\nFix: replaced per-subscription \\`client.on()\\` calls with a central \\`Map<channel, Set<handler>>\\` registry and a single permanent \\`'message'\\` dispatcher on the ioredis client. Listener count on the emitter is now permanently 1 regardless of concurrent SSE connections or replicas.\n\nPR: https://github.com/CS485-Harmony/Harmony/pull/402\nAll 641 backend tests pass.\""
+}
+```
+
+## Assistant
+
+PR is open: **https://github.com/CS485-Harmony/Harmony/pull/402**
+
+**Root cause:** Each SSE connection added a new `client.on('message', ...)` listener to the shared ioredis subscriber. With 11+ concurrent connections, Node's default MaxListeners limit (10) was exceeded.
+
+**Fix:** `eventBus.ts` now uses a single `'message'` dispatcher on the ioredis client that routes to a `Map<channel, Set<handler>>` registry. The emitter's listener count stays at **1** regardless of how many SSE connections or replicas are active. All 641 backend tests pass.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+


### PR DESCRIPTION
## Summary

- Each SSE connection called `client.on('message', messageListener)` on the shared ioredis subscriber client — adding one listener per active connection per subscribed channel
- With 11+ concurrent SSE connections the default Node.js MaxListeners limit (10) was exceeded, producing `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added to [Commander]`
- Replace per-subscription `client.on()` calls with a single internal dispatcher: a `Map<channel, Set<handler>>` registry + one permanent `'message'` listener on the ioredis client that routes to registered handlers
- The emitter's listener count is now permanently **1** regardless of how many SSE connections or replicas are active

Closes #396

## Test plan

- [x] All 74 event-bus / SSE tests pass (`npm test -- --testPathPattern="eventBus|events|sse"`)
- [x] Full backend suite: 641/641 tests pass
- [x] `unsubscribe()` still removes only the target handler and issues Redis UNSUBSCRIBE only when the last handler for a channel is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)