### PR TITLE
fix: suppress tRPC query warning for expected 401/403 auth responses

### DIFF
--- a/harmony-frontend/src/__tests__/trpc-client.test.ts
+++ b/harmony-frontend/src/__tests__/trpc-client.test.ts
@@ -132,7 +132,7 @@ describe('trpc-client', () => {
       );
     });
 
-    it('throws a typed HTTP error for non-ok tRPC responses', async () => {
+    it('throws a typed HTTP error for non-ok tRPC responses without warning on 403', async () => {
       mockedCookies.mockResolvedValue({
         get: jest.fn(() => undefined),
       } as never);
@@ -145,6 +145,40 @@ describe('trpc-client', () => {
           status: 403,
         }),
       );
+      // 403 is an expected auth-flow response (e.g. membership probe) — should not warn
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('throws a typed HTTP error for 401 without warning', async () => {
+      mockedCookies.mockResolvedValue({
+        get: jest.fn(() => undefined),
+      } as never);
+      mockFetch.mockResolvedValue(createTextResponse('Unauthorized', 401));
+
+      await expect(trpcQuery('channel.getChannels')).rejects.toEqual(
+        expect.objectContaining<Partial<TrpcHttpError>>({
+          name: 'TrpcHttpError',
+          procedure: 'channel.getChannels',
+          status: 401,
+        }),
+      );
+      // 401 is an expected auth-flow response — should not warn
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('logs a warning for unexpected non-auth tRPC failures', async () => {
+      mockedCookies.mockResolvedValue({
+        get: jest.fn(() => undefined),
+      } as never);
+      mockFetch.mockResolvedValue(createTextResponse('Internal Server Error', 500));
+
+      await expect(trpcQuery('channel.getChannels')).rejects.toEqual(
+        expect.objectContaining<Partial<TrpcHttpError>>({
+          name: 'TrpcHttpError',
+          procedure: 'channel.getChannels',
+          status: 500,
+        }),
+      );
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'tRPC query failed',
         expect.objectContaining({
@@ -152,7 +186,7 @@ describe('trpc-client', () => {
           event: 'http_failure',
           procedure: 'channel.getChannels',
           route: '/trpc/channel.getChannels',
-          statusCode: 403,
+          statusCode: 500,
         }),
       );
     });

--- a/harmony-frontend/src/lib/trpc-client.ts
+++ b/harmony-frontend/src/lib/trpc-client.ts
@@ -119,14 +119,18 @@ export async function trpcQuery<T>(procedure: string, input?: unknown): Promise<
 
   if (!res.ok) {
     const body = await res.text();
-    logger.warn('tRPC query failed', {
-      feature: 'trpc',
-      event: 'http_failure',
-      method: 'GET',
-      procedure,
-      route: `/trpc/${procedure}`,
-      statusCode: res.status,
-    });
+    // 401/403 are expected auth-flow responses (e.g. membership probes in GuestChannelView);
+    // only warn for genuinely unexpected failures.
+    if (res.status !== 401 && res.status !== 403) {
+      logger.warn('tRPC query failed', {
+        feature: 'trpc',
+        event: 'http_failure',
+        method: 'GET',
+        procedure,
+        route: `/trpc/${procedure}`,
+        statusCode: res.status,
+      });
+    }
     throw new TrpcHttpError(procedure, res.status, body);
   }
 

--- a/llm-logs/2026-04-18-010121-session-183b3f4.md
+++ b/llm-logs/2026-04-18-010121-session-183b3f4.md
@@ -1,0 +1,580 @@
+# Session Log 2026-04-18-010121
+
+## User
+
+https://github.com/CS485-Harmony/Harmony/issues/378 complete in a new branch and open a PR
+
+## Assistant
+
+Let me fetch the issue details first.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 378 --repo CS485-Harmony/Harmony"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh api repos/CS485-Harmony/Harmony/contents/dogfood-output/no-mock-2026-04-16/screenshots/issue-003-console.txt?ref=dogfood-artifacts-no-mock-2026-04-16 | python3 -c \"import sys,json,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh api repos/CS485-Harmony/Harmony/contents/dogfood-output/no-mock-2026-04-16/screenshots/issue-003-network-trpc.txt?ref=dogfood-artifacts-no-mock-2026-04-16 | python3 -c \"import sys,json,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh api \"repos/CS485-Harmony/Harmony/contents/dogfood-output/no-mock-2026-04-16/screenshots/issue-003-console.txt\" --ref \"dogfood-artifacts-no-mock-2026-04-16\" | python3 -c \"import sys,json,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())\" 2>/dev/null || echo \"Failed\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh api \"repos/CS485-Harmony/Harmony/contents/dogfood-output%2Fno-mock-2026-04-16%2Fscreenshots%2Fissue-003-console.txt?ref=dogfood-artifacts-no-mock-2026-04-16\" | python3 -c \"import sys,json,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh api \"repos/CS485-Harmony/Harmony/contents/dogfood-output%2Fno-mock-2026-04-16%2Fscreenshots%2Fissue-003-network-trpc.txt?ref=dogfood-artifacts-no-mock-2026-04-16\" | python3 -c \"import sys,json,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())\""
+}
+```
+
+## Assistant
+
+Now let me explore the channel route in the frontend.
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "harmony-frontend/src/app/**/[c]/**/*.{tsx,ts}"
+}
+```
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "harmony-frontend/src/app/**/channel*/**/*.{tsx,ts}"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "harmony-frontend/src/components/channel/GuestChannelView*"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx"
+}
+```
+
+## Assistant
+
+Let me look at the public API service and the `getChannels` service.
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "harmony-frontend/src/services/publicApiService*"
+}
+```
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "harmony-frontend/src/services/channelService*"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/publicApiService.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/channelService.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "harmony-frontend/src/lib/trpc-client*"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/trpc-client.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh api \"repos/CS485-Harmony/Harmony/contents/dogfood-output%2Fno-mock-2026-04-16%2Fscreenshots%2Fissue-003-snapshot.txt?ref=dogfood-artifacts-no-mock-2026-04-16\" | python3 -c \"import sys,json,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh api \"repos/CS485-Harmony/Harmony/contents/dogfood-output%2Fno-mock-2026-04-16%2Fscreenshots%2Fissue-003-network-api.txt?ref=dogfood-artifacts-no-mock-2026-04-16\" | python3 -c \"import sys,json,base64; print(base64.b64decode(json.load(sys.stdin)['content']).decode())\""
+}
+```
+
+## Assistant
+
+Let me look at the snapshot and understand the full rendering context before implementing a fix.
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "harmony-frontend/src/components/channel/MessageList*"
+}
+```
+
+## Assistant
+
+**Tool call: `Grep`**
+```json
+{
+  "pattern": "Welcome to",
+  "path": "harmony-frontend/src/components/channel",
+  "output_mode": "content"
+}
+```
+
+## Assistant
+
+I now have a clear picture. The root cause: `trpcQuery` in `trpc-client.ts` emits `logger.warn('tRPC query failed')` for ALL non-OK responses, including 401/403 which are expected auth-flow responses when `getChannels` is called as a membership probe in `GuestChannelView`. The fix: don't warn on 401/403 since those are valid auth-error responses, not unexpected failures.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b fix/issue-378-trpc-query-warning main"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 378 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Starting]**\n\nInvestigating the tRPC query-failure warning on the public channel route.\n\nRoot cause: \\`trpcQuery\\` in \\`trpc-client.ts\\` emits \\`logger.warn('tRPC query failed')\\` for every non-OK HTTP response, including 401/403. In \\`GuestChannelView\\`, \\`getChannels\\` is called as a membership probe \u2014 a 401 (expired/no session) or 403 (non-member) response is expected and handled by the caller, not a real failure.\n\nFix: skip the warning for 401/403 responses in \\`trpcQuery\\` so only genuinely unexpected failures (5xx, 400, etc.) are surfaced as warnings.\""
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/lib/trpc-client.ts",
+  "old_string": "  if (!res.ok) {\n    const body = await res.text();\n    logger.warn('tRPC query failed', {\n      feature: 'trpc',\n      event: 'http_failure',\n      method: 'GET',\n      procedure,\n      route: `/trpc/${procedure}`,\n      statusCode: res.status,\n    });\n    throw new TrpcHttpError(procedure, res.status, body);\n  }",
+  "new_string": "  if (!res.ok) {\n    const body = await res.text();\n    // 401/403 are expected auth-flow responses (e.g. membership probes in GuestChannelView);\n    // only warn for genuinely unexpected failures.\n    if (res.status !== 401 && res.status !== 403) {\n      logger.warn('tRPC query failed', {\n        feature: 'trpc',\n        event: 'http_failure',\n        method: 'GET',\n        procedure,\n        route: `/trpc/${procedure}`,\n        statusCode: res.status,\n      });\n    }\n    throw new TrpcHttpError(procedure, res.status, body);\n  }"
+}
+```
+
+## Assistant
+
+Now let me verify the fix looks right and run frontend tests:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd harmony-frontend && npm test -- --testPathPattern=\"trpc|channel\" --passWithNoTests 2>&1 | tail -30"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd harmony-frontend && npm test -- --testPathPatterns=\"trpc|channel\" --passWithNoTests 2>&1 | tail -40"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test -- --testPathPatterns=\"trpc|channel\" --passWithNoTests 2>&1 | tail -40"
+}
+```
+
+## Assistant
+
+There's a test expecting the 403 to warn. I need to update it to match the new expected behavior.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"403\\|warn\\|tRPC query failed\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/trpc-client.test.ts | head -40"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/trpc-client.test.ts",
+  "offset": 125,
+  "limit": 60
+}
+```
+
+## Assistant
+
+I need to update the test to reflect the new behavior (403 should not warn), and add coverage for non-auth failures that should still warn.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/trpc-client.test.ts",
+  "offset": 55,
+  "limit": 90
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/trpc-client.test.ts",
+  "old_string": "    it('throws a typed HTTP error for non-ok tRPC responses', async () => {\n      mockedCookies.mockResolvedValue({\n        get: jest.fn(() => undefined),\n      } as never);\n      mockFetch.mockResolvedValue(createTextResponse('Forbidden', 403));\n\n      await expect(trpcQuery('channel.getChannels')).rejects.toEqual(\n        expect.objectContaining<Partial<TrpcHttpError>>({\n          name: 'TrpcHttpError',\n          procedure: 'channel.getChannels',\n          status: 403,\n        }),\n      );\n      expect(mockLogger.warn).toHaveBeenCalledWith(\n        'tRPC query failed',\n        expect.objectContaining({\n          feature: 'trpc',\n          event: 'http_failure',\n          procedure: 'channel.getChannels',\n          route: '/trpc/channel.getChannels',\n          statusCode: 403,\n        }),\n      );\n    });",
+  "new_string": "    it('throws a typed HTTP error for non-ok tRPC responses without warning on 403', async () => {\n      mockedCookies.mockResolvedValue({\n        get: jest.fn(() => undefined),\n      } as never);\n      mockFetch.mockResolvedValue(createTextResponse('Forbidden', 403));\n\n      await expect(trpcQuery('channel.getChannels')).rejects.toEqual(\n        expect.objectContaining<Partial<TrpcHttpError>>({\n          name: 'TrpcHttpError',\n          procedure: 'channel.getChannels',\n          status: 403,\n        }),\n      );\n      // 403 is an expected auth-flow response (e.g. membership probe) \u2014 should not warn\n      expect(mockLogger.warn).not.toHaveBeenCalled();\n    });\n\n    it('throws a typed HTTP error for 401 without warning', async () => {\n      mockedCookies.mockResolvedValue({\n        get: jest.fn(() => undefined),\n      } as never);\n      mockFetch.mockResolvedValue(createTextResponse('Unauthorized', 401));\n\n      await expect(trpcQuery('channel.getChannels')).rejects.toEqual(\n        expect.objectContaining<Partial<TrpcHttpError>>({\n          name: 'TrpcHttpError',\n          procedure: 'channel.getChannels',\n          status: 401,\n        }),\n      );\n      // 401 is an expected auth-flow response \u2014 should not warn\n      expect(mockLogger.warn).not.toHaveBeenCalled();\n    });\n\n    it('logs a warning for unexpected non-auth tRPC failures', async () => {\n      mockedCookies.mockResolvedValue({\n        get: jest.fn(() => undefined),\n      } as never);\n      mockFetch.mockResolvedValue(createTextResponse('Internal Server Error', 500));\n\n      await expect(trpcQuery('channel.getChannels')).rejects.toEqual(\n        expect.objectContaining<Partial<TrpcHttpError>>({\n          name: 'TrpcHttpError',\n          procedure: 'channel.getChannels',\n          status: 500,\n        }),\n      );\n      expect(mockLogger.warn).toHaveBeenCalledWith(\n        'tRPC query failed',\n        expect.objectContaining({\n          feature: 'trpc',\n          event: 'http_failure',\n          procedure: 'channel.getChannels',\n          route: '/trpc/channel.getChannels',\n          statusCode: 500,\n        }),\n      );\n    });"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test -- --testPathPatterns=\"trpc|channel\" --passWithNoTests 2>&1 | tail -20"
+}
+```
+
+## Assistant
+
+All tests pass. Now run the full test suite to check for regressions:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test 2>&1 | tail -20"
+}
+```
+
+## Assistant
+
+217/217 passing. Now commit and open the PR.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git diff --cached --stat"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add harmony-frontend/src/lib/trpc-client.ts harmony-frontend/src/__tests__/trpc-client.test.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git status"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add src/__tests__/trpc-client.test.ts src/lib/trpc-client.ts && git commit -m \"$(cat <<'EOF'\nfix: suppress tRPC query warnings for expected 401/403 auth responses\n\nWhen GuestChannelView probes membership via getChannels, a 401 or 403\nresponse is expected control flow (no session / non-member). Logging a\n'tRPC query failed' warning for these cases was noisy and misleading.\n\nFixes #378\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/issue-378-trpc-query-warning"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --repo CS485-Harmony/Harmony --title \"fix: suppress tRPC query warning for expected 401/403 auth responses\" --body \"$(cat <<'EOF'\n## Summary\n\n- `trpcQuery` in `trpc-client.ts` was emitting `logger.warn('tRPC query failed')` for **every** non-OK HTTP response, including 401 and 403\n- In `GuestChannelView`, `getChannels` is called as a membership probe \u2014 a 401 (no/expired session) or 403 (non-member) is **expected control flow**, not a failure\n- Changed `trpcQuery` to only log the warning for unexpected failures (i.e. anything that isn't a 401 or 403)\n- Updated the existing 403 test and added tests for 401 (no warning) and 500 (warning expected)\n\nFixes #378\n\n## Test plan\n\n- [ ] All 217 frontend unit tests pass (`npm test` from `harmony-frontend/`)\n- [ ] Visit `/c/<server>/<channel>` without a session: no `tRPC query failed` warning in console\n- [ ] Visit `/c/<server>/<channel>` with an expired session cookie: no `tRPC query failed` warning in console\n- [ ] A genuine backend 500 on a tRPC query still surfaces the warning in console\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 378 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Complete]**\n\nFix is in PR #403.\n\n**Root cause:** \\`trpcQuery\\` in \\`trpc-client.ts\\` logged \\`logger.warn('tRPC query failed')\\` for every non-OK HTTP response. When \\`GuestChannelView\\` calls \\`getChannels\\` as a membership probe, a 401 (no/expired session) or 403 (non-member) is expected control flow \u2014 not a real failure.\n\n**Fix:** Skip the warning for 401 and 403 responses in \\`trpcQuery\\`; only warn for genuinely unexpected failures (5xx, 400, etc.). The \\`TrpcHttpError\\` is still thrown so callers can handle auth errors as before.\n\n**Tests:** 217/217 frontend tests pass. Added explicit test coverage for 401 (no warn), 403 (no warn), and 500 (warn expected).\""
+}
+```
+
+## Assistant
+
+PR is open: https://github.com/CS485-Harmony/Harmony/pull/403
+
+**Root cause:** `trpcQuery` in `trpc-client.ts` logged a warning for every non-OK HTTP response, including 401/403. In `GuestChannelView`, `getChannels` is called as a membership probe where 401 (no/expired session) and 403 (non-member) are expected — not failures.
+
+**Fix:** Two-line change in `trpc-client.ts` — skip the `logger.warn` for 401/403 responses, only fire it for genuinely unexpected errors. The `TrpcHttpError` is still thrown so callers handle auth flow identically. Updated tests: 217/217 passing.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+


### PR DESCRIPTION
## Summary

- `trpcQuery` in `trpc-client.ts` was emitting `logger.warn('tRPC query failed')` for **every** non-OK HTTP response, including 401 and 403
- In `GuestChannelView`, `getChannels` is called as a membership probe — a 401 (no/expired session) or 403 (non-member) is **expected control flow**, not a failure
- Changed `trpcQuery` to only log the warning for unexpected failures (i.e. anything that isn't a 401 or 403)
- Updated the existing 403 test and added tests for 401 (no warning) and 500 (warning expected)

Fixes #378

## Test plan

- [ ] All 217 frontend unit tests pass (`npm test` from `harmony-frontend/`)
- [ ] Visit `/c/<server>/<channel>` without a session: no `tRPC query failed` warning in console
- [ ] Visit `/c/<server>/<channel>` with an expired session cookie: no `tRPC query failed` warning in console
- [ ] A genuine backend 500 on a tRPC query still surfaces the warning in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)