### PR TITLE
feat: S3 meta tag override schema + AC-7 persistence guard

### DIFF
--- a/docs/deployment/deployment-architecture.md
+++ b/docs/deployment/deployment-architecture.md
@@ -417,3 +417,19 @@ The following decisions are now explicit:
 | `#322` | Provision Railway services and env vars to match this topology, including the worker health check / restart strategy before go-live |
 | `#323` | Write deployment-aware integration test specs using this topology                                                                   |
 | `#329` | Configure Vercel preview/production domains and env vars to match this contract                                                     |
+
+## 11. Meta Tag Override Schema
+
+The `generated_meta_tags` table (managed by Prisma) persists SEO meta tags generated per `PUBLIC_INDEXABLE` channel. Issue #352 added the following columns for admin override support:
+
+| Column               | Type           | Nullable | Description                                          |
+| -------------------- | -------------- | -------- | ---------------------------------------------------- |
+| `custom_title`       | `VARCHAR(70)`  | YES      | Admin override title; takes precedence when non-null |
+| `custom_description` | `VARCHAR(200)` | YES      | Admin override description; takes precedence when non-null |
+| `custom_og_image`    | `VARCHAR(500)` | YES      | Admin override OG image URL                          |
+| `created_at`         | `TIMESTAMPTZ`  | NO       | Record creation timestamp                            |
+| `updated_at`         | `TIMESTAMPTZ`  | NO       | Last modification timestamp (auto-updated)           |
+
+**AC-7 invariant:** Background regeneration writes via `metaTagRepository.saveGeneratedFields` are gated by a SQL `WHERE custom_title IS NULL AND custom_description IS NULL` predicate. A row with any non-null admin override is skipped entirely, so generated content can never silently replace admin-curated text.
+
+Full schema definition: `docs/dev-spec-seo-meta-tag-generation.md §11.1 D6.3`.

--- a/docs/deployment/deployment-architecture.md
+++ b/docs/deployment/deployment-architecture.md
@@ -430,6 +430,6 @@ The `generated_meta_tags` table (managed by Prisma) persists SEO meta tags gener
 | `created_at`         | `TIMESTAMPTZ`  | NO       | Record creation timestamp                            |
 | `updated_at`         | `TIMESTAMPTZ`  | NO       | Last modification timestamp (auto-updated)           |
 
-**AC-7 invariant:** Background regeneration writes via `metaTagRepository.saveGeneratedFields` are gated by a SQL `WHERE custom_title IS NULL AND custom_description IS NULL` predicate. A row with any non-null admin override is skipped entirely, so generated content can never silently replace admin-curated text.
+**AC-7 invariant:** Background regeneration writes via `metaTagRepository.saveGeneratedFields` are gated by `WHERE custom_title IS NULL AND custom_description IS NULL`. Rows with a non-null `custom_title` or `custom_description` are skipped, so generated title/description content cannot silently replace admin-curated text.
 
 Full schema definition: `docs/dev-spec-seo-meta-tag-generation.md §11.1 D6.3`.

--- a/harmony-backend/prisma/migrations/20260418000000_add_meta_tag_overrides/migration.sql
+++ b/harmony-backend/prisma/migrations/20260418000000_add_meta_tag_overrides/migration.sql
@@ -1,0 +1,20 @@
+-- Issue #352: S3 — Data schema + persistence for meta tag overrides (§11)
+--
+-- Expand-only migration: adds new nullable columns and indexes to
+-- generated_meta_tags. No existing columns are dropped or renamed so this
+-- migration is safe to apply while old backend-api replicas are still running.
+
+-- Admin override fields (AC-7: never overwritten by background regeneration)
+ALTER TABLE "generated_meta_tags"
+  ADD COLUMN IF NOT EXISTS "custom_title"       VARCHAR(70),
+  ADD COLUMN IF NOT EXISTS "custom_description" VARCHAR(200),
+  ADD COLUMN IF NOT EXISTS "custom_og_image"    VARCHAR(500);
+
+-- Timestamp bookkeeping fields
+ALTER TABLE "generated_meta_tags"
+  ADD COLUMN IF NOT EXISTS "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ADD COLUMN IF NOT EXISTS "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Index: fast lookup of records by generation time (used by cache staleness checks)
+CREATE INDEX IF NOT EXISTS "idx_meta_tags_generated"
+  ON "generated_meta_tags" ("generated_at");

--- a/harmony-backend/prisma/migrations/20260418000000_add_meta_tag_overrides/migration.sql
+++ b/harmony-backend/prisma/migrations/20260418000000_add_meta_tag_overrides/migration.sql
@@ -5,6 +5,9 @@
 -- migration is safe to apply while old backend-api replicas are still running.
 
 -- Admin override fields (AC-7: never overwritten by background regeneration)
+-- VARCHAR(70)/VARCHAR(200) are intentionally narrower than the generated title/description
+-- columns (120/320) — they reflect the stricter SEO spec limits for admin-supplied overrides
+-- (spec §11.1 D6.3: custom_title ≤70, custom_description ≤200).
 ALTER TABLE "generated_meta_tags"
   ADD COLUMN IF NOT EXISTS "custom_title"       VARCHAR(70),
   ADD COLUMN IF NOT EXISTS "custom_description" VARCHAR(200),

--- a/harmony-backend/prisma/schema.prisma
+++ b/harmony-backend/prisma/schema.prisma
@@ -263,7 +263,7 @@ model GeneratedMetaTags {
   channel Channel @relation(fields: [channelId], references: [id], onDelete: Cascade)
 
   // idx_meta_tags_channel is pinned via map: on the @unique above.
-  // idx_meta_tags_needs_regen (partial WHERE needs_regeneration = TRUE)
-  // idx_meta_tags_generated (generated_at) are added as raw SQL in the migration.
+  // idx_meta_tags_needs_regen (partial WHERE needs_regeneration = TRUE) exists in the init SQL migration.
+  // idx_meta_tags_generated (generated_at) is added as raw SQL in 20260418000000_add_meta_tag_overrides.
   @@map("generated_meta_tags")
 }

--- a/harmony-backend/prisma/schema.prisma
+++ b/harmony-backend/prisma/schema.prisma
@@ -237,25 +237,33 @@ model VisibilityAuditLog {
 }
 
 model GeneratedMetaTags {
-  id                String   @id @default(uuid()) @db.Uuid
-  channelId         String   @unique(map: "idx_meta_tags_channel") @map("channel_id") @db.Uuid
-  title             String   @db.VarChar(120)
-  description       String   @db.VarChar(320)
-  ogTitle           String   @map("og_title") @db.VarChar(120)
-  ogDescription     String   @map("og_description") @db.VarChar(320)
-  ogImage           String?  @map("og_image") @db.VarChar(500)
-  twitterCard       String   @map("twitter_card") @db.VarChar(20)
-  keywords          String   @db.Text
-  structuredData    Json     @map("structured_data")
-  contentHash       String   @map("content_hash") @db.VarChar(64)
-  needsRegeneration Boolean  @default(false) @map("needs_regeneration")
-  generatedAt       DateTime @default(now()) @map("generated_at") @db.Timestamptz
-  schemaVersion     Int      @default(1) @map("schema_version")
+  id                  String   @id @default(uuid()) @db.Uuid
+  channelId           String   @unique(map: "idx_meta_tags_channel") @map("channel_id") @db.Uuid
+  title               String   @db.VarChar(120)
+  description         String   @db.VarChar(320)
+  ogTitle             String   @map("og_title") @db.VarChar(120)
+  ogDescription       String   @map("og_description") @db.VarChar(320)
+  ogImage             String?  @map("og_image") @db.VarChar(500)
+  twitterCard         String   @map("twitter_card") @db.VarChar(20)
+  keywords            String   @db.Text
+  structuredData      Json     @map("structured_data")
+  contentHash         String   @map("content_hash") @db.VarChar(64)
+  needsRegeneration   Boolean  @default(false) @map("needs_regeneration")
+  generatedAt         DateTime @default(now()) @map("generated_at") @db.Timestamptz
+  schemaVersion       Int      @default(1) @map("schema_version")
+  /// Admin override title — takes precedence over generated title when present.
+  customTitle         String?  @map("custom_title") @db.VarChar(70)
+  /// Admin override description — takes precedence over generated description when present.
+  customDescription   String?  @map("custom_description") @db.VarChar(200)
+  /// Admin override OG image URL — takes precedence over generated og_image when present.
+  customOgImage       String?  @map("custom_og_image") @db.VarChar(500)
+  createdAt           DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt           DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
   channel Channel @relation(fields: [channelId], references: [id], onDelete: Cascade)
 
   // idx_meta_tags_channel is pinned via map: on the @unique above.
   // idx_meta_tags_needs_regen (partial WHERE needs_regeneration = TRUE)
-  // is added as raw SQL in the migration.
+  // idx_meta_tags_generated (generated_at) are added as raw SQL in the migration.
   @@map("generated_meta_tags")
 }

--- a/harmony-backend/src/repositories/metaTag.repository.ts
+++ b/harmony-backend/src/repositories/metaTag.repository.ts
@@ -13,7 +13,7 @@ export type GeneratedFieldsUpdate = {
   ogImage?: string | null;
   twitterCard: string;
   keywords: string;
-  structuredData: Record<string, unknown>;
+  structuredData: Prisma.InputJsonValue;
   contentHash: string;
   needsRegeneration: boolean;
   generatedAt: Date;
@@ -47,38 +47,41 @@ export const metaTagRepository = {
   /**
    * Persist background-generated tag fields.
    * AC-7: Never overwrites non-null customTitle or customDescription.
-   * Uses a conditional UPDATE so the constraint is enforced at the DB level.
+   * Uses a conditional UPDATE where-clause so the constraint is enforced at the DB level.
    */
   saveGeneratedFields(channelId: string, fields: GeneratedFieldsUpdate, client: Client = prisma) {
-    return (client as typeof prisma).$executeRaw`
-      UPDATE "generated_meta_tags"
-      SET
-        title               = ${fields.title},
-        description         = ${fields.description},
-        og_title            = ${fields.ogTitle},
-        og_description      = ${fields.ogDescription},
-        og_image            = ${fields.ogImage ?? null},
-        twitter_card        = ${fields.twitterCard},
-        keywords            = ${fields.keywords},
-        structured_data     = ${fields.structuredData}::jsonb,
-        content_hash        = ${fields.contentHash},
-        needs_regeneration  = ${fields.needsRegeneration},
-        generated_at        = ${fields.generatedAt},
-        schema_version      = COALESCE(${fields.schemaVersion ?? null}, schema_version),
-        updated_at          = NOW()
-      WHERE channel_id = ${channelId}::uuid
-        AND custom_title IS NULL
-        AND custom_description IS NULL
-    `;
+    return client.generatedMetaTags
+      .updateMany({
+        where: {
+          channelId,
+          customTitle: null,
+          customDescription: null,
+        },
+        data: {
+          title: fields.title,
+          description: fields.description,
+          ogTitle: fields.ogTitle,
+          ogDescription: fields.ogDescription,
+          twitterCard: fields.twitterCard,
+          keywords: fields.keywords,
+          structuredData: fields.structuredData,
+          contentHash: fields.contentHash,
+          needsRegeneration: fields.needsRegeneration,
+          generatedAt: fields.generatedAt,
+          ...(fields.ogImage !== undefined ? { ogImage: fields.ogImage } : {}),
+          ...(fields.schemaVersion !== undefined ? { schemaVersion: fields.schemaVersion } : {}),
+        },
+      })
+      .then(({ count }) => count);
   },
 
-  upsert(data: MetaTagCreateData, client: Client = prisma) {
-    const { channelId, ...rest } = data;
-    return client.generatedMetaTags.upsert({
-      where: { channelId },
-      create: data,
-      update: rest,
-    });
+  upsert(
+    where: Prisma.GeneratedMetaTagsWhereUniqueInput,
+    update: Prisma.GeneratedMetaTagsUpdateInput,
+    create: MetaTagCreateData,
+    client: Client = prisma,
+  ) {
+    return client.generatedMetaTags.upsert({ where, update, create });
   },
 
   deleteByChannelId(channelId: string, client: Client = prisma) {

--- a/harmony-backend/src/repositories/metaTag.repository.ts
+++ b/harmony-backend/src/repositories/metaTag.repository.ts
@@ -13,7 +13,7 @@ export type GeneratedFieldsUpdate = {
   ogImage?: string | null;
   twitterCard: string;
   keywords: string;
-  structuredData: Prisma.InputJsonValue;
+  structuredData: Record<string, unknown>;
   contentHash: string;
   needsRegeneration: boolean;
   generatedAt: Date;
@@ -49,11 +49,7 @@ export const metaTagRepository = {
    * AC-7: Never overwrites non-null customTitle or customDescription.
    * Uses a conditional UPDATE so the constraint is enforced at the DB level.
    */
-  saveGeneratedFields(
-    channelId: string,
-    fields: GeneratedFieldsUpdate,
-    client: Client = prisma,
-  ) {
+  saveGeneratedFields(channelId: string, fields: GeneratedFieldsUpdate, client: Client = prisma) {
     return (client as typeof prisma).$executeRaw`
       UPDATE "generated_meta_tags"
       SET
@@ -68,7 +64,8 @@ export const metaTagRepository = {
         content_hash        = ${fields.contentHash},
         needs_regeneration  = ${fields.needsRegeneration},
         generated_at        = ${fields.generatedAt},
-        schema_version      = COALESCE(${fields.schemaVersion ?? null}, schema_version)
+        schema_version      = COALESCE(${fields.schemaVersion ?? null}, schema_version),
+        updated_at          = NOW()
       WHERE channel_id = ${channelId}::uuid
         AND custom_title IS NULL
         AND custom_description IS NULL

--- a/harmony-backend/src/repositories/metaTag.repository.ts
+++ b/harmony-backend/src/repositories/metaTag.repository.ts
@@ -1,0 +1,90 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+export type MetaTagCreateData = Prisma.GeneratedMetaTagsUncheckedCreateInput;
+
+export type GeneratedFieldsUpdate = {
+  title: string;
+  description: string;
+  ogTitle: string;
+  ogDescription: string;
+  ogImage?: string | null;
+  twitterCard: string;
+  keywords: string;
+  structuredData: Prisma.InputJsonValue;
+  contentHash: string;
+  needsRegeneration: boolean;
+  generatedAt: Date;
+  schemaVersion?: number;
+};
+
+export const metaTagRepository = {
+  findByChannelId(channelId: string, client: Client = prisma) {
+    return client.generatedMetaTags.findUnique({ where: { channelId } });
+  },
+
+  create(data: MetaTagCreateData, client: Client = prisma) {
+    return client.generatedMetaTags.create({ data });
+  },
+
+  updateCustomOverrides(
+    channelId: string,
+    overrides: {
+      customTitle?: string | null;
+      customDescription?: string | null;
+      customOgImage?: string | null;
+    },
+    client: Client = prisma,
+  ) {
+    return client.generatedMetaTags.update({
+      where: { channelId },
+      data: overrides,
+    });
+  },
+
+  /**
+   * Persist background-generated tag fields.
+   * AC-7: Never overwrites non-null customTitle or customDescription.
+   * Uses a conditional UPDATE so the constraint is enforced at the DB level.
+   */
+  saveGeneratedFields(
+    channelId: string,
+    fields: GeneratedFieldsUpdate,
+    client: Client = prisma,
+  ) {
+    return (client as typeof prisma).$executeRaw`
+      UPDATE "generated_meta_tags"
+      SET
+        title               = ${fields.title},
+        description         = ${fields.description},
+        og_title            = ${fields.ogTitle},
+        og_description      = ${fields.ogDescription},
+        og_image            = ${fields.ogImage ?? null},
+        twitter_card        = ${fields.twitterCard},
+        keywords            = ${fields.keywords},
+        structured_data     = ${fields.structuredData}::jsonb,
+        content_hash        = ${fields.contentHash},
+        needs_regeneration  = ${fields.needsRegeneration},
+        generated_at        = ${fields.generatedAt},
+        schema_version      = COALESCE(${fields.schemaVersion ?? null}, schema_version)
+      WHERE channel_id = ${channelId}::uuid
+        AND custom_title IS NULL
+        AND custom_description IS NULL
+    `;
+  },
+
+  upsert(data: MetaTagCreateData, client: Client = prisma) {
+    const { channelId, ...rest } = data;
+    return client.generatedMetaTags.upsert({
+      where: { channelId },
+      create: data,
+      update: rest,
+    });
+  },
+
+  deleteByChannelId(channelId: string, client: Client = prisma) {
+    return client.generatedMetaTags.delete({ where: { channelId } });
+  },
+};

--- a/harmony-backend/tests/metaTag.repository.test.ts
+++ b/harmony-backend/tests/metaTag.repository.test.ts
@@ -1,0 +1,168 @@
+/**
+ * MetaTag repository integration tests — Issue #352
+ *
+ * Verifies AC-7: background regeneration must never overwrite a non-null
+ * customTitle or customDescription set by an admin.
+ *
+ * Requires DATABASE_URL pointing at a running Postgres instance.
+ */
+
+import { PrismaClient, ChannelVisibility } from '@prisma/client';
+import { metaTagRepository } from '../src/repositories/metaTag.repository';
+
+const prisma = new PrismaClient();
+const ts = Date.now();
+
+let userId: string;
+let serverId: string;
+let channelId: string;
+
+const BASE_TAGS = {
+  title: 'Generated Title',
+  description: 'Generated description text',
+  ogTitle: 'OG Generated Title',
+  ogDescription: 'OG Generated description text',
+  twitterCard: 'summary',
+  keywords: 'test,channel',
+  structuredData: { '@type': 'WebPage' },
+  contentHash: 'abc123def456',
+  needsRegeneration: false,
+  generatedAt: new Date(),
+};
+
+beforeAll(async () => {
+  const user = await prisma.user.create({
+    data: {
+      email: `metatag-test-${ts}@test.local`,
+      username: `metatag_${ts}`,
+      passwordHash: 'hashed',
+      displayName: 'MetaTag Tester',
+    },
+  });
+  userId = user.id;
+
+  const server = await prisma.server.create({
+    data: {
+      name: `MetaTag Test Server ${ts}`,
+      slug: `metatag-srv-${ts}`,
+      ownerId: userId,
+    },
+  });
+  serverId = server.id;
+
+  const channel = await prisma.channel.create({
+    data: {
+      serverId,
+      name: 'meta-test-channel',
+      slug: `meta-ch-${ts}`,
+      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+    },
+  });
+  channelId = channel.id;
+});
+
+afterAll(async () => {
+  await prisma.generatedMetaTags.deleteMany({ where: { channelId } });
+  await prisma.channel.delete({ where: { id: channelId } });
+  await prisma.server.delete({ where: { id: serverId } });
+  await prisma.user.delete({ where: { id: userId } });
+  await prisma.$disconnect();
+});
+
+// ─── findByChannelId ────────────────────────────────────────────────────────
+
+describe('metaTagRepository.findByChannelId', () => {
+  it('returns null when no record exists', async () => {
+    const result = await metaTagRepository.findByChannelId(channelId);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── create & findByChannelId ───────────────────────────────────────────────
+
+describe('metaTagRepository.create', () => {
+  it('creates a meta tag record with no custom overrides', async () => {
+    const created = await metaTagRepository.create({ channelId, ...BASE_TAGS });
+    expect(created.channelId).toBe(channelId);
+    expect(created.customTitle).toBeNull();
+    expect(created.customDescription).toBeNull();
+    expect(created.customOgImage).toBeNull();
+
+    const found = await metaTagRepository.findByChannelId(channelId);
+    expect(found).not.toBeNull();
+    expect(found!.title).toBe('Generated Title');
+  });
+});
+
+// ─── AC-7: saveGeneratedFields ──────────────────────────────────────────────
+
+describe('metaTagRepository.saveGeneratedFields — AC-7', () => {
+  const REGEN_FIELDS = {
+    title: 'Regenerated Title',
+    description: 'Regenerated description',
+    ogTitle: 'OG Regenerated',
+    ogDescription: 'OG Regenerated desc',
+    twitterCard: 'summary',
+    keywords: 'regen,test',
+    structuredData: { '@type': 'WebPage', name: 'Regen' } as Record<string, unknown>,
+    contentHash: 'regen_hash_789',
+    needsRegeneration: false,
+    generatedAt: new Date(),
+  };
+
+  it('AC-7: does not overwrite non-null customTitle set by admin', async () => {
+    await metaTagRepository.updateCustomOverrides(channelId, {
+      customTitle: 'Admin Custom Title',
+    });
+
+    await metaTagRepository.saveGeneratedFields(channelId, REGEN_FIELDS);
+
+    const record = await metaTagRepository.findByChannelId(channelId);
+    expect(record!.customTitle).toBe('Admin Custom Title');
+    // Generated title field should NOT have been updated due to AC-7 guard
+    expect(record!.title).toBe('Generated Title');
+  });
+
+  it('AC-7: does not overwrite non-null customDescription set by admin', async () => {
+    await metaTagRepository.updateCustomOverrides(channelId, {
+      customDescription: 'Admin Custom Description',
+    });
+
+    await metaTagRepository.saveGeneratedFields(channelId, REGEN_FIELDS);
+
+    const record = await metaTagRepository.findByChannelId(channelId);
+    expect(record!.customDescription).toBe('Admin Custom Description');
+    expect(record!.title).toBe('Generated Title');
+  });
+
+  it('AC-7: updates generated fields when no custom overrides are set', async () => {
+    // Clear overrides
+    await metaTagRepository.updateCustomOverrides(channelId, {
+      customTitle: null,
+      customDescription: null,
+    });
+
+    const rowsUpdated = await metaTagRepository.saveGeneratedFields(channelId, REGEN_FIELDS);
+
+    expect(rowsUpdated).toBe(1);
+    const record = await metaTagRepository.findByChannelId(channelId);
+    expect(record!.title).toBe('Regenerated Title');
+    expect(record!.description).toBe('Regenerated description');
+  });
+});
+
+// ─── updateCustomOverrides ──────────────────────────────────────────────────
+
+describe('metaTagRepository.updateCustomOverrides', () => {
+  it('can set and clear customOgImage', async () => {
+    await metaTagRepository.updateCustomOverrides(channelId, {
+      customOgImage: 'https://cdn.example.com/custom.png',
+    });
+    let record = await metaTagRepository.findByChannelId(channelId);
+    expect(record!.customOgImage).toBe('https://cdn.example.com/custom.png');
+
+    await metaTagRepository.updateCustomOverrides(channelId, { customOgImage: null });
+    record = await metaTagRepository.findByChannelId(channelId);
+    expect(record!.customOgImage).toBeNull();
+  });
+});

--- a/harmony-backend/tests/metaTag.repository.test.ts
+++ b/harmony-backend/tests/metaTag.repository.test.ts
@@ -30,6 +30,11 @@ const BASE_TAGS = {
   generatedAt: new Date(),
 };
 
+async function seedGeneratedMetaTags() {
+  await prisma.generatedMetaTags.deleteMany({ where: { channelId } });
+  return metaTagRepository.create({ channelId, ...BASE_TAGS });
+}
+
 beforeAll(async () => {
   const user = await prisma.user.create({
     data: {
@@ -62,10 +67,19 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await prisma.generatedMetaTags.deleteMany({ where: { channelId } });
-  await prisma.channel.delete({ where: { id: channelId } });
-  await prisma.server.delete({ where: { id: serverId } });
-  await prisma.user.delete({ where: { id: userId } });
+  if (channelId) {
+    await prisma.generatedMetaTags.deleteMany({ where: { channelId } }).catch(() => {});
+    await prisma.channel.delete({ where: { id: channelId } }).catch(() => {});
+  }
+
+  if (serverId) {
+    await prisma.server.delete({ where: { id: serverId } }).catch(() => {});
+  }
+
+  if (userId) {
+    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+  }
+
   await prisma.$disconnect();
 });
 
@@ -81,6 +95,10 @@ describe('metaTagRepository.findByChannelId', () => {
 // ─── create & findByChannelId ───────────────────────────────────────────────
 
 describe('metaTagRepository.create', () => {
+  beforeEach(async () => {
+    await prisma.generatedMetaTags.deleteMany({ where: { channelId } });
+  });
+
   it('creates a meta tag record with no custom overrides', async () => {
     const created = await metaTagRepository.create({ channelId, ...BASE_TAGS });
     expect(created.channelId).toBe(channelId);
@@ -104,19 +122,24 @@ describe('metaTagRepository.saveGeneratedFields — AC-7', () => {
     ogDescription: 'OG Regenerated desc',
     twitterCard: 'summary',
     keywords: 'regen,test',
-    structuredData: { '@type': 'WebPage', name: 'Regen' } as Record<string, unknown>,
+    structuredData: { '@type': 'WebPage', name: 'Regen' },
     contentHash: 'regen_hash_789',
     needsRegeneration: false,
     generatedAt: new Date(),
   };
+
+  beforeEach(async () => {
+    await seedGeneratedMetaTags();
+  });
 
   it('AC-7: does not overwrite non-null customTitle set by admin', async () => {
     await metaTagRepository.updateCustomOverrides(channelId, {
       customTitle: 'Admin Custom Title',
     });
 
-    await metaTagRepository.saveGeneratedFields(channelId, REGEN_FIELDS);
+    const rowsUpdated = await metaTagRepository.saveGeneratedFields(channelId, REGEN_FIELDS);
 
+    expect(rowsUpdated).toBe(0);
     const record = await metaTagRepository.findByChannelId(channelId);
     expect(record!.customTitle).toBe('Admin Custom Title');
     // Generated title field should NOT have been updated due to AC-7 guard
@@ -128,8 +151,9 @@ describe('metaTagRepository.saveGeneratedFields — AC-7', () => {
       customDescription: 'Admin Custom Description',
     });
 
-    await metaTagRepository.saveGeneratedFields(channelId, REGEN_FIELDS);
+    const rowsUpdated = await metaTagRepository.saveGeneratedFields(channelId, REGEN_FIELDS);
 
+    expect(rowsUpdated).toBe(0);
     const record = await metaTagRepository.findByChannelId(channelId);
     expect(record!.customDescription).toBe('Admin Custom Description');
     expect(record!.title).toBe('Generated Title');
@@ -169,6 +193,10 @@ describe('metaTagRepository.saveGeneratedFields — AC-7', () => {
 // ─── updateCustomOverrides ──────────────────────────────────────────────────
 
 describe('metaTagRepository.updateCustomOverrides', () => {
+  beforeEach(async () => {
+    await seedGeneratedMetaTags();
+  });
+
   it('can set and clear customOgImage', async () => {
     await metaTagRepository.updateCustomOverrides(channelId, {
       customOgImage: 'https://cdn.example.com/custom.png',

--- a/harmony-backend/tests/metaTag.repository.test.ts
+++ b/harmony-backend/tests/metaTag.repository.test.ts
@@ -149,6 +149,21 @@ describe('metaTagRepository.saveGeneratedFields — AC-7', () => {
     expect(record!.title).toBe('Regenerated Title');
     expect(record!.description).toBe('Regenerated description');
   });
+
+  it('bumps updatedAt on every successful saveGeneratedFields call', async () => {
+    const before = await metaTagRepository.findByChannelId(channelId);
+    const beforeUpdatedAt = before!.updatedAt.getTime();
+
+    // Small delay so NOW() is guaranteed to differ
+    await new Promise((r) => setTimeout(r, 10));
+    await metaTagRepository.saveGeneratedFields(channelId, {
+      ...REGEN_FIELDS,
+      title: 'Updated Again',
+    });
+
+    const after = await metaTagRepository.findByChannelId(channelId);
+    expect(after!.updatedAt.getTime()).toBeGreaterThan(beforeUpdatedAt);
+  });
 });
 
 // ─── updateCustomOverrides ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #352

- **Expand-only Prisma migration** (`20260418000000_add_meta_tag_overrides`) adds `custom_title` (VARCHAR 70), `custom_description` (VARCHAR 200), `custom_og_image` (VARCHAR 500), `created_at`, `updated_at`, and `idx_meta_tags_generated` index to `generated_meta_tags`. No columns dropped — safe to apply during a rolling restart with 2+ API replicas.
- **`metaTag.repository.ts`** — new repository with `saveGeneratedFields` enforcing **AC-7** at the DB level: `WHERE custom_title IS NULL AND custom_description IS NULL` so background regen never overwrites admin-set overrides.
- **`metaTag.repository.test.ts`** — integration tests verifying AC-7, CRUD, and custom override lifecycle.
- **`docs/deployment/deployment-architecture.md §11`** — documents override columns and AC-7 invariant.

## Test plan

- [ ] `cd harmony-backend && docker compose up -d && npx prisma migrate deploy && npm test -- tests/metaTag.repository.test.ts`
- [ ] `prisma validate` — schema valid
- [ ] `tsc --noEmit` — zero errors
- [ ] Migration is expand-only (no DROP statements)
- [ ] AC-7: `saveGeneratedFields` returns 0 rows when custom override is non-null