### PR TITLE
test(frontend): unit tests for serverService.ts (#265)

### DIFF
--- a/harmony-frontend/src/__tests__/serverService.test.ts
+++ b/harmony-frontend/src/__tests__/serverService.test.ts
@@ -1,0 +1,844 @@
+/**
+ * Unit tests for serverService.ts
+ * Issue #265 — Sprint 3 (P5 Testing)
+ */
+
+// Mock next/headers before any imports (required by trpc-client)
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+// Mock the trpc-client module used by serverService
+jest.mock('@/lib/trpc-client', () => ({
+  publicGet: jest.fn(),
+  trpcQuery: jest.fn(),
+  trpcMutate: jest.fn(),
+}));
+
+// Mock react cache to pass through
+jest.mock('react', () => ({
+  cache: <T extends (...args: never[]) => unknown>(fn: T): T => fn,
+}));
+
+import { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';
+import {
+  getServers,
+  getServer,
+  getServerAuthenticated,
+  getServerMembers,
+  updateServer,
+  deleteServer,
+  joinServer,
+  createServer,
+  getServerMembersWithRole,
+  changeMemberRole,
+  removeMember,
+} from '@/services/serverService';
+
+const mockedPublicGet = jest.mocked(publicGet);
+const mockedTrpcQuery = jest.mocked(trpcQuery);
+const mockedTrpcMutate = jest.mocked(trpcMutate);
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeRawServer(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'server-1',
+    name: 'Test Server',
+    slug: 'test-server',
+    ownerId: 'user-1',
+    iconUrl: undefined,
+    icon: undefined,
+    description: undefined,
+    bannerUrl: undefined,
+    memberCount: 5,
+    isPublic: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makePublicRawServer(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'server-1',
+    name: 'Test Server',
+    slug: 'test-server',
+    iconUrl: undefined,
+    description: undefined,
+    bannerUrl: undefined,
+    memberCount: 5,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeRawMember(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    userId: 'user-1',
+    serverId: 'server-1',
+    role: 'MEMBER',
+    joinedAt: '2026-01-01T00:00:00.000Z',
+    user: {
+      id: 'user-1',
+      username: 'alice',
+      displayName: 'Alice',
+      avatarUrl: null,
+      status: 'ONLINE',
+    },
+    ...overrides,
+  };
+}
+
+function makeRawMemberWithRole(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    userId: 'user-1',
+    serverId: 'server-1',
+    role: 'MEMBER',
+    joinedAt: '2026-01-01T00:00:00.000Z',
+    user: {
+      id: 'user-1',
+      username: 'alice',
+      displayName: 'Alice',
+      avatarUrl: null,
+    },
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('serverService', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ── getServers ─────────────────────────────────────────────────────────────
+
+  describe('getServers', () => {
+    it('returns adapted servers for valid API response', async () => {
+      const raw = [makeRawServer(), makeRawServer({ id: 'server-2', slug: 'test-server-2' })];
+      mockedTrpcQuery.mockResolvedValue(raw);
+
+      const result = await getServers();
+
+      expect(mockedTrpcQuery).toHaveBeenCalledWith('server.getServers');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ id: 'server-1', name: 'Test Server', slug: 'test-server' });
+      expect(result[1]).toMatchObject({ id: 'server-2' });
+    });
+
+    it('returns empty array when API returns null', async () => {
+      mockedTrpcQuery.mockResolvedValue(null);
+
+      const result = await getServers();
+
+      expect(result).toEqual([]);
+    });
+
+    it('propagates rejection to caller', async () => {
+      mockedTrpcQuery.mockRejectedValue(new Error('Network error'));
+
+      await expect(getServers()).rejects.toThrow('Network error');
+    });
+
+    it('propagates 401 unauthorized rejection', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedTrpcQuery.mockRejectedValue(err);
+
+      await expect(getServers()).rejects.toThrow('Unauthorized');
+    });
+
+    it('maps iconUrl to icon field', async () => {
+      mockedTrpcQuery.mockResolvedValue([
+        makeRawServer({ iconUrl: 'https://example.com/icon.png', icon: undefined }),
+      ]);
+
+      const [server] = await getServers();
+
+      expect(server.icon).toBe('https://example.com/icon.png');
+    });
+
+    it('defaults memberCount to 0 when absent', async () => {
+      mockedTrpcQuery.mockResolvedValue([makeRawServer({ memberCount: undefined })]);
+
+      const [server] = await getServers();
+
+      expect(server.memberCount).toBe(0);
+    });
+  });
+
+  // ── getServer ──────────────────────────────────────────────────────────────
+
+  describe('getServer', () => {
+    it('returns adapted server for valid API response', async () => {
+      mockedPublicGet.mockResolvedValue(makePublicRawServer());
+
+      const result = await getServer('test-server');
+
+      expect(result).toMatchObject({ id: 'server-1', slug: 'test-server' });
+    });
+
+    it('returns null for 404 (publicGet resolves null)', async () => {
+      mockedPublicGet.mockResolvedValue(null);
+
+      const result = await getServer('test-server');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when API rejects with network error', async () => {
+      mockedPublicGet.mockRejectedValue(new Error('Network error'));
+
+      const result = await getServer('test-server');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when API rejects with 401', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedPublicGet.mockRejectedValue(err);
+
+      const result = await getServer('test-server');
+
+      expect(result).toBeNull();
+    });
+
+    it('URL-encodes the slug', async () => {
+      mockedPublicGet.mockResolvedValue(makePublicRawServer({ slug: 'my server' }));
+
+      await getServer('my server');
+
+      expect(mockedPublicGet).toHaveBeenCalledWith('/servers/my%20server');
+    });
+
+    it('warns on missing id field', async () => {
+      mockedPublicGet.mockResolvedValue(makePublicRawServer({ id: undefined }));
+
+      await getServer('test-server');
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('"id"'),
+      );
+    });
+
+    it('warns on missing slug field', async () => {
+      mockedPublicGet.mockResolvedValue(makePublicRawServer({ slug: undefined }));
+
+      await getServer('test-server');
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('"slug"'),
+      );
+    });
+
+    it('warns on missing createdAt field', async () => {
+      mockedPublicGet.mockResolvedValue(makePublicRawServer({ createdAt: undefined }));
+
+      await getServer('test-server');
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('"createdAt"'),
+      );
+    });
+  });
+
+  // ── getServerAuthenticated ─────────────────────────────────────────────────
+
+  describe('getServerAuthenticated', () => {
+    it('returns adapted server for valid API response', async () => {
+      mockedTrpcQuery.mockResolvedValue(makeRawServer());
+
+      const result = await getServerAuthenticated('test-server');
+
+      expect(result).toMatchObject({ id: 'server-1', ownerId: 'user-1' });
+    });
+
+    it('returns null when API returns null', async () => {
+      mockedTrpcQuery.mockResolvedValue(null);
+
+      const result = await getServerAuthenticated('test-server');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when API returns falsy', async () => {
+      mockedTrpcQuery.mockResolvedValue(false);
+
+      const result = await getServerAuthenticated('test-server');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when API rejects with 401', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedTrpcQuery.mockRejectedValue(err);
+
+      const result = await getServerAuthenticated('test-server');
+
+      expect(result).toBeNull();
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('returns null when API rejects with 403', async () => {
+      const err = Object.assign(new Error('Forbidden'), { status: 403 });
+      mockedTrpcQuery.mockRejectedValue(err);
+
+      const result = await getServerAuthenticated('test-server');
+
+      expect(result).toBeNull();
+    });
+
+    it('forwards slug to tRPC query', async () => {
+      mockedTrpcQuery.mockResolvedValue(makeRawServer({ slug: 'test-server' }));
+
+      await getServerAuthenticated('test-server');
+
+      expect(mockedTrpcQuery).toHaveBeenCalledWith('server.getServer', { slug: 'test-server' });
+    });
+  });
+
+  // ── getServerMembers ───────────────────────────────────────────────────────
+
+  describe('getServerMembers', () => {
+    it('returns adapted members for valid API response', async () => {
+      const raw = [makeRawMember(), makeRawMember({ userId: 'user-2' })];
+      mockedTrpcQuery.mockResolvedValue(raw);
+
+      const result = await getServerMembers('s1');
+
+      expect(mockedTrpcQuery).toHaveBeenCalledWith('server.getMembers', { serverId: 's1' });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ id: 'user-1', username: 'alice' });
+    });
+
+    it('returns empty array when API returns null', async () => {
+      mockedTrpcQuery.mockResolvedValue(null);
+
+      const result = await getServerMembers('s1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when API rejects with network error', async () => {
+      mockedTrpcQuery.mockRejectedValue(new Error('Network error'));
+
+      const result = await getServerMembers('s1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when API rejects with 401', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedTrpcQuery.mockRejectedValue(err);
+
+      const result = await getServerMembers('s1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('maps OWNER role to owner', async () => {
+      mockedTrpcQuery.mockResolvedValue([makeRawMember({ role: 'OWNER' })]);
+
+      const [member] = await getServerMembers('s1');
+
+      expect(member.role).toBe('owner');
+    });
+
+    it('maps ADMIN role to admin', async () => {
+      mockedTrpcQuery.mockResolvedValue([makeRawMember({ role: 'ADMIN' })]);
+
+      const [member] = await getServerMembers('s1');
+
+      expect(member.role).toBe('admin');
+    });
+
+    it('maps unknown role to member', async () => {
+      mockedTrpcQuery.mockResolvedValue([makeRawMember({ role: 'SUPERUSER' })]);
+
+      const [member] = await getServerMembers('s1');
+
+      expect(member.role).toBe('member');
+    });
+
+    it('maps ONLINE status to online', async () => {
+      mockedTrpcQuery.mockResolvedValue([makeRawMember()]);
+
+      const [member] = await getServerMembers('s1');
+
+      expect(member.status).toBe('online');
+    });
+
+    it('maps DND status to dnd', async () => {
+      mockedTrpcQuery.mockResolvedValue([
+        makeRawMember({ user: { id: 'user-1', username: 'alice', displayName: 'Alice', avatarUrl: null, status: 'DND' } }),
+      ]);
+
+      const [member] = await getServerMembers('s1');
+
+      expect(member.status).toBe('dnd');
+    });
+
+    it('maps unknown status to offline', async () => {
+      mockedTrpcQuery.mockResolvedValue([
+        makeRawMember({ user: { id: 'user-1', username: 'alice', displayName: 'Alice', avatarUrl: null, status: 'INVISIBLE' } }),
+      ]);
+
+      const [member] = await getServerMembers('s1');
+
+      expect(member.status).toBe('offline');
+    });
+
+    it('uses null avatarUrl as undefined', async () => {
+      mockedTrpcQuery.mockResolvedValue([makeRawMember()]);
+
+      const [member] = await getServerMembers('s1');
+
+      expect(member.avatar).toBeUndefined();
+    });
+  });
+
+  // ── updateServer ───────────────────────────────────────────────────────────
+
+  describe('updateServer', () => {
+    it('updates all four editable fields', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawServer());
+
+      const result = await updateServer('server-1', {
+        name: 'New',
+        description: 'Desc',
+        icon: 'url',
+        isPublic: true,
+      });
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.updateServer', {
+        id: 'server-1',
+        name: 'New',
+        description: 'Desc',
+        iconUrl: 'url',
+        isPublic: true,
+      });
+      expect(result).toMatchObject({ id: 'server-1' });
+    });
+
+    it('updates name only', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawServer({ name: 'New Name' }));
+
+      await updateServer('server-1', { name: 'New Name' });
+
+      const call = mockedTrpcMutate.mock.calls[0][1] as Record<string, unknown>;
+      expect(call).toHaveProperty('name', 'New Name');
+      expect(call).not.toHaveProperty('description');
+      expect(call).not.toHaveProperty('iconUrl');
+      expect(call).not.toHaveProperty('isPublic');
+    });
+
+    it('updates description only', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawServer({ description: 'New desc' }));
+
+      await updateServer('server-1', { description: 'New desc' });
+
+      const call = mockedTrpcMutate.mock.calls[0][1] as Record<string, unknown>;
+      expect(call).toHaveProperty('description', 'New desc');
+      expect(call).not.toHaveProperty('name');
+      expect(call).not.toHaveProperty('iconUrl');
+      expect(call).not.toHaveProperty('isPublic');
+    });
+
+    it('updates isPublic only', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawServer({ isPublic: false }));
+
+      await updateServer('server-1', { isPublic: false });
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.updateServer', {
+        id: 'server-1',
+        isPublic: false,
+      });
+    });
+
+    it('sends only id for empty patch', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawServer());
+
+      await updateServer('server-1', {});
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.updateServer', { id: 'server-1' });
+    });
+
+    it('maps icon patch key to iconUrl mutation key', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawServer());
+
+      await updateServer('server-1', { icon: 'https://example.com/img.png' });
+
+      const call = mockedTrpcMutate.mock.calls[0][1] as Record<string, unknown>;
+      expect(call).toHaveProperty('iconUrl', 'https://example.com/img.png');
+      expect(call).not.toHaveProperty('icon');
+    });
+
+    it('propagates 401 unauthorized rejection', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(updateServer('server-1', { name: 'New' })).rejects.toThrow('Unauthorized');
+    });
+
+    it('propagates 403 rejection to caller', async () => {
+      const err = Object.assign(new Error('Forbidden'), { status: 403 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(updateServer('server-1', { name: 'New' })).rejects.toThrow('Forbidden');
+    });
+  });
+
+  // ── deleteServer ───────────────────────────────────────────────────────────
+
+  describe('deleteServer', () => {
+    it('returns true on successful deletion', async () => {
+      mockedTrpcMutate.mockResolvedValue(undefined);
+
+      const result = await deleteServer('s1');
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.deleteServer', { id: 's1' });
+      expect(result).toBe(true);
+    });
+
+    it('propagates 401 unauthorized rejection', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(deleteServer('s1')).rejects.toThrow('Unauthorized');
+    });
+
+    it('propagates rejection to caller', async () => {
+      const err = Object.assign(new Error('Not found'), { status: 404 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(deleteServer('s1')).rejects.toThrow('Not found');
+    });
+  });
+
+  // ── joinServer ─────────────────────────────────────────────────────────────
+
+  describe('joinServer', () => {
+    it('returns void on successful join', async () => {
+      mockedTrpcMutate.mockResolvedValue(undefined);
+
+      const result = await joinServer('s1');
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('serverMember.joinServer', { serverId: 's1' });
+      expect(result).toBeUndefined();
+    });
+
+    it('propagates 401 unauthorized rejection', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(joinServer('s1')).rejects.toThrow('Unauthorized');
+    });
+
+    it('propagates rejection for private server', async () => {
+      const err = Object.assign(new Error('Forbidden'), { status: 403 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(joinServer('s1')).rejects.toThrow('Forbidden');
+    });
+
+    it('propagates rejection for duplicate membership', async () => {
+      const err = Object.assign(new Error('Conflict'), { status: 409 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(joinServer('s1')).rejects.toThrow('Conflict');
+    });
+  });
+
+  // ── createServer ───────────────────────────────────────────────────────────
+
+  describe('createServer', () => {
+    it('creates server with all fields', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawServer({ isPublic: true }));
+
+      const result = await createServer({ name: 'My Server', description: 'Desc', isPublic: true });
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.createServer', {
+        name: 'My Server',
+        description: 'Desc',
+        isPublic: true,
+      });
+      expect(result).toMatchObject({ id: 'server-1' });
+    });
+
+    it('defaults isPublic to false when omitted', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawServer({ isPublic: false }));
+
+      await createServer({ name: 'My Server' });
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.createServer', {
+        name: 'My Server',
+        description: undefined,
+        isPublic: false,
+      });
+    });
+
+    it('creates public server', async () => {
+      mockedTrpcMutate.mockResolvedValue(makeRawServer({ isPublic: true }));
+
+      const result = await createServer({ name: 'My Server', isPublic: true });
+
+      expect(result).toMatchObject({ id: 'server-1' });
+    });
+
+    it('propagates 401 unauthorized rejection', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(createServer({ name: 'My Server' })).rejects.toThrow('Unauthorized');
+    });
+
+    it('propagates 400 rejection to caller', async () => {
+      const err = Object.assign(new Error('Bad Request'), { status: 400 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(createServer({ name: 'My Server' })).rejects.toThrow('Bad Request');
+    });
+  });
+
+  // ── getServerMembersWithRole ───────────────────────────────────────────────
+
+  describe('getServerMembersWithRole', () => {
+    it('returns adapted member info for valid response', async () => {
+      const raw = [makeRawMemberWithRole(), makeRawMemberWithRole({ userId: 'user-2' })];
+      mockedTrpcQuery.mockResolvedValue(raw);
+
+      const result = await getServerMembersWithRole('s1');
+
+      expect(mockedTrpcQuery).toHaveBeenCalledWith('serverMember.getMembers', { serverId: 's1' });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        userId: 'user-1',
+        username: 'alice',
+        displayName: 'Alice',
+        avatarUrl: null,
+        role: 'member',
+        joinedAt: '2026-01-01T00:00:00.000Z',
+      });
+    });
+
+    it('returns empty array when API returns null', async () => {
+      mockedTrpcQuery.mockResolvedValue(null);
+
+      const result = await getServerMembersWithRole('s1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('maps OWNER role to owner', async () => {
+      mockedTrpcQuery.mockResolvedValue([makeRawMemberWithRole({ role: 'OWNER' })]);
+
+      const [member] = await getServerMembersWithRole('s1');
+
+      expect(member.role).toBe('owner');
+    });
+
+    it('maps MODERATOR role to moderator', async () => {
+      mockedTrpcQuery.mockResolvedValue([makeRawMemberWithRole({ role: 'MODERATOR' })]);
+
+      const [member] = await getServerMembersWithRole('s1');
+
+      expect(member.role).toBe('moderator');
+    });
+
+    it('maps unknown role to member fallback', async () => {
+      mockedTrpcQuery.mockResolvedValue([makeRawMemberWithRole({ role: 'SUPERUSER' })]);
+
+      const [member] = await getServerMembersWithRole('s1');
+
+      expect(member.role).toBe('member');
+    });
+
+    it('preserves null avatarUrl', async () => {
+      mockedTrpcQuery.mockResolvedValue([makeRawMemberWithRole()]);
+
+      const [member] = await getServerMembersWithRole('s1');
+
+      expect(member.avatarUrl).toBeNull();
+    });
+
+    it('forwards displayName from user', async () => {
+      mockedTrpcQuery.mockResolvedValue([
+        makeRawMemberWithRole({
+          user: { id: 'user-1', username: 'alice', displayName: 'Alice', avatarUrl: null },
+        }),
+      ]);
+
+      const [member] = await getServerMembersWithRole('s1');
+
+      expect(member.displayName).toBe('Alice');
+    });
+
+    it('null-coerces missing displayName', async () => {
+      mockedTrpcQuery.mockResolvedValue([
+        makeRawMemberWithRole({
+          user: { id: 'user-1', username: 'alice', displayName: undefined, avatarUrl: null },
+        }),
+      ]);
+
+      const [member] = await getServerMembersWithRole('s1');
+
+      expect(member.displayName).toBeNull();
+    });
+
+    it('propagates 401 unauthorized rejection', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedTrpcQuery.mockRejectedValue(err);
+
+      await expect(getServerMembersWithRole('s1')).rejects.toThrow('Unauthorized');
+    });
+
+    it('propagates rejection to caller', async () => {
+      mockedTrpcQuery.mockRejectedValue(new Error('Network error'));
+
+      await expect(getServerMembersWithRole('s1')).rejects.toThrow('Network error');
+    });
+  });
+
+  // ── changeMemberRole ───────────────────────────────────────────────────────
+
+  describe('changeMemberRole', () => {
+    it('changes role to ADMIN', async () => {
+      mockedTrpcMutate.mockResolvedValue(undefined);
+
+      const result = await changeMemberRole('s1', 'u1', 'ADMIN');
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('serverMember.changeRole', {
+        serverId: 's1',
+        targetUserId: 'u1',
+        newRole: 'ADMIN',
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('changes role to MODERATOR', async () => {
+      mockedTrpcMutate.mockResolvedValue(undefined);
+
+      const result = await changeMemberRole('s1', 'u1', 'MODERATOR');
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('serverMember.changeRole', {
+        serverId: 's1',
+        targetUserId: 'u1',
+        newRole: 'MODERATOR',
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('changes role to MEMBER', async () => {
+      mockedTrpcMutate.mockResolvedValue(undefined);
+
+      const result = await changeMemberRole('s1', 'u1', 'MEMBER');
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('serverMember.changeRole', {
+        serverId: 's1',
+        targetUserId: 'u1',
+        newRole: 'MEMBER',
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('propagates 401 unauthorized rejection', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(changeMemberRole('s1', 'u1', 'ADMIN')).rejects.toThrow('Unauthorized');
+    });
+
+    it('propagates 403 rejection to caller', async () => {
+      const err = Object.assign(new Error('Forbidden'), { status: 403 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(changeMemberRole('s1', 'u1', 'ADMIN')).rejects.toThrow('Forbidden');
+    });
+  });
+
+  // ── removeMember ───────────────────────────────────────────────────────────
+
+  describe('removeMember', () => {
+    it('returns void on successful removal', async () => {
+      mockedTrpcMutate.mockResolvedValue(undefined);
+
+      const result = await removeMember('s1', 'u1');
+
+      expect(mockedTrpcMutate).toHaveBeenCalledWith('serverMember.removeMember', {
+        serverId: 's1',
+        targetUserId: 'u1',
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('propagates 401 unauthorized rejection', async () => {
+      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(removeMember('s1', 'u1')).rejects.toThrow('Unauthorized');
+    });
+
+    it('propagates 404 rejection to caller', async () => {
+      const err = Object.assign(new Error('Not found'), { status: 404 });
+      mockedTrpcMutate.mockRejectedValue(err);
+
+      await expect(removeMember('s1', 'u1')).rejects.toThrow('Not found');
+    });
+  });
+
+  // ── toFrontendServer field mapping (tested indirectly) ────────────────────
+
+  describe('toFrontendServer (via getServers)', () => {
+    it('maps all fields correctly from raw backend shape', async () => {
+      mockedTrpcQuery.mockResolvedValue([
+        makeRawServer({
+          description: 'A server',
+          bannerUrl: 'https://example.com/banner.png',
+          isPublic: false,
+        }),
+      ]);
+
+      const [server] = await getServers();
+
+      expect(server).toMatchObject({
+        id: 'server-1',
+        name: 'Test Server',
+        slug: 'test-server',
+        ownerId: 'user-1',
+        memberCount: 5,
+        isPublic: false,
+        description: 'A server',
+        bannerUrl: 'https://example.com/banner.png',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+    });
+
+    it('prefers iconUrl over icon when both are present', async () => {
+      mockedTrpcQuery.mockResolvedValue([
+        makeRawServer({ iconUrl: 'icon-url', icon: 'fallback-icon' }),
+      ]);
+
+      const [server] = await getServers();
+
+      expect(server.icon).toBe('icon-url');
+    });
+
+    it('falls back to icon when iconUrl is absent', async () => {
+      mockedTrpcQuery.mockResolvedValue([
+        makeRawServer({ iconUrl: undefined, icon: 'fallback-icon' }),
+      ]);
+
+      const [server] = await getServers();
+
+      expect(server.icon).toBe('fallback-icon');
+    });
+  });
+});

--- a/llm-logs/2026-04-18-091404-session-4f411033.md
+++ b/llm-logs/2026-04-18-091404-session-4f411033.md
@@ -1,0 +1,358 @@
+# Session Log 2026-04-18-091404
+
+## User
+
+complete https://github.com/CS485-Harmony/Harmony/issues/265 and open a PR
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 265 --repo CS485-Harmony/Harmony",
+  "description": "View issue #265"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 260 --repo CS485-Harmony/Harmony 2>/dev/null | head -100",
+  "description": "View dependent issue #260 for test specs"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/serverService.ts"
+}
+```
+
+## Assistant
+
+Let me check for the test spec and existing test files for reference.
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "harmony-frontend/src/__tests__/*.test.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Glob`**
+```json
+{
+  "pattern": "docs/test-specs/frontend-server-service-spec.md"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/docs/test-specs/frontend-server-service-spec.md"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/channelService.test.ts"
+}
+```
+
+## Assistant
+
+Now I have everything needed. Let me post the opening comment and write the test file.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 265 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Starting]**\n\nImplementing unit tests for \\`harmony-frontend/src/services/serverService.ts\\` per the spec in \\`docs/test-specs/frontend-server-service-spec.md\\`.\n\nWill create \\`harmony-frontend/src/__tests__/serverService.test.ts\\` covering all 11 functions, mock strategy at the \\`trpcQuery\\`/\\`trpcMutate\\`/\\`publicGet\\` layer, and run tests locally to verify 80%+ coverage.\"",
+  "description": "Post opening comment on issue #265"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/serverService.test.ts",
+  "content": "/**\n * Unit tests for serverService.ts\n * Issue #265 \u2014 Sprint 3 (P5 Testing)\n */\n\n// Mock next/headers before any imports (required by trpc-client)\njest.mock('next/headers', () => ({\n  cookies: jest.fn(),\n}));\n\n// Mock the trpc-client module used by serverService\njest.mock('@/lib/trpc-client', () => ({\n  publicGet: jest.fn(),\n  trpcQuery: jest.fn(),\n  trpcMutate: jest.fn(),\n}));\n\n// Mock react cache to pass through\njest.mock('react', () => ({\n  cache: <T extends (...args: never[]) => unknown>(fn: T): T => fn,\n}));\n\nimport { publicGet, trpcQuery, trpcMutate } from '@/lib/trpc-client';\nimport {\n  getServers,\n  getServer,\n  getServerAuthenticated,\n  getServerMembers,\n  updateServer,\n  deleteServer,\n  joinServer,\n  createServer,\n  getServerMembersWithRole,\n  changeMemberRole,\n  removeMember,\n} from '@/services/serverService';\n\nconst mockedPublicGet = jest.mocked(publicGet);\nconst mockedTrpcQuery = jest.mocked(trpcQuery);\nconst mockedTrpcMutate = jest.mocked(trpcMutate);\n\n// \u2500\u2500\u2500 Fixtures \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\nfunction makeRawServer(overrides: Record<string, unknown> = {}): Record<string, unknown> {\n  return {\n    id: 'server-1',\n    name: 'Test Server',\n    slug: 'test-server',\n    ownerId: 'user-1',\n    iconUrl: undefined,\n    icon: undefined,\n    description: undefined,\n    bannerUrl: undefined,\n    memberCount: 5,\n    isPublic: true,\n    createdAt: '2026-01-01T00:00:00.000Z',\n    updatedAt: '2026-01-01T00:00:00.000Z',\n    ...overrides,\n  };\n}\n\nfunction makePublicRawServer(overrides: Record<string, unknown> = {}): Record<string, unknown> {\n  return {\n    id: 'server-1',\n    name: 'Test Server',\n    slug: 'test-server',\n    iconUrl: undefined,\n    description: undefined,\n    bannerUrl: undefined,\n    memberCount: 5,\n    createdAt: '2026-01-01T00:00:00.000Z',\n    ...overrides,\n  };\n}\n\nfunction makeRawMember(overrides: Record<string, unknown> = {}): Record<string, unknown> {\n  return {\n    userId: 'user-1',\n    serverId: 'server-1',\n    role: 'MEMBER',\n    joinedAt: '2026-01-01T00:00:00.000Z',\n    user: {\n      id: 'user-1',\n      username: 'alice',\n      displayName: 'Alice',\n      avatarUrl: null,\n      status: 'ONLINE',\n    },\n    ...overrides,\n  };\n}\n\nfunction makeRawMemberWithRole(overrides: Record<string, unknown> = {}): Record<string, unknown> {\n  return {\n    userId: 'user-1',\n    serverId: 'server-1',\n    role: 'MEMBER',\n    joinedAt: '2026-01-01T00:00:00.000Z',\n    user: {\n      id: 'user-1',\n      username: 'alice',\n      displayName: 'Alice',\n      avatarUrl: null,\n    },\n    ...overrides,\n  };\n}\n\n// \u2500\u2500\u2500 Tests \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\ndescribe('serverService', () => {\n  beforeEach(() => {\n    jest.resetAllMocks();\n    jest.spyOn(console, 'warn').mockImplementation(() => {});\n    jest.spyOn(console, 'error').mockImplementation(() => {});\n  });\n\n  afterEach(() => {\n    jest.restoreAllMocks();\n  });\n\n  // \u2500\u2500 getServers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('getServers', () => {\n    it('returns adapted servers for valid API response', async () => {\n      const raw = [makeRawServer(), makeRawServer({ id: 'server-2', slug: 'test-server-2' })];\n      mockedTrpcQuery.mockResolvedValue(raw);\n\n      const result = await getServers();\n\n      expect(mockedTrpcQuery).toHaveBeenCalledWith('server.getServers');\n      expect(result).toHaveLength(2);\n      expect(result[0]).toMatchObject({ id: 'server-1', name: 'Test Server', slug: 'test-server' });\n      expect(result[1]).toMatchObject({ id: 'server-2' });\n    });\n\n    it('returns empty array when API returns null', async () => {\n      mockedTrpcQuery.mockResolvedValue(null);\n\n      const result = await getServers();\n\n      expect(result).toEqual([]);\n    });\n\n    it('propagates rejection to caller', async () => {\n      mockedTrpcQuery.mockRejectedValue(new Error('Network error'));\n\n      await expect(getServers()).rejects.toThrow('Network error');\n    });\n\n    it('propagates 401 unauthorized rejection', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedTrpcQuery.mockRejectedValue(err);\n\n      await expect(getServers()).rejects.toThrow('Unauthorized');\n    });\n\n    it('maps iconUrl to icon field', async () => {\n      mockedTrpcQuery.mockResolvedValue([\n        makeRawServer({ iconUrl: 'https://example.com/icon.png', icon: undefined }),\n      ]);\n\n      const [server] = await getServers();\n\n      expect(server.icon).toBe('https://example.com/icon.png');\n    });\n\n    it('defaults memberCount to 0 when absent', async () => {\n      mockedTrpcQuery.mockResolvedValue([makeRawServer({ memberCount: undefined })]);\n\n      const [server] = await getServers();\n\n      expect(server.memberCount).toBe(0);\n    });\n  });\n\n  // \u2500\u2500 getServer \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('getServer', () => {\n    it('returns adapted server for valid API response', async () => {\n      mockedPublicGet.mockResolvedValue(makePublicRawServer());\n\n      const result = await getServer('test-server');\n\n      expect(result).toMatchObject({ id: 'server-1', slug: 'test-server' });\n    });\n\n    it('returns null for 404 (publicGet resolves null)', async () => {\n      mockedPublicGet.mockResolvedValue(null);\n\n      const result = await getServer('test-server');\n\n      expect(result).toBeNull();\n    });\n\n    it('returns null when API rejects with network error', async () => {\n      mockedPublicGet.mockRejectedValue(new Error('Network error'));\n\n      const result = await getServer('test-server');\n\n      expect(result).toBeNull();\n    });\n\n    it('returns null when API rejects with 401', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedPublicGet.mockRejectedValue(err);\n\n      const result = await getServer('test-server');\n\n      expect(result).toBeNull();\n    });\n\n    it('URL-encodes the slug', async () => {\n      mockedPublicGet.mockResolvedValue(makePublicRawServer({ slug: 'my server' }));\n\n      await getServer('my server');\n\n      expect(mockedPublicGet).toHaveBeenCalledWith('/servers/my%20server');\n    });\n\n    it('warns on missing id field', async () => {\n      mockedPublicGet.mockResolvedValue(makePublicRawServer({ id: undefined }));\n\n      await getServer('test-server');\n\n      expect(console.warn).toHaveBeenCalledWith(\n        expect.stringContaining('\"id\"'),\n      );\n    });\n\n    it('warns on missing slug field', async () => {\n      mockedPublicGet.mockResolvedValue(makePublicRawServer({ slug: undefined }));\n\n      await getServer('test-server');\n\n      expect(console.warn).toHaveBeenCalledWith(\n        expect.stringContaining('\"slug\"'),\n      );\n    });\n\n    it('warns on missing createdAt field', async () => {\n      mockedPublicGet.mockResolvedValue(makePublicRawServer({ createdAt: undefined }));\n\n      await getServer('test-server');\n\n      expect(console.warn).toHaveBeenCalledWith(\n        expect.stringContaining('\"createdAt\"'),\n      );\n    });\n  });\n\n  // \u2500\u2500 getServerAuthenticated \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('getServerAuthenticated', () => {\n    it('returns adapted server for valid API response', async () => {\n      mockedTrpcQuery.mockResolvedValue(makeRawServer());\n\n      const result = await getServerAuthenticated('test-server');\n\n      expect(result).toMatchObject({ id: 'server-1', ownerId: 'user-1' });\n    });\n\n    it('returns null when API returns null', async () => {\n      mockedTrpcQuery.mockResolvedValue(null);\n\n      const result = await getServerAuthenticated('test-server');\n\n      expect(result).toBeNull();\n    });\n\n    it('returns null when API returns falsy', async () => {\n      mockedTrpcQuery.mockResolvedValue(false);\n\n      const result = await getServerAuthenticated('test-server');\n\n      expect(result).toBeNull();\n    });\n\n    it('returns null when API rejects with 401', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedTrpcQuery.mockRejectedValue(err);\n\n      const result = await getServerAuthenticated('test-server');\n\n      expect(result).toBeNull();\n      expect(console.error).not.toHaveBeenCalled();\n    });\n\n    it('returns null when API rejects with 403', async () => {\n      const err = Object.assign(new Error('Forbidden'), { status: 403 });\n      mockedTrpcQuery.mockRejectedValue(err);\n\n      const result = await getServerAuthenticated('test-server');\n\n      expect(result).toBeNull();\n    });\n\n    it('forwards slug to tRPC query', async () => {\n      mockedTrpcQuery.mockResolvedValue(makeRawServer({ slug: 'test-server' }));\n\n      await getServerAuthenticated('test-server');\n\n      expect(mockedTrpcQuery).toHaveBeenCalledWith('server.getServer', { slug: 'test-server' });\n    });\n  });\n\n  // \u2500\u2500 getServerMembers \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('getServerMembers', () => {\n    it('returns adapted members for valid API response', async () => {\n      const raw = [makeRawMember(), makeRawMember({ userId: 'user-2' })];\n      mockedTrpcQuery.mockResolvedValue(raw);\n\n      const result = await getServerMembers('s1');\n\n      expect(mockedTrpcQuery).toHaveBeenCalledWith('server.getMembers', { serverId: 's1' });\n      expect(result).toHaveLength(2);\n      expect(result[0]).toMatchObject({ id: 'user-1', username: 'alice' });\n    });\n\n    it('returns empty array when API returns null', async () => {\n      mockedTrpcQuery.mockResolvedValue(null);\n\n      const result = await getServerMembers('s1');\n\n      expect(result).toEqual([]);\n    });\n\n    it('returns empty array when API rejects with network error', async () => {\n      mockedTrpcQuery.mockRejectedValue(new Error('Network error'));\n\n      const result = await getServerMembers('s1');\n\n      expect(result).toEqual([]);\n    });\n\n    it('returns empty array when API rejects with 401', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedTrpcQuery.mockRejectedValue(err);\n\n      const result = await getServerMembers('s1');\n\n      expect(result).toEqual([]);\n    });\n\n    it('maps OWNER role to owner', async () => {\n      mockedTrpcQuery.mockResolvedValue([makeRawMember({ role: 'OWNER' })]);\n\n      const [member] = await getServerMembers('s1');\n\n      expect(member.role).toBe('owner');\n    });\n\n    it('maps ADMIN role to admin', async () => {\n      mockedTrpcQuery.mockResolvedValue([makeRawMember({ role: 'ADMIN' })]);\n\n      const [member] = await getServerMembers('s1');\n\n      expect(member.role).toBe('admin');\n    });\n\n    it('maps unknown role to member', async () => {\n      mockedTrpcQuery.mockResolvedValue([makeRawMember({ role: 'SUPERUSER' })]);\n\n      const [member] = await getServerMembers('s1');\n\n      expect(member.role).toBe('member');\n    });\n\n    it('maps ONLINE status to online', async () => {\n      mockedTrpcQuery.mockResolvedValue([makeRawMember()]);\n\n      const [member] = await getServerMembers('s1');\n\n      expect(member.status).toBe('online');\n    });\n\n    it('maps DND status to dnd', async () => {\n      mockedTrpcQuery.mockResolvedValue([\n        makeRawMember({ user: { id: 'user-1', username: 'alice', displayName: 'Alice', avatarUrl: null, status: 'DND' } }),\n      ]);\n\n      const [member] = await getServerMembers('s1');\n\n      expect(member.status).toBe('dnd');\n    });\n\n    it('maps unknown status to offline', async () => {\n      mockedTrpcQuery.mockResolvedValue([\n        makeRawMember({ user: { id: 'user-1', username: 'alice', displayName: 'Alice', avatarUrl: null, status: 'INVISIBLE' } }),\n      ]);\n\n      const [member] = await getServerMembers('s1');\n\n      expect(member.status).toBe('offline');\n    });\n\n    it('uses null avatarUrl as undefined', async () => {\n      mockedTrpcQuery.mockResolvedValue([makeRawMember()]);\n\n      const [member] = await getServerMembers('s1');\n\n      expect(member.avatar).toBeUndefined();\n    });\n  });\n\n  // \u2500\u2500 updateServer \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('updateServer', () => {\n    it('updates all four editable fields', async () => {\n      mockedTrpcMutate.mockResolvedValue(makeRawServer());\n\n      const result = await updateServer('server-1', {\n        name: 'New',\n        description: 'Desc',\n        icon: 'url',\n        isPublic: true,\n      });\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.updateServer', {\n        id: 'server-1',\n        name: 'New',\n        description: 'Desc',\n        iconUrl: 'url',\n        isPublic: true,\n      });\n      expect(result).toMatchObject({ id: 'server-1' });\n    });\n\n    it('updates name only', async () => {\n      mockedTrpcMutate.mockResolvedValue(makeRawServer({ name: 'New Name' }));\n\n      await updateServer('server-1', { name: 'New Name' });\n\n      const call = mockedTrpcMutate.mock.calls[0][1] as Record<string, unknown>;\n      expect(call).toHaveProperty('name', 'New Name');\n      expect(call).not.toHaveProperty('description');\n      expect(call).not.toHaveProperty('iconUrl');\n      expect(call).not.toHaveProperty('isPublic');\n    });\n\n    it('updates description only', async () => {\n      mockedTrpcMutate.mockResolvedValue(makeRawServer({ description: 'New desc' }));\n\n      await updateServer('server-1', { description: 'New desc' });\n\n      const call = mockedTrpcMutate.mock.calls[0][1] as Record<string, unknown>;\n      expect(call).toHaveProperty('description', 'New desc');\n      expect(call).not.toHaveProperty('name');\n      expect(call).not.toHaveProperty('iconUrl');\n      expect(call).not.toHaveProperty('isPublic');\n    });\n\n    it('updates isPublic only', async () => {\n      mockedTrpcMutate.mockResolvedValue(makeRawServer({ isPublic: false }));\n\n      await updateServer('server-1', { isPublic: false });\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.updateServer', {\n        id: 'server-1',\n        isPublic: false,\n      });\n    });\n\n    it('sends only id for empty patch', async () => {\n      mockedTrpcMutate.mockResolvedValue(makeRawServer());\n\n      await updateServer('server-1', {});\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.updateServer', { id: 'server-1' });\n    });\n\n    it('maps icon patch key to iconUrl mutation key', async () => {\n      mockedTrpcMutate.mockResolvedValue(makeRawServer());\n\n      await updateServer('server-1', { icon: 'https://example.com/img.png' });\n\n      const call = mockedTrpcMutate.mock.calls[0][1] as Record<string, unknown>;\n      expect(call).toHaveProperty('iconUrl', 'https://example.com/img.png');\n      expect(call).not.toHaveProperty('icon');\n    });\n\n    it('propagates 401 unauthorized rejection', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(updateServer('server-1', { name: 'New' })).rejects.toThrow('Unauthorized');\n    });\n\n    it('propagates 403 rejection to caller', async () => {\n      const err = Object.assign(new Error('Forbidden'), { status: 403 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(updateServer('server-1', { name: 'New' })).rejects.toThrow('Forbidden');\n    });\n  });\n\n  // \u2500\u2500 deleteServer \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('deleteServer', () => {\n    it('returns true on successful deletion', async () => {\n      mockedTrpcMutate.mockResolvedValue(undefined);\n\n      const result = await deleteServer('s1');\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.deleteServer', { id: 's1' });\n      expect(result).toBe(true);\n    });\n\n    it('propagates 401 unauthorized rejection', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(deleteServer('s1')).rejects.toThrow('Unauthorized');\n    });\n\n    it('propagates rejection to caller', async () => {\n      const err = Object.assign(new Error('Not found'), { status: 404 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(deleteServer('s1')).rejects.toThrow('Not found');\n    });\n  });\n\n  // \u2500\u2500 joinServer \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('joinServer', () => {\n    it('returns void on successful join', async () => {\n      mockedTrpcMutate.mockResolvedValue(undefined);\n\n      const result = await joinServer('s1');\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('serverMember.joinServer', { serverId: 's1' });\n      expect(result).toBeUndefined();\n    });\n\n    it('propagates 401 unauthorized rejection', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(joinServer('s1')).rejects.toThrow('Unauthorized');\n    });\n\n    it('propagates rejection for private server', async () => {\n      const err = Object.assign(new Error('Forbidden'), { status: 403 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(joinServer('s1')).rejects.toThrow('Forbidden');\n    });\n\n    it('propagates rejection for duplicate membership', async () => {\n      const err = Object.assign(new Error('Conflict'), { status: 409 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(joinServer('s1')).rejects.toThrow('Conflict');\n    });\n  });\n\n  // \u2500\u2500 createServer \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('createServer', () => {\n    it('creates server with all fields', async () => {\n      mockedTrpcMutate.mockResolvedValue(makeRawServer({ isPublic: true }));\n\n      const result = await createServer({ name: 'My Server', description: 'Desc', isPublic: true });\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.createServer', {\n        name: 'My Server',\n        description: 'Desc',\n        isPublic: true,\n      });\n      expect(result).toMatchObject({ id: 'server-1' });\n    });\n\n    it('defaults isPublic to false when omitted', async () => {\n      mockedTrpcMutate.mockResolvedValue(makeRawServer({ isPublic: false }));\n\n      await createServer({ name: 'My Server' });\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('server.createServer', {\n        name: 'My Server',\n        description: undefined,\n        isPublic: false,\n      });\n    });\n\n    it('creates public server', async () => {\n      mockedTrpcMutate.mockResolvedValue(makeRawServer({ isPublic: true }));\n\n      const result = await createServer({ name: 'My Server', isPublic: true });\n\n      expect(result).toMatchObject({ id: 'server-1' });\n    });\n\n    it('propagates 401 unauthorized rejection', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(createServer({ name: 'My Server' })).rejects.toThrow('Unauthorized');\n    });\n\n    it('propagates 400 rejection to caller', async () => {\n      const err = Object.assign(new Error('Bad Request'), { status: 400 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(createServer({ name: 'My Server' })).rejects.toThrow('Bad Request');\n    });\n  });\n\n  // \u2500\u2500 getServerMembersWithRole \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('getServerMembersWithRole', () => {\n    it('returns adapted member info for valid response', async () => {\n      const raw = [makeRawMemberWithRole(), makeRawMemberWithRole({ userId: 'user-2' })];\n      mockedTrpcQuery.mockResolvedValue(raw);\n\n      const result = await getServerMembersWithRole('s1');\n\n      expect(mockedTrpcQuery).toHaveBeenCalledWith('serverMember.getMembers', { serverId: 's1' });\n      expect(result).toHaveLength(2);\n      expect(result[0]).toMatchObject({\n        userId: 'user-1',\n        username: 'alice',\n        displayName: 'Alice',\n        avatarUrl: null,\n        role: 'member',\n        joinedAt: '2026-01-01T00:00:00.000Z',\n      });\n    });\n\n    it('returns empty array when API returns null', async () => {\n      mockedTrpcQuery.mockResolvedValue(null);\n\n      const result = await getServerMembersWithRole('s1');\n\n      expect(result).toEqual([]);\n    });\n\n    it('maps OWNER role to owner', async () => {\n      mockedTrpcQuery.mockResolvedValue([makeRawMemberWithRole({ role: 'OWNER' })]);\n\n      const [member] = await getServerMembersWithRole('s1');\n\n      expect(member.role).toBe('owner');\n    });\n\n    it('maps MODERATOR role to moderator', async () => {\n      mockedTrpcQuery.mockResolvedValue([makeRawMemberWithRole({ role: 'MODERATOR' })]);\n\n      const [member] = await getServerMembersWithRole('s1');\n\n      expect(member.role).toBe('moderator');\n    });\n\n    it('maps unknown role to member fallback', async () => {\n      mockedTrpcQuery.mockResolvedValue([makeRawMemberWithRole({ role: 'SUPERUSER' })]);\n\n      const [member] = await getServerMembersWithRole('s1');\n\n      expect(member.role).toBe('member');\n    });\n\n    it('preserves null avatarUrl', async () => {\n      mockedTrpcQuery.mockResolvedValue([makeRawMemberWithRole()]);\n\n      const [member] = await getServerMembersWithRole('s1');\n\n      expect(member.avatarUrl).toBeNull();\n    });\n\n    it('forwards displayName from user', async () => {\n      mockedTrpcQuery.mockResolvedValue([\n        makeRawMemberWithRole({\n          user: { id: 'user-1', username: 'alice', displayName: 'Alice', avatarUrl: null },\n        }),\n      ]);\n\n      const [member] = await getServerMembersWithRole('s1');\n\n      expect(member.displayName).toBe('Alice');\n    });\n\n    it('null-coerces missing displayName', async () => {\n      mockedTrpcQuery.mockResolvedValue([\n        makeRawMemberWithRole({\n          user: { id: 'user-1', username: 'alice', displayName: undefined, avatarUrl: null },\n        }),\n      ]);\n\n      const [member] = await getServerMembersWithRole('s1');\n\n      expect(member.displayName).toBeNull();\n    });\n\n    it('propagates 401 unauthorized rejection', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedTrpcQuery.mockRejectedValue(err);\n\n      await expect(getServerMembersWithRole('s1')).rejects.toThrow('Unauthorized');\n    });\n\n    it('propagates rejection to caller', async () => {\n      mockedTrpcQuery.mockRejectedValue(new Error('Network error'));\n\n      await expect(getServerMembersWithRole('s1')).rejects.toThrow('Network error');\n    });\n  });\n\n  // \u2500\u2500 changeMemberRole \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('changeMemberRole', () => {\n    it('changes role to ADMIN', async () => {\n      mockedTrpcMutate.mockResolvedValue(undefined);\n\n      const result = await changeMemberRole('s1', 'u1', 'ADMIN');\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('serverMember.changeRole', {\n        serverId: 's1',\n        targetUserId: 'u1',\n        newRole: 'ADMIN',\n      });\n      expect(result).toBeUndefined();\n    });\n\n    it('changes role to MODERATOR', async () => {\n      mockedTrpcMutate.mockResolvedValue(undefined);\n\n      const result = await changeMemberRole('s1', 'u1', 'MODERATOR');\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('serverMember.changeRole', {\n        serverId: 's1',\n        targetUserId: 'u1',\n        newRole: 'MODERATOR',\n      });\n      expect(result).toBeUndefined();\n    });\n\n    it('changes role to MEMBER', async () => {\n      mockedTrpcMutate.mockResolvedValue(undefined);\n\n      const result = await changeMemberRole('s1', 'u1', 'MEMBER');\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('serverMember.changeRole', {\n        serverId: 's1',\n        targetUserId: 'u1',\n        newRole: 'MEMBER',\n      });\n      expect(result).toBeUndefined();\n    });\n\n    it('propagates 401 unauthorized rejection', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(changeMemberRole('s1', 'u1', 'ADMIN')).rejects.toThrow('Unauthorized');\n    });\n\n    it('propagates 403 rejection to caller', async () => {\n      const err = Object.assign(new Error('Forbidden'), { status: 403 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(changeMemberRole('s1', 'u1', 'ADMIN')).rejects.toThrow('Forbidden');\n    });\n  });\n\n  // \u2500\u2500 removeMember \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('removeMember', () => {\n    it('returns void on successful removal', async () => {\n      mockedTrpcMutate.mockResolvedValue(undefined);\n\n      const result = await removeMember('s1', 'u1');\n\n      expect(mockedTrpcMutate).toHaveBeenCalledWith('serverMember.removeMember', {\n        serverId: 's1',\n        targetUserId: 'u1',\n      });\n      expect(result).toBeUndefined();\n    });\n\n    it('propagates 401 unauthorized rejection', async () => {\n      const err = Object.assign(new Error('Unauthorized'), { status: 401 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(removeMember('s1', 'u1')).rejects.toThrow('Unauthorized');\n    });\n\n    it('propagates 404 rejection to caller', async () => {\n      const err = Object.assign(new Error('Not found'), { status: 404 });\n      mockedTrpcMutate.mockRejectedValue(err);\n\n      await expect(removeMember('s1', 'u1')).rejects.toThrow('Not found');\n    });\n  });\n\n  // \u2500\u2500 toFrontendServer field mapping (tested indirectly) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\n  describe('toFrontendServer (via getServers)', () => {\n    it('maps all fields correctly from raw backend shape', async () => {\n      mockedTrpcQuery.mockResolvedValue([\n        makeRawServer({\n          description: 'A server',\n          bannerUrl: 'https://example.com/banner.png',\n          isPublic: false,\n        }),\n      ]);\n\n      const [server] = await getServers();\n\n      expect(server).toMatchObject({\n        id: 'server-1',\n        name: 'Test Server',\n        slug: 'test-server',\n        ownerId: 'user-1',\n        memberCount: 5,\n        isPublic: false,\n        description: 'A server',\n        bannerUrl: 'https://example.com/banner.png',\n        createdAt: '2026-01-01T00:00:00.000Z',\n        updatedAt: '2026-01-01T00:00:00.000Z',\n      });\n    });\n\n    it('prefers iconUrl over icon when both are present', async () => {\n      mockedTrpcQuery.mockResolvedValue([\n        makeRawServer({ iconUrl: 'icon-url', icon: 'fallback-icon' }),\n      ]);\n\n      const [server] = await getServers();\n\n      expect(server.icon).toBe('icon-url');\n    });\n\n    it('falls back to icon when iconUrl is absent', async () => {\n      mockedTrpcQuery.mockResolvedValue([\n        makeRawServer({ iconUrl: undefined, icon: 'fallback-icon' }),\n      ]);\n\n      const [server] = await getServers();\n\n      expect(server.icon).toBe('fallback-icon');\n    });\n  });\n});\n"
+}
+```
+
+## Assistant
+
+Now let me run the tests to see how they do.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npm test -- src/__tests__/serverService.test.ts --coverage --coverageReporters=text 2>&1",
+  "description": "Run serverService tests with coverage",
+  "timeout": 120000
+}
+```
+
+## Assistant
+
+All 72 tests pass with **100% statement/function/line coverage** and **95.71% branch coverage** on `serverService.ts`. Now let me create the branch and PR.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b feature/issue-265-server-service-tests",
+  "description": "Create feature branch"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add harmony-frontend/src/__tests__/serverService.test.ts && git commit -m \"$(cat <<'EOF'\ntest(frontend): add unit tests for serverService.ts (#265)\n\n72 tests covering all 11 exported functions with 100% statement/line\ncoverage and 95.71% branch coverage on serverService.ts.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit the new test file"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git -C /Users/bigfa/Documents/GitHub/Harmony add harmony-frontend/src/__tests__/serverService.test.ts && git -C /Users/bigfa/Documents/GitHub/Harmony commit -m \"$(cat <<'EOF'\ntest(frontend): add unit tests for serverService.ts (#265)\n\n72 tests covering all 11 exported functions with 100% statement/line\ncoverage and 95.71% branch coverage on serverService.ts.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit from repo root"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git -C /Users/bigfa/Documents/GitHub/Harmony push -u origin feature/issue-265-server-service-tests",
+  "description": "Push branch to remote"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --repo CS485-Harmony/Harmony --title \"test(frontend): unit tests for serverService.ts (#265)\" --body \"$(cat <<'EOF'\n## Summary\n- Implements `harmony-frontend/src/__tests__/serverService.test.ts` per the spec in `docs/test-specs/frontend-server-service-spec.md`\n- 72 tests covering all 11 exported functions: `getServers`, `getServer`, `getServerAuthenticated`, `getServerMembers`, `updateServer`, `deleteServer`, `joinServer`, `createServer`, `getServerMembersWithRole`, `changeMemberRole`, `removeMember`\n- Mocks `trpcQuery`, `trpcMutate`, and `publicGet` from `@/lib/trpc-client`; mocks `react.cache` to pass through\n\n## Coverage Report\n```\nserverService.ts | 100% Stmts | 95.71% Branch | 100% Funcs | 100% Lines\n```\nAll 72 tests pass locally.\n\n## Test plan\n- [x] All 11 functions have tests\n- [x] No hallucinated or non-existent functionality tested\n- [x] No duplicate or overlapping test cases\n- [x] All tests pass locally (`npm test -- src/__tests__/serverService.test.ts`)\n- [x] 80%+ code coverage verified (100% statements, 95.71% branches)\n- [x] Tests are fully isolated \u2014 no cross-network calls (all transports mocked)\n\nCloses #265\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.ai/claude-code)\nEOF\n)\"",
+  "description": "Open PR for issue #265"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 265 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Complete]**\n\nTests implemented and PR opened: https://github.com/CS485-Harmony/Harmony/pull/406\n\n- 72 tests covering all 11 functions from the spec\n- \\`serverService.ts\\` coverage: 100% statements/functions/lines, 95.71% branches (exceeds 80% target)\n- All mocks at \\`trpcQuery\\`/\\`trpcMutate\\`/\\`publicGet\\` layer; \\`react.cache\\` patched to pass-through\n- All tests pass locally\"",
+  "description": "Post completion comment on issue #265"
+}
+```
+
+## Assistant
+
+PR is open at **https://github.com/CS485-Harmony/Harmony/pull/406**.
+
+72 tests cover all 11 functions in `serverService.ts` with **100% statement/line/function coverage** and **95.71% branch coverage** — well above the 80% requirement. All tests are fully isolated via mocks on `trpcQuery`, `trpcMutate`, and `publicGet`.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Locate the session JSONL
+
+Run the following Python snippet to find the current session file and resolve the output path:
+
+```bash
+python3 - <<'PYEOF'
+import os, glob, json
+
+cwd = os.getcwd()
+# Claude Code maps cwd to a project key by replacing / and . with -
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+# Most recently modified = current session
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+print(f'SESSION_FILE={latest}')
+print(f'SESSION_ID={session_id}')
+PYEOF
+```
+
+Capture `SESSION_FILE` and `SESSION_ID` from the output.
+
+### Step 2: Determine the output filename
+
+Use the current date/time and the first 8 characters of `SESSION_ID`:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+TIME=$(date +%H%M%S)
+SHORT_ID="${SESSION_ID:0:8}"
+OUTFILE="llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md"
+```
+
+### Step 3: Convert JSONL to markdown and write the log file
+
+Run this Python script to parse the JSONL and write a readable markdown log:
+
+```bash
+python3 - "$SESSION_FILE" "$OUTFILE" "$DATE" "$TIME" "$SHORT_ID" <<'PYEOF'
+import sys, json
+
+session_file, outfile, date, time_str, short_id = sys.argv[1:]
+label = f"{date}-{time_str}"
+
+lines = []
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f"# Session Log {label}\n"]
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f"## User\n\n{content.strip()}\n")
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f"**Tool call: `{name}`**\n```json\n{inp_str}\n```")
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f"**Tool result:**\n```\n{str(result_content)[:2000]}\n```")
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f"## Assistant\n\n{content.strip()}\n")
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f"Written: {outfile}")
+PYEOF
+```
+
+If the script exits with an error, report it and stop.
+
+### Step 4: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 5: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find current session JSONL file"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob\n\ncwd = '/Users/bigfa/Documents/GitHub/Harmony'\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nprint(f'SESSION_FILE={latest}')\nprint(f'SESSION_ID={session_id}')\nPYEOF",
+  "description": "Find session file using repo root path"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "SESSION_FILE=\"/Users/bigfa/.claude/projects/-Users-bigfa-Documents-GitHub-Harmony/4f411033-b0b2-4f5f-80d8-c493f2d29242.jsonl\"\nSESSION_ID=\"4f411033-b0b2-4f5f-80d8-c493f2d29242\"\nDATE=$(date +%Y-%m-%d)\nTIME=$(date +%H%M%S)\nSHORT_ID=\"${SESSION_ID:0:8}\"\nOUTFILE=\"/Users/bigfa/Documents/GitHub/Harmony/llm-logs/${DATE}-${TIME}-session-${SHORT_ID}.md\"\n\npython3 - \"$SESSION_FILE\" \"$OUTFILE\" \"$DATE\" \"$TIME\" \"$SHORT_ID\" <<'PYEOF'\nimport sys, json\n\nsession_file, outfile, date, time_str, short_id = sys.argv[1:]\nlabel = f\"{date}-{time_str}\"\n\nlines = []\nwith open(session_file) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f\"# Session Log {label}\\n\"]\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f\"## User\\n\\n{content.strip()}\\n\")\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f\"**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```\")\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f\"**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```\")\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f\"## Assistant\\n\\n{content.strip()}\\n\")\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f\"Written: {outfile}\")\nPYEOF",
+  "description": "Convert JSONL to markdown log file"
+}
+```
+


### PR DESCRIPTION
## Summary
- Implements `harmony-frontend/src/__tests__/serverService.test.ts` per the spec in `docs/test-specs/frontend-server-service-spec.md`
- 72 tests covering all 11 exported functions: `getServers`, `getServer`, `getServerAuthenticated`, `getServerMembers`, `updateServer`, `deleteServer`, `joinServer`, `createServer`, `getServerMembersWithRole`, `changeMemberRole`, `removeMember`
- Mocks `trpcQuery`, `trpcMutate`, and `publicGet` from `@/lib/trpc-client`; mocks `react.cache` to pass through

## Coverage Report
```
serverService.ts | 100% Stmts | 95.71% Branch | 100% Funcs | 100% Lines
```
All 72 tests pass locally.

## Test plan
- [x] All 11 functions have tests
- [x] No hallucinated or non-existent functionality tested
- [x] No duplicate or overlapping test cases
- [x] All tests pass locally (`npm test -- src/__tests__/serverService.test.ts`)
- [x] 80%+ code coverage verified (100% statements, 95.71% branches)
- [x] Tests are fully isolated — no cross-network calls (all transports mocked)

Closes #265

🤖 Generated with [Claude Code](https://claude.ai/claude-code)