### PR TITLE
[codex] Make cloud integration frontend origin configurable

### DIFF
--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -7,7 +7,14 @@
  */
 
 import crypto from 'crypto';
-import { BACKEND_URL, isCloud, LOCAL_SEEDS, localOnlyDescribe, localOnlyTest } from './env';
+import {
+  BACKEND_URL,
+  FRONTEND_URL,
+  isCloud,
+  LOCAL_SEEDS,
+  localOnlyDescribe,
+  localOnlyTest,
+} from './env';
 import { login } from './helpers/auth';
 
 function derivePasswordVerifier(password: string, saltHex: string): string {
@@ -34,7 +41,7 @@ describe('Auth Smoke', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Origin: isCloud ? 'https://harmony.chat' : 'http://localhost:3000',
+        Origin: FRONTEND_URL,
       },
       body: JSON.stringify({ email: 'smoke@example.invalid' }),
     });
@@ -77,7 +84,10 @@ localOnlyDescribe('Auth (local-only)', () => {
     const res = await fetch(`${BACKEND_URL}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: nonExistentEmail, passwordVerifier: verifier }),
+      body: JSON.stringify({
+        email: nonExistentEmail,
+        passwordVerifier: verifier,
+      }),
     });
     expect(res.status).toBe(401);
   });
@@ -99,7 +109,9 @@ localOnlyDescribe('Auth (local-only)', () => {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { result?: { data?: { email?: string } } };
+    const body = (await res.json()) as {
+      result?: { data?: { email?: string } };
+    };
     expect(body.result?.data?.email).toBe(email);
   });
 
@@ -111,7 +123,10 @@ localOnlyDescribe('Auth (local-only)', () => {
       body: JSON.stringify({ refreshToken: first.refreshToken }),
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { accessToken?: string; refreshToken?: string };
+    const body = (await res.json()) as {
+      accessToken?: string;
+      refreshToken?: string;
+    };
     expect(typeof body.accessToken).toBe('string');
     expect(typeof body.refreshToken).toBe('string');
 

--- a/tests/integration/cors.test.ts
+++ b/tests/integration/cors.test.ts
@@ -6,10 +6,7 @@
 import { BACKEND_URL, FRONTEND_URL, isCloud, LOCAL_SEEDS } from './env';
 import { login } from './helpers/auth';
 
-const PRODUCTION_FRONTEND_ORIGIN = 'https://harmony.chat';
-const localFrontendOrigin = 'http://localhost:3000';
-
-const allowedOrigin = isCloud ? PRODUCTION_FRONTEND_ORIGIN : localFrontendOrigin;
+const allowedOrigin = FRONTEND_URL;
 
 describe('CORS Header Verification', () => {
   test('CORS-1: OPTIONS preflight returns correct CORS headers for allowed origin', async () => {
@@ -41,10 +38,7 @@ describe('CORS Header Verification', () => {
     const acao = res.headers.get('access-control-allow-origin');
     // Either 403 with error body, or no ACAO header (browser would block)
     const isBlocked =
-      res.status === 403 ||
-      acao === null ||
-      acao === '' ||
-      acao === 'null';
+      res.status === 403 || acao === null || acao === '' || acao === 'null';
     expect(isBlocked).toBe(true);
   });
 
@@ -63,7 +57,10 @@ describe('CORS Header Verification', () => {
     }
 
     // Local mode: login with alice_admin and call an authenticated endpoint
-    const { accessToken } = await login(LOCAL_SEEDS.alice.email, LOCAL_SEEDS.alice.password);
+    const { accessToken } = await login(
+      LOCAL_SEEDS.alice.email,
+      LOCAL_SEEDS.alice.password,
+    );
     const res = await fetch(`${BACKEND_URL}/trpc/user.getCurrentUser`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
## Summary
- make the cloud integration auth and CORS checks use `FRONTEND_URL` instead of assuming `https://harmony.chat`
- keep the cloud suite runnable against the actual deployed frontend origin, whether that is the custom domain or the generated Vercel production URL

## Why
The cloud integration suite had hardcoded production-origin assumptions that did not match the live deployment host used during validation. This change keeps the tests environment-driven and avoids baking temporary hostname assumptions into the suite.

## Validation
- `TEST_TARGET=cloud BACKEND_URL=https://harmony-production-13e3.up.railway.app FRONTEND_URL=https://harmony-dun-omega.vercel.app CLOUD_TEST_SERVER_SLUG=testserver CLOUD_TEST_PUBLIC_CHANNEL=new-channel npm --prefix tests/integration run test:cloud`