### PR TITLE
feat: S2 content analysis module M3 (#351)

### DIFF
--- a/harmony-backend/src/services/contentAnalysis/contentAnalyzer.ts
+++ b/harmony-backend/src/services/contentAnalysis/contentAnalyzer.ts
@@ -1,0 +1,180 @@
+/**
+ * CL-C3.1 ContentAnalyzer (dev spec §9.2.1).
+ *
+ * Orchestrates keyword extraction, summarization, and topic classification
+ * for the MetaTag service (M2). Per §9.2.1 error handling: on NLP path
+ * exception/timeout (>5s), return a deterministic fallback analysis so
+ * the MetaTagService can still emit a template-only result.
+ *
+ * The "NLP path" is currently the deterministic implementation itself —
+ * the spec calls for language-aware NLP later, at which point this
+ * module becomes the race gate between NLP and fallback.
+ */
+
+import { keywordExtractor } from './keywordExtractor';
+import { textSummarizer } from './textSummarizer';
+import { topicClassifier } from './topicClassifier';
+import type { AnalyzableMessage, ContentAnalysis } from './types';
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_MAX_KEYWORDS = 10;
+const DEFAULT_SUMMARY_LENGTH = 160;
+const DEFAULT_TOP_TOPICS = 3;
+
+const POSITIVE_WORDS = new Set([
+  'good', 'great', 'love', 'awesome', 'nice', 'happy', 'excellent',
+  'amazing', 'fantastic', 'cool', 'wonderful', 'best', 'perfect',
+  'thanks', 'welcome',
+]);
+
+const NEGATIVE_WORDS = new Set([
+  'bad', 'hate', 'terrible', 'awful', 'broken', 'worst', 'angry',
+  'sad', 'frustrated', 'bug', 'error', 'fail', 'failed', 'issue',
+  'problem',
+]);
+
+export interface ContentAnalyzerOptions {
+  timeoutMs?: number;
+  maxKeywords?: number;
+  summaryLength?: number;
+  topTopics?: number;
+  /**
+   * Injectable NLP path for tests and the future language-aware analyzer.
+   * When it rejects or exceeds `timeoutMs`, `analyzeThread` returns the
+   * deterministic fallback instead — see dev spec §9.2.1.
+   */
+  nlpPath?: (content: string) => Promise<Partial<ContentAnalysis>>;
+}
+
+function joinMessages(messages: readonly AnalyzableMessage[]): string {
+  return messages
+    .map((m) => (m?.content ?? '').trim())
+    .filter((content) => content.length > 0)
+    .join('\n');
+}
+
+function countWords(content: string): number {
+  return (content.match(/[a-z0-9][a-z0-9'-]*/gi) ?? []).length;
+}
+
+function averageWordLength(content: string): number {
+  const words = content.match(/[a-z0-9][a-z0-9'-]*/gi) ?? [];
+  if (words.length === 0) return 0;
+  const total = words.reduce((sum, w) => sum + w.length, 0);
+  return total / words.length;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const handle = setTimeout(
+      () => reject(new Error(`content analysis timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(handle);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(handle);
+        reject(err);
+      },
+    );
+  });
+}
+
+export function createContentAnalyzer(options: ContentAnalyzerOptions = {}) {
+  const {
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxKeywords = DEFAULT_MAX_KEYWORDS,
+    summaryLength = DEFAULT_SUMMARY_LENGTH,
+    topTopics = DEFAULT_TOP_TOPICS,
+    nlpPath,
+  } = options;
+
+  function deterministicAnalysis(content: string): ContentAnalysis {
+    const keywords = keywordExtractor.extractKeywords(content, maxKeywords);
+    const summary = textSummarizer.summarize(content, summaryLength)
+      || textSummarizer.extractFirstSentence(content);
+    const topics = topicClassifier.getTop(content, topTopics);
+
+    return {
+      keywords,
+      topics,
+      summary,
+      sentiment: analyzer.getSentiment(content),
+      readingLevel: analyzer.getReadingLevel(content),
+    };
+  }
+
+  function emptyFallback(): ContentAnalysis {
+    return {
+      keywords: [],
+      topics: ['general'],
+      summary: '',
+      sentiment: 'neutral',
+      readingLevel: 'basic',
+    };
+  }
+
+  const analyzer = {
+    async analyzeThread(messages: readonly AnalyzableMessage[]): Promise<ContentAnalysis> {
+      const content = joinMessages(messages);
+      if (!content) return emptyFallback();
+
+      if (!nlpPath) {
+        return deterministicAnalysis(content);
+      }
+
+      try {
+        const partial = await withTimeout(nlpPath(content), timeoutMs);
+        const fallback = deterministicAnalysis(content);
+        return {
+          keywords: partial.keywords ?? fallback.keywords,
+          topics: partial.topics ?? fallback.topics,
+          summary: partial.summary ?? fallback.summary,
+          sentiment: partial.sentiment ?? fallback.sentiment,
+          readingLevel: partial.readingLevel ?? fallback.readingLevel,
+        };
+      } catch (err) {
+        console.error('[contentAnalyzer] NLP path failed, using fallback:', err);
+        return deterministicAnalysis(content);
+      }
+    },
+
+    getTopicCategory(content: string): string[] {
+      return topicClassifier.classify(content);
+    },
+
+    getSentiment(content: string): 'positive' | 'negative' | 'neutral' {
+      if (!content) return 'neutral';
+      const tokens = content.toLowerCase().match(/[a-z][a-z'-]*/g) ?? [];
+      let score = 0;
+      for (const tok of tokens) {
+        if (POSITIVE_WORDS.has(tok)) score += 1;
+        else if (NEGATIVE_WORDS.has(tok)) score -= 1;
+      }
+      if (score > 0) return 'positive';
+      if (score < 0) return 'negative';
+      return 'neutral';
+    },
+
+    getReadingLevel(content: string): 'basic' | 'intermediate' | 'advanced' {
+      const wordCount = countWords(content);
+      if (wordCount === 0) return 'basic';
+      const avgLen = averageWordLength(content);
+      // Simple heuristic; true Flesch-Kincaid is future NLP work.
+      if (avgLen >= 6 || wordCount >= 400) return 'advanced';
+      if (avgLen >= 4.5 || wordCount >= 120) return 'intermediate';
+      return 'basic';
+    },
+  };
+
+  return analyzer;
+}
+
+export const contentAnalyzer = createContentAnalyzer();
+export type ContentAnalyzer = ReturnType<typeof createContentAnalyzer>;

--- a/harmony-backend/src/services/contentAnalysis/contentAnalyzer.ts
+++ b/harmony-backend/src/services/contentAnalysis/contentAnalyzer.ts
@@ -95,7 +95,7 @@ export function createContentAnalyzer(options: ContentAnalyzerOptions = {}) {
     nlpPath,
   } = options;
 
-  function deterministicAnalysis(content: string): ContentAnalysis {
+  function deterministicAnalysis(content: string, usedFallback: boolean): ContentAnalysis {
     const keywords = keywordExtractor.extractKeywords(content, maxKeywords);
     const summary = textSummarizer.summarize(content, summaryLength)
       || textSummarizer.extractFirstSentence(content);
@@ -107,6 +107,7 @@ export function createContentAnalyzer(options: ContentAnalyzerOptions = {}) {
       summary,
       sentiment: analyzer.getSentiment(content),
       readingLevel: analyzer.getReadingLevel(content),
+      usedFallback,
     };
   }
 
@@ -117,6 +118,7 @@ export function createContentAnalyzer(options: ContentAnalyzerOptions = {}) {
       summary: '',
       sentiment: 'neutral',
       readingLevel: 'basic',
+      usedFallback: false,
     };
   }
 
@@ -126,22 +128,23 @@ export function createContentAnalyzer(options: ContentAnalyzerOptions = {}) {
       if (!content) return emptyFallback();
 
       if (!nlpPath) {
-        return deterministicAnalysis(content);
+        return deterministicAnalysis(content, false);
       }
 
       try {
         const partial = await withTimeout(nlpPath(content), timeoutMs);
-        const fallback = deterministicAnalysis(content);
+        const fallback = deterministicAnalysis(content, false);
         return {
           keywords: partial.keywords ?? fallback.keywords,
           topics: partial.topics ?? fallback.topics,
           summary: partial.summary ?? fallback.summary,
           sentiment: partial.sentiment ?? fallback.sentiment,
           readingLevel: partial.readingLevel ?? fallback.readingLevel,
+          usedFallback: false,
         };
       } catch (err) {
         console.error('[contentAnalyzer] NLP path failed, using fallback:', err);
-        return deterministicAnalysis(content);
+        return deterministicAnalysis(content, true);
       }
     },
 

--- a/harmony-backend/src/services/contentAnalysis/index.ts
+++ b/harmony-backend/src/services/contentAnalysis/index.ts
@@ -1,0 +1,6 @@
+export { contentAnalyzer, createContentAnalyzer } from './contentAnalyzer';
+export type { ContentAnalyzer, ContentAnalyzerOptions } from './contentAnalyzer';
+export { keywordExtractor } from './keywordExtractor';
+export { textSummarizer } from './textSummarizer';
+export { topicClassifier } from './topicClassifier';
+export type { ContentAnalysis, ScoredKeyword, AnalyzableMessage } from './types';

--- a/harmony-backend/src/services/contentAnalysis/keywordExtractor.ts
+++ b/harmony-backend/src/services/contentAnalysis/keywordExtractor.ts
@@ -1,0 +1,78 @@
+/**
+ * CL-C3.2 KeywordExtractor (dev spec §9.2.2).
+ *
+ * Deterministic, pure-function implementation: no external NLP calls so it
+ * satisfies the "fallback returns a valid result within the timeout budget"
+ * acceptance criterion on its own. The future NLP-backed extractor will
+ * wrap this as a fast path degradation.
+ */
+
+import { STOP_WORDS } from './stopWords';
+import type { ScoredKeyword } from './types';
+
+const TOKEN_REGEX = /[a-z0-9][a-z0-9'-]*/gi;
+const MIN_TOKEN_LENGTH = 3;
+
+function tokenize(content: string): string[] {
+  const matches = content.toLowerCase().match(TOKEN_REGEX);
+  if (!matches) return [];
+  return matches.filter(
+    (token) => token.length >= MIN_TOKEN_LENGTH && !STOP_WORDS.has(token),
+  );
+}
+
+function frequencyMap(tokens: readonly string[]): Map<string, number> {
+  const freq = new Map<string, number>();
+  for (const token of tokens) {
+    freq.set(token, (freq.get(token) ?? 0) + 1);
+  }
+  return freq;
+}
+
+export const keywordExtractor = {
+  extractKeywords(content: string, maxKeywords: number): string[] {
+    if (!content || maxKeywords <= 0) return [];
+    const tokens = tokenize(content);
+    const freq = frequencyMap(tokens);
+
+    // Sort by frequency desc, then alphabetical for determinism.
+    return [...freq.entries()]
+      .sort((a, b) => (b[1] - a[1]) || a[0].localeCompare(b[0]))
+      .slice(0, maxKeywords)
+      .map(([word]) => word);
+  },
+
+  extractPhrases(content: string, maxPhrases: number): string[] {
+    if (!content || maxPhrases <= 0) return [];
+    const lowered = content.toLowerCase();
+    const rawTokens = lowered.match(TOKEN_REGEX) ?? [];
+
+    // Build bigrams where neither token is a stop-word, preserving order.
+    const bigramFreq = new Map<string, number>();
+    for (let i = 0; i < rawTokens.length - 1; i++) {
+      const a = rawTokens[i];
+      const b = rawTokens[i + 1];
+      if (a.length < MIN_TOKEN_LENGTH || b.length < MIN_TOKEN_LENGTH) continue;
+      if (STOP_WORDS.has(a) || STOP_WORDS.has(b)) continue;
+      const phrase = `${a} ${b}`;
+      bigramFreq.set(phrase, (bigramFreq.get(phrase) ?? 0) + 1);
+    }
+
+    return [...bigramFreq.entries()]
+      .sort((a, b) => (b[1] - a[1]) || a[0].localeCompare(b[0]))
+      .slice(0, maxPhrases)
+      .map(([phrase]) => phrase);
+  },
+
+  scoreByFrequency(keywords: string[], content: string): ScoredKeyword[] {
+    if (!keywords.length || !content) return [];
+    const tokens = tokenize(content);
+    const freq = frequencyMap(tokens);
+    const total = tokens.length || 1;
+
+    return keywords.map((keyword) => {
+      const count = freq.get(keyword.toLowerCase()) ?? 0;
+      return { keyword, score: count / total };
+    });
+  },
+};

--- a/harmony-backend/src/services/contentAnalysis/stopWords.ts
+++ b/harmony-backend/src/services/contentAnalysis/stopWords.ts
@@ -1,0 +1,23 @@
+/**
+ * English stop-word list used by KeywordExtractor and TopicClassifier.
+ * Kept intentionally small and deterministic — full NLP stop-word lists
+ * are delegated to the future NLP adapter. These are the high-frequency
+ * tokens whose presence would otherwise dominate frequency scoring.
+ */
+export const STOP_WORDS: ReadonlySet<string> = new Set([
+  'a', 'an', 'the', 'and', 'or', 'but', 'if', 'then', 'else', 'of', 'for',
+  'to', 'in', 'on', 'at', 'by', 'with', 'from', 'as', 'is', 'are', 'was',
+  'were', 'be', 'been', 'being', 'am', 'do', 'does', 'did', 'have', 'has',
+  'had', 'having', 'it', 'its', 'this', 'that', 'these', 'those', 'i',
+  'you', 'he', 'she', 'we', 'they', 'them', 'me', 'us', 'my', 'your',
+  'our', 'their', 'his', 'her', 'so', 'not', 'no', 'yes', 'can', 'will',
+  'would', 'should', 'could', 'may', 'might', 'must', 'shall', 'just',
+  'about', 'into', 'than', 'too', 'very', 'also', 'there', 'here', 'what',
+  'which', 'who', 'whom', 'when', 'where', 'why', 'how', 'all', 'any',
+  'some', 'each', 'every', 'other', 'more', 'most', 'such', 'only', 'own',
+  'same', 'over', 'under', 'again', 'up', 'down', 'out', 'off',
+]);
+
+export function isStopWord(token: string): boolean {
+  return STOP_WORDS.has(token.toLowerCase());
+}

--- a/harmony-backend/src/services/contentAnalysis/textSummarizer.ts
+++ b/harmony-backend/src/services/contentAnalysis/textSummarizer.ts
@@ -43,9 +43,12 @@ function buildWordFrequency(content: string): Map<string, number> {
 
 function truncateAtBoundary(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
-  const slice = text.slice(0, maxLength);
+  // Reserve one character for the appended ellipsis so the final string
+  // never exceeds maxLength — the summarize() contract promises this bound.
+  const budget = Math.max(1, maxLength - 1);
+  const slice = text.slice(0, budget);
   const lastSpace = slice.lastIndexOf(' ');
-  const boundary = lastSpace > maxLength * 0.6 ? lastSpace : slice.length;
+  const boundary = lastSpace > budget * 0.6 ? lastSpace : slice.length;
   return `${slice.slice(0, boundary).trimEnd()}…`;
 }
 

--- a/harmony-backend/src/services/contentAnalysis/textSummarizer.ts
+++ b/harmony-backend/src/services/contentAnalysis/textSummarizer.ts
@@ -1,0 +1,113 @@
+/**
+ * CL-C3.3 TextSummarizer (dev spec §9.2.3).
+ *
+ * Extractive, deterministic summarizer. Ranks sentences by the frequency
+ * of their non-stop-word tokens, which gives stable output for the
+ * fallback path while being good enough for short-channel descriptions.
+ */
+
+import { STOP_WORDS } from './stopWords';
+
+const SENTENCE_SPLIT = /(?<=[.!?])\s+(?=[A-Z0-9"'(])/;
+const WORD_REGEX = /[a-z0-9][a-z0-9'-]*/gi;
+
+function splitSentences(content: string): string[] {
+  const trimmed = content.trim();
+  if (!trimmed) return [];
+  return trimmed
+    .split(SENTENCE_SPLIT)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function scoreSentence(sentence: string, wordFreq: Map<string, number>): number {
+  const words = sentence.toLowerCase().match(WORD_REGEX) ?? [];
+  let score = 0;
+  for (const word of words) {
+    if (STOP_WORDS.has(word)) continue;
+    score += wordFreq.get(word) ?? 0;
+  }
+  // Normalize by length so we don't bias toward long sentences.
+  return words.length > 0 ? score / words.length : 0;
+}
+
+function buildWordFrequency(content: string): Map<string, number> {
+  const freq = new Map<string, number>();
+  const words = content.toLowerCase().match(WORD_REGEX) ?? [];
+  for (const word of words) {
+    if (STOP_WORDS.has(word)) continue;
+    freq.set(word, (freq.get(word) ?? 0) + 1);
+  }
+  return freq;
+}
+
+function truncateAtBoundary(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  const slice = text.slice(0, maxLength);
+  const lastSpace = slice.lastIndexOf(' ');
+  const boundary = lastSpace > maxLength * 0.6 ? lastSpace : slice.length;
+  return `${slice.slice(0, boundary).trimEnd()}…`;
+}
+
+export const textSummarizer = {
+  summarize(content: string, targetLength: number): string {
+    if (!content) return '';
+    if (targetLength <= 0) return '';
+
+    const sentences = splitSentences(content);
+    if (sentences.length === 0) return truncateAtBoundary(content.trim(), targetLength);
+    if (sentences.length === 1) return truncateAtBoundary(sentences[0], targetLength);
+
+    const wordFreq = buildWordFrequency(content);
+    const ranked = sentences
+      .map((sentence, index) => ({
+        sentence,
+        index,
+        score: scoreSentence(sentence, wordFreq),
+      }))
+      // Highest scoring first; ties broken by original order for determinism.
+      .sort((a, b) => (b.score - a.score) || (a.index - b.index));
+
+    const picked: { sentence: string; index: number }[] = [];
+    let length = 0;
+    for (const candidate of ranked) {
+      const projected = length + (picked.length ? 1 : 0) + candidate.sentence.length;
+      if (projected > targetLength && picked.length > 0) continue;
+      picked.push(candidate);
+      length = projected;
+      if (length >= targetLength) break;
+    }
+
+    if (picked.length === 0) {
+      return truncateAtBoundary(sentences[0], targetLength);
+    }
+
+    // Restore original order in final summary.
+    const ordered = [...picked].sort((a, b) => a.index - b.index);
+    const joined = ordered.map((p) => p.sentence).join(' ');
+    return truncateAtBoundary(joined, targetLength);
+  },
+
+  extractFirstSentence(content: string): string {
+    const sentences = splitSentences(content);
+    return sentences[0] ?? '';
+  },
+
+  extractKeySentences(content: string, maxSentences: number): string[] {
+    if (!content || maxSentences <= 0) return [];
+    const sentences = splitSentences(content);
+    if (sentences.length === 0) return [];
+
+    const wordFreq = buildWordFrequency(content);
+    return sentences
+      .map((sentence, index) => ({
+        sentence,
+        index,
+        score: scoreSentence(sentence, wordFreq),
+      }))
+      .sort((a, b) => (b.score - a.score) || (a.index - b.index))
+      .slice(0, maxSentences)
+      .sort((a, b) => a.index - b.index)
+      .map((entry) => entry.sentence);
+  },
+};

--- a/harmony-backend/src/services/contentAnalysis/topicClassifier.ts
+++ b/harmony-backend/src/services/contentAnalysis/topicClassifier.ts
@@ -1,0 +1,120 @@
+/**
+ * CL-C3.4 TopicClassifier (dev spec §9.2.4).
+ *
+ * Deterministic keyword-bag classifier. Each topic has a seed vocabulary
+ * used to score raw content; topics with at least one matching keyword
+ * are considered, the rest fall back to the "general" bucket.
+ *
+ * The vocabulary is intentionally short — it biases recall for common
+ * developer/community channel themes, and the production NLP path (future
+ * work) is expected to replace this with a learned classifier.
+ */
+
+import { STOP_WORDS } from './stopWords';
+
+const WORD_REGEX = /[a-z0-9][a-z0-9'-]*/gi;
+
+const TOPIC_VOCAB: Readonly<Record<string, readonly string[]>> = {
+  technology: [
+    'code', 'coding', 'software', 'developer', 'programming', 'api', 'bug',
+    'deploy', 'server', 'frontend', 'backend', 'database', 'typescript',
+    'javascript', 'python', 'framework', 'library', 'github', 'commit',
+  ],
+  gaming: [
+    'game', 'gaming', 'player', 'match', 'stream', 'quest', 'raid', 'boss',
+    'server', 'multiplayer', 'guild', 'loot', 'level', 'speedrun',
+  ],
+  music: [
+    'music', 'song', 'album', 'band', 'guitar', 'piano', 'drum', 'vocal',
+    'concert', 'playlist', 'remix', 'genre', 'artist',
+  ],
+  art: [
+    'art', 'drawing', 'painting', 'sketch', 'color', 'palette', 'illustration',
+    'canvas', 'design', 'portfolio',
+  ],
+  education: [
+    'study', 'learn', 'course', 'lesson', 'homework', 'exam', 'teacher',
+    'student', 'textbook', 'lecture', 'assignment', 'class',
+  ],
+  sports: [
+    'team', 'match', 'game', 'player', 'coach', 'score', 'goal', 'league',
+    'tournament', 'practice', 'fitness',
+  ],
+  business: [
+    'business', 'startup', 'customer', 'market', 'sales', 'revenue',
+    'product', 'strategy', 'meeting', 'client', 'launch',
+  ],
+  community: [
+    'welcome', 'hello', 'introduce', 'rules', 'announcement', 'event',
+    'meetup', 'chat', 'friends', 'community',
+  ],
+};
+
+const GENERAL_TOPIC = 'general';
+
+export interface TopicScore {
+  topic: string;
+  score: number;
+}
+
+function tokenize(content: string): string[] {
+  const matches = content.toLowerCase().match(WORD_REGEX);
+  if (!matches) return [];
+  return matches.filter((t) => !STOP_WORDS.has(t));
+}
+
+function scoreTopics(content: string): TopicScore[] {
+  const tokens = tokenize(content);
+  if (tokens.length === 0) return [];
+
+  const tokenSet = new Set(tokens);
+  const tokenCount = new Map<string, number>();
+  for (const tok of tokens) {
+    tokenCount.set(tok, (tokenCount.get(tok) ?? 0) + 1);
+  }
+
+  const scores: TopicScore[] = [];
+  for (const [topic, vocab] of Object.entries(TOPIC_VOCAB)) {
+    let score = 0;
+    for (const term of vocab) {
+      if (tokenSet.has(term)) {
+        score += tokenCount.get(term) ?? 0;
+      }
+    }
+    if (score > 0) {
+      scores.push({ topic, score });
+    }
+  }
+
+  return scores.sort((a, b) => (b.score - a.score) || a.topic.localeCompare(b.topic));
+}
+
+export const topicClassifier = {
+  classify(content: string): string[] {
+    if (!content) return [GENERAL_TOPIC];
+    const scored = scoreTopics(content);
+    if (scored.length === 0) return [GENERAL_TOPIC];
+    return scored.map((s) => s.topic);
+  },
+
+  getTop(content: string, count: number): string[] {
+    if (count <= 0) return [];
+    const topics = this.classify(content);
+    return topics.slice(0, count);
+  },
+
+  getKeywords(content: string): string[] {
+    if (!content) return [];
+    const scored = scoreTopics(content);
+    if (scored.length === 0) return [];
+
+    const tokenSet = new Set(tokenize(content));
+    const matched = new Set<string>();
+    for (const { topic } of scored) {
+      for (const term of TOPIC_VOCAB[topic] ?? []) {
+        if (tokenSet.has(term)) matched.add(term);
+      }
+    }
+    return [...matched].sort();
+  },
+};

--- a/harmony-backend/src/services/contentAnalysis/types.ts
+++ b/harmony-backend/src/services/contentAnalysis/types.ts
@@ -11,6 +11,13 @@ export interface ContentAnalysis {
   summary: string;
   sentiment: 'positive' | 'negative' | 'neutral';
   readingLevel: 'basic' | 'intermediate' | 'advanced';
+  /**
+   * True when the NLP path threw or timed out and the deterministic
+   * fallback was used instead. Per dev spec §9.2.1 / AC-9, MetaTagService
+   * (M-B5) must call MetaTagRepository.markForRegeneration() so the
+   * background worker can re-queue the meta tag once NLP is healthy.
+   */
+  usedFallback: boolean;
 }
 
 export interface ScoredKeyword {

--- a/harmony-backend/src/services/contentAnalysis/types.ts
+++ b/harmony-backend/src/services/contentAnalysis/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Module M3 — Content Analysis DTOs (dev spec §9.5.5, §9.2).
+ *
+ * Kept local to the module so M3 can evolve independently from the
+ * MetaTag (M2) and background-processing (M4) modules that consume it.
+ */
+
+export interface ContentAnalysis {
+  keywords: string[];
+  topics: string[];
+  summary: string;
+  sentiment: 'positive' | 'negative' | 'neutral';
+  readingLevel: 'basic' | 'intermediate' | 'advanced';
+}
+
+export interface ScoredKeyword {
+  keyword: string;
+  score: number;
+}
+
+/**
+ * Narrow subset of the Message entity (CL-E2) that M3 needs.
+ * Content analysis only reads `content`; keeping this loose avoids a
+ * hard coupling to Prisma types for a service that may be reused
+ * across background jobs, tests, and future adapters.
+ */
+export interface AnalyzableMessage {
+  id?: string;
+  content: string;
+  createdAt?: Date | string;
+}

--- a/harmony-backend/tests/contentAnalysis.test.ts
+++ b/harmony-backend/tests/contentAnalysis.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Module M3 (Content Analysis) unit tests — Issue #351.
+ *
+ * Covers acceptance criteria:
+ *   - Classes C3.1–C3.4 exist with spec'd method signatures.
+ *   - ContentAnalyzer.analyzeThread returns keywords, summary, topic for a fixture thread.
+ *   - Deterministic fallback returns a valid result when the NLP path is stubbed to fail.
+ *   - Stop-word filtering, frequency scoring, summarization, classification, timeout/fallback paths.
+ */
+
+import {
+  contentAnalyzer,
+  createContentAnalyzer,
+  keywordExtractor,
+  textSummarizer,
+  topicClassifier,
+} from '../src/services/contentAnalysis';
+import type { AnalyzableMessage, ContentAnalysis } from '../src/services/contentAnalysis';
+
+const FIXTURE_THREAD: AnalyzableMessage[] = [
+  { id: 'm1', content: 'Welcome to the TypeScript channel! We discuss TypeScript, JavaScript, and Node.js.' },
+  { id: 'm2', content: 'Today the team shipped a new backend API and fixed a tricky bug in the server.' },
+  { id: 'm3', content: 'The backend team loves TypeScript because the type system catches bugs early.' },
+  { id: 'm4', content: 'Thanks everyone for the great feedback on the new deploy pipeline.' },
+];
+
+describe('KeywordExtractor (C3.2)', () => {
+  it('filters stop words and returns frequency-ranked keywords', () => {
+    const content = 'The the the typescript typescript typescript backend backend server';
+    const keywords = keywordExtractor.extractKeywords(content, 5);
+    expect(keywords).not.toContain('the');
+    expect(keywords[0]).toBe('typescript');
+    expect(keywords).toContain('backend');
+    expect(keywords).toContain('server');
+  });
+
+  it('respects maxKeywords cap', () => {
+    const content = 'alpha beta gamma delta epsilon zeta eta theta iota kappa';
+    expect(keywordExtractor.extractKeywords(content, 3)).toHaveLength(3);
+  });
+
+  it('returns [] for empty input or non-positive max', () => {
+    expect(keywordExtractor.extractKeywords('', 5)).toEqual([]);
+    expect(keywordExtractor.extractKeywords('hello world', 0)).toEqual([]);
+  });
+
+  it('extractPhrases returns bigrams skipping stop-words', () => {
+    const content = 'backend team backend team frontend team frontend team the quick fox';
+    const phrases = keywordExtractor.extractPhrases(content, 5);
+    expect(phrases).toContain('backend team');
+    expect(phrases).toContain('frontend team');
+    expect(phrases.some((p) => p.includes('the'))).toBe(false);
+  });
+
+  it('scoreByFrequency returns normalized frequency per keyword', () => {
+    const content = 'typescript typescript typescript backend';
+    const scored = keywordExtractor.scoreByFrequency(['typescript', 'backend', 'missing'], content);
+    const ts = scored.find((s) => s.keyword === 'typescript')!;
+    const be = scored.find((s) => s.keyword === 'backend')!;
+    const missing = scored.find((s) => s.keyword === 'missing')!;
+    expect(ts.score).toBeGreaterThan(be.score);
+    expect(missing.score).toBe(0);
+    expect(ts.score).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('TextSummarizer (C3.3)', () => {
+  const content =
+    'TypeScript adds types to JavaScript. The backend uses TypeScript everywhere. ' +
+    'We deploy the backend with Docker. Docker makes deploys repeatable.';
+
+  it('summarize respects target length and is non-empty', () => {
+    const summary = textSummarizer.summarize(content, 80);
+    expect(summary.length).toBeLessThanOrEqual(80 + 1);
+    expect(summary.length).toBeGreaterThan(0);
+  });
+
+  it('summarize returns empty string for empty/zero input', () => {
+    expect(textSummarizer.summarize('', 50)).toBe('');
+    expect(textSummarizer.summarize(content, 0)).toBe('');
+  });
+
+  it('extractFirstSentence returns the first sentence verbatim', () => {
+    expect(textSummarizer.extractFirstSentence(content)).toBe('TypeScript adds types to JavaScript.');
+    expect(textSummarizer.extractFirstSentence('')).toBe('');
+  });
+
+  it('extractKeySentences returns at most maxSentences in original order', () => {
+    const keys = textSummarizer.extractKeySentences(content, 2);
+    expect(keys).toHaveLength(2);
+    const sentences = content.split(/(?<=[.!?])\s+/);
+    const orderedIndexes = keys.map((k) => sentences.indexOf(k));
+    expect(orderedIndexes).toEqual([...orderedIndexes].sort((a, b) => a - b));
+  });
+});
+
+describe('TopicClassifier (C3.4)', () => {
+  it('classifies technology content', () => {
+    const topics = topicClassifier.classify(
+      'The backend team deployed a new TypeScript API and fixed a bug in the server.',
+    );
+    expect(topics[0]).toBe('technology');
+  });
+
+  it('falls back to "general" when no vocabulary hits', () => {
+    expect(topicClassifier.classify('xx yy zz qq')).toEqual(['general']);
+  });
+
+  it('getTop respects count and ordering', () => {
+    const topics = topicClassifier.getTop(
+      'The gaming guild raided the boss and streamed the match on the server for the community.',
+      2,
+    );
+    expect(topics).toHaveLength(2);
+    expect(topics).toContain('gaming');
+  });
+
+  it('getTop with count <= 0 returns []', () => {
+    expect(topicClassifier.getTop('code', 0)).toEqual([]);
+  });
+
+  it('getKeywords returns matched vocabulary tokens only', () => {
+    const kw = topicClassifier.getKeywords(
+      'We deploy the backend API with TypeScript — a great framework.',
+    );
+    expect(kw).toEqual(expect.arrayContaining(['deploy', 'backend', 'api', 'typescript', 'framework']));
+    expect(kw).not.toContain('great');
+  });
+});
+
+describe('ContentAnalyzer (C3.1)', () => {
+  let errorSpy: jest.SpyInstance;
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('analyzeThread returns keywords, summary, topics, sentiment, reading level for fixture thread', async () => {
+    const result = await contentAnalyzer.analyzeThread(FIXTURE_THREAD);
+    expect(result.keywords.length).toBeGreaterThan(0);
+    expect(result.keywords).toContain('typescript');
+    expect(result.summary.length).toBeGreaterThan(0);
+    expect(result.topics[0]).toBe('technology');
+    expect(['positive', 'negative', 'neutral']).toContain(result.sentiment);
+    expect(['basic', 'intermediate', 'advanced']).toContain(result.readingLevel);
+  });
+
+  it('returns empty fallback analysis for an empty thread', async () => {
+    const result = await contentAnalyzer.analyzeThread([]);
+    expect(result).toEqual<ContentAnalysis>({
+      keywords: [],
+      topics: ['general'],
+      summary: '',
+      sentiment: 'neutral',
+      readingLevel: 'basic',
+    });
+  });
+
+  it('getSentiment detects positive, negative, neutral', () => {
+    expect(contentAnalyzer.getSentiment('This is great and I love it, thanks!')).toBe('positive');
+    expect(contentAnalyzer.getSentiment('This is terrible, broken, and full of bugs.')).toBe('negative');
+    expect(contentAnalyzer.getSentiment('The meeting is at three on Thursday.')).toBe('neutral');
+    expect(contentAnalyzer.getSentiment('')).toBe('neutral');
+  });
+
+  it('getReadingLevel scales with word length / count', () => {
+    expect(contentAnalyzer.getReadingLevel('cat dog run')).toBe('basic');
+    expect(contentAnalyzer.getReadingLevel('extraordinarily complicated phenomenological consideration'))
+      .toBe('advanced');
+  });
+
+  it('getTopicCategory delegates to classifier', () => {
+    expect(contentAnalyzer.getTopicCategory('code and api and developer')).toContain('technology');
+  });
+
+  it('falls back deterministically when the injected NLP path throws', async () => {
+    const analyzer = createContentAnalyzer({
+      nlpPath: async () => {
+        throw new Error('nlp exploded');
+      },
+    });
+    const result = await analyzer.analyzeThread(FIXTURE_THREAD);
+    expect(result.keywords.length).toBeGreaterThan(0);
+    expect(result.topics[0]).toBe('technology');
+    expect(result.summary.length).toBeGreaterThan(0);
+  });
+
+  it('falls back deterministically when the NLP path exceeds the timeout budget', async () => {
+    const analyzer = createContentAnalyzer({
+      timeoutMs: 50,
+      nlpPath: () => new Promise<Partial<ContentAnalysis>>(() => {
+        // never resolves — simulates hung NLP backend
+      }),
+    });
+    const start = Date.now();
+    const result = await analyzer.analyzeThread(FIXTURE_THREAD);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(1000);
+    expect(result.keywords).toContain('typescript');
+    expect(result.topics[0]).toBe('technology');
+  });
+
+  it('merges partial NLP output with deterministic fallback fields', async () => {
+    const analyzer = createContentAnalyzer({
+      nlpPath: async () => ({ keywords: ['nlp-only'], sentiment: 'positive' }),
+    });
+    const result = await analyzer.analyzeThread(FIXTURE_THREAD);
+    expect(result.keywords).toEqual(['nlp-only']);
+    expect(result.sentiment).toBe('positive');
+    // fields NLP didn't return still come from the deterministic fallback
+    expect(result.summary.length).toBeGreaterThan(0);
+    expect(result.topics[0]).toBe('technology');
+  });
+});

--- a/harmony-backend/tests/contentAnalysis.test.ts
+++ b/harmony-backend/tests/contentAnalysis.test.ts
@@ -71,7 +71,7 @@ describe('TextSummarizer (C3.3)', () => {
 
   it('summarize respects target length and is non-empty', () => {
     const summary = textSummarizer.summarize(content, 80);
-    expect(summary.length).toBeLessThanOrEqual(80 + 1);
+    expect(summary.length).toBeLessThanOrEqual(80);
     expect(summary.length).toBeGreaterThan(0);
   });
 
@@ -155,6 +155,7 @@ describe('ContentAnalyzer (C3.1)', () => {
       summary: '',
       sentiment: 'neutral',
       readingLevel: 'basic',
+      usedFallback: false,
     });
   });
 
@@ -185,6 +186,9 @@ describe('ContentAnalyzer (C3.1)', () => {
     expect(result.keywords.length).toBeGreaterThan(0);
     expect(result.topics[0]).toBe('technology');
     expect(result.summary.length).toBeGreaterThan(0);
+    // AC-9: surface the fallback signal so MetaTagService can mark the
+    // meta tag for regeneration (dev spec §9.2.1).
+    expect(result.usedFallback).toBe(true);
   });
 
   it('falls back deterministically when the NLP path exceeds the timeout budget', async () => {
@@ -200,6 +204,7 @@ describe('ContentAnalyzer (C3.1)', () => {
     expect(elapsed).toBeLessThan(1000);
     expect(result.keywords).toContain('typescript');
     expect(result.topics[0]).toBe('technology');
+    expect(result.usedFallback).toBe(true);
   });
 
   it('merges partial NLP output with deterministic fallback fields', async () => {
@@ -212,5 +217,7 @@ describe('ContentAnalyzer (C3.1)', () => {
     // fields NLP didn't return still come from the deterministic fallback
     expect(result.summary.length).toBeGreaterThan(0);
     expect(result.topics[0]).toBe('technology');
+    // NLP succeeded (partial output is still success), so no regeneration needed.
+    expect(result.usedFallback).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #351

## Summary
Implements Module M3 (Content Analysis) per dev-spec §9.2. All four classes are deterministic-by-default so `MetaTagService` can always fall back to template-only output when the future NLP path times out or throws.

- **C3.1 `ContentAnalyzer`** — `analyzeThread`, `getTopicCategory`, `getSentiment`, `getReadingLevel`. Accepts an injectable `nlpPath` with a 5s timeout budget (§9.2.1). Rejection or timeout merges partial NLP output with the deterministic fallback.
- **C3.2 `KeywordExtractor`** — `extractKeywords`, `extractPhrases`, `scoreByFrequency`. Stop-word filtered, frequency-ranked, deterministic tiebreaks.
- **C3.3 `TextSummarizer`** — `summarize`, `extractFirstSentence`, `extractKeySentences`. Extractive ranker with target-length truncation.
- **C3.4 `TopicClassifier`** — `classify`, `getTop`, `getKeywords`. Keyword-bag classifier with `general` fallback.

## Acceptance Criteria
- [x] Classes C3.1–C3.4 with spec'd method signatures (§3/§4)
- [x] `analyzeThread()` returns keywords, summary, and topic for a fixture thread
- [x] Deterministic fallback returns a valid non-null result within the timeout budget when NLP is stubbed to fail
- [x] Unit tests cover stop-word filtering, frequency scoring, summarization, topic classification, and timeout/fallback paths (22 tests)

## Test plan
- [x] `cd harmony-backend && npx jest tests/contentAnalysis.test.ts` — 22/22 passing
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/services/contentAnalysis tests/contentAnalysis.test.ts` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)