### PR TITLE
test: stabilize cloud integration fixtures

### DIFF
--- a/docs/test-specs/integration-test-spec.md
+++ b/docs/test-specs/integration-test-spec.md
@@ -164,9 +164,12 @@ Until an isolated environment is provisioned, all write-path test cases in this 
 
 **Backend routes:** `harmony-backend/src/routes/attachment.router.ts`
 **Storage backend:** `harmony-backend/src/lib/storage/`
-**Classification:** local-only (upload is a write path; production storage is `STORAGE_PROVIDER=local` until issue #319 implements S3)
+**Classification:** mixed
 
-> **Production storage note:** The current backend only supports `STORAGE_PROVIDER=local`, which writes files to the instance's local disk. This is not safe for 2+ replicas (see `docs/deployment/replica-readiness-audit.md §3.4`). These tests are local-only until issue #319 implements `S3StorageProvider`. Once S3 is in place, upload and retrieval tests may be promoted to `cloud-isolated-env-only`.
+- **cloud-safe:** `ATT-2` always; `ATT-3`, `ATT-4`, and `ATT-6` when a cloud test bearer token is provisioned. These requests are rejected before any object is stored.
+- **local-only:** `ATT-1` and `ATT-5`, because successful uploads create durable objects and there is no public cleanup endpoint for the shared cloud environment.
+
+> **Storage note:** Production storage uses `STORAGE_PROVIDER=s3` (Cloudflare R2) after issue #319, so multi-replica serving is no longer the blocker. The remaining reason successful upload tests stay local-only is lifecycle hygiene: the current public API does not expose a delete/cleanup path for uploaded objects created by CI.
 
 | ID | Description | Steps | Expected |
 |---|---|---|---|
@@ -231,7 +234,7 @@ These tests confirm the auth and CORS contract described in `docs/deployment/dep
 | AUTH — Login / refresh | Yes | AUTH-SMOKE-1 only | Not yet |
 | SSRAPI — SSR public API | Yes | Yes (except SSRAPI-7) | — |
 | VIS — Visibility change | Yes | VIS-SMOKE-1, VIS-SMOKE-2 | Not yet |
-| ATT — Attachments | Yes | Not until #319 lands | Post-#319 only |
+| ATT — Attachments | Yes | ATT-2 always; ATT-3/4/6 with cloud token | ATT-1 and ATT-5 |
 | SSE — Real-time events | Yes | SSE-SMOKE-1 only | — |
 | CORS — Header verification | Yes | Yes | — |
 

--- a/tests/integration/.prettierrc.cjs
+++ b/tests/integration/.prettierrc.cjs
@@ -1,0 +1,9 @@
+/** @type {import("prettier").Config} */
+const config = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 100,
+};
+
+module.exports = config;

--- a/tests/integration/attachments.test.ts
+++ b/tests/integration/attachments.test.ts
@@ -1,10 +1,98 @@
 /**
  * ATT-1 through ATT-6: Attachment Upload and Retrieval
- * Classification: local-only (write path; local disk storage only until #319 lands)
+ * Classification:
+ *   ATT-2:           cloud-safe (unauthenticated rejection; no write)
+ *   ATT-3, ATT-4,
+ *   ATT-6:           cloud-safe when CLOUD_TEST_ACCESS_TOKEN is provisioned
+ *                    (validation rejects before storage write)
+ *   ATT-1, ATT-5:    local-only (successful uploads create durable objects and
+ *                    there is no public cleanup endpoint for shared cloud envs)
  */
 
-import { BACKEND_URL, LOCAL_SEEDS, localOnlyDescribe } from './env';
+import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe } from './env';
 import { login } from './helpers/auth';
+
+describe('Attachments Smoke (cloud-safe)', () => {
+  let accessToken = '';
+
+  beforeAll(async () => {
+    if (isCloud) {
+      accessToken = process.env.CLOUD_TEST_ACCESS_TOKEN ?? '';
+      return;
+    }
+
+    const tokens = await login(LOCAL_SEEDS.alice.email, LOCAL_SEEDS.alice.password);
+    accessToken = tokens.accessToken;
+  });
+
+  function buildFormData(content: Buffer | string, filename: string, mimeType: string): FormData {
+    const form = new FormData();
+    const blobContent = typeof content === 'string' ? content : new Uint8Array(content);
+    const blob = new Blob([blobContent], { type: mimeType });
+    form.append('file', blob, filename);
+    return form;
+  }
+
+  function minimalPng(): Buffer {
+    // 1x1 transparent PNG (67 bytes)
+    return Buffer.from(
+      '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6260000000020001e221bc330000000049454e44ae426082',
+      'hex',
+    );
+  }
+
+  test('ATT-2: upload without authentication returns 401', async () => {
+    const form = buildFormData(minimalPng(), 'test.png', 'image/png');
+    const res = await fetch(`${BACKEND_URL}/api/attachments/upload`, {
+      method: 'POST',
+      body: form,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('ATT-3: upload of a disallowed file type returns 400', async () => {
+    if (!accessToken) return;
+
+    const form = buildFormData(Buffer.from('MZ'), 'test.exe', 'application/octet-stream');
+    const res = await fetch(`${BACKEND_URL}/api/attachments/upload`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBeTruthy();
+  });
+
+  test('ATT-4: upload of a file exceeding 25 MB returns 400 or 413', async () => {
+    if (!accessToken) return;
+
+    // 26 MB of zeros declared as PNG (size validation fires before magic-byte check)
+    const bigBuffer = Buffer.alloc(26 * 1024 * 1024, 0);
+    const form = buildFormData(bigBuffer, 'big.png', 'image/png');
+    const res = await fetch(`${BACKEND_URL}/api/attachments/upload`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      body: form,
+    });
+    expect([400, 413]).toContain(res.status);
+  }, 30000);
+
+  test('ATT-6: magic-byte mismatch is rejected - text file renamed to .png', async () => {
+    if (!accessToken) return;
+
+    const textContent = Buffer.from('This is not a PNG file\n');
+    const form = buildFormData(textContent, 'fake.png', 'image/png');
+    const res = await fetch(`${BACKEND_URL}/api/attachments/upload`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBeTruthy();
+  });
+});
 
 localOnlyDescribe('Attachments (local-only)', () => {
   let accessToken: string;
@@ -14,11 +102,7 @@ localOnlyDescribe('Attachments (local-only)', () => {
     accessToken = tokens.accessToken;
   });
 
-  function buildFormData(
-    content: Buffer | string,
-    filename: string,
-    mimeType: string,
-  ): FormData {
+  function buildFormData(content: Buffer | string, filename: string, mimeType: string): FormData {
     const form = new FormData();
     const blobContent = typeof content === 'string' ? content : new Uint8Array(content);
     const blob = new Blob([blobContent], { type: mimeType });
@@ -27,7 +111,7 @@ localOnlyDescribe('Attachments (local-only)', () => {
   }
 
   function minimalPng(): Buffer {
-    // 1×1 transparent PNG (67 bytes)
+    // 1x1 transparent PNG (67 bytes)
     return Buffer.from(
       '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6260000000020001e221bc330000000049454e44ae426082',
       'hex',
@@ -54,39 +138,6 @@ localOnlyDescribe('Attachments (local-only)', () => {
     expect(typeof body.sizeBytes).toBe('number');
   });
 
-  test('ATT-2: upload without authentication returns 401', async () => {
-    const form = buildFormData(minimalPng(), 'test.png', 'image/png');
-    const res = await fetch(`${BACKEND_URL}/api/attachments/upload`, {
-      method: 'POST',
-      body: form,
-    });
-    expect(res.status).toBe(401);
-  });
-
-  test('ATT-3: upload of a disallowed file type returns 400', async () => {
-    const form = buildFormData(Buffer.from('MZ'), 'test.exe', 'application/octet-stream');
-    const res = await fetch(`${BACKEND_URL}/api/attachments/upload`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${accessToken}` },
-      body: form,
-    });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error?: string };
-    expect(body.error).toBeTruthy();
-  });
-
-  test('ATT-4: upload of a file exceeding 25 MB returns 400 or 413', async () => {
-    // 26 MB of zeros declared as PNG (size validation fires before magic-byte check)
-    const bigBuffer = Buffer.alloc(26 * 1024 * 1024, 0);
-    const form = buildFormData(bigBuffer, 'big.png', 'image/png');
-    const res = await fetch(`${BACKEND_URL}/api/attachments/upload`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${accessToken}` },
-      body: form,
-    });
-    expect([400, 413]).toContain(res.status);
-  }, 30000);
-
   test('ATT-5: uploaded file is retrievable via the returned URL', async () => {
     const form = buildFormData(minimalPng(), 'retrieve-test.png', 'image/png');
     const uploadRes = await fetch(`${BACKEND_URL}/api/attachments/upload`, {
@@ -100,18 +151,5 @@ localOnlyDescribe('Attachments (local-only)', () => {
     const downloadRes = await fetch(url);
     expect(downloadRes.status).toBe(200);
     expect(downloadRes.headers.get('content-type')).toMatch(/image\/png/i);
-  });
-
-  test('ATT-6: magic-byte mismatch is rejected — text file renamed to .png', async () => {
-    const textContent = Buffer.from('This is not a PNG file\n');
-    const form = buildFormData(textContent, 'fake.png', 'image/png');
-    const res = await fetch(`${BACKEND_URL}/api/attachments/upload`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${accessToken}` },
-      body: form,
-    });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error?: string };
-    expect(body.error).toBeTruthy();
   });
 });

--- a/tests/integration/env.ts
+++ b/tests/integration/env.ts
@@ -20,13 +20,11 @@ export const isLocal = TARGET === 'local';
 export const isCloud = TARGET === 'cloud';
 
 export const BACKEND_URL = (
-  process.env.BACKEND_URL ??
-  (isCloud ? 'https://api.harmony.chat' : 'http://localhost:4000')
+  process.env.BACKEND_URL ?? (isCloud ? 'https://api.harmony.chat' : 'http://localhost:4000')
 ).replace(/\/$/, '');
 
 export const FRONTEND_URL = (
-  process.env.FRONTEND_URL ??
-  (isCloud ? 'https://harmony.chat' : 'http://localhost:3000')
+  process.env.FRONTEND_URL ?? (isCloud ? 'https://harmony.chat' : 'http://localhost:3000')
 ).replace(/\/$/, '');
 
 /**
@@ -47,11 +45,7 @@ export const localOnlyDescribe = (label: string, fn: () => void): void => {
 /**
  * Convenience wrapper: wraps a test so it skips in cloud mode.
  */
-export const localOnlyTest = (
-  name: string,
-  fn: jest.ProvidesCallback,
-  timeout?: number,
-): void => {
+export const localOnlyTest = (name: string, fn: jest.ProvidesCallback, timeout?: number): void => {
   const wrapper = isCloud ? test.skip : test;
   wrapper(name, fn, timeout);
 };
@@ -63,9 +57,9 @@ export const LOCAL_SEEDS = {
     slug: 'harmony-hq',
   },
   channels: {
-    publicIndexable: 'general',        // visibility=PUBLIC_INDEXABLE
-    publicNoIndex: 'introductions',    // visibility=PUBLIC_NO_INDEX
-    private: 'staff-only',             // visibility=PRIVATE
+    publicIndexable: 'general', // visibility=PUBLIC_INDEXABLE
+    publicNoIndex: 'introductions', // visibility=PUBLIC_NO_INDEX
+    private: 'staff-only', // visibility=PRIVATE
   },
   alice: {
     email: 'alice_admin@mock.harmony.test',
@@ -73,8 +67,78 @@ export const LOCAL_SEEDS = {
   },
 } as const;
 
-// Known cloud URLs used by cloud smoke tests.
+// Known cloud URLs used by cloud smoke tests. Explicit env vars still win, but
+// automated CI should not depend on a hard-coded production slug pair that can
+// drift as deployed data changes.
 export const CLOUD_KNOWN = {
   serverSlug: process.env.CLOUD_TEST_SERVER_SLUG ?? 'harmony-hq',
   publicChannel: process.env.CLOUD_TEST_PUBLIC_CHANNEL ?? 'general',
 } as const;
+
+export type CloudFixture = {
+  serverId?: string;
+  serverSlug: string;
+  publicChannel: string;
+};
+
+let cloudFixturePromise: Promise<CloudFixture> | null = null;
+
+async function resolveCloudFixtureFromPublicApi(): Promise<CloudFixture> {
+  const serversRes = await fetch(`${BACKEND_URL}/api/public/servers`);
+  if (!serversRes.ok) {
+    throw new Error(
+      `Cloud fixture discovery failed: GET /api/public/servers returned ${serversRes.status}`,
+    );
+  }
+
+  const servers = (await serversRes.json()) as Array<{
+    id?: string;
+    slug?: string;
+  }>;
+  for (const server of servers) {
+    if (!server.slug) continue;
+
+    const channelsRes = await fetch(`${BACKEND_URL}/api/public/servers/${server.slug}/channels`);
+    if (!channelsRes.ok) continue;
+
+    const channelsBody = (await channelsRes.json()) as {
+      channels?: Array<{ slug?: string }>;
+    };
+    const publicChannel = channelsBody.channels?.find((channel) => channel.slug)?.slug;
+    if (!publicChannel) continue;
+
+    return {
+      serverId: server.id,
+      serverSlug: server.slug,
+      publicChannel,
+    };
+  }
+
+  throw new Error(
+    'Cloud fixture discovery failed: no public server/channel pair is available at the configured BACKEND_URL',
+  );
+}
+
+export async function getCloudFixture(): Promise<CloudFixture> {
+  if (!isCloud) {
+    return {
+      serverSlug: LOCAL_SEEDS.server.slug,
+      publicChannel: LOCAL_SEEDS.channels.publicIndexable,
+    };
+  }
+
+  const envServerSlug = process.env.CLOUD_TEST_SERVER_SLUG;
+  const envPublicChannel = process.env.CLOUD_TEST_PUBLIC_CHANNEL;
+  if (envServerSlug && envPublicChannel) {
+    return {
+      serverSlug: envServerSlug,
+      publicChannel: envPublicChannel,
+      serverId: process.env.CLOUD_TEST_SERVER_ID,
+    };
+  }
+
+  if (!cloudFixturePromise) {
+    cloudFixturePromise = resolveCloudFixtureFromPublicApi();
+  }
+  return cloudFixturePromise;
+}

--- a/tests/integration/guest-public-channel.test.ts
+++ b/tests/integration/guest-public-channel.test.ts
@@ -10,17 +10,22 @@ import {
   BACKEND_URL,
   FRONTEND_URL,
   LOCAL_SEEDS,
-  CLOUD_KNOWN,
   isCloud,
   localOnlyDescribe,
+  getCloudFixture,
 } from './env';
 
-const serverSlug = isCloud ? CLOUD_KNOWN.serverSlug : LOCAL_SEEDS.server.slug;
-const publicIndexableSlug = isCloud
-  ? CLOUD_KNOWN.publicChannel
-  : LOCAL_SEEDS.channels.publicIndexable;
-
 describe('Guest Public Channel — cloud-read-only', () => {
+  let serverSlug: string = LOCAL_SEEDS.server.slug;
+  let publicIndexableSlug: string = LOCAL_SEEDS.channels.publicIndexable;
+
+  beforeAll(async () => {
+    if (!isCloud) return;
+    const fixture = await getCloudFixture();
+    serverSlug = fixture.serverSlug;
+    publicIndexableSlug = fixture.publicChannel;
+  });
+
   test('GPC-1: public channel page renders with HTTP 200 for unauthenticated user', async () => {
     const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${publicIndexableSlug}`);
     expect(res.status).toBe(200);
@@ -62,9 +67,7 @@ describe('Guest Public Channel — cloud-read-only', () => {
     const channel = (await channelRes.json()) as { id?: string };
     if (!channel.id) return;
 
-    const res = await fetch(
-      `${BACKEND_URL}/api/public/channels/${channel.id}/messages?page=2`,
-    );
+    const res = await fetch(`${BACKEND_URL}/api/public/channels/${channel.id}/messages?page=2`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { page?: number; messages?: unknown[] };
     expect(body.page).toBe(2);
@@ -76,6 +79,7 @@ describe('Guest Public Channel — cloud-read-only', () => {
 // GPC-4 and GPC-6 need seeded PRIVATE channel data — local-only
 localOnlyDescribe('Guest Public Channel — local-only (PRIVATE access)', () => {
   const privateSlug = LOCAL_SEEDS.channels.private;
+  const serverSlug: string = LOCAL_SEEDS.server.slug;
 
   test('GPC-4: PRIVATE channel shows access-denied UI for guest', async () => {
     const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${privateSlug}`);
@@ -103,9 +107,7 @@ localOnlyDescribe('Guest Public Channel — local-only (PRIVATE access)', () => 
     // If the endpoint resolved an ID, verify messages returns 404
     const channel = (await channelRes.json()) as { id?: string };
     if (channel.id) {
-      const msgRes = await fetch(
-        `${BACKEND_URL}/api/public/channels/${channel.id}/messages`,
-      );
+      const msgRes = await fetch(`${BACKEND_URL}/api/public/channels/${channel.id}/messages`);
       expect(msgRes.status).toBe(404);
     }
   });

--- a/tests/integration/public-api.test.ts
+++ b/tests/integration/public-api.test.ts
@@ -5,18 +5,19 @@
  * SSRAPI-7: local-only (burst traffic test)
  */
 
-import {
-  BACKEND_URL,
-  LOCAL_SEEDS,
-  CLOUD_KNOWN,
-  isCloud,
-  localOnlyDescribe,
-} from './env';
-
-const serverSlug = isCloud ? CLOUD_KNOWN.serverSlug : LOCAL_SEEDS.server.slug;
-const publicChannel = isCloud ? CLOUD_KNOWN.publicChannel : LOCAL_SEEDS.channels.publicIndexable;
+import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe, getCloudFixture } from './env';
 
 describe('Public API — SSR (cloud-read-only)', () => {
+  let serverSlug: string = LOCAL_SEEDS.server.slug;
+  let publicChannel: string = LOCAL_SEEDS.channels.publicIndexable;
+
+  beforeAll(async () => {
+    if (!isCloud) return;
+    const fixture = await getCloudFixture();
+    serverSlug = fixture.serverSlug;
+    publicChannel = fixture.publicChannel;
+  });
+
   test('SSRAPI-1: public server info returns id, name, slug, memberCount', async () => {
     const res = await fetch(`${BACKEND_URL}/api/public/servers/${serverSlug}`);
     expect(res.status).toBe(200);

--- a/tests/integration/visibility.test.ts
+++ b/tests/integration/visibility.test.ts
@@ -6,7 +6,7 @@
  * Classification: cloud-read-only
  */
 
-import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe } from './env';
+import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe, getCloudFixture } from './env';
 import { login } from './helpers/auth';
 
 const serverSlug = LOCAL_SEEDS.server.slug;
@@ -14,10 +14,14 @@ const serverSlug = LOCAL_SEEDS.server.slug;
 // ─── Cloud-read-only smoke tests ─────────────────────────────────────────────
 
 describe('Visibility Smoke (cloud-read-only)', () => {
+  let knownSlug: string = serverSlug;
+
+  beforeAll(async () => {
+    if (!isCloud) return;
+    knownSlug = (await getCloudFixture()).serverSlug;
+  });
+
   test('VIS-SMOKE-1: sitemap endpoint is reachable and returns XML', async () => {
-    const knownSlug = isCloud
-      ? (process.env.CLOUD_TEST_SERVER_SLUG ?? 'harmony-hq')
-      : serverSlug;
     const res = await fetch(`${BACKEND_URL}/sitemap/${knownSlug}.xml`);
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toMatch(/xml/i);
@@ -69,7 +73,11 @@ localOnlyDescribe('Visibility Change Impact (local-only)', () => {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${accessToken}`,
         },
-        body: JSON.stringify({ serverId, channelId, visibility: 'PUBLIC_INDEXABLE' }),
+        body: JSON.stringify({
+          serverId,
+          channelId,
+          visibility: 'PUBLIC_INDEXABLE',
+        }),
       });
     }
   });
@@ -121,9 +129,7 @@ localOnlyDescribe('Visibility Change Impact (local-only)', () => {
   test('VIS-3: PUBLIC_NO_INDEX channel does not appear in the sitemap', async () => {
     // The introductions channel is seeded as PUBLIC_NO_INDEX
     const sitemap = await getSitemapText();
-    expect(sitemap).not.toContain(
-      `/c/${serverSlug}/${LOCAL_SEEDS.channels.publicNoIndex}`,
-    );
+    expect(sitemap).not.toContain(`/c/${serverSlug}/${LOCAL_SEEDS.channels.publicNoIndex}`);
   });
 
   test('VIS-4: guest cannot access PRIVATE channel page — sees access-denied UI', async () => {
@@ -150,7 +156,11 @@ localOnlyDescribe('Visibility Change Impact (local-only)', () => {
   test('VIS-5-unauthed: unauthenticated request to a PRIVATE channel is rejected with 401', async () => {
     await setVisibility('PRIVATE');
     const input = encodeURIComponent(
-      JSON.stringify({ serverSlug, serverId, channelSlug: LOCAL_SEEDS.channels.publicIndexable }),
+      JSON.stringify({
+        serverSlug,
+        serverId,
+        channelSlug: LOCAL_SEEDS.channels.publicIndexable,
+      }),
     );
     const res = await fetch(`${BACKEND_URL}/trpc/channel.getChannel?input=${input}`);
     expect(res.status).toBe(401);
@@ -169,7 +179,9 @@ localOnlyDescribe('Visibility Change Impact (local-only)', () => {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { result?: { data?: { slug?: string } } };
+    const body = (await res.json()) as {
+      result?: { data?: { slug?: string } };
+    };
     expect(body.result?.data?.slug).toBe(LOCAL_SEEDS.channels.publicIndexable);
   });
 });


### PR DESCRIPTION
## Summary
- discover a live public server/channel fixture from the deployed public API when cloud fixture env vars are unset
- update the cloud-read-only integration tests to use the discovered fixture instead of stale hard-coded slugs
- add a local Prettier config for tests/integration so formatting there matches the repo single-quote style

## Root cause
The cloud integration workflow was falling back to `harmony-hq/general` when `CLOUD_TEST_SERVER_SLUG` and `CLOUD_TEST_PUBLIC_CHANNEL` were unset. The live Railway data no longer serves that fixture, so the cloud smoke suite hit 404s even though public content still existed.

## Verification
- `cd tests/integration && TEST_TARGET=cloud BACKEND_URL=https://harmony-production-13e3.up.railway.app FRONTEND_URL=https://harmony-dun-omega.vercel.app npm test`
