### PR TITLE
test(integration): explicit skip for auth-dependent attachment cases

### DIFF
--- a/llm-logs/2026-04-20-100616-session-12bb34ec.md
+++ b/llm-logs/2026-04-20-100616-session-12bb34ec.md
@@ -1,0 +1,468 @@
+# Session Log 2026-04-20-100616
+
+## User
+
+complete https://github.com/CS485-Harmony/Harmony/issues/420 in a new branch
+
+## Assistant
+
+**Tool call: `ToolSearch`**
+```json
+{
+  "query": "select:WebFetch",
+  "max_results": 1
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 420 --repo CS485-Harmony/Harmony"
+}
+```
+
+## Assistant
+
+Let me read the relevant test file.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/tests/integration/attachments.test.ts"
+}
+```
+
+## Assistant
+
+Let me check the Jest/test runner config and how `env.ts` is set up.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/tests/integration/env.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/tests/integration && cat package.json | grep jest"
+}
+```
+
+## Assistant
+
+Now I have a clear picture. I'll create a branch and fix the three tests that silently pass when `CLOUD_TEST_ACCESS_TOKEN` is absent.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b fix/issue-420-explicit-skip-cloud-attachment-tests"
+}
+```
+
+## Assistant
+
+I'll add a `cloudTokenTest` helper to `env.ts` (matching the existing `localOnlyTest` pattern), then update the three attachment tests.
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/tests/integration/env.ts",
+  "old_string": "/**\n * Convenience wrapper: wraps a test so it skips in cloud mode.\n */\nexport const localOnlyTest = (name: string, fn: jest.ProvidesCallback, timeout?: number): void => {\n  const wrapper = isCloud ? test.skip : test;\n  wrapper(name, fn, timeout);\n};",
+  "new_string": "/**\n * Convenience wrapper: wraps a test so it skips in cloud mode.\n */\nexport const localOnlyTest = (name: string, fn: jest.ProvidesCallback, timeout?: number): void => {\n  const wrapper = isCloud ? test.skip : test;\n  wrapper(name, fn, timeout);\n};\n\n/**\n * Convenience wrapper: wraps a test so it skips when running in cloud mode\n * without a CLOUD_TEST_ACCESS_TOKEN. Keeps the test active in local mode\n * (where login() always provides a token) and in cloud mode when the token\n * is provisioned.\n */\nexport const cloudTokenTest = (name: string, fn: jest.ProvidesCallback, timeout?: number): void => {\n  const needsSkip = isCloud && !process.env.CLOUD_TEST_ACCESS_TOKEN;\n  (needsSkip ? test.skip : test)(name, fn, timeout);\n};"
+}
+```
+
+## Assistant
+
+Now update `attachments.test.ts` to import `cloudTokenTest` and replace the three early-return tests:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/tests/integration/attachments.test.ts",
+  "old_string": "import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe } from './env';",
+  "new_string": "import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe, cloudTokenTest } from './env';"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/tests/integration/attachments.test.ts",
+  "old_string": "  test('ATT-3: upload of a disallowed file type returns 400', async () => {\n    if (!accessToken) return;\n\n    const form = buildFormData(Buffer.from('MZ'), 'test.exe', 'application/octet-stream');",
+  "new_string": "  cloudTokenTest('ATT-3: upload of a disallowed file type returns 400', async () => {\n    const form = buildFormData(Buffer.from('MZ'), 'test.exe', 'application/octet-stream');"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/tests/integration/attachments.test.ts",
+  "old_string": "  test('ATT-4: upload of a file exceeding 25 MB returns 400 or 413', async () => {\n    if (!accessToken) return;\n\n    // 26 MB of zeros declared as PNG (size validation fires before magic-byte check)",
+  "new_string": "  cloudTokenTest('ATT-4: upload of a file exceeding 25 MB returns 400 or 413', async () => {\n    // 26 MB of zeros declared as PNG (size validation fires before magic-byte check)"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/tests/integration/attachments.test.ts",
+  "old_string": "  test('ATT-6: magic-byte mismatch is rejected - text file renamed to .png', async () => {\n    if (!accessToken) return;\n\n    const textContent = Buffer.from('This is not a PNG file\\n');",
+  "new_string": "  cloudTokenTest('ATT-6: magic-byte mismatch is rejected - text file renamed to .png', async () => {\n    const textContent = Buffer.from('This is not a PNG file\\n');"
+}
+```
+
+## Assistant
+
+Now let me verify the final state of both files looks right:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/tests/integration/attachments.test.ts",
+  "limit": 96
+}
+```
+
+## Assistant
+
+Good. Now let me run the integration tests' TypeScript check to make sure it compiles:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "pwd && ls tests/integration/"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/tests/integration/ && npm install 2>&1 | tail -3"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit -p /Users/bigfa/Documents/GitHub/Harmony/tests/integration/tsconfig.json 2>&1"
+}
+```
+
+## Assistant
+
+TypeScript compiles cleanly. Now let me commit and open the PR.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git diff --stat"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add tests/integration/attachments.test.ts tests/integration/env.ts && git commit -m \"$(cat <<'EOF'\ntest(integration): explicit skip for auth-dependent attachment cases when token is absent\n\nReplace silent `if (!accessToken) return;` early returns in ATT-3, ATT-4,\nand ATT-6 with `cloudTokenTest`, a new helper in env.ts that calls\n`test.skip` when running in cloud mode without CLOUD_TEST_ACCESS_TOKEN.\nATT-2 (unauthenticated smoke) is unchanged and always runs.\n\nCloses #420\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git -C /Users/bigfa/Documents/GitHub/Harmony add tests/integration/attachments.test.ts tests/integration/env.ts && git -C /Users/bigfa/Documents/GitHub/Harmony commit -m \"$(cat <<'EOF'\ntest(integration): explicit skip for auth-dependent attachment cases when token is absent\n\nReplace silent `if (!accessToken) return;` early returns in ATT-3, ATT-4,\nand ATT-6 with `cloudTokenTest`, a new helper in env.ts that calls\n`test.skip` when running in cloud mode without CLOUD_TEST_ACCESS_TOKEN.\nATT-2 (unauthenticated smoke) is unchanged and always runs.\n\nCloses #420\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git -C /Users/bigfa/Documents/GitHub/Harmony push -u origin fix/issue-420-explicit-skip-cloud-attachment-tests"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --repo CS485-Harmony/Harmony --title \"test(integration): explicit skip for auth-dependent attachment cases\" --body \"$(cat <<'EOF'\n## Summary\n\n- Adds `cloudTokenTest` helper to `tests/integration/env.ts` (mirrors existing `localOnlyTest` pattern): calls `test.skip` when `isCloud && !CLOUD_TEST_ACCESS_TOKEN`, otherwise calls `test` normally\n- Replaces `if (!accessToken) return;` silent early-returns in ATT-3, ATT-4, ATT-6 with `cloudTokenTest(...)`, making the skip visible in CI output\n- ATT-2 (unauthenticated 401 smoke) is untouched and always runs\n\nCloses #420\n\n## Test plan\n\n- [ ] Local run (`TEST_TARGET=local`): ATT-3, ATT-4, ATT-6 run normally (token comes from `login()`)\n- [ ] Cloud run without token (`TEST_TARGET=cloud`, no `CLOUD_TEST_ACCESS_TOKEN`): ATT-3, ATT-4, ATT-6 appear as **skipped** in Jest output, ATT-2 still passes\n- [ ] Cloud run with token: all four tests run and pass\n- [ ] TypeScript: `tsc --noEmit` passes cleanly\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\""
+}
+```
+
+## Assistant
+
+PR created: https://github.com/CS485-Harmony/Harmony/pull/444
+
+**What changed:** Added a `cloudTokenTest` helper to `env.ts` that calls `test.skip` when running in cloud mode without `CLOUD_TEST_ACCESS_TOKEN`, then replaced the three `if (!accessToken) return;` silent early-returns in ATT-3, ATT-4, and ATT-6 with it. ATT-2 (unauthenticated smoke) is untouched.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 /tmp/harmony_export_logs.py 2>&1 || true"
+}
+```
+

--- a/tests/integration/attachments.test.ts
+++ b/tests/integration/attachments.test.ts
@@ -9,7 +9,7 @@
  *                    there is no public cleanup endpoint for shared cloud envs)
  */
 
-import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe } from './env';
+import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe, cloudTokenTest } from './env';
 import { login } from './helpers/auth';
 
 describe('Attachments Smoke (cloud-safe)', () => {
@@ -50,9 +50,7 @@ describe('Attachments Smoke (cloud-safe)', () => {
     expect(res.status).toBe(401);
   });
 
-  test('ATT-3: upload of a disallowed file type returns 400', async () => {
-    if (!accessToken) return;
-
+  cloudTokenTest('ATT-3: upload of a disallowed file type returns 400', async () => {
     const form = buildFormData(Buffer.from('MZ'), 'test.exe', 'application/octet-stream');
     const res = await fetch(`${BACKEND_URL}/api/attachments/upload`, {
       method: 'POST',
@@ -64,9 +62,7 @@ describe('Attachments Smoke (cloud-safe)', () => {
     expect(body.error).toBeTruthy();
   });
 
-  test('ATT-4: upload of a file exceeding 25 MB returns 400 or 413', async () => {
-    if (!accessToken) return;
-
+  cloudTokenTest('ATT-4: upload of a file exceeding 25 MB returns 400 or 413', async () => {
     // 26 MB of zeros declared as PNG (size validation fires before magic-byte check)
     const bigBuffer = Buffer.alloc(26 * 1024 * 1024, 0);
     const form = buildFormData(bigBuffer, 'big.png', 'image/png');
@@ -78,9 +74,7 @@ describe('Attachments Smoke (cloud-safe)', () => {
     expect([400, 413]).toContain(res.status);
   }, 30000);
 
-  test('ATT-6: magic-byte mismatch is rejected - text file renamed to .png', async () => {
-    if (!accessToken) return;
-
+  cloudTokenTest('ATT-6: magic-byte mismatch is rejected - text file renamed to .png', async () => {
     const textContent = Buffer.from('This is not a PNG file\n');
     const form = buildFormData(textContent, 'fake.png', 'image/png');
     const res = await fetch(`${BACKEND_URL}/api/attachments/upload`, {

--- a/tests/integration/env.ts
+++ b/tests/integration/env.ts
@@ -50,6 +50,17 @@ export const localOnlyTest = (name: string, fn: jest.ProvidesCallback, timeout?:
   wrapper(name, fn, timeout);
 };
 
+/**
+ * Convenience wrapper: wraps a test so it skips when running in cloud mode
+ * without a CLOUD_TEST_ACCESS_TOKEN. Keeps the test active in local mode
+ * (where login() always provides a token) and in cloud mode when the token
+ * is provisioned.
+ */
+export const cloudTokenTest = (name: string, fn: jest.ProvidesCallback, timeout?: number): void => {
+  const needsSkip = isCloud && !process.env.CLOUD_TEST_ACCESS_TOKEN;
+  (needsSkip ? test.skip : test)(name, fn, timeout);
+};
+
 // Known mock-seed data used by local tests (harmony-backend/src/dev/mock-seed-data.json).
 // Server server-001 is "harmony-hq".
 export const LOCAL_SEEDS = {


### PR DESCRIPTION
## Summary

- Adds `cloudTokenTest` helper to `tests/integration/env.ts` (mirrors existing `localOnlyTest` pattern): calls `test.skip` when `isCloud && !CLOUD_TEST_ACCESS_TOKEN`, otherwise calls `test` normally
- Replaces `if (!accessToken) return;` silent early-returns in ATT-3, ATT-4, ATT-6 with `cloudTokenTest(...)`, making the skip visible in CI output
- ATT-2 (unauthenticated 401 smoke) is untouched and always runs

Closes #420

## Test plan

- [ ] Local run (`TEST_TARGET=local`): ATT-3, ATT-4, ATT-6 run normally (token comes from `login()`)
- [ ] Cloud run without token (`TEST_TARGET=cloud`, no `CLOUD_TEST_ACCESS_TOKEN`): ATT-3, ATT-4, ATT-6 appear as **skipped** in Jest output, ATT-2 still passes
- [ ] Cloud run with token: all four tests run and pass
- [ ] TypeScript: `tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)