### PR TITLE
[codex] Disable automatic frontend E2E workflow runs

### DIFF
--- a/.github/workflows/run-frontend-e2e.yml
+++ b/.github/workflows/run-frontend-e2e.yml
@@ -1,10 +1,6 @@
 name: Frontend E2E
 
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- stop running the frontend E2E workflow on `push`
- stop running the frontend E2E workflow on `pull_request`
- keep the workflow available through manual `workflow_dispatch`

## Why
The frontend E2E workflow was adding noisy failing checks to PRs even though it is not a required status check. This keeps the job available for manual runs without having it execute on every branch update and PR.

## Validation
- inspected the workflow diff to confirm only the trigger block changed
- did not run tests because this change only adjusts GitHub Actions triggers
