### PR TITLE
fix: show username requirements on signup form

### DIFF
--- a/harmony-frontend/src/app/auth/signup/page.tsx
+++ b/harmony-frontend/src/app/auth/signup/page.tsx
@@ -76,6 +76,9 @@ function SignupForm() {
               placeholder='Choose a username'
               disabled={isSubmitting}
             />
+            <p className='mt-1 text-xs text-discord-text-muted'>
+              3–32 characters. Letters, numbers, underscores, and hyphens only.
+            </p>
           </div>
 
           <div>

--- a/llm-logs/2026-04-21-155338-session-e486c421.md
+++ b/llm-logs/2026-04-21-155338-session-e486c421.md
@@ -1,0 +1,340 @@
+# Session Log 2026-04-21-155338
+
+## User
+
+complete https://github.com/CS485-Harmony/Harmony/issues/451 in a new branch
+
+## Assistant
+
+**Tool call: `ToolSearch`**
+```json
+{
+  "query": "select:WebFetch",
+  "max_results": 1
+}
+```
+
+## Assistant
+
+Let me read the issue details first.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 451 --repo CS485-Harmony/Harmony"
+}
+```
+
+## Assistant
+
+Now let me find the signup form component.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend -type f -name \"*.tsx\" | xargs grep -l \"signup\\|SignUp\\|sign-up\" -i 2>/dev/null"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/auth/signup/page.tsx"
+}
+```
+
+## Assistant
+
+Now let me find the backend username validation to get the exact rules.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"username\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src --include=\"*.ts\" -l | head -10"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"username\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src --include=\"*.ts\" -n | grep -i \"min\\|max\\|length\\|regex\\|pattern\\|alphanum\" | head -20"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"username\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/routes/auth.router.ts -n -A2 -B2 | head -60"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -r \"username\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src --include=\"*.ts\" -n | grep -i \"z\\.\\|zod\\|string\\|min\\|max\\|regex\" | head -20"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/routes/auth.router.ts",
+  "limit": 50
+}
+```
+
+## Assistant
+
+I have all the info I need. Now let me create the branch and implement the fix.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b feature/issue-451-username-requirements"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/auth/signup/page.tsx",
+  "old_string": "          <div>\n            <label\n              htmlFor='username'\n              className='mb-2 block text-xs font-bold uppercase text-discord-text-muted'\n            >\n              Username <span className='text-red-400'>*</span>\n            </label>\n            <input\n              id='username'\n              type='text'\n              required\n              value={username}\n              onChange={e => setUsername(e.target.value)}\n              className='w-full rounded bg-discord-bg-tertiary p-2.5 text-white placeholder-discord-text-muted outline-none focus:ring-2 focus:ring-discord-accent'\n              placeholder='Choose a username'\n              disabled={isSubmitting}\n            />\n          </div>",
+  "new_string": "          <div>\n            <label\n              htmlFor='username'\n              className='mb-2 block text-xs font-bold uppercase text-discord-text-muted'\n            >\n              Username <span className='text-red-400'>*</span>\n            </label>\n            <input\n              id='username'\n              type='text'\n              required\n              value={username}\n              onChange={e => setUsername(e.target.value)}\n              className='w-full rounded bg-discord-bg-tertiary p-2.5 text-white placeholder-discord-text-muted outline-none focus:ring-2 focus:ring-discord-accent'\n              placeholder='Choose a username'\n              disabled={isSubmitting}\n            />\n            <p className='mt-1 text-xs text-discord-text-muted'>\n              3\u201332 characters. Letters, numbers, underscores, and hyphens only.\n            </p>\n          </div>"
+}
+```
+
+## Assistant
+
+Now let me verify the frontend tests still pass.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npm test -- --passWithNoTests 2>&1 | tail -20"
+}
+```
+
+## Assistant
+
+All 304 tests pass. Let me commit and push.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add harmony-frontend/src/app/auth/signup/page.tsx && git commit -m \"$(cat <<'EOF'\nfix: show username requirements on signup form\n\nAdds a helper text line below the username field displaying the\n3\u201332 character length and allowed character constraints, matching\nthe backend validation rules in auth.router.ts.\n\nCloses #451\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/auth/signup/page.tsx && git status"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-frontend/src/app/auth/signup/page.tsx && git status"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git commit -m \"$(cat <<'EOF'\nfix: show username requirements on signup form\n\nAdds a helper text line below the username field displaying the\n3\u201332 character length and allowed character constraints, matching\nthe backend validation rules in auth.router.ts.\n\nCloses #451\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin feature/issue-451-username-requirements"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --title \"fix: show username requirements on signup form\" --body \"$(cat <<'EOF'\n## Summary\n- Adds a helper text line below the username field on `/auth/signup` showing: _\"3\u201332 characters. Letters, numbers, underscores, and hyphens only.\"_\n- Requirements are derived directly from the backend `registerSchema` in `auth.router.ts` (min 3, max 32, regex `^[a-zA-Z0-9_-]+$`)\n\n## Test plan\n- [ ] Visit `/auth/signup` and confirm helper text appears beneath the Username field\n- [ ] Verify all 304 frontend unit tests pass (`npm test` in `harmony-frontend/`)\n\nCloses #451\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\""
+}
+```
+
+## Assistant
+
+PR created: https://github.com/CS485-Harmony/Harmony/pull/452
+
+The fix adds a single helper text line — `"3–32 characters. Letters, numbers, underscores, and hyphens only."` — directly below the username input, matching the exact constraints enforced by the backend `registerSchema` in `auth.router.ts`. All 304 frontend tests still pass.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+


### PR DESCRIPTION
## Summary
- Adds a helper text line below the username field on `/auth/signup` showing: _"3–32 characters. Letters, numbers, underscores, and hyphens only."_
- Requirements are derived directly from the backend `registerSchema` in `auth.router.ts` (min 3, max 32, regex `^[a-zA-Z0-9_-]+$`)

## Test plan
- [ ] Visit `/auth/signup` and confirm helper text appears beneath the Username field
- [ ] Verify all 304 frontend unit tests pass (`npm test` in `harmony-frontend/`)

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)