### PR TITLE
fix: redirect guests on /channels/[server]/[channel] to public /c/ route

### DIFF
--- a/harmony-frontend/src/__tests__/middleware.test.ts
+++ b/harmony-frontend/src/__tests__/middleware.test.ts
@@ -76,6 +76,22 @@ describe('middleware', () => {
     );
   });
 
+  it('redirects unauthenticated channel+slug routes to the guest /c/ path', () => {
+    const response = middleware(buildRequest('/channels/my-server/my-channel'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost/c/my-server/my-channel');
+  });
+
+  it('redirects to login (not /c/) for server-only channel routes without a channel slug', () => {
+    const response = middleware(buildRequest('/channels/my-server'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost/auth/login?returnUrl=%2Fchannels%2Fmy-server',
+    );
+  });
+
   it('redirects the exact settings route when no auth cookie is present', () => {
     const response = middleware(buildRequest('/settings'));
 

--- a/harmony-frontend/src/middleware.ts
+++ b/harmony-frontend/src/middleware.ts
@@ -86,8 +86,16 @@ export function middleware(request: NextRequest) {
 
   const tokenCookie = request.cookies.get(AUTH_COOKIE_NAME);
 
-  // ── Unauthenticated: redirect to login ────────────────────────────────────
+  // ── Unauthenticated ───────────────────────────────────────────────────────
   if (!tokenCookie?.value) {
+    // /channels/[serverSlug]/[channelSlug] → hand off to the public guest route
+    // which checks visibility and renders or shows a locked pane accordingly.
+    const channelRouteMatch = pathname.match(/^\/channels\/([^/]+)\/([^/]+)$/);
+    if (channelRouteMatch) {
+      const guestUrl = new URL(`/c/${channelRouteMatch[1]}/${channelRouteMatch[2]}`, request.url);
+      return NextResponse.redirect(guestUrl);
+    }
+
     const loginUrl = new URL('/auth/login', request.url);
     loginUrl.searchParams.set('returnUrl', pathname);
     return NextResponse.redirect(loginUrl);

--- a/llm-logs/2026-04-21-182843-session-9078ccc0.md
+++ b/llm-logs/2026-04-21-182843-session-9078ccc0.md
@@ -1,0 +1,396 @@
+# Session Log 2026-04-21-182843
+
+## User
+
+https://github.com/CS485-Harmony/Harmony/issues/450 complete this issue and open a PR.
+
+## Assistant
+
+Let me fetch the GitHub issue to understand what's needed.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 450 --repo CS485-Harmony/Harmony",
+  "description": "View GitHub issue 450"
+}
+```
+
+## Assistant
+
+Now let me explore the relevant parts of the codebase to understand the routing and auth middleware.
+
+## Assistant
+
+**Tool call: `Agent`**
+```json
+{
+  "description": "Explore auth middleware and channel routing",
+  "subagent_type": "Explore",
+  "prompt": "I need to understand how authentication and route protection work in this Next.js + Express/tRPC codebase for a \"Harmony\" chat app. The issue is that public (search indexed) channels should be viewable by unauthenticated guests, but visiting a channel URL redirects to /auth/login.\n\nChannel URLs follow the pattern: /channels/[serverId]/[channelId] or similar.\n\nPlease explore:\n1. The Next.js middleware file (middleware.ts or similar) that handles route protection/redirects\n2. The frontend channel page component(s) in harmony-frontend/\n3. Any auth guards or HOCs that wrap channel pages\n4. How channel visibility (PUBLIC_INDEXABLE, PUBLIC_NO_INDEX, PRIVATE) is used in the frontend routing\n5. The backend tRPC router for channels - particularly how channel data is fetched for guests vs authenticated users\n\nReport file paths and relevant code sections (line numbers) for each finding. Be thorough - this is medium exploration."
+}
+```
+
+## Assistant
+
+Let me read the middleware file to understand the exact redirect logic.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/middleware.ts"
+}
+```
+
+## Assistant
+
+Now let me check the channels route structure to confirm the URL path segments are slugs.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels -type f | head -30 && echo \"---\" && find /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/c -type f | head -20",
+  "description": "List channel route files"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/channels/[serverSlug]/[channelSlug]/page.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx"
+}
+```
+
+## Assistant
+
+Now I have everything I need. The fix is clean: when an unauthenticated user visits `/channels/[serverSlug]/[channelSlug]`, redirect to `/c/[serverSlug]/[channelSlug]` instead of `/auth/login`. The `/c/` guest route already handles visibility correctly.
+
+Let me check for existing tests and post an issue comment first.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__ -name \"*middleware*\" -o -name \"*routing*\" 2>/dev/null | head -10",
+  "description": "Find middleware tests"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 450 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Starting]**\n\nInvestigating root cause. The Next.js middleware (\\`src/middleware.ts\\`) unconditionally redirects all unauthenticated \\`/channels/*\\` requests to \\`/auth/login\\`, ignoring channel visibility.\n\nFix: when an unauthenticated user visits \\`/channels/[serverSlug]/[channelSlug]\\`, redirect to the existing guest route \\`/c/[serverSlug]/[channelSlug]\\` instead of login. The \\`/c/\\` route already handles visibility correctly \u2014 showing content for PUBLIC_INDEXABLE channels and a locked pane for PRIVATE ones.\"",
+  "description": "Post issue comment"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/middleware.test.ts"
+}
+```
+
+## Assistant
+
+Now I'll implement the fix. The change is in the middleware: redirect unauthenticated users from `/channels/[serverSlug]/[channelSlug]` to `/c/[serverSlug]/[channelSlug]` instead of `/auth/login`.
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/middleware.ts",
+  "old_string": "  const tokenCookie = request.cookies.get(AUTH_COOKIE_NAME);\n\n  // \u2500\u2500 Unauthenticated: redirect to login \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  if (!tokenCookie?.value) {\n    const loginUrl = new URL('/auth/login', request.url);\n    loginUrl.searchParams.set('returnUrl', pathname);\n    return NextResponse.redirect(loginUrl);\n  }",
+  "new_string": "  const tokenCookie = request.cookies.get(AUTH_COOKIE_NAME);\n\n  // \u2500\u2500 Unauthenticated \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  if (!tokenCookie?.value) {\n    // /channels/[serverSlug]/[channelSlug] \u2192 hand off to the public guest route\n    // which checks visibility and renders or shows a locked pane accordingly.\n    const channelRouteMatch = pathname.match(/^\\/channels\\/([^/]+)\\/([^/]+)$/);\n    if (channelRouteMatch) {\n      const guestUrl = new URL(`/c/${channelRouteMatch[1]}/${channelRouteMatch[2]}`, request.url);\n      return NextResponse.redirect(guestUrl);\n    }\n\n    const loginUrl = new URL('/auth/login', request.url);\n    loginUrl.searchParams.set('returnUrl', pathname);\n    return NextResponse.redirect(loginUrl);\n  }"
+}
+```
+
+## Assistant
+
+Now add tests for this new behavior:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/middleware.test.ts",
+  "old_string": "  it('redirects the exact channels route when no auth cookie is present', () => {\n    const response = middleware(buildRequest('/channels'));\n\n    expect(response.status).toBe(307);\n    expect(response.headers.get('location')).toBe(\n      'http://localhost/auth/login?returnUrl=%2Fchannels',\n    );\n  });",
+  "new_string": "  it('redirects the exact channels route when no auth cookie is present', () => {\n    const response = middleware(buildRequest('/channels'));\n\n    expect(response.status).toBe(307);\n    expect(response.headers.get('location')).toBe(\n      'http://localhost/auth/login?returnUrl=%2Fchannels',\n    );\n  });\n\n  it('redirects unauthenticated channel+slug routes to the guest /c/ path', () => {\n    const response = middleware(buildRequest('/channels/my-server/my-channel'));\n\n    expect(response.status).toBe(307);\n    expect(response.headers.get('location')).toBe('http://localhost/c/my-server/my-channel');\n  });\n\n  it('redirects to login (not /c/) for server-only channel routes without a channel slug', () => {\n    const response = middleware(buildRequest('/channels/my-server'));\n\n    expect(response.status).toBe(307);\n    expect(response.headers.get('location')).toBe(\n      'http://localhost/auth/login?returnUrl=%2Fchannels%2Fmy-server',\n    );\n  });"
+}
+```
+
+## Assistant
+
+Now run the tests to verify everything passes:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npx jest --testPathPattern=\"middleware\" --no-coverage 2>&1",
+  "description": "Run middleware tests"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npx jest --testPathPatterns=\"middleware\" --no-coverage 2>&1",
+  "description": "Run middleware tests"
+}
+```
+
+## Assistant
+
+All 12 tests pass (10 existing + 2 new). Let me also run the full frontend test suite to check for regressions:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test -- --no-coverage 2>&1 | tail -20",
+  "description": "Run all frontend tests"
+}
+```
+
+## Assistant
+
+306/306 tests pass. Now let me create the branch, commit, and open a PR.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b fix/issue-450-public-channel-guest-redirect 2>&1",
+  "description": "Create feature branch"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git diff HEAD && git status",
+  "description": "Review changes before committing"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-frontend/src/middleware.ts harmony-frontend/src/__tests__/middleware.test.ts && git commit -m \"$(cat <<'EOF'\nfix: redirect unauthenticated users on /channels/[server]/[channel] to guest /c/ route\n\nFixes #450. The middleware was unconditionally sending all unauthenticated\n/channels/* requests to /auth/login, including public (search-indexed) channels.\nNow, /channels/[serverSlug]/[channelSlug] routes hand unauthenticated visitors\noff to /c/[serverSlug]/[channelSlug], which already handles visibility correctly\n\u2014 rendering content for PUBLIC_INDEXABLE channels and showing a locked pane for\nPRIVATE ones.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit the fix"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/issue-450-public-channel-guest-redirect 2>&1",
+  "description": "Push branch to remote"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --repo CS485-Harmony/Harmony --title \"fix: redirect guests on /channels/[server]/[channel] to public /c/ route\" --body \"$(cat <<'EOF'\n## Summary\n\nFixes #450.\n\n- The Next.js middleware (`src/middleware.ts`) was unconditionally redirecting all unauthenticated `/channels/*` requests to `/auth/login`, including channels with `PUBLIC_INDEXABLE` visibility.\n- Now, when an unauthenticated user visits `/channels/[serverSlug]/[channelSlug]`, the middleware redirects to `/c/[serverSlug]/[channelSlug]` (the existing guest channel route) instead of login.\n- The `/c/` guest route already handles visibility correctly: it renders full content for public channels and shows a locked pane with login CTAs for private channels.\n- All other unauthenticated `/channels/*` paths (e.g. `/channels`, `/channels/[serverSlug]`) still redirect to login as before, since there is no guest-accessible equivalent.\n\n## Test plan\n\n- [x] New test: unauthenticated request to `/channels/my-server/my-channel` \u2192 redirects to `/c/my-server/my-channel`\n- [x] New test: unauthenticated request to `/channels/my-server` (no channel slug) \u2192 still redirects to `/auth/login`\n- [x] All existing middleware tests pass (12/12 total)\n- [x] Full frontend test suite passes (306/306)\n- Manual repro: visit a `PUBLIC_INDEXABLE` channel URL while logged out \u2014 channel content is now visible without forced login\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\"",
+  "description": "Create pull request"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 450 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Complete]**\n\nFix implemented and PR opened: #454\n\nRoot cause: \\`src/middleware.ts\\` unconditionally redirected all unauthenticated \\`/channels/*\\` requests to \\`/auth/login\\`.\n\nFix: When an unauthenticated user visits \\`/channels/[serverSlug]/[channelSlug]\\`, the middleware now redirects to \\`/c/[serverSlug]/[channelSlug]\\` (the existing guest route) instead of login. The \\`/c/\\` route already handles visibility correctly \u2014 rendering content for PUBLIC_INDEXABLE channels and showing a locked pane for PRIVATE ones. All other unauthenticated \\`/channels/*\\` paths continue to redirect to login.\n\nTwo new tests added; all 306 frontend tests pass.\"",
+  "description": "Post completion comment on issue"
+}
+```
+
+## Assistant
+
+PR is open at https://github.com/CS485-Harmony/Harmony/pull/454.
+
+**Root cause:** `src/middleware.ts` was redirecting all unauthenticated `/channels/*` requests to `/auth/login`, regardless of channel visibility.
+
+**Fix (3 lines in middleware.ts):** When an unauthenticated user visits `/channels/[serverSlug]/[channelSlug]`, redirect to `/c/[serverSlug]/[channelSlug]` instead of login. The `/c/` guest route already handles visibility — it renders content for `PUBLIC_INDEXABLE` channels and shows a locked pane for `PRIVATE` ones. Other unauthenticated `/channels/*` paths (e.g. `/channels`, `/channels/[serverSlug]`) still redirect to login since there's no guest equivalent.
+
+Two new tests were added; all 306 frontend tests pass.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+


### PR DESCRIPTION
## Summary

Fixes #450.

- The Next.js middleware (`src/middleware.ts`) was unconditionally redirecting all unauthenticated `/channels/*` requests to `/auth/login`, including channels with `PUBLIC_INDEXABLE` visibility.
- Now, when an unauthenticated user visits `/channels/[serverSlug]/[channelSlug]`, the middleware redirects to `/c/[serverSlug]/[channelSlug]` (the existing guest channel route) instead of login.
- The `/c/` guest route already handles visibility correctly: it renders full content for public channels and shows a locked pane with login CTAs for private channels.
- All other unauthenticated `/channels/*` paths (e.g. `/channels`, `/channels/[serverSlug]`) still redirect to login as before, since there is no guest-accessible equivalent.

## Test plan

- [x] New test: unauthenticated request to `/channels/my-server/my-channel` → redirects to `/c/my-server/my-channel`
- [x] New test: unauthenticated request to `/channels/my-server` (no channel slug) → still redirects to `/auth/login`
- [x] All existing middleware tests pass (12/12 total)
- [x] Full frontend test suite passes (306/306)
- Manual repro: visit a `PUBLIC_INDEXABLE` channel URL while logged out — channel content is now visible without forced login

🤖 Generated with [Claude Code](https://claude.com/claude-code)