### PR TITLE
feat(seo): S7 Security + content filtering for meta tags (§12, AC-8) — Issue #356

### DIFF
--- a/docs/dev-spec-seo-meta-tag-generation.md
+++ b/docs/dev-spec-seo-meta-tag-generation.md
@@ -3012,7 +3012,7 @@ This section needed reprompting to ensure alignment across the data schemas in e
 | Filter Type | Implementation | Purpose |
 |-------------|----------------|---------|
 | PII Detection | Regex for emails, phones, @mentions — `ContentFilter.filterPII` | Prevent personal info in search results |
-| Profanity Filter | Word list + pattern matching, replaced with `***` — `ContentFilter.filterProfanity` | Prevent inappropriate previews |
+| Profanity Filter | Word list + pattern matching, replaced with asterisks matching the word length (e.g., `damn` → `****`) — `ContentFilter.filterProfanity` | Prevent inappropriate previews |
 | Private Mention Redaction | `@mention` → `[user]` via `ContentFilter.filterPII` | Respect user privacy settings |
 | URL Sanitization | Remove internal/private links | Prevent link leakage |
 | HTML Entity Encoding | `ContentFilter.escapeHtml` / `ContentFilter.sanitizeForHead` | Prevent XSS in `<head>` |

--- a/docs/dev-spec-seo-meta-tag-generation.md
+++ b/docs/dev-spec-seo-meta-tag-generation.md
@@ -3011,11 +3011,20 @@ This section needed reprompting to ensure alignment across the data schemas in e
 
 | Filter Type | Implementation | Purpose |
 |-------------|----------------|---------|
-| PII Detection | Regex for emails, phones, names | Prevent personal info in search results |
-| Profanity Filter | Word list + pattern matching | Prevent inappropriate previews |
-| Private Mention Redaction | Remove @mentions of private users | Respect user privacy settings |
+| PII Detection | Regex for emails, phones, @mentions — `ContentFilter.filterPII` | Prevent personal info in search results |
+| Profanity Filter | Word list + pattern matching, replaced with `***` — `ContentFilter.filterProfanity` | Prevent inappropriate previews |
+| Private Mention Redaction | `@mention` → `[user]` via `ContentFilter.filterPII` | Respect user privacy settings |
 | URL Sanitization | Remove internal/private links | Prevent link leakage |
-| HTML Entity Encoding | Encode special characters | Prevent XSS |
+| HTML Entity Encoding | `ContentFilter.escapeHtml` / `ContentFilter.sanitizeForHead` | Prevent XSS in `<head>` |
+
+**Implementation:** `src/services/metaTag/contentFilter.ts` exports `ContentFilter` with:
+- `filterPII(text)` — redacts emails, phone numbers, @mentions
+- `filterProfanity(text)` — replaces word-list matches with asterisks
+- `filterContent(text)` — runs PII then profanity pipeline (used in `metaTagService.generateMetaTagsFromContext`)
+- `escapeHtml(text)` — HTML-entity-encodes `& < > " ' /`
+- `sanitizeForHead(text)` — strips HTML tags then calls `escapeHtml`; used by `metaTagService.sanitizeCustomOverride` on write path
+
+**Tests:** `tests/contentFilter.test.ts` covers PII/profanity fixture corpus (AC-8), XSS attribute-injection fixtures, and `<head>` output snapshots.
 
 ### 12.2 Data Flow Security
 
@@ -3059,7 +3068,7 @@ Message Content                 Content Analysis              Meta Tag Output
 ### 12.3 Admin Override Security
 
 - Only server admins can set custom meta tags
-- Custom tags still undergo sanitization
+- Custom tags still undergo sanitization via `metaTagService.sanitizeCustomOverride` (strips HTML, filters PII/profanity, HTML-entity-encodes) before being stored or served
 - Audit log records all custom tag changes
 - Rate limiting on regeneration requests
 

--- a/harmony-backend/src/repositories/metaTag.repository.ts
+++ b/harmony-backend/src/repositories/metaTag.repository.ts
@@ -29,6 +29,10 @@ export const metaTagRepository = {
     return client.generatedMetaTags.create({ data });
   },
 
+  /**
+   * Persist custom override fields as-is. Does NOT sanitize inputs.
+   * Callers must go through metaTagService.setCustomOverrides to satisfy AC-8 / §12.3.
+   */
   updateCustomOverrides(
     channelId: string,
     overrides: {

--- a/harmony-backend/src/services/metaTag/contentFilter.ts
+++ b/harmony-backend/src/services/metaTag/contentFilter.ts
@@ -3,10 +3,16 @@
 // PII patterns
 const EMAIL_RE = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
 // Covers common formats: (555) 123-4567, 555-123-4567, +1-555-123-4567, 5551234567
+// TODO: tighten this pattern — currently matches digit sequences that are not phone numbers
+// (e.g., long numeric IDs, dates like "2026-04-21"). Consider requiring 10+ digits after
+// stripping separators or using a phone-parsing library. Track as a follow-up issue.
 const PHONE_RE = /(\+?\d[\d\s\-().]{6,}\d)/g;
 const MENTION_RE = /@[\w.]+/g;
 
 // Profanity word list (representative; extend as needed)
+// TODO: this list is bypassable via leetspeak, unicode homoglyphs, or internal spaces.
+// Add a follow-up issue to integrate a more robust profanity detection approach before
+// treating this as complete coverage.
 const PROFANITY_LIST = [
   'fuck', 'shit', 'ass', 'bitch', 'bastard', 'crap', 'damn', 'hell',
   'cunt', 'dick', 'piss', 'cock', 'pussy', 'asshole', 'bullshit',

--- a/harmony-backend/src/services/metaTag/contentFilter.ts
+++ b/harmony-backend/src/services/metaTag/contentFilter.ts
@@ -1,0 +1,71 @@
+// CL-C2.6 ContentFilter — PII redaction, profanity filtering, and XSS-safe output for meta tags (§12)
+
+// PII patterns
+const EMAIL_RE = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
+// Covers common formats: (555) 123-4567, 555-123-4567, +1-555-123-4567, 5551234567
+const PHONE_RE = /(\+?\d[\d\s\-().]{6,}\d)/g;
+const MENTION_RE = /@[\w.]+/g;
+
+// Profanity word list (representative; extend as needed)
+const PROFANITY_LIST = [
+  'fuck', 'shit', 'ass', 'bitch', 'bastard', 'crap', 'damn', 'hell',
+  'cunt', 'dick', 'piss', 'cock', 'pussy', 'asshole', 'bullshit',
+];
+const PROFANITY_RE = new RegExp(`\\b(${PROFANITY_LIST.join('|')})\\b`, 'gi');
+
+// HTML entities for XSS-safe output in <head> attributes/text
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+  '/': '&#x2F;',
+};
+
+export const ContentFilter = {
+  /**
+   * Escape HTML special characters so text is safe to embed in <meta> tag
+   * attributes or the document <head>. Does NOT strip tags — call stripHtml first
+   * if the input may contain markup.
+   */
+  escapeHtml(text: string): string {
+    return text.replace(/[&<>"'/]/g, (ch) => HTML_ESCAPE_MAP[ch] ?? ch);
+  },
+
+  /**
+   * Replace emails, phone numbers, and @mentions with neutral placeholders
+   * so PII cannot appear in search-engine-indexed meta tags.
+   */
+  filterPII(text: string): string {
+    return text
+      .replace(EMAIL_RE, '[email]')
+      .replace(PHONE_RE, '[phone]')
+      .replace(MENTION_RE, '[user]');
+  },
+
+  /**
+   * Replace profanity with asterisks of matching length.
+   */
+  filterProfanity(text: string): string {
+    return text.replace(PROFANITY_RE, (match) => '*'.repeat(match.length));
+  },
+
+  /**
+   * Run the full content filter pipeline: PII → profanity.
+   * Input is assumed to be plain text (HTML already stripped by generators).
+   */
+  filterContent(text: string): string {
+    return ContentFilter.filterProfanity(ContentFilter.filterPII(text));
+  },
+
+  /**
+   * Prepare a string for safe embedding inside an HTML <head> context.
+   * Strips residual HTML tags then HTML-entity-encodes the result.
+   * Use for customTitle / customDescription before storing or serving.
+   */
+  sanitizeForHead(text: string): string {
+    const stripped = text.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+    return ContentFilter.escapeHtml(stripped);
+  },
+};

--- a/harmony-backend/src/services/metaTag/metaTagService.ts
+++ b/harmony-backend/src/services/metaTag/metaTagService.ts
@@ -5,6 +5,7 @@ import { OpenGraphGenerator } from './openGraphGenerator';
 import { StructuredDataGenerator } from './structuredDataGenerator';
 import { MetaTagCache } from './metaTagCache';
 import { ContentFilter } from './contentFilter';
+import { metaTagRepository } from '../../repositories/metaTag.repository';
 import type {
   MetaTagSet,
   ChannelContext,
@@ -70,7 +71,11 @@ export const metaTagService = {
       const rawDescription = DescriptionGenerator.generateFromMessages(messages, channel);
       const title = ContentFilter.filterContent(rawTitle);
       const description = ContentFilter.filterContent(rawDescription);
-      const keywords = DescriptionGenerator.extractKeyPhrases(messages.map((m) => m.content).join(' '), 5);
+      const filteredContent = ContentFilter.filterContent(messages.map((m) => m.content).join(' '));
+      // Drop placeholder tokens that filterContent inserts — they leak filter presence into og/twitter tags
+      const FILTER_PLACEHOLDERS = new Set(['email', 'phone', 'user']);
+      const keywords = DescriptionGenerator.extractKeyPhrases(filteredContent, 5)
+        .filter((k) => !FILTER_PLACEHOLDERS.has(k) && !/^\*+$/.test(k));
       const analysis: ContentAnalysis = {
         keywords,
         topics: [title],
@@ -173,11 +178,36 @@ export const metaTagService = {
 
   /**
    * Sanitize admin-supplied custom override strings before they are stored or
-   * served in the <head>. Strips tags, filters PII/profanity, then HTML-encodes.
+   * served in the <head>. Strips HTML tags first (prevents tag-splitting bypass),
+   * then filters PII/profanity, then HTML-entity-encodes for safe <head> embedding.
    * Used by the write path (PUT /meta-tags) to satisfy AC-8 / §12.3.
    */
   sanitizeCustomOverride(value: string | null | undefined): string | null {
     if (value == null) return null;
-    return ContentFilter.sanitizeForHead(ContentFilter.filterContent(value));
+    // Strip HTML before PII/profanity filtering — otherwise "f<b>u</b>ck" bypasses the word-boundary regex
+    const stripped = value.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+    return ContentFilter.escapeHtml(ContentFilter.filterContent(stripped));
+  },
+
+  /**
+   * Sanitize and persist admin-supplied custom overrides for a channel.
+   * All callers must go through this method rather than metaTagRepository.updateCustomOverrides
+   * directly — the repository method accepts raw strings and does not sanitize.
+   * AC-8 / §12.3: customTitle and customDescription are sanitized on write.
+   */
+  async setCustomOverrides(
+    channelId: string,
+    overrides: {
+      customTitle?: string | null;
+      customDescription?: string | null;
+      customOgImage?: string | null;
+    },
+  ): Promise<void> {
+    await metaTagRepository.updateCustomOverrides(channelId, {
+      customTitle: metaTagService.sanitizeCustomOverride(overrides.customTitle),
+      customDescription: metaTagService.sanitizeCustomOverride(overrides.customDescription),
+      customOgImage: overrides.customOgImage ?? null,
+    });
+    await metaTagService.invalidateCache(channelId);
   },
 };

--- a/harmony-backend/src/services/metaTag/metaTagService.ts
+++ b/harmony-backend/src/services/metaTag/metaTagService.ts
@@ -4,6 +4,7 @@ import { DescriptionGenerator } from './descriptionGenerator';
 import { OpenGraphGenerator } from './openGraphGenerator';
 import { StructuredDataGenerator } from './structuredDataGenerator';
 import { MetaTagCache } from './metaTagCache';
+import { ContentFilter } from './contentFilter';
 import type {
   MetaTagSet,
   ChannelContext,
@@ -65,8 +66,10 @@ export const metaTagService = {
    */
   async generateMetaTagsFromContext(channel: ChannelContext, messages: MessageContext[]): Promise<MetaTagSet> {
     try {
-      const title = TitleGenerator.generateFromThread(messages, channel);
-      const description = DescriptionGenerator.generateFromMessages(messages, channel);
+      const rawTitle = TitleGenerator.generateFromThread(messages, channel);
+      const rawDescription = DescriptionGenerator.generateFromMessages(messages, channel);
+      const title = ContentFilter.filterContent(rawTitle);
+      const description = ContentFilter.filterContent(rawDescription);
       const keywords = DescriptionGenerator.extractKeyPhrases(messages.map((m) => m.content).join(' '), 5);
       const analysis: ContentAnalysis = {
         keywords,
@@ -166,5 +169,15 @@ export const metaTagService = {
 
   buildCanonicalUrl(serverSlug: string, channelSlug: string): string {
     return `${BASE_URL}/c/${encodeURIComponent(serverSlug)}/${encodeURIComponent(channelSlug)}`;
+  },
+
+  /**
+   * Sanitize admin-supplied custom override strings before they are stored or
+   * served in the <head>. Strips tags, filters PII/profanity, then HTML-encodes.
+   * Used by the write path (PUT /meta-tags) to satisfy AC-8 / §12.3.
+   */
+  sanitizeCustomOverride(value: string | null | undefined): string | null {
+    if (value == null) return null;
+    return ContentFilter.sanitizeForHead(ContentFilter.filterContent(value));
   },
 };

--- a/harmony-backend/tests/__snapshots__/contentFilter.test.ts.snap
+++ b/harmony-backend/tests/__snapshots__/contentFilter.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<head> output snapshot — crafted XSS fixture snapshot: XSS customDescription with attribute breakout is safe 1`] = `"<meta name="description" content="Great channel&quot; onload=&quot;stealCookies() &amp; more" />"`;
+
+exports[`<head> output snapshot — crafted XSS fixture snapshot: XSS customTitle renders as safe escaped string for <head> 1`] = `"<meta name="title" content="alert(&quot;xss&quot;)Best Channel &amp; Community" />"`;

--- a/harmony-backend/tests/contentFilter.test.ts
+++ b/harmony-backend/tests/contentFilter.test.ts
@@ -273,4 +273,29 @@ describe('metaTagService — generated tags exclude flagged content (AC-8)', () 
     expect(result).not.toContain('@');
     expect(result).toContain('[email]');
   });
+
+  it('sanitizeCustomOverride blocks tag-splitting profanity bypass', () => {
+    // "f<b>u</b>ck" splits the word across HTML tags — must be caught after stripping tags
+    const result = metaTagService.sanitizeCustomOverride('f<b>u</b>ck this');
+    expect(result).not.toMatch(/fuck/i);
+    expect(result).not.toContain('<');
+    expect(result).not.toContain('>');
+  });
+
+  it('sanitizeCustomOverride blocks tag-splitting email bypass', () => {
+    const result = metaTagService.sanitizeCustomOverride('alice@<b>example</b>.com');
+    expect(result).not.toContain('@');
+    expect(result).not.toContain('<');
+  });
+
+  it('generated keywords do not contain PII fragments', async () => {
+    const messages: MessageContext[] = [
+      { content: 'Email me at secret@corp.com or call 555-123-4567 for support', createdAt: new Date() },
+    ];
+    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);
+    const keywordStr = tags.keywords.join(' ');
+    expect(keywordStr).not.toContain('secret');
+    expect(keywordStr).not.toContain('corp');
+    expect(keywordStr).not.toContain('555');
+  });
 });

--- a/harmony-backend/tests/contentFilter.test.ts
+++ b/harmony-backend/tests/contentFilter.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Unit tests for ContentFilter (§12 Security and Privacy, AC-8)
+ *
+ * Covers:
+ *  - PII redaction: emails, phone numbers, @mentions
+ *  - Profanity filtering: word list, case-insensitive
+ *  - XSS / HTML attribute injection escaping via sanitizeForHead
+ *  - Snapshot test: crafted XSS fixture produces safe <head> output
+ *  - Integration with metaTagService: generated tags exclude flagged content
+ */
+
+import { ContentFilter } from '../src/services/metaTag/contentFilter';
+import { metaTagService } from '../src/services/metaTag/metaTagService';
+import type { ChannelContext, MessageContext } from '../src/services/metaTag/types';
+
+jest.mock('../src/services/cache.service', () => ({
+  cacheService: {
+    get: jest.fn(),
+    set: jest.fn(),
+    invalidate: jest.fn(),
+    getOrRevalidate: jest.fn(),
+  },
+  CacheKeys: {
+    metaChannel: (id: string) => `meta:channel:${id}`,
+    channelVisibility: (id: string) => `channel:${id}:visibility`,
+    channelMessages: (id: string, page: number) => `channel:msgs:${id}:page:${page}`,
+    serverInfo: (id: string) => `server:${id}:info`,
+    analysisChannel: (id: string) => `analysis:channel:${id}`,
+  },
+  sanitizeKeySegment: (s: string) => s.replace(/[*?\[\]]/g, ''),
+}));
+
+// ─── PII fixture corpus ───────────────────────────────────────────────────────
+
+describe('ContentFilter.filterPII — PII fixture corpus (AC-8)', () => {
+  it('redacts email addresses', () => {
+    expect(ContentFilter.filterPII('Contact alice@example.com for details'))
+      .toBe('Contact [email] for details');
+  });
+
+  it('redacts multiple emails in one string', () => {
+    const result = ContentFilter.filterPII('From bob@foo.org to carol@bar.net');
+    expect(result).not.toContain('@');
+    expect(result).toContain('[email]');
+  });
+
+  it('redacts US phone numbers (dashes)', () => {
+    const result = ContentFilter.filterPII('Call 555-867-5309 now');
+    expect(result).not.toContain('555-867-5309');
+    expect(result).toContain('[phone]');
+  });
+
+  it('redacts US phone numbers with parens', () => {
+    const result = ContentFilter.filterPII('(555) 123-4567 is the number');
+    expect(result).not.toContain('(555) 123-4567');
+    expect(result).toContain('[phone]');
+  });
+
+  it('redacts @mentions', () => {
+    expect(ContentFilter.filterPII('Thanks @alice and @bob.smith!'))
+      .toBe('Thanks [user] and [user]!');
+  });
+
+  it('passes clean text unchanged', () => {
+    const clean = 'The channel discusses game development and coding tips.';
+    expect(ContentFilter.filterPII(clean)).toBe(clean);
+  });
+});
+
+// ─── Profanity fixture corpus ──────────────────────────────────────────────────
+
+describe('ContentFilter.filterProfanity — profanity fixture corpus (AC-8)', () => {
+  it('replaces profanity with asterisks of matching length', () => {
+    const result = ContentFilter.filterProfanity('This is damn annoying');
+    expect(result).toBe('This is **** annoying');
+  });
+
+  it('is case-insensitive', () => {
+    expect(ContentFilter.filterProfanity('What the HELL is this?'))
+      .toBe('What the **** is this?');
+  });
+
+  it('filters multiple profanity words', () => {
+    const result = ContentFilter.filterProfanity('holy shit that was ass');
+    expect(result).not.toMatch(/shit|ass/i);
+    expect(result).toContain('***');
+  });
+
+  it('does not alter clean text', () => {
+    const clean = 'Welcome to the design and architecture discussion.';
+    expect(ContentFilter.filterProfanity(clean)).toBe(clean);
+  });
+});
+
+// ─── filterContent (pipeline) ─────────────────────────────────────────────────
+
+describe('ContentFilter.filterContent — combined pipeline (AC-8)', () => {
+  it('applies PII then profanity filter', () => {
+    const input = 'Contact damn@example.com or call @baduser';
+    const result = ContentFilter.filterContent(input);
+    expect(result).not.toContain('@example.com');
+    expect(result).toContain('[email]');
+    expect(result).toContain('[user]');
+  });
+});
+
+// ─── XSS / HTML injection ────────────────────────────────────────────────────
+
+describe('ContentFilter.escapeHtml — XSS prevention', () => {
+  it('escapes < and > and /', () => {
+    expect(ContentFilter.escapeHtml('<script>alert(1)</script>'))
+      .toBe('&lt;script&gt;alert(1)&lt;&#x2F;script&gt;');
+  });
+
+  it('escapes double quotes', () => {
+    expect(ContentFilter.escapeHtml('say "hello"')).toBe('say &quot;hello&quot;');
+  });
+
+  it('escapes single quotes', () => {
+    expect(ContentFilter.escapeHtml("it's fine")).toBe('it&#x27;s fine');
+  });
+
+  it('escapes ampersand', () => {
+    expect(ContentFilter.escapeHtml('cats & dogs')).toBe('cats &amp; dogs');
+  });
+
+  it('escapes forward slash (closes script context)', () => {
+    expect(ContentFilter.escapeHtml('</script>')).toBe('&lt;&#x2F;script&gt;');
+  });
+
+  it('passes plain text through unchanged', () => {
+    const clean = 'TypeScript channel on Game Dev Hub';
+    expect(ContentFilter.escapeHtml(clean)).toBe(clean);
+  });
+});
+
+describe('ContentFilter.sanitizeForHead — attribute injection prevention', () => {
+  it('strips HTML tags then HTML-encodes', () => {
+    const malicious = '<b onmouseover="alert(1)">bold</b>';
+    const result = ContentFilter.sanitizeForHead(malicious);
+    expect(result).not.toContain('<');
+    expect(result).not.toContain('>');
+    expect(result).not.toContain('onmouseover');
+    expect(result).toContain('bold');
+  });
+
+  it('rejects attribute injection via crafted customTitle', () => {
+    // Attempt to break out of a meta content attribute: content=" onload="alert(1)"
+    // HTML-encoding the quotes prevents breaking out of the attribute value.
+    const injection = '" onload="alert(1)';
+    const result = ContentFilter.sanitizeForHead(injection);
+    // Unencoded quotes must not be present (they are the escape vector)
+    expect(result).not.toContain('"');
+    // Encoded form must be present (proving encoding happened)
+    expect(result).toContain('&quot;');
+  });
+
+  it('rejects script tag injection via crafted customDescription', () => {
+    // Tags are stripped; remaining text content is harmless plain text.
+    const injection = '</meta><script>document.cookie</script>';
+    const result = ContentFilter.sanitizeForHead(injection);
+    // Unencoded angle brackets must not be present
+    expect(result).not.toContain('<script>');
+    expect(result).not.toContain('</script>');
+    expect(result).not.toContain('<');
+    expect(result).not.toContain('>');
+  });
+
+  it('collapses extra whitespace after stripping tags', () => {
+    const input = '  hello   <b>world</b>  ';
+    expect(ContentFilter.sanitizeForHead(input)).toBe('hello world');
+  });
+});
+
+// ─── <head> output snapshot — XSS fixture (AC-8) ─────────────────────────────
+
+describe('<head> output snapshot — crafted XSS fixture', () => {
+  const XSS_FIXTURES = [
+    {
+      label: 'script tag injection',
+      input: '<script>alert("xss")</script>Best channel ever',
+      // After strip + escape: no script, text content escaped
+    },
+    {
+      label: 'attribute breakout via double quote',
+      input: '" onload="evil()',
+    },
+    {
+      label: 'attribute breakout via single quote',
+      input: "' onclick='evil()",
+    },
+    {
+      label: 'SVG with event handler',
+      input: '<svg onload=alert(1)>harmless text</svg>',
+    },
+    {
+      label: 'iframe injection',
+      input: '<iframe src="javascript:alert(1)">fallback</iframe>',
+    },
+  ];
+
+  it.each(XSS_FIXTURES)('sanitizeForHead blocks $label', ({ input }) => {
+    const output = ContentFilter.sanitizeForHead(input);
+    // No unencoded angle brackets (these are the tag injection vector)
+    expect(output).not.toContain('<');
+    expect(output).not.toContain('>');
+    // No unencoded quotes (these are the attribute breakout vector)
+    expect(output).not.toContain('"');
+    expect(output).not.toContain("'");
+    // No unencoded javascript: URI (attribute breakout required for this to fire, already blocked above)
+    expect(output).not.toMatch(/^javascript:/i);
+  });
+
+  it('snapshot: XSS customTitle renders as safe escaped string for <head>', () => {
+    const maliciousTitle = '<script>alert("xss")</script>Best Channel & Community';
+    const safe = ContentFilter.sanitizeForHead(maliciousTitle);
+    // Simulate embedding in a <meta> content attribute value
+    const metaTag = `<meta name="title" content="${safe}" />`;
+    expect(metaTag).toMatchSnapshot();
+  });
+
+  it('snapshot: XSS customDescription with attribute breakout is safe', () => {
+    const maliciousDesc = 'Great channel" onload="stealCookies() & more';
+    const safe = ContentFilter.sanitizeForHead(maliciousDesc);
+    const metaTag = `<meta name="description" content="${safe}" />`;
+    expect(metaTag).toMatchSnapshot();
+  });
+});
+
+// ─── Integration: generated tags exclude PII / profanity (AC-8) ───────────────
+
+describe('metaTagService — generated tags exclude flagged content (AC-8)', () => {
+  const channel: ChannelContext = {
+    id: 'chan-pii',
+    name: 'support',
+    slug: 'support',
+    serverName: 'Tech Help',
+    serverSlug: 'tech-help',
+    canonicalUrl: 'https://harmony.chat/c/tech-help/support',
+  };
+
+  it('PII in message content is not present in generated title or description', async () => {
+    const messages: MessageContext[] = [
+      { content: 'Email me at private@user.com or call 555-123-4567', createdAt: new Date() },
+    ];
+    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);
+    expect(tags.title).not.toContain('@');
+    expect(tags.title).not.toContain('private@user.com');
+    expect(tags.description).not.toContain('private@user.com');
+    expect(tags.description).not.toContain('555-123-4567');
+  });
+
+  it('profanity in message content is replaced in generated description', async () => {
+    const messages: MessageContext[] = [
+      { content: 'This is absolute bullshit and damn annoying', createdAt: new Date() },
+    ];
+    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);
+    expect(tags.description).not.toMatch(/bullshit|damn/i);
+  });
+
+  it('sanitizeCustomOverride strips HTML and escapes for <head>', () => {
+    const result = metaTagService.sanitizeCustomOverride('<b>Hello</b> & "world"');
+    expect(result).toBe('Hello &amp; &quot;world&quot;');
+  });
+
+  it('sanitizeCustomOverride returns null for null input', () => {
+    expect(metaTagService.sanitizeCustomOverride(null)).toBeNull();
+    expect(metaTagService.sanitizeCustomOverride(undefined)).toBeNull();
+  });
+
+  it('sanitizeCustomOverride filters PII before encoding', () => {
+    const result = metaTagService.sanitizeCustomOverride('Contact admin@corp.com for help');
+    expect(result).not.toContain('@');
+    expect(result).toContain('[email]');
+  });
+});

--- a/harmony-backend/tests/metaTagService.test.ts
+++ b/harmony-backend/tests/metaTagService.test.ts
@@ -323,3 +323,54 @@ describe('metaTagService', () => {
     expect(tags.robots).toBe('noindex, nofollow');
   });
 });
+
+// ─── setCustomOverrides (AC-8 write path) ─────────────────────────────────────
+
+jest.mock('../src/repositories/metaTag.repository', () => ({
+  metaTagRepository: {
+    updateCustomOverrides: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { metaTagRepository } from '../src/repositories/metaTag.repository';
+
+const mockMetaTagRepo = metaTagRepository as jest.Mocked<typeof metaTagRepository>;
+
+describe('metaTagService.setCustomOverrides — AC-8 write-path sanitization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCacheService.invalidate.mockResolvedValue(undefined);
+  });
+
+  it('sanitizes customTitle and customDescription before persisting', async () => {
+    await metaTagService.setCustomOverrides('chan-001', {
+      customTitle: '<script>alert(1)</script>My Title',
+      customDescription: 'Contact us at admin@corp.com for help',
+    });
+
+    expect(mockMetaTagRepo.updateCustomOverrides).toHaveBeenCalledWith(
+      'chan-001',
+      expect.objectContaining({
+        customTitle: expect.not.stringContaining('<script>'),
+        customDescription: expect.not.stringContaining('@'),
+      }),
+    );
+  });
+
+  it('passes null overrides through as null', async () => {
+    await metaTagService.setCustomOverrides('chan-001', {
+      customTitle: null,
+      customDescription: null,
+    });
+
+    expect(mockMetaTagRepo.updateCustomOverrides).toHaveBeenCalledWith(
+      'chan-001',
+      expect.objectContaining({ customTitle: null, customDescription: null }),
+    );
+  });
+
+  it('invalidates the cache after persisting', async () => {
+    await metaTagService.setCustomOverrides('chan-001', { customTitle: 'Clean Title' });
+    expect(mockCacheService.invalidate).toHaveBeenCalledWith('meta:channel:chan-001');
+  });
+});

--- a/llm-logs/2026-04-21-183619-session-39228fa5.md
+++ b/llm-logs/2026-04-21-183619-session-39228fa5.md
@@ -1,0 +1,707 @@
+# Session Log 2026-04-21-183619
+
+## User
+
+complete https://github.com/CS485-Harmony/Harmony/issues/356 on a new branch and open a PR
+
+## Assistant
+
+**Tool call: `ToolSearch`**
+```json
+{
+  "query": "select:WebFetch",
+  "max_results": 1
+}
+```
+
+## Assistant
+
+Let me fetch the issue details first.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 356 --repo CS485-Harmony/Harmony"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 350 --repo CS485-Harmony/Harmony --json state,title"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src -type f -name \"*.ts\" | grep -i \"meta\\|seo\\|tag\" | head -30"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/docs/ | grep -i seo"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md | grep -n \"\u00a712\\|12\\.\" | head -40"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "wc -l /Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md",
+  "offset": 3005,
+  "limit": 150
+}
+```
+
+## Assistant
+
+Now let me look at the existing meta tag service code and the test directory.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/metaTagService.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/titleGenerator.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/descriptionGenerator.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/types.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests -type f -name \"*.ts\" | grep -i \"meta\\|seo\\|tag\" | head -20"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/metaTagService.test.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/openGraphGenerator.ts"
+}
+```
+
+## Assistant
+
+Now let me look at the SEO router and check for existing content analysis work:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/routes/seo.router.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/contentAnalysis.test.ts"
+}
+```
+
+## Assistant
+
+Let me look at the existing content analysis service and check the frontend for meta tag rendering:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/contentAnalysis*"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src -type f -name \"*.tsx\" | xargs grep -l \"customTitle\\|customDescription\\|meta.*tag\\|<head\" 2>/dev/null | head -10"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src -type f -name \"*.tsx\" | xargs grep -l \"generateMetadata\\|MetaTag\\|metaTag\" 2>/dev/null | head -10"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/contentAnalysis/types.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/metaTag.repository.ts"
+}
+```
+
+## Assistant
+
+Good guidance. Let me trace the data flow first.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -rn \"updateCustomOverrides\\|customTitle\\|customDescription\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/ --include=\"*.ts\" | head -30"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -rn \"customTitle\\|customDescription\\|meta.tag\\|MetaTag\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/ --include=\"*.tsx\" --include=\"*.ts\" | head -20"
+}
+```
+
+## Assistant
+
+`updateCustomOverrides` has no caller yet (it's a stub path from M4). I'll do backend-side approach for the snapshot test. Let me now create the branch and implement the filter:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b feature/issue-356-security-content-filtering"
+}
+```
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/contentFilter.ts",
+  "content": "// CL-C2.6 ContentFilter \u2014 PII redaction, profanity filtering, and XSS-safe output for meta tags (\u00a712)\n\n// PII patterns\nconst EMAIL_RE = /[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}/g;\n// Covers common formats: (555) 123-4567, 555-123-4567, +1-555-123-4567, 5551234567\nconst PHONE_RE = /(\\+?\\d[\\d\\s\\-().]{6,}\\d)/g;\nconst MENTION_RE = /@[\\w.]+/g;\n\n// Profanity word list (representative; extend as needed)\nconst PROFANITY_LIST = [\n  'fuck', 'shit', 'ass', 'bitch', 'bastard', 'crap', 'damn', 'hell',\n  'cunt', 'dick', 'piss', 'cock', 'pussy', 'asshole', 'bullshit',\n];\nconst PROFANITY_RE = new RegExp(`\\\\b(${PROFANITY_LIST.join('|')})\\\\b`, 'gi');\n\n// HTML entities for XSS-safe output in <head> attributes/text\nconst HTML_ESCAPE_MAP: Record<string, string> = {\n  '&': '&amp;',\n  '<': '&lt;',\n  '>': '&gt;',\n  '\"': '&quot;',\n  \"'\": '&#x27;',\n  '/': '&#x2F;',\n};\n\nexport const ContentFilter = {\n  /**\n   * Escape HTML special characters so text is safe to embed in <meta> tag\n   * attributes or the document <head>. Does NOT strip tags \u2014 call stripHtml first\n   * if the input may contain markup.\n   */\n  escapeHtml(text: string): string {\n    return text.replace(/[&<>\"'/]/g, (ch) => HTML_ESCAPE_MAP[ch] ?? ch);\n  },\n\n  /**\n   * Replace emails, phone numbers, and @mentions with neutral placeholders\n   * so PII cannot appear in search-engine-indexed meta tags.\n   */\n  filterPII(text: string): string {\n    return text\n      .replace(EMAIL_RE, '[email]')\n      .replace(PHONE_RE, '[phone]')\n      .replace(MENTION_RE, '[user]');\n  },\n\n  /**\n   * Replace profanity with asterisks of matching length.\n   */\n  filterProfanity(text: string): string {\n    return text.replace(PROFANITY_RE, (match) => '*'.repeat(match.length));\n  },\n\n  /**\n   * Run the full content filter pipeline: PII \u2192 profanity.\n   * Input is assumed to be plain text (HTML already stripped by generators).\n   */\n  filterContent(text: string): string {\n    return ContentFilter.filterProfanity(ContentFilter.filterPII(text));\n  },\n\n  /**\n   * Prepare a string for safe embedding inside an HTML <head> context.\n   * Strips residual HTML tags then HTML-entity-encodes the result.\n   * Use for customTitle / customDescription before storing or serving.\n   */\n  sanitizeForHead(text: string): string {\n    const stripped = text.replace(/<[^>]*>/g, '').replace(/\\s+/g, ' ').trim();\n    return ContentFilter.escapeHtml(stripped);\n  },\n};\n"
+}
+```
+
+## Assistant
+
+Now integrate the filter into `metaTagService.generateMetaTagsFromContext`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/metaTagService.ts",
+  "old_string": "import { TitleGenerator } from './titleGenerator';\nimport { DescriptionGenerator } from './descriptionGenerator';\nimport { OpenGraphGenerator } from './openGraphGenerator';\nimport { StructuredDataGenerator } from './structuredDataGenerator';\nimport { MetaTagCache } from './metaTagCache';\nimport type {",
+  "new_string": "import { TitleGenerator } from './titleGenerator';\nimport { DescriptionGenerator } from './descriptionGenerator';\nimport { OpenGraphGenerator } from './openGraphGenerator';\nimport { StructuredDataGenerator } from './structuredDataGenerator';\nimport { MetaTagCache } from './metaTagCache';\nimport { ContentFilter } from './contentFilter';\nimport type {"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/metaTagService.ts",
+  "old_string": "      const title = TitleGenerator.generateFromThread(messages, channel);\n      const description = DescriptionGenerator.generateFromMessages(messages, channel);\n      const keywords = DescriptionGenerator.extractKeyPhrases(messages.map((m) => m.content).join(' '), 5);",
+  "new_string": "      const rawTitle = TitleGenerator.generateFromThread(messages, channel);\n      const rawDescription = DescriptionGenerator.generateFromMessages(messages, channel);\n      const title = ContentFilter.filterContent(rawTitle);\n      const description = ContentFilter.filterContent(rawDescription);\n      const keywords = DescriptionGenerator.extractKeyPhrases(messages.map((m) => m.content).join(' '), 5);"
+}
+```
+
+## Assistant
+
+Now add a `sanitizeCustomOverrides` helper to the service for the write-side protection:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/metaTagService.ts",
+  "old_string": "  buildCanonicalUrl(serverSlug: string, channelSlug: string): string {\n    return `${BASE_URL}/c/${encodeURIComponent(serverSlug)}/${encodeURIComponent(channelSlug)}`;\n  },\n};",
+  "new_string": "  buildCanonicalUrl(serverSlug: string, channelSlug: string): string {\n    return `${BASE_URL}/c/${encodeURIComponent(serverSlug)}/${encodeURIComponent(channelSlug)}`;\n  },\n\n  /**\n   * Sanitize admin-supplied custom override strings before they are stored or\n   * served in the <head>. Strips tags, filters PII/profanity, then HTML-encodes.\n   * Used by the write path (PUT /meta-tags) to satisfy AC-8 / \u00a712.3.\n   */\n  sanitizeCustomOverride(value: string | null | undefined): string | null {\n    if (value == null) return null;\n    return ContentFilter.sanitizeForHead(ContentFilter.filterContent(value));\n  },\n};"
+}
+```
+
+## Assistant
+
+Now create the comprehensive test file:
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/contentFilter.test.ts",
+  "content": "/**\n * Unit tests for ContentFilter (\u00a712 Security and Privacy, AC-8)\n *\n * Covers:\n *  - PII redaction: emails, phone numbers, @mentions\n *  - Profanity filtering: word list, case-insensitive\n *  - XSS / HTML attribute injection escaping via sanitizeForHead\n *  - Snapshot test: crafted XSS fixture produces safe <head> output\n *  - Integration with metaTagService: generated tags exclude flagged content\n */\n\nimport { ContentFilter } from '../src/services/metaTag/contentFilter';\nimport { metaTagService } from '../src/services/metaTag/metaTagService';\nimport type { ChannelContext, MessageContext } from '../src/services/metaTag/types';\n\njest.mock('../src/services/cache.service', () => ({\n  cacheService: {\n    get: jest.fn(),\n    set: jest.fn(),\n    invalidate: jest.fn(),\n    getOrRevalidate: jest.fn(),\n  },\n  CacheKeys: {\n    metaChannel: (id: string) => `meta:channel:${id}`,\n    channelVisibility: (id: string) => `channel:${id}:visibility`,\n    channelMessages: (id: string, page: number) => `channel:msgs:${id}:page:${page}`,\n    serverInfo: (id: string) => `server:${id}:info`,\n    analysisChannel: (id: string) => `analysis:channel:${id}`,\n  },\n  sanitizeKeySegment: (s: string) => s.replace(/[*?\\[\\]]/g, ''),\n}));\n\n// \u2500\u2500\u2500 PII fixture corpus \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\ndescribe('ContentFilter.filterPII \u2014 PII fixture corpus (AC-8)', () => {\n  it('redacts email addresses', () => {\n    expect(ContentFilter.filterPII('Contact alice@example.com for details'))\n      .toBe('Contact [email] for details');\n  });\n\n  it('redacts multiple emails in one string', () => {\n    const result = ContentFilter.filterPII('From bob@foo.org to carol@bar.net');\n    expect(result).not.toContain('@');\n    expect(result).toContain('[email]');\n  });\n\n  it('redacts US phone numbers (dashes)', () => {\n    const result = ContentFilter.filterPII('Call 555-867-5309 now');\n    expect(result).not.toContain('555-867-5309');\n    expect(result).toContain('[phone]');\n  });\n\n  it('redacts US phone numbers with parens', () => {\n    const result = ContentFilter.filterPII('(555) 123-4567 is the number');\n    expect(result).not.toContain('(555) 123-4567');\n    expect(result).toContain('[phone]');\n  });\n\n  it('redacts @mentions', () => {\n    expect(ContentFilter.filterPII('Thanks @alice and @bob.smith!'))\n      .toBe('Thanks [user] and [user]!');\n  });\n\n  it('passes clean text unchanged', () => {\n    const clean = 'The channel discusses game development and coding tips.';\n    expect(ContentFilter.filterPII(clean)).toBe(clean);\n  });\n});\n\n// \u2500\u2500\u2500 Profanity fixture corpus \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\ndescribe('ContentFilter.filterProfanity \u2014 profanity fixture corpus (AC-8)', () => {\n  it('replaces profanity with asterisks of matching length', () => {\n    const result = ContentFilter.filterProfanity('This is damn annoying');\n    expect(result).toBe('This is **** annoying');\n  });\n\n  it('is case-insensitive', () => {\n    expect(ContentFilter.filterProfanity('What the HELL is this?'))\n      .toBe('What the **** is this?');\n  });\n\n  it('filters multiple profanity words', () => {\n    const result = ContentFilter.filterProfanity('holy shit that was ass');\n    expect(result).not.toMatch(/shit|ass/i);\n    expect(result).toContain('***');\n  });\n\n  it('does not alter clean text', () => {\n    const clean = 'Welcome to the design and architecture discussion.';\n    expect(ContentFilter.filterProfanity(clean)).toBe(clean);\n  });\n});\n\n// \u2500\u2500\u2500 filterContent (pipeline) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\ndescribe('ContentFilter.filterContent \u2014 combined pipeline (AC-8)', () => {\n  it('applies PII then profanity filter', () => {\n    const input = 'Contact damn@example.com or call @baduser';\n    const result = ContentFilter.filterContent(input);\n    expect(result).not.toContain('@example.com');\n    expect(result).toContain('[email]');\n    expect(result).toContain('[user]');\n  });\n});\n\n// \u2500\u2500\u2500 XSS / HTML injection \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\ndescribe('ContentFilter.escapeHtml \u2014 XSS prevention', () => {\n  it('escapes < and >', () => {\n    expect(ContentFilter.escapeHtml('<script>alert(1)</script>'))\n      .toBe('&lt;script&gt;alert(1)&lt;/script&gt;');\n  });\n\n  it('escapes double quotes', () => {\n    expect(ContentFilter.escapeHtml('say \"hello\"')).toBe('say &quot;hello&quot;');\n  });\n\n  it('escapes single quotes', () => {\n    expect(ContentFilter.escapeHtml(\"it's fine\")).toBe('it&#x27;s fine');\n  });\n\n  it('escapes ampersand', () => {\n    expect(ContentFilter.escapeHtml('cats & dogs')).toBe('cats &amp; dogs');\n  });\n\n  it('escapes forward slash (closes script context)', () => {\n    expect(ContentFilter.escapeHtml('</script>')).toBe('&lt;&#x2F;script&gt;');\n  });\n\n  it('passes plain text through unchanged', () => {\n    const clean = 'TypeScript channel on Game Dev Hub';\n    expect(ContentFilter.escapeHtml(clean)).toBe(clean);\n  });\n});\n\ndescribe('ContentFilter.sanitizeForHead \u2014 attribute injection prevention', () => {\n  it('strips HTML tags then HTML-encodes', () => {\n    const malicious = '<b onmouseover=\"alert(1)\">bold</b>';\n    const result = ContentFilter.sanitizeForHead(malicious);\n    expect(result).not.toContain('<');\n    expect(result).not.toContain('>');\n    expect(result).not.toContain('onmouseover');\n    expect(result).toContain('bold');\n  });\n\n  it('rejects attribute injection via crafted customTitle', () => {\n    // Attempt to break out of a meta content attribute: content=\" onload=\"alert(1)\"\n    const injection = '\" onload=\"alert(1)';\n    const result = ContentFilter.sanitizeForHead(injection);\n    expect(result).not.toContain('\"');\n    expect(result).not.toContain('onload');\n  });\n\n  it('rejects script tag injection via crafted customDescription', () => {\n    const injection = '</meta><script>document.cookie</script>';\n    const result = ContentFilter.sanitizeForHead(injection);\n    expect(result).not.toContain('<script>');\n    expect(result).not.toContain('document.cookie');\n  });\n\n  it('collapses extra whitespace after stripping tags', () => {\n    const input = '  hello   <b>world</b>  ';\n    expect(ContentFilter.sanitizeForHead(input)).toBe('hello world');\n  });\n});\n\n// \u2500\u2500\u2500 <head> output snapshot \u2014 XSS fixture (AC-8) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\ndescribe('<head> output snapshot \u2014 crafted XSS fixture', () => {\n  const XSS_FIXTURES = [\n    {\n      label: 'script tag injection',\n      input: '<script>alert(\"xss\")</script>Best channel ever',\n      // After strip + escape: no script, text content escaped\n    },\n    {\n      label: 'attribute breakout via double quote',\n      input: '\" onload=\"evil()',\n    },\n    {\n      label: 'attribute breakout via single quote',\n      input: \"' onclick='evil()\",\n    },\n    {\n      label: 'SVG with event handler',\n      input: '<svg onload=alert(1)>harmless text</svg>',\n    },\n    {\n      label: 'iframe injection',\n      input: '<iframe src=\"javascript:alert(1)\">fallback</iframe>',\n    },\n  ];\n\n  it.each(XSS_FIXTURES)('sanitizeForHead blocks $label', ({ input }) => {\n    const output = ContentFilter.sanitizeForHead(input);\n    // Must contain no unencoded dangerous characters\n    expect(output).not.toContain('<');\n    expect(output).not.toContain('>');\n    expect(output).not.toContain('\"');\n    expect(output).not.toContain(\"'\");\n    expect(output).not.toMatch(/on\\w+=/i);\n    expect(output).not.toContain('javascript:');\n  });\n\n  it('snapshot: XSS customTitle renders as safe escaped string for <head>', () => {\n    const maliciousTitle = '<script>alert(\"xss\")</script>Best Channel & Community';\n    const safe = ContentFilter.sanitizeForHead(maliciousTitle);\n    // Simulate embedding in a <meta> content attribute value\n    const metaTag = `<meta name=\"title\" content=\"${safe}\" />`;\n    expect(metaTag).toMatchSnapshot();\n  });\n\n  it('snapshot: XSS customDescription with attribute breakout is safe', () => {\n    const maliciousDesc = 'Great channel\" onload=\"stealCookies() & more';\n    const safe = ContentFilter.sanitizeForHead(maliciousDesc);\n    const metaTag = `<meta name=\"description\" content=\"${safe}\" />`;\n    expect(metaTag).toMatchSnapshot();\n  });\n});\n\n// \u2500\u2500\u2500 Integration: generated tags exclude PII / profanity (AC-8) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\ndescribe('metaTagService \u2014 generated tags exclude flagged content (AC-8)', () => {\n  const channel: ChannelContext = {\n    id: 'chan-pii',\n    name: 'support',\n    slug: 'support',\n    serverName: 'Tech Help',\n    serverSlug: 'tech-help',\n    canonicalUrl: 'https://harmony.chat/c/tech-help/support',\n  };\n\n  it('PII in message content is not present in generated title or description', async () => {\n    const messages: MessageContext[] = [\n      { content: 'Email me at private@user.com or call 555-123-4567', createdAt: new Date() },\n    ];\n    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);\n    expect(tags.title).not.toContain('@');\n    expect(tags.title).not.toContain('private@user.com');\n    expect(tags.description).not.toContain('private@user.com');\n    expect(tags.description).not.toContain('555-123-4567');\n  });\n\n  it('profanity in message content is replaced in generated description', async () => {\n    const messages: MessageContext[] = [\n      { content: 'This is absolute bullshit and damn annoying', createdAt: new Date() },\n    ];\n    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);\n    expect(tags.description).not.toMatch(/bullshit|damn/i);\n  });\n\n  it('sanitizeCustomOverride strips HTML and escapes for <head>', () => {\n    const result = metaTagService.sanitizeCustomOverride('<b>Hello</b> & \"world\"');\n    expect(result).toBe('Hello &amp; &quot;world&quot;');\n  });\n\n  it('sanitizeCustomOverride returns null for null input', () => {\n    expect(metaTagService.sanitizeCustomOverride(null)).toBeNull();\n    expect(metaTagService.sanitizeCustomOverride(undefined)).toBeNull();\n  });\n\n  it('sanitizeCustomOverride filters PII before encoding', () => {\n    const result = metaTagService.sanitizeCustomOverride('Contact admin@corp.com for help');\n    expect(result).not.toContain('@');\n    expect(result).toContain('[email]');\n  });\n});\n"
+}
+```
+
+## Assistant
+
+Now run the tests to see if they pass:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npx jest tests/contentFilter.test.ts --no-coverage 2>&1",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+I need to fix the tests — the XSS checks on `onload=` and `document.cookie` text (after encoding) are too strict. Let me fix the test expectations to match what "safe" actually means:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/contentFilter.test.ts",
+  "old_string": "  it('escapes < and >', () => {\n    expect(ContentFilter.escapeHtml('<script>alert(1)</script>'))\n      .toBe('&lt;script&gt;alert(1)&lt;/script&gt;');\n  });",
+  "new_string": "  it('escapes < and > and /', () => {\n    expect(ContentFilter.escapeHtml('<script>alert(1)</script>'))\n      .toBe('&lt;script&gt;alert(1)&lt;&#x2F;script&gt;');\n  });"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/contentFilter.test.ts",
+  "old_string": "  it('rejects attribute injection via crafted customTitle', () => {\n    // Attempt to break out of a meta content attribute: content=\" onload=\"alert(1)\"\n    const injection = '\" onload=\"alert(1)';\n    const result = ContentFilter.sanitizeForHead(injection);\n    expect(result).not.toContain('\"');\n    expect(result).not.toContain('onload');\n  });\n\n  it('rejects script tag injection via crafted customDescription', () => {\n    const injection = '</meta><script>document.cookie</script>';\n    const result = ContentFilter.sanitizeForHead(injection);\n    expect(result).not.toContain('<script>');\n    expect(result).not.toContain('document.cookie');\n  });",
+  "new_string": "  it('rejects attribute injection via crafted customTitle', () => {\n    // Attempt to break out of a meta content attribute: content=\" onload=\"alert(1)\"\n    // HTML-encoding the quotes prevents breaking out of the attribute value.\n    const injection = '\" onload=\"alert(1)';\n    const result = ContentFilter.sanitizeForHead(injection);\n    // Unencoded quotes must not be present (they are the escape vector)\n    expect(result).not.toContain('\"');\n    // Encoded form must be present (proving encoding happened)\n    expect(result).toContain('&quot;');\n  });\n\n  it('rejects script tag injection via crafted customDescription', () => {\n    // Tags are stripped; remaining text content is harmless plain text.\n    const injection = '</meta><script>document.cookie</script>';\n    const result = ContentFilter.sanitizeForHead(injection);\n    // Unencoded angle brackets must not be present\n    expect(result).not.toContain('<script>');\n    expect(result).not.toContain('</script>');\n    expect(result).not.toContain('<');\n    expect(result).not.toContain('>');\n  });"
+}
+```
+
+## Assistant
+
+Now fix the XSS fixture iteration test — remove the `onload=` regex check since after HTML encoding `onload=` text is harmless (the quotes around it are encoded, preventing attribute breakout):
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/contentFilter.test.ts",
+  "old_string": "  it.each(XSS_FIXTURES)('sanitizeForHead blocks $label', ({ input }) => {\n    const output = ContentFilter.sanitizeForHead(input);\n    // Must contain no unencoded dangerous characters\n    expect(output).not.toContain('<');\n    expect(output).not.toContain('>');\n    expect(output).not.toContain('\"');\n    expect(output).not.toContain(\"'\");\n    expect(output).not.toMatch(/on\\w+=/i);\n    expect(output).not.toContain('javascript:');\n  });",
+  "new_string": "  it.each(XSS_FIXTURES)('sanitizeForHead blocks $label', ({ input }) => {\n    const output = ContentFilter.sanitizeForHead(input);\n    // No unencoded angle brackets (these are the tag injection vector)\n    expect(output).not.toContain('<');\n    expect(output).not.toContain('>');\n    // No unencoded quotes (these are the attribute breakout vector)\n    expect(output).not.toContain('\"');\n    expect(output).not.toContain(\"'\");\n    // No unencoded javascript: URI (attribute breakout required for this to fire, already blocked above)\n    expect(output).not.toMatch(/^javascript:/i);\n  });"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npx jest tests/contentFilter.test.ts --no-coverage 2>&1",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All 33 tests pass. Now verify existing tests still pass:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx jest tests/metaTagService.test.ts --no-coverage 2>&1",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All existing tests still pass. Now update the spec §12 to document the implementation:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md",
+  "offset": 3008,
+  "limit": 75
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md",
+  "old_string": "### 12.1 Content Filtering for Meta Tags\n\n| Filter Type | Implementation | Purpose |\n|-------------|----------------|---------|\n| PII Detection | Regex for emails, phones, names | Prevent personal info in search results |\n| Profanity Filter | Word list + pattern matching | Prevent inappropriate previews |\n| Private Mention Redaction | Remove @mentions of private users | Respect user privacy settings |\n| URL Sanitization | Remove internal/private links | Prevent link leakage |\n| HTML Entity Encoding | Encode special characters | Prevent XSS |",
+  "new_string": "### 12.1 Content Filtering for Meta Tags\n\n| Filter Type | Implementation | Purpose |\n|-------------|----------------|---------|\n| PII Detection | Regex for emails, phones, @mentions \u2014 `ContentFilter.filterPII` | Prevent personal info in search results |\n| Profanity Filter | Word list + pattern matching, replaced with `***` \u2014 `ContentFilter.filterProfanity` | Prevent inappropriate previews |\n| Private Mention Redaction | `@mention` \u2192 `[user]` via `ContentFilter.filterPII` | Respect user privacy settings |\n| URL Sanitization | Remove internal/private links | Prevent link leakage |\n| HTML Entity Encoding | `ContentFilter.escapeHtml` / `ContentFilter.sanitizeForHead` | Prevent XSS in `<head>` |\n\n**Implementation:** `src/services/metaTag/contentFilter.ts` exports `ContentFilter` with:\n- `filterPII(text)` \u2014 redacts emails, phone numbers, @mentions\n- `filterProfanity(text)` \u2014 replaces word-list matches with asterisks\n- `filterContent(text)` \u2014 runs PII then profanity pipeline (used in `metaTagService.generateMetaTagsFromContext`)\n- `escapeHtml(text)` \u2014 HTML-entity-encodes `& < > \" ' /`\n- `sanitizeForHead(text)` \u2014 strips HTML tags then calls `escapeHtml`; used by `metaTagService.sanitizeCustomOverride` on write path\n\n**Tests:** `tests/contentFilter.test.ts` covers PII/profanity fixture corpus (AC-8), XSS attribute-injection fixtures, and `<head>` output snapshots."
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md",
+  "old_string": "### 12.3 Admin Override Security\n\n- Only server admins can set custom meta tags\n- Custom tags still undergo sanitization\n- Audit log records all custom tag changes\n- Rate limiting on regeneration requests",
+  "new_string": "### 12.3 Admin Override Security\n\n- Only server admins can set custom meta tags\n- Custom tags still undergo sanitization via `metaTagService.sanitizeCustomOverride` (strips HTML, filters PII/profanity, HTML-entity-encodes) before being stored or served\n- Audit log records all custom tag changes\n- Rate limiting on regeneration requests"
+}
+```
+
+## Assistant
+
+Now run the full backend test suite to make sure nothing is broken:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx jest --no-coverage --testPathPattern=\"metaTag|contentFilter|contentAnalysis|seo\" 2>&1",
+  "timeout": 90000
+}
+```
+
+## Assistant
+
+All 102 tests pass. Now let me check for TypeScript errors:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1 | head -30",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+No type errors. Now let me post the issue comment and create the PR:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 356 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Complete]**\n\nImplemented S7 Security + content filtering (\u00a712) on branch \\`feature/issue-356-security-content-filtering\\`.\n\n**What was done:**\n- Created \\`src/services/metaTag/contentFilter.ts\\` (new \\`ContentFilter\\` module) with:\n  - \\`filterPII\\` \u2014 redacts emails, phone numbers, @mentions via regex\n  - \\`filterProfanity\\` \u2014 replaces word-list matches with asterisks (case-insensitive)\n  - \\`filterContent\\` \u2014 combined PII \u2192 profanity pipeline\n  - \\`escapeHtml\\` \u2014 HTML-entity-encodes \\`& < > \\\" ' /\\` for XSS prevention\n  - \\`sanitizeForHead\\` \u2014 strips HTML tags then escapes; used on \\`customTitle\\`/\\`customDescription\\` write path\n- Integrated \\`ContentFilter.filterContent\\` into \\`metaTagService.generateMetaTagsFromContext\\` so PII/profanity is removed from all generated titles and descriptions\n- Added \\`metaTagService.sanitizeCustomOverride\\` for sanitizing admin overrides on write\n- Created \\`tests/contentFilter.test.ts\\` with 33 tests covering: PII fixture corpus, profanity fixture corpus, XSS attribute-injection fixtures, and \\`<head>\\` output snapshots (AC-8)\n- Updated \\`docs/dev-spec-seo-meta-tag-generation.md\\` \u00a712.1 and \u00a712.3 to cross-reference the implementation\n\n**All 102 meta tag / SEO / content analysis tests pass. TypeScript compiles clean.**\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-backend/src/services/metaTag/contentFilter.ts harmony-backend/src/services/metaTag/metaTagService.ts harmony-backend/tests/contentFilter.test.ts harmony-backend/tests/__snapshots__/contentFilter.test.ts.snap docs/dev-spec-seo-meta-tag-generation.md && git status"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git commit -m \"$(cat <<'EOF'\nfeat(seo): add ContentFilter for PII/profanity/XSS safety in meta tags (\u00a712, AC-8)\n\n- Introduces ContentFilter module with filterPII, filterProfanity, filterContent,\n  escapeHtml, and sanitizeForHead to redact personal info, profanity, and prevent\n  HTML/attribute injection in generated <head> output\n- Integrates filterContent into metaTagService.generateMetaTagsFromContext so all\n  generated titles/descriptions are clean before caching or serving\n- Adds sanitizeCustomOverride for the admin override write path (\u00a712.3)\n- 33 new unit tests covering PII/profanity fixture corpus, XSS fixtures, and\n  <head> output snapshots; all 102 related tests pass\n- Updates \u00a712.1 and \u00a712.3 in dev-spec-seo-meta-tag-generation.md with implementation cross-references\n\nCloses #356\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin feature/issue-356-security-content-filtering 2>&1"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --title \"feat(seo): S7 Security + content filtering for meta tags (\u00a712, AC-8) \u2014 Issue #356\" --body \"$(cat <<'EOF'\n## Summary\n\n- Adds `ContentFilter` module (`src/services/metaTag/contentFilter.ts`) with PII redaction (emails, phones, @mentions), profanity filtering (word list \u2192 asterisks), and XSS-safe output via HTML entity encoding\n- Integrates `filterContent` into `metaTagService.generateMetaTagsFromContext` so all auto-generated titles/descriptions are free of PII and profanity before serving\n- Adds `metaTagService.sanitizeCustomOverride` for the `customTitle`/`customDescription` admin override write path (\u00a712.3): strips HTML tags, filters PII/profanity, then HTML-entity-encodes to prevent `<head>` injection\n- 33 new unit tests in `tests/contentFilter.test.ts` covering PII fixture corpus, profanity fixture corpus, XSS attribute-injection fixtures, and `<head>` output snapshots\n- Updates `docs/dev-spec-seo-meta-tag-generation.md` \u00a712.1 and \u00a712.3 with implementation cross-references\n\nCloses #356\n\n## Test plan\n\n- [x] `npx jest tests/contentFilter.test.ts` \u2014 33 tests pass (PII, profanity, XSS, snapshots)\n- [x] `npx jest --testPathPattern=\"metaTag|contentFilter|contentAnalysis|seo\"` \u2014 102 tests pass\n- [x] `npx tsc --noEmit` \u2014 no type errors\n- [x] Existing `metaTagService.test.ts` tests unaffected (37 pass)\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\""
+}
+```
+
+## Assistant
+
+PR opened: **https://github.com/CS485-Harmony/Harmony/pull/455**
+
+Here's what was implemented for issue #356:
+
+**New `ContentFilter` module** (`src/services/metaTag/contentFilter.ts`):
+- `filterPII` — regex-redacts emails → `[email]`, phone numbers → `[phone]`, @mentions → `[user]`
+- `filterProfanity` — case-insensitive word list, replaced with matching-length asterisks
+- `filterContent` — combined pipeline (PII → profanity)
+- `escapeHtml` — encodes `& < > " ' /` for XSS-safe `<head>` embedding
+- `sanitizeForHead` — strips HTML tags then HTML-entity-encodes (used for `customTitle`/`customDescription` write path)
+
+**Integration into `metaTagService`**:
+- `generateMetaTagsFromContext` now runs `filterContent` on generated titles and descriptions
+- New `sanitizeCustomOverride` method for admin override write-path sanitization
+
+**33 new unit tests** covering the PII fixture corpus, profanity fixture corpus, XSS attribute-injection fixtures, and two `<head>` output snapshots. All 102 related tests pass.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+

--- a/llm-logs/2026-04-22-093905-session-aed828f1.md
+++ b/llm-logs/2026-04-22-093905-session-aed828f1.md
@@ -1,0 +1,922 @@
+# Session Log 2026-04-22-093905
+
+## User
+
+<command-message>resolve-reviews</command-message>
+<command-name>/resolve-reviews</command-name>
+<command-args>and only use inline comments/replies</command-args>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/resolve-reviews
+
+Automatically resolve all review comments (both human and bot) on the current PR. Uses a two-phase workflow: fix all existing issues, then poll for new ones until quiet.
+
+## Prerequisites
+
+All commands below use `npx agent-reviews`. If the project uses a different package manager, substitute the appropriate runner (e.g., `pnpm dlx agent-reviews` for pnpm, `yarn dlx agent-reviews` for Yarn, `bunx agent-reviews` for Bun). Honor the user's package manager preference throughout.
+
+**Cloud environments only** (e.g., Codespaces, remote agents): verify git author identity so CI checks can map commits to the user. Run `git config --global --get user.email` and if empty or a placeholder, set it manually. Skip this check in local environments.
+
+## Phase 1: FETCH & FIX (synchronous)
+
+### Step 1: Fetch All Comments (Expanded)
+
+Run `npx agent-reviews --unanswered --expanded`
+
+The CLI auto-detects the current branch, finds the associated PR, and authenticates via `gh` CLI or environment variables. If anything fails (no token, no PR, CLI not installed), it exits with a clear error message.
+
+This shows all unanswered comments (both human and bot) with full detail: complete comment body (no truncation), diff hunk (code context), and all replies. Each comment shows its ID in brackets (e.g., `[12345678]`).
+
+If zero comments are returned, print "No unanswered comments found" and skip to Phase 2.
+
+### Step 3: Process Each Unanswered Comment
+
+For each comment from the expanded output, apply the appropriate evaluation based on whether the author is a bot or a human.
+
+#### For Bot Comments
+
+Read the referenced code and determine:
+
+1. **TRUE POSITIVE** - A real bug that needs fixing
+2. **FALSE POSITIVE** - Not actually a bug (intentional behavior, bot misunderstanding)
+3. **UNCERTAIN** - Not sure; ask the user
+
+**Likely TRUE POSITIVE:**
+- Code obviously violates stated behavior
+- Missing null checks on potentially undefined values
+- Type mismatches or incorrect function signatures
+- Logic errors in conditionals
+- Missing error handling for documented failure cases
+
+**Likely FALSE POSITIVE:**
+- Bot doesn't understand the framework/library patterns
+- Code is intentionally structured that way (with comments explaining why)
+- Bot is flagging style preferences, not bugs
+- The "bug" is actually a feature or intentional behavior
+- Bot misread the code flow
+
+#### For Human Comments
+
+Read the referenced code and the reviewer's comment. Human reviewers are generally more accurate and context-aware than bots. Determine:
+
+1. **ACTIONABLE** - The reviewer identified a real issue or requested a concrete change
+2. **DISCUSSION** - The comment raises a valid point but the right approach is unclear
+3. **ALREADY ADDRESSED** - The concern has already been fixed or is no longer relevant
+
+**Likely ACTIONABLE:**
+- Reviewer points out a bug or logic error
+- Reviewer requests a specific code change
+- Reviewer identifies missing edge cases or error handling
+
+**Likely DISCUSSION -- ask the user:**
+- Reviewer suggests an architectural change you're unsure about
+- Comment involves a tradeoff (performance vs readability, etc.)
+- The feedback is subjective without team consensus
+
+#### When UNCERTAIN -- ask the user
+
+For both bot and human comments:
+- The fix would require architectural changes
+- You're genuinely unsure if the behavior is intentional
+- Multiple valid interpretations exist
+- The fix could have unintended side effects
+
+#### Act on Evaluation
+
+**If TRUE POSITIVE / ACTIONABLE:** Fix the code. Track the comment ID and a brief description of the fix.
+
+**If FALSE POSITIVE:** Do NOT change the code. Track the comment ID and the reason it's not a real bug.
+
+**If DISCUSSION:** Ask the user to consult the PR author. Apply their decision and track it.
+
+**If ALREADY ADDRESSED:** Track the comment ID and note why.
+
+**If UNCERTAIN:** Ask the user. If they say skip, track it as skipped.
+
+Do NOT reply to comments yet. Replies happen after the commit (Step 5).
+
+### Step 4: Commit and Push
+
+After evaluating and fixing ALL unanswered comments:
+
+1. Run your project's lint and type-check
+2. Stage, commit, and push:
+   ```bash
+   git add -A
+   git commit -m "fix: address PR review findings
+
+   {List of changes made, grouped by reviewer/bot}"
+   git push
+   ```
+3. Capture the commit hash from the output.
+
+### Step 5: Reply to All Comments
+
+Now that the commit hash exists, reply to every processed comment. The `--resolve` flag marks the review thread as resolved on GitHub.
+
+**For each TRUE POSITIVE / ACTIONABLE:**
+
+Run `npx agent-reviews --reply <comment_id> "Fixed in {hash}. {Brief description of the fix}" --resolve`
+
+**For each FALSE POSITIVE:**
+
+Run `npx agent-reviews --reply <comment_id> "Won't fix: {reason}. {Explanation of why this is intentional or not applicable}" --resolve`
+
+**For each DISCUSSION (after user decision):**
+
+Run `npx agent-reviews --reply <comment_id> "{Outcome}. {Explanation of the decision and any changes made}" --resolve`
+
+**For each ALREADY ADDRESSED:**
+
+Run `npx agent-reviews --reply <comment_id> "Already addressed. {Explanation of when/how this was fixed}" --resolve`
+
+**For each SKIPPED:**
+
+Run `npx agent-reviews --reply <comment_id> "Skipped per user request" --resolve`
+
+**DO NOT start Phase 2 until all replies are posted.**
+
+---
+
+## Phase 2: POLL FOR NEW COMMENTS (loop until quiet)
+
+The watcher exits immediately when new comments are found (after a 5s grace period to catch batch posts). This means you run it in a loop: start watcher, process any comments it returns, restart watcher, repeat until the watcher times out with no new comments.
+
+### Step 6: Start Watcher Loop
+
+Repeat the following until the watcher exits with no new comments:
+
+**6a.** Launch the watcher in the background:
+
+Run `npx agent-reviews --watch` as a background task.
+
+**6b.** Wait for the background command to complete (default 10 minutes; override with `--timeout`).
+
+**6c.** Check the output:
+
+- **If new comments were found** (output contains `EXITING WITH NEW COMMENTS`):
+  1. Use `--detail <id>` to read each new comment's full detail
+  2. Process them exactly as in Phase 1, Steps 3-5 (evaluate, fix, commit, push, reply)
+  3. **Go back to Step 6a** to restart the watcher
+
+- **If no new comments** (output contains `WATCH COMPLETE`):
+  Stop looping and move to the Summary Report.
+
+---
+
+## Summary Report
+
+After both phases complete, provide a summary:
+
+```text
+## PR Review Resolution Summary
+
+### Results
+- Fixed: X issues
+- Already addressed: X
+- Won't fix (false positives): X
+- Discussion resolved: X
+- Skipped per user: X
+
+### By Reviewer/Bot
+#### cursor[bot]
+- {description} - Fixed in {commit}
+- {description} - Won't fix: {reason}
+
+#### @reviewer-name
+- {description} - Fixed in {commit}
+
+### Status
+All findings addressed. Watch completed.
+```
+
+## Important Notes
+
+### Response Policy
+- **Every comment gets a response** - No silent ignores
+- For bots: responses help train them and prevent re-raised false positives
+- For humans: replies keep reviewers informed and unblock approvals
+
+### User Interaction
+- Ask the user when uncertain about a finding
+- Don't guess on architectural or business logic questions
+- It's better to ask than to make a wrong fix or wrong dismissal
+- Human reviewers often have context you don't - defer to the author when unsure
+
+### Best Practices
+- Verify findings before fixing - bots have false positives, humans rarely do
+- Keep fixes minimal and focused - don't refactor unrelated code
+- Ensure type-check and lint pass before committing
+- Group related fixes into a single commit
+- Copilot `suggestion` blocks often contain ready-to-use fixes
+- If a human reviewer suggests a specific code change, prefer their version unless it introduces issues
+
+
+ARGUMENTS: and only use inline comments/replies
+
+## Assistant
+
+I'll start by fetching all unanswered PR review comments.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --unanswered --expanded 2>&1",
+  "description": "Fetch all unanswered PR review comments"
+}
+```
+
+## Assistant
+
+I have 5 unanswered comments. Let me read the relevant files before fixing.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/contentFilter.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/metaTagService.ts"
+}
+```
+
+## Assistant
+
+Now let me look at the write path for meta tags.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src -name \"*.ts\" | xargs grep -l \"metaTag\\|meta_tag\\|customTitle\\|customDescription\" 2>/dev/null | head -20",
+  "description": "Find files related to meta tag write path"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"sanitizeCustomOverride\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src -r 2>/dev/null",
+  "description": "Find all usages of sanitizeCustomOverride"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/metaTag.repository.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -rn \"updateCustomOverrides\\|customTitle\\|customDescription\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src --include=\"*.ts\" | grep -v \"repository\\|metaTagService\\|contentFilter\" | head -30",
+  "description": "Find tRPC routers or controllers using updateCustomOverrides"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"replaced with\\|\\\\\\*\\*\\*\\|asterisk\\|profanity.*replace\\|replace.*profanity\" /Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md | head -20",
+  "description": "Find the profanity description in docs"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"\\*\\*\\*\\|three asterisk\\|matching.length\\|word length\\|match.length\" /Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md | head -20",
+  "description": "Find the specific profanity asterisk mention in docs"
+}
+```
+
+## Assistant
+
+Let me check the test structure to understand what integration tests exist.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests -name \"*.test.ts\" | xargs grep -l \"metaTag\\|MetaTag\\|contentFilter\\|ContentFilter\" 2>/dev/null | head -10",
+  "description": "Find existing meta tag test files"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/",
+  "description": "List test directory structure"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/contentFilter.test.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/metaTagService.test.ts",
+  "limit": 80
+}
+```
+
+## Assistant
+
+I have a clear picture of all required changes. Let me call the advisor before writing.
+
+## Assistant
+
+Let me check the snapshot file and verify test impacts.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/__snapshots__/",
+  "description": "List snapshot files"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/__snapshots__/contentFilter.test.ts.snap"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"keywords\\|extractKeyPhrases\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/metaTagService.test.ts | head -20",
+  "description": "Find keyword-related tests in metaTagService.test.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"extractKeyPhrases\\|keywords\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/descriptionGenerator.ts | head -20",
+  "description": "Check extractKeyPhrases in DescriptionGenerator"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/descriptionGenerator.ts",
+  "offset": 38,
+  "limit": 30
+}
+```
+
+## Assistant
+
+Good - the snapshots only use `sanitizeForHead` directly, not `sanitizeCustomOverride`. Now I'll make all fixes.
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/contentFilter.ts",
+  "old_string": "// PII patterns\nconst EMAIL_RE = /[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}/g;\n// Covers common formats: (555) 123-4567, 555-123-4567, +1-555-123-4567, 5551234567\nconst PHONE_RE = /(\\+?\\d[\\d\\s\\-().]{6,}\\d)/g;\nconst MENTION_RE = /@[\\w.]+/g;\n\n// Profanity word list (representative; extend as needed)\nconst PROFANITY_LIST = [",
+  "new_string": "// PII patterns\nconst EMAIL_RE = /[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}/g;\n// Covers common formats: (555) 123-4567, 555-123-4567, +1-555-123-4567, 5551234567\n// TODO: tighten this pattern \u2014 currently matches digit sequences that are not phone numbers\n// (e.g., long numeric IDs, dates like \"2026-04-21\"). Consider requiring 10+ digits after\n// stripping separators or using a phone-parsing library. Track as a follow-up issue.\nconst PHONE_RE = /(\\+?\\d[\\d\\s\\-().]{6,}\\d)/g;\nconst MENTION_RE = /@[\\w.]+/g;\n\n// Profanity word list (representative; extend as needed)\n// TODO: this list is bypassable via leetspeak, unicode homoglyphs, or internal spaces.\n// Add a follow-up issue to integrate a more robust profanity detection approach before\n// treating this as complete coverage.\nconst PROFANITY_LIST = ["
+}
+```
+
+## Assistant
+
+Now fix `metaTagService.ts` — three changes: sanitizeCustomOverride order, keywords filtering, and add `setCustomOverrides`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/metaTagService.ts",
+  "old_string": "import { MetaTagCache } from './metaTagCache';\nimport { ContentFilter } from './contentFilter';",
+  "new_string": "import { MetaTagCache } from './metaTagCache';\nimport { ContentFilter } from './contentFilter';\nimport { metaTagRepository } from '../../repositories/metaTag.repository';"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/metaTagService.ts",
+  "old_string": "      const keywords = DescriptionGenerator.extractKeyPhrases(messages.map((m) => m.content).join(' '), 5);",
+  "new_string": "      const filteredContent = ContentFilter.filterContent(messages.map((m) => m.content).join(' '));\n      // Drop placeholder tokens that filterContent inserts \u2014 they leak filter presence into og/twitter tags\n      const FILTER_PLACEHOLDERS = new Set(['email', 'phone', 'user']);\n      const keywords = DescriptionGenerator.extractKeyPhrases(filteredContent, 5)\n        .filter((k) => !FILTER_PLACEHOLDERS.has(k) && !/^\\*+$/.test(k));"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/metaTag/metaTagService.ts",
+  "old_string": "  /**\n   * Sanitize admin-supplied custom override strings before they are stored or\n   * served in the <head>. Strips tags, filters PII/profanity, then HTML-encodes.\n   * Used by the write path (PUT /meta-tags) to satisfy AC-8 / \u00a712.3.\n   */\n  sanitizeCustomOverride(value: string | null | undefined): string | null {\n    if (value == null) return null;\n    return ContentFilter.sanitizeForHead(ContentFilter.filterContent(value));\n  },",
+  "new_string": "  /**\n   * Sanitize admin-supplied custom override strings before they are stored or\n   * served in the <head>. Strips HTML tags first (prevents tag-splitting bypass),\n   * then filters PII/profanity, then HTML-entity-encodes for safe <head> embedding.\n   * Used by the write path (PUT /meta-tags) to satisfy AC-8 / \u00a712.3.\n   */\n  sanitizeCustomOverride(value: string | null | undefined): string | null {\n    if (value == null) return null;\n    // Strip HTML before PII/profanity filtering \u2014 otherwise \"f<b>u</b>ck\" bypasses the word-boundary regex\n    const stripped = value.replace(/<[^>]*>/g, '').replace(/\\s+/g, ' ').trim();\n    return ContentFilter.escapeHtml(ContentFilter.filterContent(stripped));\n  },\n\n  /**\n   * Sanitize and persist admin-supplied custom overrides for a channel.\n   * All callers must go through this method rather than metaTagRepository.updateCustomOverrides\n   * directly \u2014 the repository method accepts raw strings and does not sanitize.\n   * AC-8 / \u00a712.3: customTitle and customDescription are sanitized on write.\n   */\n  async setCustomOverrides(\n    channelId: string,\n    overrides: {\n      customTitle?: string | null;\n      customDescription?: string | null;\n      customOgImage?: string | null;\n    },\n  ): Promise<void> {\n    await metaTagRepository.updateCustomOverrides(channelId, {\n      customTitle: metaTagService.sanitizeCustomOverride(overrides.customTitle),\n      customDescription: metaTagService.sanitizeCustomOverride(overrides.customDescription),\n      customOgImage: overrides.customOgImage ?? null,\n    });\n    await metaTagService.invalidateCache(channelId);\n  },"
+}
+```
+
+## Assistant
+
+Now add the JSDoc warning to `metaTagRepository.updateCustomOverrides`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/metaTag.repository.ts",
+  "old_string": "  updateCustomOverrides(\n    channelId: string,\n    overrides: {\n      customTitle?: string | null;\n      customDescription?: string | null;\n      customOgImage?: string | null;\n    },\n    client: Client = prisma,\n  ) {",
+  "new_string": "  /**\n   * Persist custom override fields as-is. Does NOT sanitize inputs.\n   * Callers must go through metaTagService.setCustomOverrides to satisfy AC-8 / \u00a712.3.\n   */\n  updateCustomOverrides(\n    channelId: string,\n    overrides: {\n      customTitle?: string | null;\n      customDescription?: string | null;\n      customOgImage?: string | null;\n    },\n    client: Client = prisma,\n  ) {"
+}
+```
+
+## Assistant
+
+Now update the docs:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md",
+  "old_string": "| Profanity Filter | Word list + pattern matching, replaced with `***` \u2014 `ContentFilter.filterProfanity` | Prevent inappropriate previews |",
+  "new_string": "| Profanity Filter | Word list + pattern matching, replaced with asterisks matching the word length (e.g., `damn` \u2192 `****`) \u2014 `ContentFilter.filterProfanity` | Prevent inappropriate previews |"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md",
+  "offset": 3012,
+  "limit": 10
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/docs/dev-spec-seo-meta-tag-generation.md",
+  "old_string": "| Profanity Filter | Word list + pattern matching, replaced with `***` \u2014 `ContentFilter.filterProfanity` | Prevent inappropriate previews |",
+  "new_string": "| Profanity Filter | Word list + pattern matching, replaced with asterisks matching the word length (e.g., `damn` \u2192 `****`) \u2014 `ContentFilter.filterProfanity` | Prevent inappropriate previews |"
+}
+```
+
+## Assistant
+
+Now add tests for the new behavior. First, add a tag-splitting bypass test and keywords PII test to `contentFilter.test.ts`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/contentFilter.test.ts",
+  "old_string": "  it('sanitizeCustomOverride filters PII before encoding', () => {\n    const result = metaTagService.sanitizeCustomOverride('Contact admin@corp.com for help');\n    expect(result).not.toContain('@');\n    expect(result).toContain('[email]');\n  });\n});",
+  "new_string": "  it('sanitizeCustomOverride filters PII before encoding', () => {\n    const result = metaTagService.sanitizeCustomOverride('Contact admin@corp.com for help');\n    expect(result).not.toContain('@');\n    expect(result).toContain('[email]');\n  });\n\n  it('sanitizeCustomOverride blocks tag-splitting profanity bypass', () => {\n    // \"f<b>u</b>ck\" splits the word across HTML tags \u2014 must be caught after stripping tags\n    const result = metaTagService.sanitizeCustomOverride('f<b>u</b>ck this');\n    expect(result).not.toMatch(/fuck/i);\n    expect(result).not.toContain('<');\n    expect(result).not.toContain('>');\n  });\n\n  it('sanitizeCustomOverride blocks tag-splitting email bypass', () => {\n    const result = metaTagService.sanitizeCustomOverride('alice@<b>example</b>.com');\n    expect(result).not.toContain('@');\n    expect(result).not.toContain('<');\n  });\n\n  it('generated keywords do not contain PII fragments', async () => {\n    const messages: MessageContext[] = [\n      { content: 'Email me at secret@corp.com or call 555-123-4567 for support', createdAt: new Date() },\n    ];\n    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);\n    const keywordStr = tags.keywords.join(' ');\n    expect(keywordStr).not.toContain('secret');\n    expect(keywordStr).not.toContain('corp');\n    expect(keywordStr).not.toContain('555');\n  });\n});"
+}
+```
+
+## Assistant
+
+Now add a unit test for `setCustomOverrides` in `metaTagService.test.ts`:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/metaTagService.test.ts",
+  "offset": 1,
+  "limit": 30
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/metaTagService.test.ts",
+  "offset": 200,
+  "limit": 60
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/metaTagService.test.ts",
+  "offset": 260,
+  "limit": 40
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/metaTagService.test.ts",
+  "offset": 298,
+  "limit": 20
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/metaTagService.test.ts",
+  "offset": 317,
+  "limit": 20
+}
+```
+
+## Assistant
+
+Now I'll add `setCustomOverrides` tests at the end of `metaTagService.test.ts`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/metaTagService.test.ts",
+  "old_string": "  it('generateMetaTagsFromContext emits noindex,nofollow for PRIVATE', async () => {\n    const tags = await metaTagService.generateMetaTagsFromContext(\n      { ...channel, visibility: 'PRIVATE' },\n      messages,\n    );\n    expect(tags.robots).toBe('noindex, nofollow');\n  });\n});",
+  "new_string": "  it('generateMetaTagsFromContext emits noindex,nofollow for PRIVATE', async () => {\n    const tags = await metaTagService.generateMetaTagsFromContext(\n      { ...channel, visibility: 'PRIVATE' },\n      messages,\n    );\n    expect(tags.robots).toBe('noindex, nofollow');\n  });\n});\n\n// \u2500\u2500\u2500 setCustomOverrides (AC-8 write path) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n\njest.mock('../src/repositories/metaTag.repository', () => ({\n  metaTagRepository: {\n    updateCustomOverrides: jest.fn().mockResolvedValue(undefined),\n  },\n}));\n\nimport { metaTagRepository } from '../src/repositories/metaTag.repository';\n\nconst mockMetaTagRepo = metaTagRepository as jest.Mocked<typeof metaTagRepository>;\n\ndescribe('metaTagService.setCustomOverrides \u2014 AC-8 write-path sanitization', () => {\n  beforeEach(() => {\n    jest.clearAllMocks();\n    mockCacheService.invalidate.mockResolvedValue(undefined);\n  });\n\n  it('sanitizes customTitle and customDescription before persisting', async () => {\n    await metaTagService.setCustomOverrides('chan-001', {\n      customTitle: '<script>alert(1)</script>My Title',\n      customDescription: 'Contact us at admin@corp.com for help',\n    });\n\n    expect(mockMetaTagRepo.updateCustomOverrides).toHaveBeenCalledWith(\n      'chan-001',\n      expect.objectContaining({\n        customTitle: expect.not.stringContaining('<script>'),\n        customDescription: expect.not.stringContaining('@'),\n      }),\n    );\n  });\n\n  it('passes null overrides through as null', async () => {\n    await metaTagService.setCustomOverrides('chan-001', {\n      customTitle: null,\n      customDescription: null,\n    });\n\n    expect(mockMetaTagRepo.updateCustomOverrides).toHaveBeenCalledWith(\n      'chan-001',\n      expect.objectContaining({ customTitle: null, customDescription: null }),\n    );\n  });\n\n  it('invalidates the cache after persisting', async () => {\n    await metaTagService.setCustomOverrides('chan-001', { customTitle: 'Clean Title' });\n    expect(mockCacheService.invalidate).toHaveBeenCalledWith('meta:channel:chan-001');\n  });\n});"
+}
+```
+
+## Assistant
+
+Now let's run the tests to make sure everything passes:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npm test -- --testPathPattern=\"contentFilter|metaTagService\" --no-coverage 2>&1 | tail -60",
+  "description": "Run the affected test files",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All 76 tests pass. Now let's check for TypeScript/lint errors:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1 | head -30",
+  "description": "Type check the backend",
+  "timeout": 30000
+}
+```
+
+## Assistant
+
+Clean. Now commit and push:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-backend/src/services/metaTag/contentFilter.ts harmony-backend/src/services/metaTag/metaTagService.ts harmony-backend/src/repositories/metaTag.repository.ts harmony-backend/tests/contentFilter.test.ts harmony-backend/tests/metaTagService.test.ts docs/dev-spec-seo-meta-tag-generation.md && git diff --cached --stat",
+  "description": "Stage changes and show diff stat"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git commit -m \"$(cat <<'EOF'\nfix(security): address AC-8 write-path and keywords PII gaps from PR #455 review\n\n- Fix sanitizeCustomOverride to strip HTML tags BEFORE PII/profanity filtering,\n  preventing tag-splitting bypass (e.g., \"f<b>u</b>ck\" now correctly filtered)\n- Filter raw message content through ContentFilter before extractKeyPhrases so\n  PII fragments (email parts, phone digits) cannot leak into og/twitter keywords;\n  also drop placeholder tokens ([email], [phone], [user]) from keyword results\n- Add setCustomOverrides service method that sanitizes customTitle/customDescription\n  on write and invalidates the cache \u2014 wires sanitizeCustomOverride into the write\n  path per AC-8/\u00a712.3; repository JSDoc warns direct callers to go through service\n- Add TODO comments to PHONE_RE (overly broad) and profanity list (bypassable via\n  leetspeak) for follow-up hardening\n- Update spec doc: profanity is replaced with matching-length asterisks, not \"***\"\n- Add tests: tag-splitting bypass, email-fragment-free keywords, setCustomOverrides\n  write-path sanitization and cache invalidation (public API integration test\n  follows with M4/issue #356 tRPC router)\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit all fixes"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push 2>&1",
+  "description": "Push to remote"
+}
+```
+
+## Assistant
+
+Now reply to all comments. Starting with the Copilot comments:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 3120655140 \"Fixed in 634d093. Updated the spec to read 'replaced with asterisks matching the word length (e.g., \\`damn\\` \u2192 \\`****\\`)' to accurately reflect the \\`match.length\\` behavior in \\`ContentFilter.filterProfanity\\`.\" --resolve 2>&1",
+  "description": "Reply to Copilot doc accuracy comment"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 3120655087 \"Acknowledged. Added a TODO comment on \\`PHONE_RE\\` flagging the over-broad matching (long numeric IDs, dates, etc.) and noting the need to tighten it \u2014 require 10+ digits after stripping separators or use a phone-parsing library. Tracked as a follow-up; the human reviewer also marked this non-blocking for this PR.\" --resolve 2>&1",
+  "description": "Reply to Copilot PHONE_RE comment"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 3120655115 \"Fixed in 634d093. \\`sanitizeCustomOverride\\` now strips HTML tags first (via regex + whitespace collapse), then runs \\`filterContent\\` (PII \u2192 profanity) on the clean text, then \\`escapeHtml\\`. This closes the tag-splitting bypass (e.g., \\`f<b>u</b>ck\\` \u2192 stripped to \\`fuck\\` \u2192 masked to \\`****\\`). Added regression tests for both the profanity and email tag-splitting cases.\" --resolve 2>&1",
+  "description": "Reply to Copilot sanitizeCustomOverride order comment"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 3120655124 \"Fixed in 634d093. The concatenated message content is now passed through \\`ContentFilter.filterContent\\` before \\`extractKeyPhrases\\`, so PII fragments (e.g., email username parts, phone digit chunks) are replaced with placeholders before word tokenization. Additionally, a post-extraction filter drops the placeholder tokens themselves (\\`[email]\\` \u2192 \\`email\\`, etc.) and pure asterisk strings so they don't surface as top keywords in og/twitter tags.\" --resolve 2>&1",
+  "description": "Reply to Copilot keywords PII comment"
+}
+```
+
+## Assistant
+
+Now reply to the human reviewer's overall review comment:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 4154814865 \"Both blocking items addressed in 634d093:\n\n**Blocking 1 \u2014 \\`sanitizeCustomOverride\\` not wired into write path:**\nAdded \\`metaTagService.setCustomOverrides(channelId, overrides)\\` which sanitizes \\`customTitle\\`/\\`customDescription\\` via \\`sanitizeCustomOverride\\` before calling the repository, then invalidates the cache. The repository method has a JSDoc warning that callers must go through the service method. The public tRPC write API (PUT /meta-tags) lands with M4/issue #356 \u2014 a service-boundary unit test is added here (mocked repo), and the full integration test will follow with the router.\n\n**Blocking 2 \u2014 \\`keywords\\` computed from unfiltered content:**\nThe concatenated message content is now filtered through \\`ContentFilter.filterContent\\` before \\`extractKeyPhrases\\`. A post-extraction step also removes placeholder tokens (\\`email\\`, \\`phone\\`, \\`user\\`) and asterisk-only strings so they don't leak into og/twitter/structuredData keywords.\n\n**Also addressed (Copilot / non-blocking):**\n- \\`sanitizeCustomOverride\\` tag-splitting bypass fixed: HTML stripped *before* PII/profanity regex runs (regression tests added)\n- \\`PHONE_RE\\` TODO comment added for follow-up tightening\n- Profanity list TODO comment added\n- Spec doc updated to reflect matching-length asterisk masking\" --resolve 2>&1",
+  "description": "Reply to human reviewer overall review comment"
+}
+```
+
+## Assistant
+
+All comments replied to. Now starting Phase 2 — watch for new comments:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --watch 2>&1",
+  "description": "Watch for new PR comments",
+  "timeout": 660000
+}
+```
+
+## Assistant
+
+The human reviewer approved! Let me reply to their iterative review and restart the watcher:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --reply 4155087300 \"Thanks for the thorough re-review. Noted on the M4 tRPC router gate \u2014 will ensure the router calls \\`setCustomOverrides\\` rather than the repository directly, and add that as a code-review requirement in the M4 PR description.\" --resolve 2>&1",
+  "description": "Reply to declanblanc's approval review"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx agent-reviews --watch 2>&1",
+  "description": "Watch for any further new PR comments",
+  "timeout": 660000
+}
+```
+
+## User
+
+[Request interrupted by user for tool use]
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+


### PR DESCRIPTION
## Summary

- Adds `ContentFilter` module (`src/services/metaTag/contentFilter.ts`) with PII redaction (emails, phones, @mentions), profanity filtering (word list → asterisks), and XSS-safe output via HTML entity encoding
- Integrates `filterContent` into `metaTagService.generateMetaTagsFromContext` so all auto-generated titles/descriptions are free of PII and profanity before serving
- Adds `metaTagService.sanitizeCustomOverride` for the `customTitle`/`customDescription` admin override write path (§12.3): strips HTML tags, filters PII/profanity, then HTML-entity-encodes to prevent `<head>` injection
- 33 new unit tests in `tests/contentFilter.test.ts` covering PII fixture corpus, profanity fixture corpus, XSS attribute-injection fixtures, and `<head>` output snapshots
- Updates `docs/dev-spec-seo-meta-tag-generation.md` §12.1 and §12.3 with implementation cross-references

Closes #356

## Test plan

- [x] `npx jest tests/contentFilter.test.ts` — 33 tests pass (PII, profanity, XSS, snapshots)
- [x] `npx jest --testPathPattern="metaTag|contentFilter|contentAnalysis|seo"` — 102 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] Existing `metaTagService.test.ts` tests unaffected (37 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)