### PR TITLE
[codex] Retry failed cloud fixture discovery in integration tests

### DIFF
--- a/llm-logs/2026-04-23-122348-session-6d495841.md
+++ b/llm-logs/2026-04-23-122348-session-6d495841.md
@@ -1,0 +1,308 @@
+# Session Log 2026-04-23-122348
+
+## User
+
+<command-message>review</command-message>
+<command-name>/review</command-name>
+<command-args>458 for issue completion and approve if and only if the issue is complete. otherwise request changes</command-args>
+
+## User
+
+You are an expert code reviewer. Follow these steps:
+
+      1. If no PR number is provided in the args, run `gh pr list` to show open PRs
+      2. If a PR number is provided, run `gh pr view <number>` to get PR details
+      3. Run `gh pr diff <number>` to get the diff
+      4. Analyze the changes and provide a thorough code review that includes:
+         - Overview of what the PR does
+         - Analysis of code quality and style
+         - Specific suggestions for improvements
+         - Any potential issues or risks
+
+      Keep your review concise but thorough. Focus on:
+      - Code correctness
+      - Following project conventions
+      - Performance implications
+      - Test coverage
+      - Security considerations
+
+      Format your review with clear sections and bullet points.
+
+      PR number: 458 for issue completion and approve if and only if the issue is complete. otherwise request changes
+
+## Assistant
+
+I'll start by fetching the PR details and diff for PR #458.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 458 2>&1",
+  "description": "Get PR #458 details"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr diff 458 2>&1",
+  "description": "Get PR #458 diff"
+}
+```
+
+## Assistant
+
+Now let me look at the linked issue #419 and the original `env.ts` file for context.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 419 2>&1",
+  "description": "Get issue #419 details"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/tests/integration/env.ts",
+  "offset": 130,
+  "limit": 30
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/tests/integration/env.ts",
+  "offset": 1,
+  "limit": 130
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr checks 458 2>&1",
+  "description": "Check CI status for PR #458"
+}
+```
+
+## Assistant
+
+Now let me check the PR review guidelines and existing test file for completeness.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/.github/PR_REVIEW.md"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr comments 458 2>&1",
+  "description": "Get existing PR comments"
+}
+```
+
+## Assistant
+
+I have everything needed. Let me submit the review.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr review 458 --approve --body \"$(cat <<'EOF'\n## PR Review Guidelines Checklist\n\n- [x] **Logic over Style** \u2014 The `.catch()` handler correctly nulls `cloudFixturePromise` synchronously before re-throwing, so any subsequent caller will always see `null` and start a fresh attempt. No logic issues.\n- [x] **Security First** \u2014 No security implications; this is an internal test utility touching no auth paths, user data, or external-facing APIs.\n- [x] **Architectural Alignment** \u2014 Integration-test utility change only; unified-backend-architecture.md is not applicable here.\n- [x] **Issue Completion** \u2014 Issue #419 requested exactly two things: (1) clear cached promise on rejection so later calls retry, and (2) preserve single-flight behavior for successful discovery. Both are delivered and verified by the new tests.\n- [x] **No Nitpicking** \u2014 N/A.\n- [x] **Avoid Repetition** \u2014 No prior reviews on this PR.\n- [x] **Iterative Reviews** \u2014 First review; N/A.\n- [x] **Prevent CI Failures** \u2014 All checks pass: Backend Lint/Build, Frontend Lint/Build, Backend Tests, Frontend Tests, Integration Tests, Vercel.\n\n---\n\n## Review\n\nThe PR is minimal, targeted, and fully satisfies issue #419.\n\n**`tests/integration/env.ts` (core fix, +4 lines)**\n\nThe original code cached the raw `resolveCloudFixtureFromPublicApi()` promise forever. The fix chains a `.catch()` onto that promise and assigns *the chained promise* to `cloudFixturePromise`. When the inner promise rejects, the `.catch()` callback executes synchronously (as a microtask), nulling `cloudFixturePromise` before the rejection propagates to any awaiting caller \u2014 so the next `getCloudFixture()` invocation always finds `null` and starts fresh. The single-flight guarantee for in-flight successful requests is unchanged because the assignment still happens before `return cloudFixturePromise`.\n\n**`tests/integration/env.test.ts` (new, 86 lines)**\n\nTwo tests covering both issue requirements:\n\n1. *Retry-after-failure* \u2014 mocks fetch to 503 on the first call, then returns valid data on the next two calls. Confirms the first call rejects with the right message, the second call resolves correctly, and exactly 3 fetch invocations occurred. This directly validates the fix.\n\n2. *Single-flight for concurrent callers* \u2014 holds the servers response unresolved while two concurrent `getCloudFixture()` calls are in flight, confirms only one fetch was issued, then resolves both to the same fixture. This validates the preserved behavior.\n\nThe use of `jest.resetModules()` + dynamic `import('./env')` in `loadCloudEnvModule()` is the correct pattern for resetting module-level singletons between test cases.\n\nNo issues found. Issue #419 is complete.\nEOF\n)\"\n",
+  "description": "Approve PR #458 with review"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 458 --json reviews 2>&1",
+  "description": "Confirm review was submitted"
+}
+```
+
+## Assistant
+
+PR #458 has been **approved**. Here's a summary of the review:
+
+**Issue #419 is fully complete.** The PR makes a minimal, correct 4-line fix and adds solid test coverage.
+
+- **Core fix** (`env.ts`): Chains a `.catch()` onto the discovery promise that nulls `cloudFixturePromise` before re-throwing. This ensures any subsequent caller sees `null` and can start a fresh retry, while the single-flight behavior for concurrent in-flight requests remains intact.
+
+- **Tests** (`env.test.ts`): Two cases covering exactly what the issue required — retry-after-transient-failure, and concurrent callers sharing one in-flight promise. Uses `jest.resetModules()` + dynamic import, which is the correct pattern for testing module-level singletons.
+
+- **All CI checks pass** (backend/frontend lint, build, unit tests, integration tests, Vercel).
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 /tmp/harmony_export_logs.py 2>&1 || true",
+  "description": "Check if script already exists"
+}
+```
+

--- a/llm-logs/acabrera04-logs/final/2026-04-23-complete-issue-419-019dbaff.md
+++ b/llm-logs/acabrera04-logs/final/2026-04-23-complete-issue-419-019dbaff.md
@@ -1,0 +1,3225 @@
+# Codex Conversation Export
+
+## Metadata
+
+- Thread ID: 019dbaff-4d65-7021-8ff6-dd2bb29ed4d2
+- Timestamp: 2026-04-23T15:39:46.923Z
+- CWD: /Users/allen/.codex/worktrees/9d14/Harmony
+- Source: vscode
+- Model Provider: openai
+- Model: gpt-5.4
+- Reasoning Effort: medium
+- Rollout Path: /Users/allen/.codex/sessions/2026/04/23/rollout-2026-04-23T11-39-46-019dbaff-4d65-7021-8ff6-dd2bb29ed4d2.jsonl
+
+## Transcript
+
+### Turn 1: Complete this issue
+
+#### 👤 User Prompt
+
+- Time: 2026-04-23T15:39:50.938Z
+
+```text
+Complete this issue https://github.com/CS485-Harmony/Harmony/issues/419
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:40:01.226Z
+
+I’m treating this as repo work in Harmony, so I’m starting by loading the repo workflow instructions and the issue details, then I’ll reproduce the problem locally before changing code.
+
+#### Tool: exec_command
+
+```sh
+pwd && rg -n "issue #419|419" /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+/Users/allen/.codex/worktrees/9d14/Harmony
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,220p' WORKFLOW.md
+```
+
+Output:
+
+````text
+## Workflow Orchestration
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean 
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop 
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests - then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+This project uses a **hybrid approach**: `tasks/todo.md` for AI context, GitHub Issues as the canonical tracker on the Harmony Project Board (course requirement).
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items (local scratch pad for AI context)
+2. **Identify the Issue**: If the task maps to an existing GitHub Issue, note the issue number at the top of `tasks/todo.md`
+3. **Announce Start**: Post an opening comment to the issue — `gh issue comment <number> --body "..."` — describing what will be done
+4. **Track Progress**: Mark items complete in `tasks/todo.md` as you go; post a comment to the issue at meaningful milestones (e.g., after a major step or when blocked)
+5. **Explain Changes**: High-level summary at each step
+6. **Document Results**: Add a review section to `tasks/todo.md` and post a final summary comment to the issue when complete
+7. **Capture Lessons**: Update `tasks/lessons.md` after corrections. Post the new lessons learned as a comment to the issue.
+
+### Issue Comment Format
+Use this structure for issue comments to keep the audit trail readable:
+
+```
+**[AI Agent — <Step>]**
+
+<What was done or decided>
+
+<Any blockers, decisions, or next steps>
+```
+
+Example steps: `Starting`, `In Progress`, `Blocked`, `Complete`
+
+## Core Principles
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
+- **Lean Context Files**: Keep AGENTS.md and similar files to only non-obvious, non-discoverable essentials. Research shows context file bloat decreases task success rates and increases inference cost by 20%+ with 2–4 extra steps per task (Gloaguen et al., 2026).
+
+
+#### Taken from https://x.com/mdancho84/status/2023738764841894352
+
+Gloaguen, T., Mündler, N., Müller, M., Raychev, V., & Vechev, M. (2026, February 12). Evaluating AGENTS.MD: Are Repository-Level context Files helpful for coding agents? arXiv.org. https://arxiv.org/abs/2602.11988
+````
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,260p' AGENTS.md
+```
+
+Output:
+
+```text
+# Agent Instructions for Harmony
+
+This file provides context and guidelines for AI coding agents (GitHub Copilot, Cursor, etc.) working on the Harmony project.
+
+## Harmony is a **search engine indexable chat application** @README.md .
+
+## Agent Workflow Guidelines
+Always write design rationale comments if intentions are not immediately obvious and ensure these comments are up to date.
+Before starting any development task, read and follow the rules in @WORKFLOW.md 
+It defines workflow orchestration, task management, and core principles all agents must follow.
+
+Always check for lint or build errors before committing code.
+
+### Specs/Docs
+- No build/test commands for specifications
+- Jest/Playwright/Lighthouse referenced in specs are design intent for future implementation
+- Specs and architecture documents are located in @docs/
+
+## Key repository conventions
+- Dev specs use a strict numbered structure (`1`–`13`; SEO spec also has `14. Acceptance Criteria`).
+- Preserve spec labeling prefixes exactly: `M#` (modules), `CL-C#`/`CL-D#`/`CL-E#`/`CL-I#` (classes/DTOs/entities/interfaces), `D#`/`T#`/`F#`/`S#`/`B#` (schemas/tech/flows/states).
+- Keep **Section 3 (Class Diagram)** and **Section 4 (List of Classes)** synchronized whenever classes are added/renamed.
+- Preserve canonical visibility enum values exactly: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.
+
+- Always verify tests are running successfully in both the backend and the frontend before pushing changes
+
+### Role-Specific Behaviors
+
+#### PR Reviews
+IF your current task involves conducting a code review or reviewing a Pull Request, THEN you MUST read and strictly adhere to the guidelines defined in `@.github/PR_REVIEW.md`. Do not begin the review until you have parsed this file.
+
+#### Addressing Open PRs
+IF your current task involves addressing review comments or requested changes on an open PR (e.g. "babysit PRs", "get PR into approvable state"), THEN use the `resolve-reviews` skill if it is available.
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 419 --repo CS485-Harmony/Harmony
+```
+
+Output:
+
+```text
+title:	test(integration): retry cloud fixture discovery after transient failure
+state:	OPEN
+author:	acabrera04
+labels:	
+comments:	0
+assignees:	
+projects:	Harmony Project Board (Backlog)
+milestone:	
+number:	419
+--
+Follow-up from PR #417 approval review.
+
+Problem:
+`tests/integration/env.ts` caches `cloudFixturePromise` permanently. If the first fixture discovery attempt fails due to a transient network error, every later call in the same test process reuses the rejected promise and cannot recover.
+
+Requested change:
+- clear the cached promise on rejection so later calls can retry
+- preserve the current single-flight behavior for successful discovery
+
+Context:
+Raised as a non-blocking review comment on PR #417.
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:40:11.272Z
+
+I have the issue details and the failure mode now: a rejected cached promise in `tests/integration/env.ts` poisons the rest of the test process. Next I’m checking the current implementation, updating `tasks/todo.md`, and posting the required start comment on the issue before editing.
+
+#### Tool: exec_command
+
+```sh
+git status --short
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,240p' tests/integration/env.ts
+```
+
+Output:
+
+```text
+/**
+ * Environment configuration for integration tests.
+ *
+ * TEST_TARGET=local  (default) — tests run against localhost services.
+ * TEST_TARGET=cloud             — tests run against deployed URLs; local-only tests skip.
+ *
+ * BACKEND_URL  overrides the backend base URL (e.g. https://api.harmony.chat).
+ * FRONTEND_URL overrides the frontend base URL (e.g. https://harmony.chat).
+ */
+
+export type TestTarget = 'local' | 'cloud';
+
+const raw = (process.env.TEST_TARGET ?? 'local').toLowerCase();
+if (raw !== 'local' && raw !== 'cloud') {
+  throw new Error(`TEST_TARGET must be "local" or "cloud", got "${raw}"`);
+}
+
+export const TARGET: TestTarget = raw as TestTarget;
+export const isLocal = TARGET === 'local';
+export const isCloud = TARGET === 'cloud';
+
+export const BACKEND_URL = (
+  process.env.BACKEND_URL ?? (isCloud ? 'https://api.harmony.chat' : 'http://localhost:4000')
+).replace(/\/$/, '');
+
+export const FRONTEND_URL = (
+  process.env.FRONTEND_URL ?? (isCloud ? 'https://harmony.chat' : 'http://localhost:3000')
+).replace(/\/$/, '');
+
+/**
+ * Returns true when the current test should be skipped in cloud mode.
+ * Usage: test.skipIf(cloudOnly())('...', ...) or check at the top of a test.
+ */
+export const cloudOnly = (): boolean => isCloud;
+
+/**
+ * Convenience wrapper: wraps a describe block so all tests inside skip in cloud mode.
+ * Pass the classification label as documentation.
+ */
+export const localOnlyDescribe = (label: string, fn: () => void): void => {
+  const wrapper = isCloud ? describe.skip : describe;
+  wrapper(`[local-only] ${label}`, fn);
+};
+
+/**
+ * Convenience wrapper: wraps a test so it skips in cloud mode.
+ */
+export const localOnlyTest = (name: string, fn: jest.ProvidesCallback, timeout?: number): void => {
+  const wrapper = isCloud ? test.skip : test;
+  wrapper(name, fn, timeout);
+};
+
+/**
+ * Convenience wrapper: wraps a test so it skips when running in cloud mode
+ * without a CLOUD_TEST_ACCESS_TOKEN. Keeps the test active in local mode
+ * (where login() always provides a token) and in cloud mode when the token
+ * is provisioned.
+ */
+export const cloudTokenTest = (name: string, fn: jest.ProvidesCallback, timeout?: number): void => {
+  const needsSkip = isCloud && !process.env.CLOUD_TEST_ACCESS_TOKEN;
+  (needsSkip ? test.skip : test)(name, fn, timeout);
+};
+
+// Known mock-seed data used by local tests (harmony-backend/src/dev/mock-seed-data.json).
+// Server server-001 is "harmony-hq".
+export const LOCAL_SEEDS = {
+  server: {
+    slug: 'harmony-hq',
+  },
+  channels: {
+    publicIndexable: 'general', // visibility=PUBLIC_INDEXABLE
+    publicNoIndex: 'introductions', // visibility=PUBLIC_NO_INDEX
+    private: 'staff-only', // visibility=PRIVATE
+  },
+  alice: {
+    email: 'alice_admin@mock.harmony.test',
+    password: 'HarmonyAdmin123!',
+  },
+} as const;
+
+// Known cloud URLs used by cloud smoke tests. Explicit env vars still win, but
+// automated CI should not depend on a hard-coded production slug pair that can
+// drift as deployed data changes.
+export const CLOUD_KNOWN = {
+  serverSlug: process.env.CLOUD_TEST_SERVER_SLUG ?? 'harmony-hq',
+  publicChannel: process.env.CLOUD_TEST_PUBLIC_CHANNEL ?? 'general',
+} as const;
+
+export type CloudFixture = {
+  serverId?: string;
+  serverSlug: string;
+  publicChannel: string;
+};
+
+let cloudFixturePromise: Promise<CloudFixture> | null = null;
+
+async function resolveCloudFixtureFromPublicApi(): Promise<CloudFixture> {
+  const serversRes = await fetch(`${BACKEND_URL}/api/public/servers`);
+  if (!serversRes.ok) {
+    throw new Error(
+      `Cloud fixture discovery failed: GET /api/public/servers returned ${serversRes.status}`,
+    );
+  }
+
+  const servers = (await serversRes.json()) as Array<{
+    id?: string;
+    slug?: string;
+  }>;
+  for (const server of servers) {
+    if (!server.slug) continue;
+
+    const channelsRes = await fetch(`${BACKEND_URL}/api/public/servers/${server.slug}/channels`);
+    if (!channelsRes.ok) continue;
+
+    const channelsBody = (await channelsRes.json()) as {
+      channels?: Array<{ slug?: string }>;
+    };
+    const publicChannel = channelsBody.channels?.find((channel) => channel.slug)?.slug;
+    if (!publicChannel) continue;
+
+    return {
+      serverId: server.id,
+      serverSlug: server.slug,
+      publicChannel,
+    };
+  }
+
+  throw new Error(
+    'Cloud fixture discovery failed: no public server/channel pair is available at the configured BACKEND_URL',
+  );
+}
+
+export async function getCloudFixture(): Promise<CloudFixture> {
+  if (!isCloud) {
+    return {
+      serverSlug: LOCAL_SEEDS.server.slug,
+      publicChannel: LOCAL_SEEDS.channels.publicIndexable,
+    };
+  }
+
+  const envServerSlug = process.env.CLOUD_TEST_SERVER_SLUG;
+  const envPublicChannel = process.env.CLOUD_TEST_PUBLIC_CHANNEL;
+  if (envServerSlug && envPublicChannel) {
+    return {
+      serverSlug: envServerSlug,
+      publicChannel: envPublicChannel,
+      serverId: process.env.CLOUD_TEST_SERVER_ID,
+    };
+  }
+
+  if (!cloudFixturePromise) {
+    cloudFixturePromise = resolveCloudFixtureFromPublicApi();
+  }
+  return cloudFixturePromise;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,220p' tasks/todo.md
+```
+
+Output:
+
+```text
+sed: tasks/todo.md: No such file or directory
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue comment 419 --repo CS485-Harmony/Harmony --body $'**[AI Agent — Starting]**\n\nInvestigating the integration test fixture discovery cache in `tests/integration/env.ts` and reproducing the rejected-promise behavior locally before patching it.\n\nNext I will implement the retry-safe cache behavior, run the relevant backend/frontend verification, and post the results here.'
+```
+
+Output:
+
+```text
+
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:40:23.234Z
+
+`tasks/todo.md` does not exist in this worktree, so I’m treating that as part of the task setup rather than a blocker. I’m checking the existing test layout around `env.ts` and then I’ll create the task tracker plus a regression test before patching the cache logic.
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 52261,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 3000
+}
+```
+
+Output:
+
+```text
+Chunk ID: ffe6e9
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 19
+Output:
+https://github.com/CS485-Harmony/Harmony/issues/419#issuecomment-4305775506
+```
+
+#### Tool: exec_command
+
+```sh
+rg --files tests/integration | sed -n '1,200p'
+```
+
+Output:
+
+```text
+tests/integration/health.test.ts
+tests/integration/helpers/auth.ts
+tests/integration/sse.test.ts
+tests/integration/env.ts
+tests/integration/tsconfig.json
+tests/integration/visibility.test.ts
+tests/integration/package.json
+tests/integration/package-lock.json
+tests/integration/guest-public-channel.test.ts
+tests/integration/public-api.test.ts
+tests/integration/jest.config.js
+tests/integration/auth.test.ts
+tests/integration/cors.test.ts
+tests/integration/attachments.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+ls -la && ls -la tasks 2>/dev/null || true
+```
+
+Output:
+
+```text
+total 1088
+drwxr-xr-x@ 23 allen  staff     736 Apr 23 11:39 .
+drwxr-xr-x@  3 allen  staff      96 Apr 23 11:39 ..
+drwxr-xr-x@  3 allen  staff      96 Apr 23 11:39 .claude
+-rw-r--r--@  1 allen  staff      59 Apr 23 11:39 .git
+drwxr-xr-x@  4 allen  staff     128 Apr 23 11:39 .github
+-rw-r--r--@  1 allen  staff      66 Apr 23 11:39 .gitignore
+drwxr-xr-x@  3 allen  staff      96 Apr 23 11:39 .vscode
+-rw-r--r--@  1 allen  staff    1996 Apr 23 11:39 AGENTS.md
+-rw-r--r--@  1 allen  staff      11 Apr 23 11:39 CLAUDE.md
+-rw-r--r--@  1 allen  staff    7624 Apr 23 11:39 README.md
+-rw-r--r--@  1 allen  staff    3806 Apr 23 11:39 WORKFLOW.md
+-rw-r--r--@  1 allen  staff  519704 Apr 23 11:39 dev-spec-guidelines.pdf
+-rwxr-xr-x@  1 allen  staff    2142 Apr 23 11:39 dev.sh
+drwxr-xr-x@ 10 allen  staff     320 Apr 23 11:39 docs
+drwxr-xr-x@ 20 allen  staff     640 Apr 23 11:39 harmony-backend
+drwxr-xr-x@ 21 allen  staff     672 Apr 23 11:39 harmony-frontend
+drwxr-xr-x@ 61 allen  staff    1952 Apr 23 11:39 llm-logs
+drwxr-xr-x@  9 allen  staff     288 Apr 23 11:39 mockups
+-rw-r--r--@  1 allen  staff     422 Apr 23 11:39 package.json
+drwxr-xr-x@  8 allen  staff     256 Apr 23 11:39 planning
+drwxr-xr-x@  3 allen  staff      96 Apr 23 11:39 scripts
+drwxr-xr-x@  3 allen  staff      96 Apr 23 11:39 tasks
+drwxr-xr-x@  3 allen  staff      96 Apr 23 11:39 tests
+total 24
+drwxr-xr-x@  3 allen  staff    96 Apr 23 11:39 .
+drwxr-xr-x@ 23 allen  staff   736 Apr 23 11:39 ..
+-rw-r--r--@  1 allen  staff  9164 Apr 23 11:39 lessons.md
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "getCloudFixture|resolveCloudFixtureFromPublicApi|cloudFixturePromise" tests -S
+```
+
+Output:
+
+```text
+tests/integration/env.ts:95:let cloudFixturePromise: Promise<CloudFixture> | null = null;
+tests/integration/env.ts:97:async function resolveCloudFixtureFromPublicApi(): Promise<CloudFixture> {
+tests/integration/env.ts:133:export async function getCloudFixture(): Promise<CloudFixture> {
+tests/integration/env.ts:151:  if (!cloudFixturePromise) {
+tests/integration/env.ts:152:    cloudFixturePromise = resolveCloudFixtureFromPublicApi();
+tests/integration/env.ts:154:  return cloudFixturePromise;
+tests/integration/visibility.test.ts:9:import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe, getCloudFixture } from './env';
+tests/integration/visibility.test.ts:21:    knownSlug = (await getCloudFixture()).serverSlug;
+tests/integration/guest-public-channel.test.ts:15:  getCloudFixture,
+tests/integration/guest-public-channel.test.ts:24:    const fixture = await getCloudFixture();
+tests/integration/public-api.test.ts:8:import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe, getCloudFixture } from './env';
+tests/integration/public-api.test.ts:16:    const fixture = await getCloudFixture();
+```
+
+#### Tool: update_plan
+
+- Explanation: Captured the issue, read Harmony workflow, and confirmed the bug is isolated to the integration test fixture cache in tests/integration/env.ts. I’m proceeding with a regression test first, then the fix, then repo-required verification and issue updates.
+
+- Plan:
+  - [completed] Create task tracking entry for issue #419 and inspect the current integration fixture cache behavior
+  - [in_progress] Add a regression test covering retry after an initial cloud fixture discovery failure
+  - [pending] Patch the cached promise logic so rejections clear the cache while successful discovery remains single-flight
+  - [pending] Run relevant formatting, integration/backend/frontend verification, then post completion details to the issue
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,220p' tests/integration/package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony-integration-tests",
+  "private": true,
+  "scripts": {
+    "test": "jest --config jest.config.js --runInBand",
+    "test:local": "TEST_TARGET=local jest --config jest.config.js --runInBand",
+    "test:cloud": "TEST_TARGET=cloud jest --config jest.config.js"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/node": "^20.17.19",
+    "dotenv": "^17.3.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.6",
+    "typescript": "^5.8.2"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,220p' tests/integration/jest.config.js
+```
+
+Output:
+
+```text
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  setupFiles: ['dotenv/config'],
+  roots: ['<rootDir>'],
+  testMatch: ['**/*.test.ts'],
+  testTimeout: 15000,
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
+  },
+};
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,220p' tests/integration/public-api.test.ts
+```
+
+Output:
+
+```text
+/**
+ * SSRAPI-1 through SSRAPI-7: Public API path used by SSR metadata and page rendering
+ *
+ * SSRAPI-1 to SSRAPI-6: cloud-read-only
+ * SSRAPI-7: local-only (burst traffic test)
+ */
+
+import { BACKEND_URL, LOCAL_SEEDS, isCloud, localOnlyDescribe, getCloudFixture } from './env';
+
+describe('Public API — SSR (cloud-read-only)', () => {
+  let serverSlug: string = LOCAL_SEEDS.server.slug;
+  let publicChannel: string = LOCAL_SEEDS.channels.publicIndexable;
+
+  beforeAll(async () => {
+    if (!isCloud) return;
+    const fixture = await getCloudFixture();
+    serverSlug = fixture.serverSlug;
+    publicChannel = fixture.publicChannel;
+  });
+
+  test('SSRAPI-1: public server info returns id, name, slug, memberCount', async () => {
+    const res = await fetch(`${BACKEND_URL}/api/public/servers/${serverSlug}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id?: string;
+      name?: string;
+      slug?: string;
+      memberCount?: number;
+    };
+    expect(typeof body.id).toBe('string');
+    expect(typeof body.name).toBe('string');
+    expect(body.slug).toBe(serverSlug);
+    expect(typeof body.memberCount).toBe('number');
+  });
+
+  test('SSRAPI-2: public server list endpoint is reachable and returns an array', async () => {
+    const res = await fetch(`${BACKEND_URL}/api/public/servers`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  test('SSRAPI-3: public channel endpoint returns id, name, visibility', async () => {
+    const res = await fetch(
+      `${BACKEND_URL}/api/public/servers/${serverSlug}/channels/${publicChannel}`,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id?: string;
+      name?: string;
+      visibility?: string;
+    };
+    expect(typeof body.id).toBe('string');
+    expect(typeof body.name).toBe('string');
+    expect(body.visibility).toBe('PUBLIC_INDEXABLE');
+  });
+
+  test('SSRAPI-4: public channel list returns only PUBLIC_INDEXABLE channels with expected fields', async () => {
+    const res = await fetch(`${BACKEND_URL}/api/public/servers/${serverSlug}/channels`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      channels?: Array<{
+        id?: string;
+        name?: string;
+        slug?: string;
+        type?: string;
+        topic?: unknown;
+        visibility?: string;
+      }>;
+    };
+    expect(Array.isArray(body.channels)).toBe(true);
+    const channels = body.channels ?? [];
+    expect(channels.length).toBeGreaterThan(0);
+    for (const ch of channels) {
+      expect(typeof ch.id).toBe('string');
+      expect(typeof ch.name).toBe('string');
+      expect(typeof ch.slug).toBe('string');
+      expect(typeof ch.type).toBe('string');
+      // visibility field must not be present per SSRAPI-4
+      expect(ch.visibility).toBeUndefined();
+    }
+  });
+
+  test('SSRAPI-5: unknown server slug returns 404', async () => {
+    const res = await fetch(`${BACKEND_URL}/api/public/servers/nonexistent-server-slug-xyz`);
+    expect(res.status).toBe(404);
+  });
+
+  test('SSRAPI-6: SSR metadata renders title and meta description for a public channel page', async () => {
+    const { FRONTEND_URL } = await import('./env');
+    const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${publicChannel}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toMatch(/<title[^>]*>/i);
+    expect(html).toMatch(/<meta[^>]+name=["']description["']/i);
+  });
+});
+
+// SSRAPI-7 is local-only (burst traffic could affect other users on cloud IPs)
+localOnlyDescribe('Public API rate limiter (local-only)', () => {
+  test('SSRAPI-7: >100 requests/min from same IP returns 429', async () => {
+    const endpoint = `${BACKEND_URL}/api/public/servers`;
+    const requests = Array.from({ length: 110 }, () => fetch(endpoint));
+    const responses = await Promise.all(requests);
+    const statuses = responses.map((r) => r.status);
+    const has429 = statuses.some((s) => s === 429);
+    expect(has429).toBe(true);
+  }, 30000);
+});
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:40:41.894Z
+
+I’ve confirmed there isn’t an existing focused test for `getCloudFixture`, so I’m adding one at the integration-test layer that exercises the cached promise behavior directly with a mocked `fetch`. After that I’ll wire the cache reset into the implementation and run the targeted suite first.
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,220p' tests/integration/tsconfig.json
+```
+
+Output:
+
+```text
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["./**/*.ts"]
+}
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,220p' tasks/lessons.md
+```
+
+Output:
+
+```text
+# Lessons Learned
+
+Shared knowledge base for the Harmony team. Add an entry whenever a mistake is caught, a better approach is discovered, or an AI agent is corrected.
+
+---
+
+## Template
+
+**Date:** YYYY-MM-DD  
+**Caught by:** [Human: @username] or [AI Agent: Copilot/Cursor]  
+**Related Issue:** #<number> (optional)  
+**Mistake / Situation:** One sentence describing what went wrong or what was unclear.  
+**Rule / Fix:** The actionable rule derived — written so it prevents the same mistake next time.
+
+---
+
+## Log
+
+<!-- Most recent entries at the top -->
+
+**Date:** 2026-04-11  
+**Caught by:** [Human: user]  
+**Related Issue:** #313  
+**Mistake / Situation:** I changed the password verifier flow but left backend-only PBKDF2 helpers and E2E bootstrap code deriving with the literal hex salt string instead of decoded salt bytes, so browser auth and E2E diverged from local service tests.  
+**Rule / Fix:** When introducing a client/server crypto contract, centralize or explicitly mirror the byte-level encoding rules across backend helpers, tests, seed data, and E2E bootstraps; verify at least one browser-facing path, not just service-level tests.
+
+**Date:** 2026-04-11  
+**Caught by:** [Human: user]  
+**Related Issue:** #313  
+**Mistake / Situation:** I updated auth-related tests for the new verifier contract but missed another backend suite that still called `authService.register` with the old 3-argument signature, which broke CI.  
+**Rule / Fix:** After changing any shared service contract, grep the full repo for old call sites and run at least the affected package typecheck before pushing so stale compile-time usages do not escape to CI.
+
+**Date:** 2026-04-11  
+**Caught by:** [Human: user]  
+**Related Issue:** #313  
+**Mistake / Situation:** I began patching the auth implementation in the same pass as test creation instead of first proving the security regression with a failing test run.  
+**Rule / Fix:** For every non-trivial Harmony code change, especially security work, do strict red-green-refactor: write or update the regression tests first, run them to capture the red state, and only then modify implementation.
+
+**Date:** 2026-04-04  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I assumed serial CI workers and relaxed auth throttles were enough, but the WebKit-only auth flake was still tied to running the Next frontend in dev mode inside GitHub Actions.  
+**Rule / Fix:** For browser E2E in CI, prefer production-style frontend serving (`build + start`) over `next dev`; dev-mode tooling can introduce non-product flakiness that hides the real signal of the suite.
+
+**Date:** 2026-04-04  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I kept a browser matrix in the PR-gating CI path even after reproducing that only WebKit was flaky under CI-mode E2E, which blocked the suite without proving a product defect.  
+**Rule / Fix:** Keep every-PR E2E checks focused on the stable smoke browser for this repo, and move additional browser coverage like WebKit to non-blocking or follow-up coverage until the browser-specific flake has a rooted product cause.
+
+**Date:** 2026-04-01  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The new E2E suite passed locally but still failed in CI because production-style auth rate limits and full worker parallelism interacted badly with concurrent browser runs.  
+**Rule / Fix:** When adding full-stack E2E to CI, review backend throttles and shared-state assumptions explicitly; either relax them for `NODE_ENV=e2e` or reduce CI concurrency so auth/setup traffic cannot invalidate the suite.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The E2E suite mixed selector expectations based on route slugs with UI labels rendered from channel display names, and one startup preflight used a one-shot auth check while the rest of setup retried.  
+**Rule / Fix:** E2E assertions must target the exact accessibility text the UI renders, not adjacent seed identifiers, and all backend readiness checks should share the same retry semantics so cold-start timing does not create false failures.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** E2E preflight initially verified seeded content but skipped critical auth assumptions, and the shared E2E helper encoded environment defaults too implicitly.  
+**Rule / Fix:** E2E preconditions must verify every special-case fixture the suite depends on, including auth overrides, and shared test helpers should avoid hidden runtime defaults like hardcoded `NODE_ENV`.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The first true-E2E pass duplicated stack constants across TS and Node launcher files and allowed local server reuse, which made reruns stateful and brittle.  
+**Rule / Fix:** For stateful E2E stacks, keep shared ports/URLs/test credentials in one cross-runtime JS module and force the backend launcher to restart/reset locally unless there is an explicit reason to preserve state.
+**Date:** 2026-03-31  
+**Caught by:** [Human: user]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I left brittle expectations inside integration-test helpers, used a vacuous exclusion assertion in a membership-scoping test, hardcoded a slug-collision suffix, and missed unauthenticated plus join/leave coverage in the server lifecycle suite.  
+**Rule / Fix:** In Harmony integration tests, keep helpers assertion-light with descriptive failures, avoid vacuous negatives by asserting the response shape/status first, never hardcode collision suffixes when uniqueness is data-dependent, and cover both unauthenticated access and core membership transitions for authenticated server flows.
+
+**Date:** 2026-03-31  
+**Caught by:** [Human: user]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I initially called a mocked page-level test an integration test and also let a backend integration suite depend on state created in a prior `it` block.  
+**Rule / Fix:** In this repo, only call a test "integration" when it crosses real module boundaries without mocking application internals, and keep each integration test self-contained so it does not rely on execution order across `it` blocks.
+**Date:** 2026-04-03  
+**Caught by:** [Human: user]  
+**Mistake / Situation:** I renamed the branch and PR for a log export when the user meant to rename the exported log file itself.  
+**Rule / Fix:** When a user asks to "rename it" during log-export/PR work, confirm whether the target is the file, branch, PR, or commit before changing GitHub metadata; if context strongly points to the artifact path, rename the file first.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Related Issue:** #331  
+**Mistake / Situation:** I described the preferred custom-domain deployment contract too prominently in the root README when the user wanted the current live Vercel and Railway hostnames treated as the actual deployment URLs.  
+**Rule / Fix:** In Harmony deployment docs, present the currently serving hostnames as the source of truth unless the task is explicitly about future domain setup; mention custom domains only as preferred future state when they are not actually configured.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Related Issue:** #331  
+**Mistake / Situation:** I documented `npm run dev` and `npm run dev:worker` as if the worker would naturally stay on `4100`, but the backend `.env.example` sets `PORT=4000`, so both processes collide unless the worker port is overridden explicitly.  
+**Rule / Fix:** When documenting split-process local startup in Harmony, verify how `.env` values interact with entrypoint defaults; if a shared `PORT` variable exists, either force the worker dev script to `4100` or document an explicit `PORT=4100` override instead of relying on fallback defaults.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Related Issue:** #331  
+**Mistake / Situation:** I wrote a chained `cd` sequence in the README that ended with `cd ..` after entering `tests/integration`, which only returns to `tests/` rather than the repository root.  
+**Rule / Fix:** When documenting multi-step shell navigation in Harmony, trace the working directory after each `cd` and prefer exact return paths like `cd ../..` when the instructions are meant to end back at the repo root.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Mistake / Situation:** I documented `npm run test:integration` from the repo root without verifying the actual root script invocation. The root script was forwarding an extra `--config jest.config.js` even though the integration package already sets its own config, which breaks Jest argument parsing.  
+**Rule / Fix:** For Harmony root wrapper scripts, always execute the command once from the repo root before documenting it. If the delegated package already owns its config flags, the root wrapper should forward cleanly instead of duplicating CLI options.
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:40:49.393Z
+
+I’m at the edit point now. I’m creating the issue tracker entry, adding a focused regression test for the rejected-promise cache case plus the single-flight success case, and then I’ll update `env.ts` to clear the cache on failure.
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:41:12.613Z
+
+The regression test and the cache fix are in place. I’m running the focused integration suite first to verify the exact behavior around retry and single-flight, then I’ll do the broader repo checks required by this repo before closing the issue.
+
+#### Tool: exec_command
+
+```sh
+npm test -- env.test.ts
+```
+
+Output:
+
+```text
+
+> test
+> jest --config jest.config.js --runInBand env.test.ts
+
+sh: jest: command not found
+```
+
+#### Tool: exec_command
+
+```sh
+git diff -- tests/integration/env.ts tests/integration/env.test.ts tasks/todo.md
+```
+
+Output:
+
+```text
+diff --git a/tests/integration/env.ts b/tests/integration/env.ts
+index c4a330b..0c6fd62 100644
+--- a/tests/integration/env.ts
++++ b/tests/integration/env.ts
+@@ -149,7 +149,10 @@ export async function getCloudFixture(): Promise<CloudFixture> {
+   }
+ 
+   if (!cloudFixturePromise) {
+-    cloudFixturePromise = resolveCloudFixtureFromPublicApi();
++    cloudFixturePromise = resolveCloudFixtureFromPublicApi().catch((error: unknown) => {
++      cloudFixturePromise = null;
++      throw error;
++    });
+   }
+   return cloudFixturePromise;
+ }
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:41:20.347Z
+
+The first verification run failed for an environment reason rather than the code path: `tests/integration` does not currently have its local Jest binary installed in this worktree. I’m checking what dependencies are present and then I’ll run the repo’s available verification commands from the correct package roots.
+
+#### Tool: exec_command
+
+```sh
+ls -la node_modules/.bin 2>/dev/null | sed -n '1,80p'
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+cat package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony",
+  "private": true,
+  "scripts": {
+    "test": "node ./scripts/run-root-jest.cjs",
+    "jest": "node ./scripts/run-root-jest.cjs",
+    "test:backend": "npm --prefix harmony-backend test --",
+    "test:frontend": "npm --prefix harmony-frontend test --",
+    "test:integration": "npm --prefix tests/integration test",
+    "test:integration:cloud": "npm --prefix tests/integration run test:cloud"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+ls -la harmony-backend && cat harmony-backend/package.json
+```
+
+Output:
+
+```text
+total 824
+drwxr-xr-x@ 20 allen  staff     640 Apr 23 11:39 .
+drwxr-xr-x@ 23 allen  staff     736 Apr 23 11:39 ..
+-rw-r--r--@  1 allen  staff    2906 Apr 23 11:39 .env.example
+-rw-r--r--@  1 allen  staff     203 Apr 23 11:39 .gitignore
+-rw-r--r--@  1 allen  staff       3 Apr 23 11:39 .nvmrc
+-rw-r--r--@  1 allen  staff     165 Apr 23 11:39 .prettierrc.cjs
+-rw-r--r--@  1 allen  staff   15753 Apr 23 11:39 README.md
+-rw-r--r--@  1 allen  staff     642 Apr 23 11:39 docker-compose.e2e.yml
+-rw-r--r--@  1 allen  staff     541 Apr 23 11:39 docker-compose.yml
+-rw-r--r--@  1 allen  staff     558 Apr 23 11:39 eslint.config.mjs
+-rw-r--r--@  1 allen  staff     352 Apr 23 11:39 jest.config.js
+-rw-r--r--@  1 allen  staff  350741 Apr 23 11:39 package-lock.json
+-rw-r--r--@  1 allen  staff    1896 Apr 23 11:39 package.json
+drwxr-xr-x@  5 allen  staff     160 Apr 23 11:39 prisma
+-rw-r--r--@  1 allen  staff     216 Apr 23 11:39 railway.toml
+drwxr-xr-x@ 15 allen  staff     480 Apr 23 11:39 src
+-rw-r--r--@  1 allen  staff     285 Apr 23 11:39 start.sh
+drwxr-xr-x@ 53 allen  staff    1696 Apr 23 11:39 tests
+-rw-r--r--@  1 allen  staff     609 Apr 23 11:39 tsconfig.json
+-rw-r--r--@  1 allen  staff     174 Apr 23 11:39 tsconfig.test.json
+{
+  "name": "harmony-backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "dev:worker": "PORT=4100 tsx watch src/worker.ts",
+    "dev:e2e": "NODE_ENV=e2e PORT=4000 tsx src/index.ts",
+    "dev:e2e:worker": "NODE_ENV=e2e PORT=4100 tsx src/worker.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "start:api": "node dist/index.js",
+    "start:worker": "node dist/worker.js",
+    "lint": "eslint src tests",
+    "test": "jest",
+    "db:seed:mock": "prisma db seed",
+    "db:seed:demo": "tsx src/dev/demoSeed.ts"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.1030.0",
+    "@prisma/client": "^5.22.0",
+    "@trpc/server": "^11.0.0",
+    "bcryptjs": "^3.0.3",
+    "cors": "^2.8.5",
+    "express": "^4.21.2",
+    "express-rate-limit": "^8.3.0",
+    "file-type": "^21.3.2",
+    "helmet": "^8.1.0",
+    "ioredis": "^5.10.0",
+    "jsonwebtoken": "^9.0.3",
+    "multer": "^2.1.1",
+    "pino": "^10.3.1",
+    "rate-limit-redis": "^4.3.1",
+    "serverless-http": "^3.2.0",
+    "twilio": "^5.13.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/ioredis": "^4.28.10",
+    "@types/jest": "^29.5.14",
+    "@types/jsonwebtoken": "^9.0.10",
+    "@types/multer": "^2.1.0",
+    "@types/node": "^20.17.19",
+    "@types/supertest": "^6.0.2",
+    "@typescript-eslint/eslint-plugin": "^8.26.0",
+    "@typescript-eslint/parser": "^8.26.0",
+    "dotenv": "^17.3.1",
+    "eslint": "^9.22.0",
+    "eslint-config-prettier": "^10.1.1",
+    "jest": "^29.7.0",
+    "pino-pretty": "^13.1.3",
+    "prettier": "^3.5.3",
+    "prisma": "^5.22.0",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.6",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+ls -la harmony-frontend && cat harmony-frontend/package.json
+```
+
+Output:
+
+```text
+total 1264
+drwxr-xr-x@ 21 allen  staff     672 Apr 23 11:39 .
+drwxr-xr-x@ 23 allen  staff     736 Apr 23 11:39 ..
+-rw-r--r--@  1 allen  staff     233 Apr 23 11:39 .env.example
+-rw-r--r--@  1 allen  staff     540 Apr 23 11:39 .gitignore
+-rw-r--r--@  1 allen  staff      47 Apr 23 11:39 .prettierignore
+-rw-r--r--@  1 allen  staff     342 Apr 23 11:39 .prettierrc.cjs
+-rw-r--r--@  1 allen  staff    5871 Apr 23 11:39 README.md
+-rw-r--r--@  1 allen  staff  178821 Apr 23 11:39 bun.lock
+-rw-r--r--@  1 allen  staff     786 Apr 23 11:39 eslint.config.mjs
+-rw-r--r--@  1 allen  staff     587 Apr 23 11:39 jest.config.js
+-rw-r--r--@  1 allen  staff    1123 Apr 23 11:39 next.config.ts
+-rw-r--r--@  1 allen  staff  403882 Apr 23 11:39 package-lock.json
+-rw-r--r--@  1 allen  staff    1448 Apr 23 11:39 package.json
+-rw-r--r--@  1 allen  staff    1540 Apr 23 11:39 playwright.config.ts
+-rw-r--r--@  1 allen  staff      94 Apr 23 11:39 postcss.config.mjs
+drwxr-xr-x@  7 allen  staff     224 Apr 23 11:39 public
+drwxr-xr-x@ 15 allen  staff     480 Apr 23 11:39 src
+-rw-r--r--@  1 allen  staff     853 Apr 23 11:39 tailwind.config.ts
+drwxr-xr-x@  3 allen  staff      96 Apr 23 11:39 tests
+-rw-r--r--@  1 allen  staff     670 Apr 23 11:39 tsconfig.json
+-rw-r--r--@  1 allen  staff     159 Apr 23 11:39 vercel.json
+{
+  "name": "harmony-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "build:e2e": "NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next build",
+    "start:e2e": "PORT=3000 NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next start",
+    "test": "jest --forceExit",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "lint": "eslint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "axios": "^1.13.5",
+    "clsx": "^2.1.1",
+    "next": "16.1.6",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.4.1",
+    "twilio-video": "3.0.0-preview.3"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@playwright/test": "^1.55.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "16.1.6",
+    "eslint-config-prettier": "^10.1.8",
+    "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
+    "prettier": "^3.8.1",
+    "tailwindcss": "^4",
+    "ts-jest": "^29.4.6",
+    "typescript": "5.9.3"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+[ -d node_modules ] && echo root:yes || echo root:no; [ -d harmony-backend/node_modules ] && echo backend:yes || echo backend:no; [ -d harmony-frontend/node_modules ] && echo frontend:yes || echo frontend:no; [ -d tests/integration/node_modules ] && echo integration:yes || echo integration:no
+```
+
+Output:
+
+```text
+root:no
+backend:no
+frontend:no
+integration:no
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --stat
+```
+
+Output:
+
+```text
+ tests/integration/env.ts | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:41:37.257Z
+
+This worktree is missing all package installs, so verification needs bootstrap first. I’m installing dependencies in the integration, backend, and frontend packages in parallel so I can run the repo-required checks instead of guessing.
+
+#### Tool: exec_command
+
+```sh
+npm ci
+```
+
+Output:
+
+```text
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+```
+
+#### Tool: exec_command
+
+```sh
+npm ci
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+npm ci
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 23862,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 1dcab7
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 36
+Output:
+
+added 282 packages, and audited 283 packages in 1s
+
+35 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 85899,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Chunk ID: abde6e
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 238
+Output:
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated scmp@2.1.0: Just use Node.js's crypto.timingSafeEqual()
+
+added 685 packages, and audited 686 packages in 5s
+
+109 packages are looking for funding
+  run `npm fund` for details
+
+26 vulnerabilities (22 moderate, 3 high, 1 critical)
+
+To address issues that do not require attention, run:
+  npm audit fix
+
+To address all issues (including breaking changes), run:
+  npm audit fix --force
+
+Run `npm audit` for details.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 26188,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 6910b9
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 311
+Output:
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated whatwg-encoding@3.1.1: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+added 704 packages, and audited 705 packages in 6s
+
+187 packages are looking for funding
+  run `npm fund` for details
+
+9 vulnerabilities (4 moderate, 4 high, 1 critical)
+
+To address issues that do not require attention, run:
+  npm audit fix
+
+To address all issues, run:
+  npm audit fix --force
+
+Run `npm audit` for details.
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:41:57.733Z
+
+The workspace is bootstrapped now. I’m running the focused integration verification for the new cache behavior, plus the repo’s backend and frontend test suites so this doesn’t get closed with only a narrow local signal.
+
+#### Tool: exec_command
+
+```sh
+npm test -- env.test.ts
+```
+
+Output:
+
+```text
+
+> test
+> jest --config jest.config.js --runInBand env.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+npx tsc --noEmit -p tsconfig.json
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+npm test -- --runInBand
+```
+
+Output:
+
+```text
+
+> harmony-backend@0.1.0 test
+> jest --runInBand
+```
+
+#### Tool: exec_command
+
+```sh
+npm test -- --runInBand
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 test
+> jest --forceExit --runInBand
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 24657,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 98878b
+Wall time: 0.0000 seconds
+Process exited with code 1
+Original token count: 186
+Output:
+FAIL ./env.test.ts
+  ● Test suite failed to run
+
+    [96menv.test.ts[0m:[93m20[0m:[93m11[0m - [91merror[0m[90m TS2743: [0mNo overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
+
+    [7m20[0m       .fn<typeof fetch>()
+    [7m  [0m [91m          ~~~~~~~~~~~~[0m
+    [96menv.test.ts[0m:[93m48[0m:[93m11[0m - [91merror[0m[90m TS2743: [0mNo overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
+
+    [7m48[0m       .fn<typeof fetch>()
+    [7m  [0m [91m          ~~~~~~~~~~~~[0m
+
+Test Suites: 1 failed, 1 total
+Tests:       0 total
+Snapshots:   0 total
+Time:        1.673 s
+Ran all test suites matching /env.test.ts/i.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 81582,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Chunk ID: fadcc6
+Wall time: 0.0000 seconds
+Process exited with code 2
+Original token count: 69
+Output:
+env.test.ts(20,11): error TS2743: No overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
+env.test.ts(48,11): error TS2743: No overload expects 1 type arguments, but overloads do exist that expect either 0 or 2 type arguments.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 30847,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: a42db1
+Wall time: 5.0018 seconds
+Process running with session ID 30847
+Original token count: 13439
+Output:
+Total output lines: 1365
+
+PASS tests/public.router.test.ts
+PASS tests/server.service.test.ts
+PASS tests/auth.service.test.ts
+FAIL tests/channel.service.test.ts
+  ● channelService.getChannels › CS-1: returns channels in ascending position order
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:62:34
+
+      59 let channelSlug: string;
+      60 
+      61 beforeAll(async () => {
+    → 62   const user = await prisma.user.create(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      60 |
+      61 | beforeAll(async () => {
+    > 62 |   const user = await prisma.user.create({
+         |                ^
+      63 |     data: {
+      64 |       email: `cs-test-${ts}@example.com`,
+      65 |       username: `cs_test_${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:62:16)
+
+  ● channelService.getChannels › CS-2: returns empty array when server has no channels
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:62:34
+
+      59 let channelSlug: string;
+      60 
+      61 beforeAll(async () => {
+    → 62   const user = await prisma.user.create(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      60 |
+      61 | beforeAll(async () => {
+    > 62 |   const user = await prisma.user.create({
+         |                ^
+      63 |     data: {
+      64 |       email: `cs-test-${ts}@example.com`,
+      65 |       username: `cs_test_${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:62:16)
+
+  ● channelService.getChannelBySlug › CS-3: returns channel when both slugs match
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:62:34
+
+      59 let channelSlug: string;
+      60 
+      61 beforeAll(async () => {
+    → 62   const user = await prisma.user.create(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      60 |
+      61 | beforeAll(async () => {
+    > 62 |   const user = await prisma.user.create({
+         |                ^
+      63 |     data: {
+      64 |       email: `cs-test-${ts}@example.com`,
+      65 |       username: `cs_test_${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:62:16)
+
+  ● channelService.getChannelBySlug › CS-4: throws NOT_FOUND when server slug does not match any server
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:62:34
+
+      59 let channelSlug: string;
+      60 
+      61 beforeAll(async () => {
+    → 62   const user = await prisma.user.create(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      60 |
+      61 | beforeAll(async () => {
+    > 62 |   const user = await prisma.user.create({
+         |                ^
+      63 |     data: {
+      64 |       email: `cs-test-${ts}@example.com`,
+      65 |       username: `cs_test_${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:62:16)
+
+  ● channelService.getChannelBySlug › CS-5: throws NOT_FOUND when channel slug does not match any channel in the server
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:62:34
+
+      59 let channelSlug: string;
+      60 
+      61 beforeAll(async () => {
+    → 62   const user = await prisma.user.create(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      60 |
+      61 | beforeAll(async () => {
+    > 62 |   const user = await prisma.user.create({
+         |                ^
+      63 |     data: {
+      64 |       email: `cs-test-${ts}@example.com`,
+      65 |       username: `cs_test_${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:62:16)
+
+  ● channelService.createChannel › CS-6: creates a TEXT channel and fires cache + event side effects
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:62:34
+
+      59 let channelSlug: string;
+      60 
+      61 beforeAll(async () => {
+    → 62   const user = await prisma.user.create(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      60 |
+      61 | beforeAll(async () => {
+    > 62 |   const user = await prisma.user.create({
+         |                ^
+      63 |     data: {
+      64 |       email: `cs-test-${ts}@example.com`,
+      65 |       username: `cs_test_${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:62:16)
+
+  ● channelService.createChannel › CS-7: defaults position to 0 when not supplied
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:62:34
+
+      59 let channelSlug: string;
+      60 
+      61 beforeAll(async () => {
+    → 62   const user = await prisma.user.create(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      60 |
+      61 | beforeAll(async () => {
+    > 62 |   const user = await prisma.user.create({
+         |                ^
+      63 |     data: {
+      64 |       email: `cs-test-${ts}@example.com`,
+      65 |       username: `cs_test_${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:62:16)
+
+  ● channelService.createChannel › CS-8: throws BAD_REQUEST for VOICE + PUBLIC_INDEXABLE before any DB call
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:62:34
+
+      59 let channelSlug: string;
+      60 
+      61 beforeAll(async () => {
+    → 62   const user = await prisma.user.create(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      60 |
+      61 | beforeAll(async () => {
+    > 62 |   const user = await prisma.user.create({
+         |                ^
+      63 |     data: {
+      64 |       email: `cs-test-${ts}@example.com`,
+      65 |       username: `cs_test_${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:62:16)
+
+  ● channelService.createChannel › CS-9: allows VOICE channel with PRIVATE visibility
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:62:34
+
+      59 let channelSlug: string;
+      60 
+      61 beforeAll(async () => {
+    → 62   const user = await prisma.user.create(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      60 |
+      61 | beforeAll(async () => {
+    > 62 |   const user = await prisma.user.create({
+         |                ^
+      63 |     data: {
+      64 |       email: `cs-test-${ts}@example.com`,
+      65 |       username: `cs_test_${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:62:16)
+
+  ● channelService.createChannel › CS-10: allows VOICE channel with PUBLIC_NO_INDEX visibility
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:62:34
+
+      59 let channelSlug: string;
+      60 
+      61 beforeAll(async () => {
+    → 62   const …7439 tokens truncated… env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      60 |
+      61 | beforeAll(async () => {
+    > 62 |   const user = await prisma.user.create({
+         |                ^
+      63 |     data: {
+      64 |       email: `cs-test-${ts}@example.com`,
+      65 |       username: `cs_test_${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:62:16)
+
+  ● channelService.createDefaultChannel › CS-27: propagates error when underlying createChannel fails (server not found)
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.server.create()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/channel.service.test.ts:518:40
+
+      515 let defaultChannelServerId: string;
+      516 
+      517 beforeAll(async () => {
+    → 518   const server = await prisma.server.create(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      516 |
+      517 |   beforeAll(async () => {
+    > 518 |     const server = await prisma.server.create({
+          |                    ^
+      519 |       data: {
+      520 |         name: 'Default Channel Test Server',
+      521 |         slug: `cs26-server-${ts}`,
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at Object.<anonymous> (tests/channel.service.test.ts:518:20)
+
+FAIL tests/server.flow.integration.test.ts
+  ● server flow integration › creates a server via tRPC and wires owner membership, default channel, and member queries
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.findUnique()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/server.flow.integration.test.ts:86:36
+
+      83   .post('/api/auth/register')
+      84   .send({ email, username, ...verifierPayload });
+      85 
+    → 86 const user = await prisma.user.findUnique(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      84 |       .send({ email, username, ...verifierPayload });
+      85 |
+    > 86 |     const user = await prisma.user.findUnique({
+         |                  ^
+      87 |       where: { email },
+      88 |       select: { id: true },
+      89 |     });
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at registerUser (tests/server.flow.integration.test.ts:86:18)
+      at Object.<anonymous> (tests/server.flow.integration.test.ts:144:19)
+
+  ● server flow integration › keeps server listings scoped to memberships and forbids non-members from reading members
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.findUnique()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/server.flow.integration.test.ts:86:36
+
+      83   .post('/api/auth/register')
+      84   .send({ email, username, ...verifierPayload });
+      85 
+    → 86 const user = await prisma.user.findUnique(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      84 |       .send({ email, username, ...verifierPayload });
+      85 |
+    > 86 |     const user = await prisma.user.findUnique({
+         |                  ^
+      87 |       where: { email },
+      88 |       select: { id: true },
+      89 |     });
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at registerUser (tests/server.flow.integration.test.ts:86:18)
+      at Object.<anonymous> (tests/server.flow.integration.test.ts:255:19)
+
+  ● server flow integration › forbids non-owners from updating or deleting a server
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.findUnique()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/server.flow.integration.test.ts:86:36
+
+      83   .post('/api/auth/register')
+      84   .send({ email, username, ...verifierPayload });
+      85 
+    → 86 const user = await prisma.user.findUnique(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      84 |       .send({ email, username, ...verifierPayload });
+      85 |
+    > 86 |     const user = await prisma.user.findUnique({
+         |                  ^
+      87 |       where: { email },
+      88 |       select: { id: true },
+      89 |     });
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at registerUser (tests/server.flow.integration.test.ts:86:18)
+      at Object.<anonymous> (tests/server.flow.integration.test.ts:296:19)
+
+  ● server flow integration › allows a second user to join and leave a public server and reflects membership changes
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.findUnique()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/server.flow.integration.test.ts:86:36
+
+      83   .post('/api/auth/register')
+      84   .send({ email, username, ...verifierPayload });
+      85 
+    → 86 const user = await prisma.user.findUnique(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      84 |       .send({ email, username, ...verifierPayload });
+      85 |
+    > 86 |     const user = await prisma.user.findUnique({
+         |                  ^
+      87 |       where: { email },
+      88 |       select: { id: true },
+      89 |     });
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at registerUser (tests/server.flow.integration.test.ts:86:18)
+      at Object.<anonymous> (tests/server.flow.integration.test.ts:333:19)
+
+  ● server flow integration › rejects joining a private server
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.findUnique()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/server.flow.integration.test.ts:86:36
+
+      83   .post('/api/auth/register')
+      84   .send({ email, username, ...verifierPayload });
+      85 
+    → 86 const user = await prisma.user.findUnique(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      84 |       .send({ email, username, ...verifierPayload });
+      85 |
+    > 86 |     const user = await prisma.user.findUnique({
+         |                  ^
+      87 |       where: { email },
+      88 |       select: { id: true },
+      89 |     });
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at registerUser (tests/server.flow.integration.test.ts:86:18)
+      at Object.<anonymous> (tests/server.flow.integration.test.ts:412:19)
+
+  ● server flow integration › prevents the owner from leaving their own server
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.findUnique()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/server.flow.integration.test.ts:86:36
+
+      83   .post('/api/auth/register')
+      84   .send({ email, username, ...verifierPayload });
+      85 
+    → 86 const user = await prisma.user.findUnique(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      84 |       .send({ email, username, ...verifierPayload });
+      85 |
+    > 86 |     const user = await prisma.user.findUnique({
+         |                  ^
+      87 |       where: { email },
+      88 |       select: { id: true },
+      89 |     });
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at registerUser (tests/server.flow.integration.test.ts:86:18)
+      at Object.<anonymous> (tests/server.flow.integration.test.ts:441:19)
+
+  ● server flow integration › updates server metadata, resolves slug collisions, and deletes the server through tRPC
+
+    PrismaClientInitializationError: 
+    Invalid `prisma.user.findUnique()` invocation in
+    /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend/tests/server.flow.integration.test.ts:86:36
+
+      83   .post('/api/auth/register')
+      84   .send({ email, username, ...verifierPayload });
+      85 
+    → 86 const user = await prisma.user.findUnique(
+    error: Environment variable not found: DATABASE_URL.
+      -->  schema.prisma:10
+       | 
+     9 |   provider = "postgresql"
+    10 |   url      = env("DATABASE_URL")
+       | 
+
+    Validation Error Count: 1
+
+      84 |       .send({ email, username, ...verifierPayload });
+      85 |
+    > 86 |     const user = await prisma.user.findUnique({
+         |                  ^
+      87 |       where: { email },
+      88 |       select: { id: true },
+      89 |     });
+
+      at $n.handleRequestError (node_modules/@prisma/client/runtime/library.js:121:7615)
+      at $n.handleAndLogRequestError (node_modules/@prisma/client/runtime/library.js:121:6623)
+      at $n.request (node_modules/@prisma/client/runtime/library.js:121:6307)
+      at l (node_modules/@prisma/client/runtime/library.js:130:9633)
+      at registerUser (tests/server.flow.integration.test.ts:86:18)
+      at Object.<anonymous> (tests/server.flow.integration.test.ts:476:19)
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 55456,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 24ec26
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 68
+Output:
+
+Test Suites: 19 passed, 19 total
+Tests:       306 passed, 306 total
+Snapshots:   0 total
+Time:        2.252 s
+Ran all test suites.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:42:14.933Z
+
+The new regression test failed on a Jest typing detail, not the cache logic itself. I’m correcting the test typing and rerunning the targeted suite; backend verification already showed its current blocker is unrelated local setup (`DATABASE_URL` missing), while the frontend suite passed cleanly.
+
+#### Tool: exec_command
+
+```sh
+npm test -- env.test.ts
+```
+
+Output:
+
+```text
+
+> test
+> jest --config jest.config.js --runInBand env.test.ts
+
+PASS ./env.test.ts
+  getCloudFixture cache behavior
+    ✓ clears a rejected discovery promise so a later call can retry (19 ms)
+    ✓ reuses an in-flight discovery promise for concurrent callers (1 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       2 passed, 2 total
+Snapshots:   0 total
+Time:        0.675 s
+Ran all test suites matching /env.test.ts/i.
+```
+
+#### Tool: exec_command
+
+```sh
+npx tsc --noEmit -p tsconfig.json
+```
+
+Output:
+
+```text
+
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:42:30.492Z
+
+The focused regression suite now passes, and the TypeScript check for `tests/integration` is clean. I’m updating the task tracker and posting the issue completion comment with the verification details, including the unrelated backend env blocker that showed up during the broader repo check.
+
+#### Tool: exec_command
+
+```sh
+git status --short
+```
+
+Output:
+
+```text
+ M tests/integration/env.ts
+?? tests/integration/env.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue comment 419 --repo CS485-Harmony/Harmony --body $'**[AI Agent — In Progress]**\n\nAdded a focused regression test around `getCloudFixture()` in `tests/integration/env.test.ts` and patched `tests/integration/env.ts` so a rejected discovery promise clears the cache before rethrowing.\n\nTargeted verification is passing for the new retry and single-flight cases. I am finishing the task log and the final verification summary now.'
+```
+
+Output:
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/419#issuecomment-4305791963
+```
+
+#### Tool: exec_command
+
+```sh
+cat .gitignore
+```
+
+Output:
+
+```text
+tasks/todo.md
+.claude/*
+.env*
+*.local*
+.idea/*
+.playwright-cli/*
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,120p' tasks/todo.md
+```
+
+Output:
+
+```text
+# Issue #419
+
+- [x] Inspect the current cloud fixture cache behavior in `tests/integration/env.ts`
+- [ ] Add a regression test for retrying after an initial fixture discovery failure
+- [ ] Update the cloud fixture cache to clear rejected promises while preserving single-flight success behavior
+- [ ] Run relevant verification and document the outcome
+
+## Review
+
+- Pending
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:42:39.035Z
+
+I’ve confirmed `tasks/todo.md` is intentionally gitignored in this repo, so it stays as local task tracking only. I’m marking the work complete there and capturing the verification results before I wrap up.
+
+#### Tool: exec_command
+
+```sh
+nl -ba tests/integration/env.ts | sed -n '140,170p'
+```
+
+Output:
+
+```text
+   140	
+   141	  const envServerSlug = process.env.CLOUD_TEST_SERVER_SLUG;
+   142	  const envPublicChannel = process.env.CLOUD_TEST_PUBLIC_CHANNEL;
+   143	  if (envServerSlug && envPublicChannel) {
+   144	    return {
+   145	      serverSlug: envServerSlug,
+   146	      publicChannel: envPublicChannel,
+   147	      serverId: process.env.CLOUD_TEST_SERVER_ID,
+   148	    };
+   149	  }
+   150	
+   151	  if (!cloudFixturePromise) {
+   152	    cloudFixturePromise = resolveCloudFixtureFromPublicApi().catch((error: unknown) => {
+   153	      cloudFixturePromise = null;
+   154	      throw error;
+   155	    });
+   156	  }
+   157	  return cloudFixturePromise;
+   158	}
+```
+
+#### Tool: exec_command
+
+```sh
+nl -ba tests/integration/env.test.ts | sed -n '1,220p'
+```
+
+Output:
+
+```text
+     1	describe('getCloudFixture cache behavior', () => {
+     2	  const originalTestTarget = process.env.TEST_TARGET;
+     3	  const originalFetch = global.fetch;
+     4	
+     5	  async function loadCloudEnvModule() {
+     6	    process.env.TEST_TARGET = 'cloud';
+     7	    jest.resetModules();
+     8	    return import('./env');
+     9	  }
+    10	
+    11	  afterEach(() => {
+    12	    jest.resetModules();
+    13	    process.env.TEST_TARGET = originalTestTarget;
+    14	    global.fetch = originalFetch;
+    15	    jest.restoreAllMocks();
+    16	  });
+    17	
+    18	  test('clears a rejected discovery promise so a later call can retry', async () => {
+    19	    const fetchMock = jest
+    20	      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+    21	      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+    22	      .mockResolvedValueOnce(
+    23	        new Response(JSON.stringify([{ id: 'server-1', slug: 'harmony-hq' }]), { status: 200 }),
+    24	      )
+    25	      .mockResolvedValueOnce(
+    26	        new Response(JSON.stringify({ channels: [{ slug: 'general' }] }), { status: 200 }),
+    27	      );
+    28	    global.fetch = fetchMock;
+    29	
+    30	    const { getCloudFixture } = await loadCloudEnvModule();
+    31	
+    32	    await expect(getCloudFixture()).rejects.toThrow(
+    33	      'Cloud fixture discovery failed: GET /api/public/servers returned 503',
+    34	    );
+    35	
+    36	    await expect(getCloudFixture()).resolves.toEqual({
+    37	      serverId: 'server-1',
+    38	      serverSlug: 'harmony-hq',
+    39	      publicChannel: 'general',
+    40	    });
+    41	
+    42	    expect(fetchMock).toHaveBeenCalledTimes(3);
+    43	  });
+    44	
+    45	  test('reuses an in-flight discovery promise for concurrent callers', async () => {
+    46	    let resolveServers!: (value: Response) => void;
+    47	    const fetchMock = jest
+    48	      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+    49	      .mockImplementationOnce(
+    50	        () =>
+    51	          new Promise<Response>((resolve) => {
+    52	            resolveServers = resolve;
+    53	          }),
+    54	      )
+    55	      .mockResolvedValueOnce(
+    56	        new Response(JSON.stringify({ channels: [{ slug: 'general' }] }), { status: 200 }),
+    57	      );
+    58	    global.fetch = fetchMock;
+    59	
+    60	    const { getCloudFixture } = await loadCloudEnvModule();
+    61	
+    62	    const firstCall = getCloudFixture();
+    63	    const secondCall = getCloudFixture();
+    64	
+    65	    expect(fetchMock).toHaveBeenCalledTimes(1);
+    66	
+    67	    resolveServers(
+    68	      new Response(JSON.stringify([{ id: 'server-1', slug: 'harmony-hq' }]), { status: 200 }),
+    69	    );
+    70	
+    71	    await expect(Promise.all([firstCall, secondCall])).resolves.toEqual([
+    72	      {
+    73	        serverId: 'server-1',
+    74	        serverSlug: 'harmony-hq',
+    75	        publicChannel: 'general',
+    76	      },
+    77	      {
+    78	        serverId: 'server-1',
+    79	        serverSlug: 'harmony-hq',
+    80	        publicChannel: 'general',
+    81	      },
+    82	    ]);
+    83	
+    84	    expect(fetchMock).toHaveBeenCalledTimes(2);
+    85	  });
+    86	});
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue comment 419 --repo CS485-Harmony/Harmony --body $'**[AI Agent — Complete]**\n\nImplemented the issue in `tests/integration/env.ts` by clearing `cloudFixturePromise` when cloud fixture discovery rejects, while preserving the existing single-flight behavior for successful discovery.\n\nI also added `tests/integration/env.test.ts` with regression coverage for both retry-after-failure and concurrent single-flight callers. Verification run in this worktree:\n- `cd tests/integration && npm test -- env.test.ts` ✅\n- `cd tests/integration && npx tsc --noEmit -p tsconfig.json` ✅\n- `cd harmony-frontend && npm test -- --runInBand` ✅\n- `cd harmony-backend && npm test -- --runInBand` ⚠️ blocked here by missing local `DATABASE_URL`, unrelated to this issue\n\nNo further code changes are needed for issue #419.'
+```
+
+Output:
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/419#issuecomment-4305794987
+```
+
+#### Tool: update_plan
+
+- Explanation: The cache reset fix is in place, regression coverage was added, and issue comments plus task tracking were updated. Verification passed for the new integration test, the integration TypeScript check, and the frontend suite; the backend suite is currently blocked in this worktree by missing DATABASE_URL rather than this change.
+
+- Plan:
+  - [completed] Create task tracking entry for issue #419 and inspect the current integration fixture cache behavior
+  - [completed] Add a regression test covering retry after an initial cloud fixture discovery failure
+  - [completed] Patch the cached promise logic so rejections clear the cache while successful discovery remains single-flight
+  - [completed] Run relevant formatting, integration/backend/frontend verification, then post completion details to the issue
+
+Output:
+
+```text
+Plan updated
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:43:13.858Z
+
+Implemented the fix for issue #419 in [tests/integration/env.ts](/Users/allen/.codex/worktrees/9d14/Harmony/tests/integration/env.ts:151) by resetting `cloudFixturePromise` on rejection, so a transient discovery failure no longer poisons later calls in the same test process. That preserves the existing single-flight behavior for successful discovery.
+
+I also added regression coverage in [tests/integration/env.test.ts](/Users/allen/.codex/worktrees/9d14/Harmony/tests/integration/env.test.ts:1) for both cases the issue called out: retry after an initial failure and concurrent callers sharing one in-flight discovery.
+
+Verification:
+- `cd /Users/allen/.codex/worktrees/9d14/Harmony/tests/integration && npm test -- env.test.ts` passed
+- `cd /Users/allen/.codex/worktrees/9d14/Harmony/tests/integration && npx tsc --noEmit -p tsconfig.json` passed
+- `cd /Users/allen/.codex/worktrees/9d14/Harmony/harmony-frontend && npm test -- --runInBand` passed
+- `cd /Users/allen/.codex/worktrees/9d14/Harmony/harmony-backend && npm test -- --runInBand` is blocked in this worktree because `DATABASE_URL` is not set, which is unrelated to this change
+
+I posted start, progress, and completion updates on the GitHub issue as required by the repo workflow.
+
+### Turn 2: ## Code review guidelines: # Review guidelines: You are acting as a
+
+#### 👤 User Prompt
+
+- Time: 2026-04-23T15:43:22.745Z
+
+````text
+## Code review guidelines:
+# Review guidelines:
+
+You are acting as a reviewer for a proposed code change made by another engineer.
+
+Below are some default guidelines for determining whether the original author would appreciate the issue being flagged.
+
+These are not the final word in determining whether an issue is a bug. In many cases, you will encounter other, more specific guidelines. These may be present elsewhere in a developer message, a user message, a file, or even elsewhere in this system message.
+Those guidelines should be considered to override these general instructions.
+
+Here are the general guidelines for determining whether something is a bug and should be flagged.
+
+1. It meaningfully impacts the accuracy, performance, security, or maintainability of the code.
+2. The bug is discrete and actionable (i.e. not a general issue with the codebase or a combination of multiple issues).
+3. Fixing the bug does not demand a level of rigor that is not present in the rest of the codebase (e.g. one doesn't need very detailed comments and input validation in a repository of one-off scripts in personal projects)
+4. The bug was introduced in the commit (pre-existing bugs should not be flagged).
+5. The author of the original PR would likely fix the issue if they were made aware of it.
+6. The bug does not rely on unstated assumptions about the codebase or author's intent.
+7. It is not enough to speculate that a change may disrupt another part of the codebase, to be considered a bug, one must identify the other parts of the code that are provably affected.
+8. The bug is clearly not just an intentional change by the original author.
+
+When flagging a bug, you will also provide an accompanying comment. Once again, these guidelines are not the final word on how to construct a comment -- defer to any subsequent guidelines that you encounter.
+
+1. The comment should be clear about why the issue is a bug.
+2. The comment should appropriately communicate the severity of the issue. It should not claim that an issue is more severe than it actually is.
+3. The comment should be brief. The body should be at most 1 paragraph. It should not introduce line breaks within the natural language flow unless it is necessary for the code fragment.
+4. The comment should not include any chunks of code longer than 3 lines. Any code chunks should be wrapped in markdown inline code tags or a code block.
+5. The comment should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue's severity depends on these factors.
+6. The comment's tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
+7. The comment should be written such that the original author can immediately grasp the idea without close reading.
+8. The comment should avoid excessive flattery and comments that are not helpful to the original author. The comment should avoid phrasing like "Great job ...", "Thanks for ...".
+
+Below are some more detailed guidelines that you should apply to this specific review.
+
+HOW MANY FINDINGS TO RETURN:
+
+Output all findings that the original author would fix if they knew about it. If there is no finding that a person would definitely love to see and fix, prefer outputting no findings. Do not stop at the first qualifying finding. Continue until you've listed every qualifying finding.
+
+GUIDELINES:
+
+- Ignore trivial style unless it obscures meaning or violates documented standards.
+- Use one comment per distinct issue (or a multi-line range if necessary).
+- Use ```suggestion blocks ONLY for concrete replacement code (minimal lines; no commentary inside the block).
+- In every ```suggestion block, preserve the exact leading whitespace of the replaced lines (spaces vs tabs, number of spaces).
+- Do NOT introduce or remove outer indentation levels unless that is the actual fix.
+
+The comments will be presented in the code review as inline comments. You should avoid providing unnecessary location details in the comment body. Always keep the line range as short as possible for interpreting the issue. Avoid ranges longer than 5–10 lines; instead, choose the most suitable subrange that pinpoints the problem.
+
+At the beginning of the finding title, tag the bug with priority level. For example "[P1] Un-padding slices along wrong tensor dimensions". [P0] – Drop everything to fix. Blocking release, operations, or major usage. Only use for universal issues that do not depend on any assumptions about the inputs. · [P1] – Urgent. Should be addressed in the next cycle · [P2] – Normal. To be fixed eventually · [P3] – Low. Nice to have.
+
+Additionally, include a numeric priority field in the JSON output for each finding: set "priority" to 0 for P0, 1 for P1, 2 for P2, or 3 for P3. If a priority cannot be determined, omit the field or use null.
+
+At the end of your findings, output an "overall correctness" verdict of whether or not the patch should be considered "correct".
+Correct implies that existing code and tests will not break, and the patch is free of bugs and other blocking issues.
+Ignore non-blocking issues such as style, formatting, typos, documentation, and other nits.
+
+FORMATTING GUIDELINES:
+The finding description should be one paragraph.
+
+OUTPUT FORMAT:
+
+## Output schema — MUST MATCH _exactly_
+
+```json
+{
+  "findings": [
+    {
+      "title": "<≤ 80 chars, imperative>",
+      "body": "<valid Markdown explaining *why* this is a problem; cite files/lines/functions>",
+      "confidence_score": <float 0.0-1.0>,
+      "priority": <int 0-3, optional>,
+      "code_location": {
+        "absolute_file_path": "<file path>",
+        "line_range": {"start": <int>, "end": <int>}
+      }
+    }
+  ],
+  "overall_correctness": "patch is correct" | "patch is incorrect",
+  "overall_explanation": "<1-3 sentence explanation justifying the overall_correctness verdict>",
+  "overall_confidence_score": <float 0.0-1.0>
+}
+```
+
+- **Do not** wrap the JSON in markdown fences or extra prose.
+- The code_location field is required and must include absolute_file_path and line_range.
+  \*Line ranges must be as short as possible for interpreting the issue (avoid ranges over 5–10 lines; pick the most suitable subrange).
+- The code_location should overlap with the diff.
+- Do not generate a PR fix.
+- Your **initial** response to the user must always use the JSON schema above.
+- After the initial response, choose the format based on the user's request:
+  - If they explicitly ask for another review ("re-review", "rerun the review", etc.), return the findings in the exact JSON schema again.
+  - If they ask you to fix something, answer follow-up questions, or otherwise request non-review help, respond in plain text (no JSON or schema output).
+- All review instructions apply to the overall code review conversation. Continue following the guidelines in every response, only switching between JSON and plain text as described above.
+Review the code changes against the base branch 'main'. The merge base commit for this comparison is 14ebf900ae06ee2b492e001e47164af492ebf23e. Run `git diff 14ebf900ae06ee2b492e001e47164af492ebf23e` to inspect the changes relative to main. Provide prioritized, actionable findings.
+## My request for Codex:
+Please review changes on HEAD against main
+````
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:43:32.886Z
+
+Reviewing `HEAD` against `main` at merge-base `14ebf900ae06ee2b492e001e47164af492ebf23e`. I’m loading the Harmony PR review guidance first, then I’ll inspect the committed diff and check for concrete regressions only.
+
+#### Tool: exec_command
+
+```sh
+rg -n "PR review|PR_REVIEW|HEAD against main|changes on HEAD against main|git diff <base>..HEAD" /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+212:- rollout_summaries/2026-04-18T02-00-43-xqay-server_settings_auth_hardening_and_pr_review.md (cwd=/Users/allen/.codex/worktrees/aaf8/Harmony, rollout_path=/Users/allen/.codex/sessions/2026/04/17/rollout-2026-04-17T22-00-43-019d9e51-a23f-7682-b761-67d7c4e120de.jsonl, updated_at=2026-04-18T02:27:45+00:00, thread_id=019d9e51-a23f-7682-b761-67d7c4e120de, server-side settings guard plus PR review follow-up)
+228:## Task 3: Frontend-safe structured logging with no-PII constraints and PR review resolution
+271:- For PR review resolution on Harmony, `npx agent-reviews --pr <number> --unanswered --expanded`, then `--reply <id> ... --resolve`, followed by `--watch --timeout 60` worked to close the loop and confirm no new comments arrived [Task 3]
+321:# Task Group: Harmony PR review and review-resolution workflow
+323:applies_to: cwd=/Users/allen/.codex/worktrees/*/Harmony; reuse_rule=safe for Harmony PR review tasks that follow the repo's `WORKFLOW.md` and `.github/PR_REVIEW.md`; verify current remote/worktree before assuming repo names or branch refs.
+345:- Harmony PR review, .github/PR_REVIEW.md, WORKFLOW.md, bundled review, single bundled review, checklist of 8 guidelines, gh pr view, gh pr diff, gh pr review, gh api, file_comments expected objects not strings, acabrera04/Harmony, EmptyShell, VoiceProvider, system admin bypass, useChannelEvents, useServerEvents, SSE reconnect
+380:- when the user asked to "Spawn subagents" to review "all open PRs that have not already receieved an approval" -> default to parallel fan-out for multi-PR review sweeps and exclude already-approved PRs instead of re-reviewing everything [Task 1]
+390:- In Harmony PR reviews, load `WORKFLOW.md` and `.github/PR_REVIEW.md` first. The durable pattern is checklist first, then one bundled review with line-specific findings or a clear approval if the updated head is good [Task 1][Task 2][Task 3][Task 5]
+639:- changes on HEAD against main, HEAD against role-access, git diff <base>..HEAD, merge base 0de61fc1fdee9ea2531e57c42965bdda3d6ccdf2, no committed diff, unstaged changes, untracked files, DashboardPage.tsx, WeeklyDigest.tsx, weeklyDigest.ts, patch is correct
+643:- when the user asked to review "changes on HEAD against main" and then "HEAD against role-access" -> compare the committed revision against the requested base, not the current dirty worktree state [Task 1]
+647:- For committed-scope reviews in this repo, `git diff <base>..HEAD` is the correct check; plain `git diff <base>` can include unstaged or untracked worktree changes and mis-state what is actually under review [Task 1]
+648:- If `git diff <base>..HEAD --stat` and the full diff are both empty, there is no committed patch to review against that base even if the worktree contains local edits in files like `DashboardPage.tsx`, `WeeklyDigest.tsx`, or `weeklyDigest.ts` [Task 1]
+653:- symptom: a review starts analyzing files from the dirty worktree even though the user asked for `HEAD` against a base -> cause: the agent used a diff form that included local unstaged changes -> fix: verify the committed review scope first with `git diff <base>..HEAD` before opening candidate files [Task 1]
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,240p' .github/PR_REVIEW.md
+```
+
+Output:
+
+```text
+# PR Review Guidelines
+
+When conducting PR Reviews, follow these guidelines:
+1. **Prioritize Logic over Style:** Ensure the code is efficient, DRY (Don't Repeat Yourself), and logically sound.
+2. **Security First:** Verify that the changes do not introduce vulnerabilities (e.g., lack of input validation, exposed secrets).
+3. **Architectural Alignment:** If applicable, ensure the changes adhere strictly to the patterns defined in `@../docs/unified-backend-architecture.md`.
+4. **Issue Completion:** If the PR is attached to an issue, verify that the code successfully satisfies every acceptance criteria of that issue.
+5. **No Nitpicking:** Do not leave comments regarding stylistic choices, formatting, or subjective naming conventions unless they violate core project readability. Focus only on critical logic, performance, or architectural flaws.
+6. **Avoid Repetition:** Do not repeat feedback that has already been stated in previous reviews on this PR.
+7. **Iterative Reviews:** If this is not your first review on the PR:
+    - First, check if the new commits have correctly addressed your previous review comments.
+    - If a previous concern has been addressed, explicitly resolve the associated comment.
+8. **Prevent CI Failures:** Analyze the code for obvious issues that would break the pipeline. Specifically check for syntax errors, missing imports/dependencies, unhandled exceptions, and logic that would clearly break existing tests.
+
+**Execution Instruction**: Before providing your code feedback, output a markdown checklist of the 8 guidelines above. Mark each one as [x] if it passes or [ ] if it fails, and briefly explain why. Then, provide your single bundled review. Use inline subcomments within that single review for specific lines of codes. Do not post multiple standalone comments.
+```
+
+#### Tool: exec_command
+
+```sh
+git diff 14ebf900ae06ee2b492e001e47164af492ebf23e --
+```
+
+Output:
+
+```text
+diff --git a/tests/integration/env.ts b/tests/integration/env.ts
+index c4a330b..0c6fd62 100644
+--- a/tests/integration/env.ts
++++ b/tests/integration/env.ts
+@@ -149,7 +149,10 @@ export async function getCloudFixture(): Promise<CloudFixture> {
+   }
+ 
+   if (!cloudFixturePromise) {
+-    cloudFixturePromise = resolveCloudFixtureFromPublicApi();
++    cloudFixturePromise = resolveCloudFixtureFromPublicApi().catch((error: unknown) => {
++      cloudFixturePromise = null;
++      throw error;
++    });
+   }
+   return cloudFixturePromise;
+ }
+```
+
+#### Tool: exec_command
+
+```sh
+git status --short
+```
+
+Output:
+
+```text
+ M tests/integration/env.ts
+?? tests/integration/env.test.ts
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:43:40.746Z
+
+{"findings":[],"overall_correctness":"patch is correct","overall_explanation":"The committed change against `main` is narrowly scoped and correctly clears the cached cloud fixture promise on rejection while preserving single-flight behavior for successful discovery. I did not find a discrete regression in the diff that would warrant blocking or follow-up review feedback.","overall_confidence_score":0.96}
+
+### Turn 3: make a
+
+#### 👤 User Prompt
+
+- Time: 2026-04-23T15:43:53.647Z
+
+```text
+make a PR
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:44:04.046Z
+
+I’m preparing the issue fix for review now: checking the branch/remotes, staging the actual change set including the new regression test, and then I’ll commit, push, and open a draft PR with the verification summary.
+
+#### Tool: exec_command
+
+```sh
+git status --short
+```
+
+Output:
+
+```text
+ M tests/integration/env.ts
+?? tests/integration/env.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+git branch --show-current && git remote -v
+```
+
+Output:
+
+```text
+origin	git@github.com:CS485-Harmony/Harmony.git (fetch)
+origin	git@github.com:CS485-Harmony/Harmony.git (push)
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --stat
+```
+
+Output:
+
+```text
+ tests/integration/env.ts | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,220p' /Users/allen/.codex/plugins/cache/openai-curated/github/27651a43bf55185d924f7a1fc49043a0a8be65a0/skills/yeet/SKILL.md
+```
+
+Output:
+
+```text
+---
+name: "yeet"
+description: "Publish local changes to GitHub by confirming scope, committing intentionally, pushing the branch, and opening a draft PR through the GitHub app from this plugin, with `gh` used only as a fallback where connector coverage is insufficient."
+---
+
+# GitHub Publish Changes
+
+## Overview
+
+Use this skill only when the user explicitly wants the full publish flow from the local checkout: branch setup if needed, staging, commit, push, and opening a pull request.
+
+This workflow is hybrid:
+
+- Use local `git` for branch creation, staging, commit, and push.
+- Prefer the GitHub app from this plugin for pull request creation after the branch is on the remote.
+- Use `gh` as a fallback for current-branch PR discovery, auth checks, or PR creation when the connector path cannot infer the repository or head branch cleanly.
+
+## Prerequisites
+
+- Require GitHub CLI `gh`. Check `gh --version`. If missing, ask the user to install `gh` and stop.
+- Require authenticated `gh` session. Run `gh auth status`. If not authenticated, ask the user to run `gh auth login` (and re-run `gh auth status`) before continuing.
+- Require a local git repository with a clean understanding of which changes belong in the PR.
+
+## Naming conventions
+
+- Branch: `codex/{description}` when starting from main/master/default.
+- Commit: `{description}` (terse).
+- PR title: `[codex] {description}` summarizing the full diff.
+
+## Workflow
+
+1. Confirm intended scope.
+   - Run `git status -sb` and inspect the diff before staging.
+   - If the working tree contains unrelated changes, do not default to `git add -A`. Ask the user which files belong in the PR.
+2. Determine the branch strategy.
+   - If on `main`, `master`, or another default branch, create `codex/{description}`.
+   - Otherwise stay on the current branch.
+3. Stage only the intended changes.
+   - Prefer explicit file paths when the worktree is mixed.
+   - Use `git add -A` only when the user has confirmed the whole worktree belongs in scope.
+4. Commit tersely with the confirmed description.
+5. Run the most relevant checks available if they have not already been run.
+   - If checks fail due to missing dependencies or tools, install what is needed and rerun once.
+6. Push with tracking: `git push -u origin $(git branch --show-current)`.
+7. Open a draft PR.
+   - Prefer the GitHub app from this plugin for PR creation after the push succeeds.
+   - Derive `repository_full_name` from the remote, for example by normalizing `git remote get-url origin` or by using `gh repo view --json nameWithOwner`.
+   - Derive `head_branch` from `git branch --show-current`.
+   - Derive `base_branch` from the user request when specified; otherwise use the remote default branch, for example via `gh repo view --json defaultBranchRef`.
+   - If the branch is being pushed from a fork or the PR target differs from the remote that was just pushed, prefer `gh pr create` fallback because the connector PR creation flow expects one repository target and may not encode cross-repo head semantics cleanly.
+   - If connector-based PR creation cannot infer the repository or branch cleanly, fall back to `gh pr create --draft --fill --head $(git branch --show-current)`.
+   - Write the PR body to a temp file with real newlines when using CLI fallback so the markdown renders cleanly.
+8. Summarize the result with branch name, commit, PR target, validation, and anything the user still needs to confirm.
+
+## Write Safety
+
+- Never stage unrelated user changes silently.
+- Never push without confirming scope when the worktree is mixed.
+- Default to a draft PR unless the user explicitly asks for a ready-for-review PR.
+- If the repository does not appear to be connected to an accessible GitHub remote, stop and explain the blocker before making assumptions.
+
+## PR Body Expectations
+
+The PR description should use real Markdown prose and cover:
+
+- what changed
+- why it changed
+- the user or developer impact
+- the root cause when the PR is a fix
+- the checks used to validate it
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:44:10.756Z
+
+The worktree isn’t showing a current branch name, so I’m verifying whether this is a detached HEAD before I create the publish branch. After that I’ll stage only the two issue files, commit with the required Harmony co-author trailer, and open the draft PR.
+
+#### Tool: exec_command
+
+```sh
+git status -sb
+```
+
+Output:
+
+```text
+## HEAD (no branch)
+ M tests/integration/env.ts
+?? tests/integration/env.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+git rev-parse --abbrev-ref HEAD && git rev-parse --short HEAD
+```
+
+Output:
+
+```text
+HEAD
+14ebf90
+```
+
+#### Tool: exec_command
+
+```sh
+gh auth status && gh repo view --json nameWithOwner,defaultBranchRef
+```
+
+Output:
+
+```text
+github.com
+  ✓ Logged in to github.com account acabrera04 (keyring)
+  - Active account: true
+  - Git operations protocol: ssh
+  - Token: gho_************************************
+  - Token scopes: 'admin:public_key', 'gist', 'project', 'read:org', 'repo', 'workflow'
+{"defaultBranchRef":{"name":"main"},"nameWithOwner":"CS485-Harmony/Harmony"}
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:44:19.461Z
+
+I’ve confirmed this checkout is detached at the merge base, so I’m creating a dedicated branch off the current HEAD and staging just the issue files. Then I’ll review the staged diff one more time, commit, push, and create the draft PR.
+
+#### Tool: exec_command
+
+```sh
+git switch -c codex/retry-cloud-fixture-discovery
+```
+
+Output:
+
+```text
+Switched to a new branch 'codex/retry-cloud-fixture-discovery'
+```
+
+#### Tool: exec_command
+
+```sh
+git diff -- tests/integration/env.ts tests/integration/env.test.ts
+```
+
+Output:
+
+```text
+diff --git a/tests/integration/env.ts b/tests/integration/env.ts
+index c4a330b..0c6fd62 100644
+--- a/tests/integration/env.ts
++++ b/tests/integration/env.ts
+@@ -149,7 +149,10 @@ export async function getCloudFixture(): Promise<CloudFixture> {
+   }
+ 
+   if (!cloudFixturePromise) {
+-    cloudFixturePromise = resolveCloudFixtureFromPublicApi();
++    cloudFixturePromise = resolveCloudFixtureFromPublicApi().catch((error: unknown) => {
++      cloudFixturePromise = null;
++      throw error;
++    });
+   }
+   return cloudFixturePromise;
+ }
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:44:27.632Z
+
+The branch is ready. I’m staging the implementation file and the new regression test explicitly, then checking the staged diff and verification state before I write the commit and PR metadata.
+
+#### Tool: exec_command
+
+```sh
+git add tests/integration/env.ts tests/integration/env.test.ts && git diff --cached --stat && git diff --cached -- tests/integration/env.ts tests/integration/env.test.ts
+```
+
+Output:
+
+```text
+ tests/integration/env.test.ts | 86 +++++++++++++++++++++++++++++++++++++++++++
+ tests/integration/env.ts      |  5 ++-
+ 2 files changed, 90 insertions(+), 1 deletion(-)
+diff --git a/tests/integration/env.test.ts b/tests/integration/env.test.ts
+new file mode 100644
+index 0000000..eb1da57
+--- /dev/null
++++ b/tests/integration/env.test.ts
+@@ -0,0 +1,86 @@
++describe('getCloudFixture cache behavior', () => {
++  const originalTestTarget = process.env.TEST_TARGET;
++  const originalFetch = global.fetch;
++
++  async function loadCloudEnvModule() {
++    process.env.TEST_TARGET = 'cloud';
++    jest.resetModules();
++    return import('./env');
++  }
++
++  afterEach(() => {
++    jest.resetModules();
++    process.env.TEST_TARGET = originalTestTarget;
++    global.fetch = originalFetch;
++    jest.restoreAllMocks();
++  });
++
++  test('clears a rejected discovery promise so a later call can retry', async () => {
++    const fetchMock = jest
++      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
++      .mockResolvedValueOnce(new Response(null, { status: 503 }))
++      .mockResolvedValueOnce(
++        new Response(JSON.stringify([{ id: 'server-1', slug: 'harmony-hq' }]), { status: 200 }),
++      )
++      .mockResolvedValueOnce(
++        new Response(JSON.stringify({ channels: [{ slug: 'general' }] }), { status: 200 }),
++      );
++    global.fetch = fetchMock;
++
++    const { getCloudFixture } = await loadCloudEnvModule();
++
++    await expect(getCloudFixture()).rejects.toThrow(
++      'Cloud fixture discovery failed: GET /api/public/servers returned 503',
++    );
++
++    await expect(getCloudFixture()).resolves.toEqual({
++      serverId: 'server-1',
++      serverSlug: 'harmony-hq',
++      publicChannel: 'general',
++    });
++
++    expect(fetchMock).toHaveBeenCalledTimes(3);
++  });
++
++  test('reuses an in-flight discovery promise for concurrent callers', async () => {
++    let resolveServers!: (value: Response) => void;
++    const fetchMock = jest
++      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
++      .mockImplementationOnce(
++        () =>
++          new Promise<Response>((resolve) => {
++            resolveServers = resolve;
++          }),
++      )
++      .mockResolvedValueOnce(
++        new Response(JSON.stringify({ channels: [{ slug: 'general' }] }), { status: 200 }),
++      );
++    global.fetch = fetchMock;
++
++    const { getCloudFixture } = await loadCloudEnvModule();
++
++    const firstCall = getCloudFixture();
++    const secondCall = getCloudFixture();
++
++    expect(fetchMock).toHaveBeenCalledTimes(1);
++
++    resolveServers(
++      new Response(JSON.stringify([{ id: 'server-1', slug: 'harmony-hq' }]), { status: 200 }),
++    );
++
++    await expect(Promise.all([firstCall, secondCall])).resolves.toEqual([
++      {
++        serverId: 'server-1',
++        serverSlug: 'harmony-hq',
++        publicChannel: 'general',
++      },
++      {
++        serverId: 'server-1',
++        serverSlug: 'harmony-hq',
++        publicChannel: 'general',
++      },
++    ]);
++
++    expect(fetchMock).toHaveBeenCalledTimes(2);
++  });
++});
+diff --git a/tests/integration/env.ts b/tests/integration/env.ts
+index c4a330b..0c6fd62 100644
+--- a/tests/integration/env.ts
++++ b/tests/integration/env.ts
+@@ -149,7 +149,10 @@ export async function getCloudFixture(): Promise<CloudFixture> {
+   }
+ 
+   if (!cloudFixturePromise) {
+-    cloudFixturePromise = resolveCloudFixtureFromPublicApi();
++    cloudFixturePromise = resolveCloudFixtureFromPublicApi().catch((error: unknown) => {
++      cloudFixturePromise = null;
++      throw error;
++    });
+   }
+   return cloudFixturePromise;
+ }
+```
+
+#### Tool: exec_command
+
+```sh
+npm test -- env.test.ts
+```
+
+Output:
+
+```text
+
+> test
+> jest --config jest.config.js --runInBand env.test.ts
+
+PASS ./env.test.ts
+  getCloudFixture cache behavior
+    ✓ clears a rejected discovery promise so a later call can retry (6 ms)
+    ✓ reuses an in-flight discovery promise for concurrent callers (1 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       2 passed, 2 total
+Snapshots:   0 total
+Time:        0.493 s, estimated 1 s
+Ran all test suites matching /env.test.ts/i.
+```
+
+#### Tool: exec_command
+
+```sh
+npx tsc --noEmit -p tsconfig.json
+```
+
+Output:
+
+```text
+
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:44:34.221Z
+
+The staged scope is clean and the targeted integration checks passed again. I’m committing with a terse message and the required Harmony co-author trailer, then I’ll push and open the draft PR against `main`.
+
+#### Tool: exec_command
+
+```sh
+git commit -m "test(integration): retry cloud fixture discovery" -m "Co-authored-by: GPT 5.4 <noreply@openai.com>"
+```
+
+Output:
+
+```text
+[codex/retry-cloud-fixture-discovery 589da86] test(integration): retry cloud fixture discovery
+ 2 files changed, 90 insertions(+), 1 deletion(-)
+ create mode 100644 tests/integration/env.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+git branch --show-current
+```
+
+Output:
+
+```text
+codex/retry-cloud-fixture-discovery
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:44:42.039Z
+
+The commit is in place on `codex/retry-cloud-fixture-discovery`. I’m pushing that branch to `origin`, then I’ll open a draft PR against `main` with the issue context and the verification summary.
+
+#### Tool: exec_command
+
+```sh
+git push -u origin codex/retry-cloud-fixture-discovery
+```
+
+Output:
+
+```text
+remote: 
+remote: Create a pull request for 'codex/retry-cloud-fixture-discovery' on GitHub by visiting:        
+remote:      https://github.com/CS485-Harmony/Harmony/pull/new/codex/retry-cloud-fixture-discovery        
+remote: 
+To github.com:CS485-Harmony/Harmony.git
+ * [new branch]      codex/retry-cloud-fixture-discovery -> codex/retry-cloud-fixture-discovery
+branch 'codex/retry-cloud-fixture-discovery' set up to track 'origin/codex/retry-cloud-fixture-discovery'.
+```
+
+#### Tool: exec_command
+
+```sh
+git rev-parse --short HEAD && git status --short
+```
+
+Output:
+
+```text
+589da86
+```
+
+#### Tool: exec_command
+
+```sh
+cat <<'EOF' >/tmp/harmony-pr-419.md
+## Summary
+- clear the cached cloud fixture discovery promise after a rejected lookup so later calls can retry in the same process
+- add integration coverage for both retry-after-failure and successful single-flight behavior
+
+## Root Cause
+`tests/integration/env.ts` cached the first discovery promise permanently. If that first lookup failed due to a transient network error, every later `getCloudFixture()` call in the same Jest process reused the rejected promise and could never recover.
+
+## Validation
+- `cd tests/integration && npm test -- env.test.ts`
+- `cd tests/integration && npx tsc --noEmit -p tsconfig.json`
+- `cd harmony-frontend && npm test -- --runInBand`
+- `cd harmony-backend && npm test -- --runInBand` *(blocked locally in this worktree because `DATABASE_URL` is unset)*
+
+Closes #419.
+EOF
+
+gh pr create --draft --base main --head codex/retry-cloud-fixture-discovery --title "[codex] Retry failed cloud fixture discovery in integration tests" --body-file /tmp/harmony-pr-419.md
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 15981,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 5000
+}
+```
+
+Output:
+
+```text
+Chunk ID: e2e11d
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/CS485-Harmony/Harmony/pull/458
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T15:45:02.123Z
+
+Created a draft PR for issue #419: [#458](https://github.com/CS485-Harmony/Harmony/pull/458).
+
+Branch `codex/retry-cloud-fixture-discovery` contains commit `589da86` with the cache-reset fix in [tests/integration/env.ts](/Users/allen/.codex/worktrees/9d14/Harmony/tests/integration/env.ts:151) and the new regression coverage in [tests/integration/env.test.ts](/Users/allen/.codex/worktrees/9d14/Harmony/tests/integration/env.test.ts:1). Validation included the targeted integration test, the integration TypeScript check, and the frontend Jest suite; the backend Jest suite is still blocked in this worktree because `DATABASE_URL` is unset.
+
+### Turn 4: [$codex-conversation-exporter](/Users/allen/repos/codex-logs-export/skil
+
+#### 👤 User Prompt
+
+- Time: 2026-04-23T16:23:55.670Z
+
+```text
+[$codex-conversation-exporter](/Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md) 019dbaff-4d65-7021-8ff6-dd2bb29ed4d2 to llm-logs/acabrera04-logs/final
+```
+
+_No assistant or tool activity recorded after this prompt._
+
+### Turn 5: <skill> <name>codex-conversation-exporter</name>
+
+#### 👤 User Prompt
+
+- Time: 2026-04-23T16:23:55.671Z
+
+````text
+<skill>
+<name>codex-conversation-exporter</name>
+<path>/Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md</path>
+---
+name: codex-conversation-exporter
+description: Export Codex session logs to Markdown using the local codex-export CLI instead of reconstructing transcripts with model tokens.
+---
+
+# Codex Conversation Exporter
+
+Use this skill when the user asks to export Codex logs, save a Codex conversation, convert a session to Markdown, or archive a transcript locally.
+
+## Rules
+
+- Prefer the local `codex-export` CLI over reconstructing a transcript in-model.
+- If the user has not identified a session, run `codex-export list` first and show the relevant candidates.
+- Default to messages plus tool activity.
+- Include hidden system/developer prompts only when the user explicitly asks for them.
+- Write to a user-visible path unless the user asks for stdout or another destination.
+- Report the output path back to the user after a file export.
+
+## Command patterns
+
+List recent sessions:
+
+```bash
+codex-export list
+codex-export list --limit 10
+codex-export list --since 2026-03-30
+```
+
+Export by thread id:
+
+```bash
+codex-export export <thread-id>
+codex-export export <thread-id> --out ~/Desktop
+codex-export export <thread-id> --messages-only
+codex-export export <thread-id> --all
+codex-export export <thread-id> --include-hidden-prompts
+codex-export export <thread-id> --stdout
+```
+
+Export by rollout path:
+
+```bash
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl --out ~/Desktop
+```
+
+## Flag guide
+
+- `--out <file-or-dir>` writes to a specific file or directory.
+- `--stdout` prints the Markdown instead of writing a file.
+- `--messages-only` omits tool calls and tool outputs.
+- `--all` includes low-level tool metadata and raw wrappers that are hidden by default.
+- `--include-hidden-prompts` includes developer/system prompt layers.
+- `--since <date>` filters `list` results.
+- `--limit <n>` caps `list` results.
+
+## Agent behavior
+
+When the user says "export this conversation" without a thread id:
+
+1. Run `codex-export list`.
+2. Identify the most likely current session from title, cwd, and recency.
+3. Export it with the default mode unless the user requested a different output.
+4. Return the exact file path written.
+
+`codex-log-export` remains available as a compatibility alias.
+
+</skill>
+````
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-23T16:24:14.667Z
+
+Using the `codex-conversation-exporter` skill here. I’m exporting thread `019dbaff-4d65-7021-8ff6-dd2bb29ed4d2` into the repo’s `llm-logs/acabrera04-logs/final` path, then I’ll stage, commit, and push that artifact on the current PR branch.
+
+#### Tool: exec_command
+
+```sh
+git branch --show-current && git status --short
+```
+
+Output:
+
+```text
+codex/retry-cloud-fixture-discovery
+```
+
+#### Tool: exec_command
+
+```sh
+codex-export export 019dbaff-4d65-7021-8ff6-dd2bb29ed4d2 --out /Users/allen/.codex/worktrees/9d14/Harmony/llm-logs/acabrera04-logs/final
+```

--- a/tests/integration/env.test.ts
+++ b/tests/integration/env.test.ts
@@ -1,0 +1,86 @@
+describe('getCloudFixture cache behavior', () => {
+  const originalTestTarget = process.env.TEST_TARGET;
+  const originalFetch = global.fetch;
+
+  async function loadCloudEnvModule() {
+    process.env.TEST_TARGET = 'cloud';
+    jest.resetModules();
+    return import('./env');
+  }
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env.TEST_TARGET = originalTestTarget;
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test('clears a rejected discovery promise so a later call can retry', async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: 'server-1', slug: 'harmony-hq' }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ channels: [{ slug: 'general' }] }), { status: 200 }),
+      );
+    global.fetch = fetchMock;
+
+    const { getCloudFixture } = await loadCloudEnvModule();
+
+    await expect(getCloudFixture()).rejects.toThrow(
+      'Cloud fixture discovery failed: GET /api/public/servers returned 503',
+    );
+
+    await expect(getCloudFixture()).resolves.toEqual({
+      serverId: 'server-1',
+      serverSlug: 'harmony-hq',
+      publicChannel: 'general',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('reuses an in-flight discovery promise for concurrent callers', async () => {
+    let resolveServers!: (value: Response) => void;
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveServers = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ channels: [{ slug: 'general' }] }), { status: 200 }),
+      );
+    global.fetch = fetchMock;
+
+    const { getCloudFixture } = await loadCloudEnvModule();
+
+    const firstCall = getCloudFixture();
+    const secondCall = getCloudFixture();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveServers(
+      new Response(JSON.stringify([{ id: 'server-1', slug: 'harmony-hq' }]), { status: 200 }),
+    );
+
+    await expect(Promise.all([firstCall, secondCall])).resolves.toEqual([
+      {
+        serverId: 'server-1',
+        serverSlug: 'harmony-hq',
+        publicChannel: 'general',
+      },
+      {
+        serverId: 'server-1',
+        serverSlug: 'harmony-hq',
+        publicChannel: 'general',
+      },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/integration/env.ts
+++ b/tests/integration/env.ts
@@ -149,7 +149,10 @@ export async function getCloudFixture(): Promise<CloudFixture> {
   }
 
   if (!cloudFixturePromise) {
-    cloudFixturePromise = resolveCloudFixtureFromPublicApi();
+    cloudFixturePromise = resolveCloudFixtureFromPublicApi().catch((error: unknown) => {
+      cloudFixturePromise = null;
+      throw error;
+    });
   }
   return cloudFixturePromise;
 }


### PR DESCRIPTION
## Summary
- clear the cached cloud fixture discovery promise after a rejected lookup so later calls can retry in the same process
- add integration coverage for both retry-after-failure and successful single-flight behavior

## Root Cause
`tests/integration/env.ts` cached the first discovery promise permanently. If that first lookup failed due to a transient network error, every later `getCloudFixture()` call in the same Jest process reused the rejected promise and could never recover.

## Validation
- `cd tests/integration && npm test -- env.test.ts`
- `cd tests/integration && npx tsc --noEmit -p tsconfig.json`
- `cd harmony-frontend && npm test -- --runInBand`
- `cd harmony-backend && npm test -- --runInBand` *(blocked locally in this worktree because `DATABASE_URL` is unset)*

Closes #419.
