### PR TITLE
fix: align DiscussionForumPosting JSON-LD with persisted SEO metadata

### DIFF
--- a/harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+++ b/harmony-frontend/src/__tests__/channel-page-metadata.test.ts
@@ -4,7 +4,10 @@
  */
 
 const mockCache = jest.fn(<T extends (...args: never[]) => unknown>(fn: T): T => fn);
-jest.mock('react', () => ({ cache: mockCache }));
+jest.mock('react', () => {
+  const actualReact = jest.requireActual('react');
+  return { ...actualReact, cache: mockCache };
+});
 
 jest.mock('@/services/publicApiService', () => ({
   fetchPublicServer: jest.fn(),
@@ -16,12 +19,18 @@ jest.mock('@/components/channel/GuestChannelView', () => ({
   GuestChannelView: () => null,
 }));
 
-import { generateMetadata } from '@/app/c/[serverSlug]/[channelSlug]/page';
-import { fetchPublicServer, fetchPublicChannel } from '@/services/publicApiService';
+import { renderToStaticMarkup } from 'react-dom/server';
+import GuestChannelPage, { generateMetadata } from '@/app/c/[serverSlug]/[channelSlug]/page';
+import {
+  fetchPublicServer,
+  fetchPublicChannel,
+  fetchPublicMetaTags,
+} from '@/services/publicApiService';
 import { ChannelType, ChannelVisibility } from '@/types';
 
 const mockFetchPublicServer = fetchPublicServer as jest.Mock;
 const mockFetchPublicChannel = fetchPublicChannel as jest.Mock;
+const mockFetchPublicMetaTags = fetchPublicMetaTags as jest.Mock;
 
 const originalEnv = process.env;
 
@@ -112,6 +121,54 @@ describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
         title: 'general - Harmony HQ | Harmony',
         description: 'Welcome to general',
       },
+    });
+  });
+
+  it('renders JSON-LD with author, text, and headline for rich results', async () => {
+    const page = await GuestChannelPage(makeParams());
+    const html = renderToStaticMarkup(page);
+    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+
+    expect(ldMatch).not.toBeNull();
+    const jsonLd = JSON.parse(ldMatch![1]);
+    expect(jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'DiscussionForumPosting',
+      'name': 'general - Harmony HQ | Harmony',
+      'headline': 'general - Harmony HQ | Harmony',
+      'description': 'Welcome to general',
+      'text': 'Welcome to general',
+      'author': {
+        '@type': 'Organization',
+        'name': 'Harmony HQ',
+      },
+      'url': 'https://harmony.chat/c/harmony-hq/general',
+      'datePublished': '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('reuses persisted SEO metadata in JSON-LD when present', async () => {
+    mockFetchPublicMetaTags.mockResolvedValue({
+      title: 'Custom SEO Title',
+      description: 'Custom SEO Description',
+      ogTitle: 'Custom OG Title',
+      ogDescription: 'Custom OG Description',
+      ogImage: 'https://example.com/custom.png',
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      visibility: 'PUBLIC_INDEXABLE',
+    });
+
+    const page = await GuestChannelPage(makeParams());
+    const html = renderToStaticMarkup(page);
+    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+
+    expect(ldMatch).not.toBeNull();
+    const jsonLd = JSON.parse(ldMatch![1]);
+    expect(jsonLd).toMatchObject({
+      name: 'Custom SEO Title',
+      headline: 'Custom SEO Title',
+      description: 'Custom SEO Description',
+      text: 'Custom SEO Description',
     });
   });
 });

--- a/harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+++ b/harmony-frontend/src/__tests__/channel-page-metadata.test.ts
@@ -171,6 +171,27 @@ describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
       text: 'Custom SEO Description',
     });
   });
+
+  it('uses the same server-name fallback for JSON-LD author as the page metadata', async () => {
+    mockFetchPublicServer.mockResolvedValue(null);
+
+    const page = await GuestChannelPage(makeParams('fallback-server', 'general'));
+    const html = renderToStaticMarkup(page);
+    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+
+    expect(ldMatch).not.toBeNull();
+    const jsonLd = JSON.parse(ldMatch![1]);
+    expect(jsonLd).toMatchObject({
+      name: 'general - fallback-server | Harmony',
+      headline: 'general - fallback-server | Harmony',
+      description: 'Welcome to general',
+      text: 'Welcome to general',
+      author: {
+        '@type': 'Organization',
+        'name': 'fallback-server',
+      },
+    });
+  });
 });
 
 describe('generateMetadata — PUBLIC_NO_INDEX channel', () => {

--- a/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+++ b/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
@@ -56,24 +56,36 @@ export default async function GuestChannelPage({ params }: PageProps) {
   const { serverSlug, channelSlug } = await params;
 
   // Fetch data for JSON-LD; React cache deduplicates these within the same render pass
-  const [server, channelResult] = await Promise.all([
+  const [server, channelResult, publicMetaTags] = await Promise.all([
     fetchPublicServer(serverSlug),
     fetchPublicChannel(serverSlug, channelSlug),
+    fetchPublicMetaTags(serverSlug, channelSlug),
   ]);
 
   const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
   const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+  const channelName = channel?.name ?? channelSlug;
+  const serverName = server?.name ?? serverSlug;
+  const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+  const text =
+    publicMetaTags?.description ??
+    channel?.topic ??
+    server?.description ??
+    `Join ${serverName} on Harmony`;
 
   const jsonLd = isIndexable
     ? {
         '@context': 'https://schema.org',
         '@type': 'DiscussionForumPosting',
-        name: `${channel?.name ?? channelSlug} - ${server?.name ?? serverSlug} | Harmony`,
-        url: getChannelUrl(serverSlug, channelSlug),
-        description:
-          channel?.topic ??
-          server?.description ??
-          `Join ${server?.name ?? serverSlug} on Harmony`,
+        'name': title,
+        'headline': title,
+        'url': getChannelUrl(serverSlug, channelSlug),
+        'description': text,
+        text,
+        'author': {
+          '@type': 'Organization',
+          'name': server?.name ?? 'Harmony',
+        },
         ...(channel?.createdAt && { datePublished: channel.createdAt }),
       }
     : null;
@@ -82,7 +94,7 @@ export default async function GuestChannelPage({ params }: PageProps) {
     <>
       {jsonLd && (
         <script
-          type="application/ld+json"
+          type='application/ld+json'
           // Escape </script> breakout sequences per OWASP JSON-LD injection guidance
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(jsonLd)

--- a/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+++ b/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
@@ -12,6 +12,31 @@ interface PageProps {
   params: Promise<{ serverSlug: string; channelSlug: string }>;
 }
 
+function getSeoContent(
+  serverSlug: string,
+  channelSlug: string,
+  server: Awaited<ReturnType<typeof fetchPublicServer>>,
+  channelResult: Awaited<ReturnType<typeof fetchPublicChannel>>,
+  publicMetaTags: Awaited<ReturnType<typeof fetchPublicMetaTags>>,
+) {
+  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
+  const channelName = channel?.name ?? channelSlug;
+  const serverName = server?.name ?? serverSlug;
+  const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+  const description =
+    publicMetaTags?.description ??
+    channel?.topic ??
+    server?.description ??
+    `Join ${serverName} on Harmony`;
+
+  return {
+    channel,
+    serverName,
+    title,
+    description,
+  };
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { serverSlug, channelSlug } = await params;
   const [server, channelResult, publicMetaTags] = await Promise.all([
@@ -20,16 +45,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     fetchPublicMetaTags(serverSlug, channelSlug),
   ]);
 
-  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
-  const channelName = channel?.name ?? channelSlug;
-  const serverName = server?.name ?? serverSlug;
+  const { channel, title, description } = getSeoContent(
+    serverSlug,
+    channelSlug,
+    server,
+    channelResult,
+    publicMetaTags,
+  );
   const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
-  const description =
-    publicMetaTags?.description ??
-    channel?.topic ??
-    server?.description ??
-    `Join ${serverName} on Harmony`;
-  const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
   const canonicalUrl = getChannelUrl(serverSlug, channelSlug);
 
   return {
@@ -62,16 +85,14 @@ export default async function GuestChannelPage({ params }: PageProps) {
     fetchPublicMetaTags(serverSlug, channelSlug),
   ]);
 
-  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
+  const { channel, serverName, title, description } = getSeoContent(
+    serverSlug,
+    channelSlug,
+    server,
+    channelResult,
+    publicMetaTags,
+  );
   const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
-  const channelName = channel?.name ?? channelSlug;
-  const serverName = server?.name ?? serverSlug;
-  const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
-  const text =
-    publicMetaTags?.description ??
-    channel?.topic ??
-    server?.description ??
-    `Join ${serverName} on Harmony`;
 
   const jsonLd = isIndexable
     ? {
@@ -80,11 +101,11 @@ export default async function GuestChannelPage({ params }: PageProps) {
         'name': title,
         'headline': title,
         'url': getChannelUrl(serverSlug, channelSlug),
-        'description': text,
-        text,
+        'description': description,
+        'text': description,
         'author': {
           '@type': 'Organization',
-          'name': server?.name ?? 'Harmony',
+          'name': serverName,
         },
         ...(channel?.createdAt && { datePublished: channel.createdAt }),
       }

--- a/llm-logs/2026-04-25-152611-session-85d01715.md
+++ b/llm-logs/2026-04-25-152611-session-85d01715.md
@@ -1,0 +1,355 @@
+# Session Log 2026-04-25-152611
+
+## User
+
+<command-message>review</command-message>
+<command-name>/review</command-name>
+<command-args>469</command-args>
+
+## User
+
+You are an expert code reviewer. Follow these steps:
+
+      1. If no PR number is provided in the args, run `gh pr list` to show open PRs
+      2. If a PR number is provided, run `gh pr view <number>` to get PR details
+      3. Run `gh pr diff <number>` to get the diff
+      4. Analyze the changes and provide a thorough code review that includes:
+         - Overview of what the PR does
+         - Analysis of code quality and style
+         - Specific suggestions for improvements
+         - Any potential issues or risks
+
+      Keep your review concise but thorough. Focus on:
+      - Code correctness
+      - Following project conventions
+      - Performance implications
+      - Test coverage
+      - Security considerations
+
+      Format your review with clear sections and bullet points.
+
+      PR number: 469
+
+## Assistant
+
+I'll fetch the PR details and diff for PR #469.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 469 && echo \"---DIFF---\" && gh pr diff 469",
+  "description": "Fetch PR 469 details and diff"
+}
+```
+
+## Assistant
+
+Now let me check the PR review guidelines and the relevant source files for context.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /Users/bigfa/Documents/GitHub/Harmony/.github/PR_REVIEW.md",
+  "description": "Read PR review guidelines"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/app/c/\\[serverSlug\\]/\\[channelSlug\\]/page.tsx",
+  "description": "Read the full page.tsx file"
+}
+```
+
+## Assistant
+
+Let me check the publicApiService for cache usage and the issue #468 acceptance criteria.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"fetchPublicMetaTags\\|cache\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/publicApiService.ts | head -40",
+  "description": "Check publicApiService for fetchPublicMetaTags and cache usage"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 468",
+  "description": "Get issue #468 acceptance criteria"
+}
+```
+
+## Assistant
+
+Now I have everything I need. Here is my review:
+
+---
+
+## PR Review Checklist
+
+- [x] **Logic over Style** — Core logic is sound; one DRY violation flagged below.
+- [x] **Security First** — No new vulnerabilities. Existing XSS escape chain is preserved. Author name uses server data, not user-supplied input.
+- [x] **Architectural Alignment** — `fetchPublicMetaTags` is already wrapped in React `cache()` in `publicApiService.ts`, so the extra call in `GuestChannelPage` is properly deduplicated within the render pass.
+- [x] **Issue Completion** — All three acceptance criteria from #468 are satisfied: `author`, `text`, and `headline` are added to the JSON-LD.
+- [x] **No Nitpicking** — Only substantive issues are raised.
+- [x] **Avoid Repetition** — First review on this PR.
+- [x] **Iterative Reviews** — N/A (first review).
+- [x] **Prevent CI Failures** — The `jest.requireActual('react')` fix for the mock is correct and prevents a regression. No missing imports or obvious breakage found.
+
+---
+
+## Review
+
+**Overall:** This PR correctly resolves all three acceptance criteria from #468 and extends test coverage appropriately. There is one substantive issue and one minor inconsistency worth addressing before merge.
+
+---
+
+### Issue 1 — DRY violation: `title` and `text`/`description` logic is duplicated across two functions
+
+**`page.tsx`, `generateMetadata` (lines ~29–33) vs `GuestChannelPage` (lines ~65–71)**
+
+Both functions independently compute the same fallback chain:
+
+```ts
+// generateMetadata
+const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+const description = publicMetaTags?.description ?? channel?.topic ?? server?.description ?? `Join ${serverName} on Harmony`;
+
+// GuestChannelPage
+const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+const text  = publicMetaTags?.description ?? channel?.topic ?? server?.description ?? `Join ${serverName} on Harmony`;
+```
+
+If the title format or description fallback changes in one function, the JSON-LD will silently diverge from the `<title>` and OG tags — exactly the kind of misalignment this PR is trying to fix. The two functions call the same three fetches (deduplicated by `cache()`), so the data is available to share. Extracting a small shared helper that accepts the three fetch results and returns `{ title, description }` would eliminate the drift risk entirely.
+
+---
+
+### Issue 2 — `author.name` ignores the already-computed `serverName`
+
+**`page.tsx`, `GuestChannelPage` (~line 79)**
+
+```ts
+const serverName = server?.name ?? serverSlug;   // computed above
+// ...
+'author': {
+  '@type': 'Organization',
+  'name': server?.name ?? 'Harmony',   // ← should be serverName
+},
+```
+
+`serverName` is already computed two lines earlier for exactly this fallback purpose. Using `server?.name ?? 'Harmony'` instead means that when `server` is null (e.g. a fetch error), the author becomes `'Harmony'` while the page title and description use the slug. Using `serverName` keeps all three consistent.
+
+## User
+
+request changes
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr review 469 --request-changes --body \"## PR Review Checklist\n\n- [x] **Logic over Style** \u2014 Core logic is sound; one DRY violation flagged below.\n- [x] **Security First** \u2014 No new vulnerabilities. Existing XSS escape chain is preserved. Author name uses server data, not user-supplied input.\n- [x] **Architectural Alignment** \u2014 \\`fetchPublicMetaTags\\` is already wrapped in React \\`cache()\\` in \\`publicApiService.ts\\`, so the extra call in \\`GuestChannelPage\\` is properly deduplicated within the render pass.\n- [x] **Issue Completion** \u2014 All three acceptance criteria from #468 are satisfied: \\`author\\`, \\`text\\`, and \\`headline\\` are added to the JSON-LD.\n- [x] **No Nitpicking** \u2014 Only substantive issues are raised.\n- [x] **Avoid Repetition** \u2014 First review on this PR.\n- [x] **Iterative Reviews** \u2014 N/A (first review).\n- [x] **Prevent CI Failures** \u2014 The \\`jest.requireActual('react')\\` fix for the mock is correct and prevents a regression. No missing imports or obvious breakage found.\n\n---\n\n## Review\n\n**Overall:** This PR correctly resolves all three acceptance criteria from #468 and extends test coverage appropriately. There are two substantive issues to address before merge.\n\n---\n\n### Issue 1 \u2014 DRY violation: \\`title\\` and \\`text\\`/\\`description\\` logic is duplicated across two functions\n\n**\\`page.tsx\\`, \\`generateMetadata\\` vs \\`GuestChannelPage\\`**\n\nBoth functions independently compute the same fallback chain:\n\n\\`\\`\\`ts\n// generateMetadata\nconst title = publicMetaTags?.title ?? \\`\\${channelName} - \\${serverName} | Harmony\\`;\nconst description = publicMetaTags?.description ?? channel?.topic ?? server?.description ?? \\`Join \\${serverName} on Harmony\\`;\n\n// GuestChannelPage\nconst title = publicMetaTags?.title ?? \\`\\${channelName} - \\${serverName} | Harmony\\`;\nconst text  = publicMetaTags?.description ?? channel?.topic ?? server?.description ?? \\`Join \\${serverName} on Harmony\\`;\n\\`\\`\\`\n\nIf the title format or description fallback changes in one function, the JSON-LD will silently diverge from the \\`<title>\\` and OG tags \u2014 exactly the kind of misalignment this PR is trying to fix. The two functions call the same three fetches (deduplicated by \\`cache()\\`), so the data is available to share. Extracting a small shared helper that accepts the three fetch results and returns \\`{ title, description }\\` would eliminate the drift risk entirely.\n\n---\n\n### Issue 2 \u2014 \\`author.name\\` ignores the already-computed \\`serverName\\`\n\n**\\`page.tsx\\`, \\`GuestChannelPage\\`**\n\n\\`\\`\\`ts\nconst serverName = server?.name ?? serverSlug;   // computed above\n// ...\n'author': {\n  '@type': 'Organization',\n  'name': server?.name ?? 'Harmony',   // \u2190 should be serverName\n},\n\\`\\`\\`\n\n\\`serverName\\` is already computed for exactly this fallback purpose. Using \\`server?.name ?? 'Harmony'\\` instead means that when \\`server\\` is null (e.g. a fetch error), the author becomes \\`'Harmony'\\` while the page title and description use the slug. Using \\`serverName\\` keeps all three consistent.\"",
+  "description": "Request changes on PR 469 with review feedback"
+}
+```
+
+## Assistant
+
+Done. Changes requested on PR #469 with two items for Allen to address: extracting the duplicated `title`/`description` fallback logic into a shared helper, and replacing `server?.name ?? 'Harmony'` with the already-computed `serverName` variable in the `author` field.
+
+## User
+
+pr author responded, review again and request changes or approve
+
+## Assistant
+
+Let me check the latest state of the PR.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 469 --comments && echo \"---DIFF---\" && gh pr diff 469",
+  "description": "Fetch PR 469 comments and latest diff"
+}
+```
+
+## Assistant
+
+Both issues have been fully addressed. The author extracted a `getSeoContent()` helper that both `generateMetadata` and `GuestChannelPage` now call — eliminating the drift risk — and `author.name` now uses `serverName` from that helper. A regression test covering the null-server slug fallback was also added. I'll approve.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr review 469 --approve --body \"Both issues addressed. The \\`getSeoContent()\\` helper cleanly eliminates the duplication and the \\`author.name\\` now correctly uses \\`serverName\\`. The slug-fallback regression test confirms the fix holds when \\`server\\` is null. LGTM.\"",
+  "description": "Approve PR 469"
+}
+```
+
+## Assistant
+
+PR #469 approved. The author cleanly resolved both issues in commit `85c2463` — the shared helper prevents future drift between JSON-LD and page metadata, `author.name` is consistent with `serverName`, and a new regression test locks in the null-server behavior.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 /tmp/harmony_export_logs.py 2>&1 || echo \"Script not found, writing first\"",
+  "description": "Check if script exists"
+}
+```
+

--- a/llm-logs/acabrera04-logs/final/2026-04-25-fix-issue-468-019dc607.md
+++ b/llm-logs/acabrera04-logs/final/2026-04-25-fix-issue-468-019dc607.md
@@ -1,0 +1,5527 @@
+# Codex Conversation Export
+
+## Metadata
+
+- Thread ID: 019dc607-d54b-7cc3-9903-e8d702ca2a8c
+- Timestamp: 2026-04-25T19:04:55.378Z
+- CWD: /Users/allen/.codex/worktrees/afcf/Harmony
+- Source: vscode
+- Model Provider: openai
+- Model: gpt-5.4
+- Reasoning Effort: medium
+- Rollout Path: /Users/allen/.codex/sessions/2026/04/25/rollout-2026-04-25T15-04-55-019dc607-d54b-7cc3-9903-e8d702ca2a8c.jsonl
+
+## Transcript
+
+### Turn 1: https://github.com/CS485-Harmony/Harmony/issues/468 Fix this issue and
+
+#### 👤 User Prompt
+
+- Time: 2026-04-25T19:04:59.500Z
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/468 Fix this issue and test it to ensure that it works properly
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:05:06.385Z
+
+I’m pulling the repo workflow rules and the issue details first, then I’ll reproduce the bug locally before changing code.
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "Harmony PR review and approval workflow|Harmony frontend lock|settings auth|issue #468" /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+🔍 1 in 1F:
+
+📄 /Users/allen/.codex/memories/MEMORY.md (1):
+   314: - settings auth, server-side guard, requireServerSettingsAccess, ServerSettin...
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read WORKFLOW.md
+```
+
+Output:
+
+````text
+## Workflow Orchestration
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean 
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop 
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests - then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+This project uses a **hybrid approach**: `tasks/todo.md` for AI context, GitHub Issues as the canonical tracker on the Harmony Project Board (course requirement).
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items (local scratch pad for AI context)
+2. **Identify the Issue**: If the task maps to an existing GitHub Issue, note the issue number at the top of `tasks/todo.md`
+3. **Announce Start**: Post an opening comment to the issue — `gh issue comment <number> --body "..."` — describing what will be done
+4. **Track Progress**: Mark items complete in `tasks/todo.md` as you go; post a comment to the issue at meaningful milestones (e.g., after a major step or when blocked)
+5. **Explain Changes**: High-level summary at each step
+6. **Document Results**: Add a review section to `tasks/todo.md` and post a final summary comment to the issue when complete
+7. **Capture Lessons**: Update `tasks/lessons.md` after corrections. Post the new lessons learned as a comment to the issue.
+
+### Issue Comment Format
+Use this structure for issue comments to keep the audit trail readable:
+
+```
+**[AI Agent — <Step>]**
+
+<What was done or decided>
+
+<Any blockers, decisions, or next steps>
+```
+
+Example steps: `Starting`, `In Progress`, `Blocked`, `Complete`
+
+## Core Principles
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
+- **Lean Context Files**: Keep AGENTS.md and similar files to only non-obvious, non-discoverable essentials. Research shows context file bloat decreases task success rates and increases inference cost by 20%+ with 2–4 extra steps per task (Gloaguen et al., 2026).
+
+#### Taken from https://x.com/mdancho84/status/2023738764841894352
+
+Gloaguen, T., Mündler, N., Müller, M., Raychev, V., & Vechev, M. (2026, February 12). Evaluating AGENTS.MD: Are Repository-Level context Files helpful for coding agents? arXiv.org. https://arxiv.org/abs/2602.11988
+````
+
+#### Tool: exec_command
+
+```sh
+rtk read AGENTS.md
+```
+
+Output:
+
+```text
+# Agent Instructions for Harmony
+
+This file provides context and guidelines for AI coding agents (GitHub Copilot, Cursor, etc.) working on the Harmony project.
+
+## Harmony is a **search engine indexable chat application** @README.md .
+
+## Agent Workflow Guidelines
+Always write design rationale comments if intentions are not immediately obvious and ensure these comments are up to date.
+Before starting any development task, read and follow the rules in @WORKFLOW.md 
+It defines workflow orchestration, task management, and core principles all agents must follow.
+
+Always check for lint or build errors before committing code.
+
+### Specs/Docs
+- No build/test commands for specifications
+- Jest/Playwright/Lighthouse referenced in specs are design intent for future implementation
+- Specs and architecture documents are located in @docs/
+
+## Key repository conventions
+- Dev specs use a strict numbered structure (`1`–`13`; SEO spec also has `14. Acceptance Criteria`).
+- Preserve spec labeling prefixes exactly: `M#` (modules), `CL-C#`/`CL-D#`/`CL-E#`/`CL-I#` (classes/DTOs/entities/interfaces), `D#`/`T#`/`F#`/`S#`/`B#` (schemas/tech/flows/states).
+- Keep **Section 3 (Class Diagram)** and **Section 4 (List of Classes)** synchronized whenever classes are added/renamed.
+- Preserve canonical visibility enum values exactly: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.
+
+- Always verify tests are running successfully in both the backend and the frontend before pushing changes
+
+### Role-Specific Behaviors
+
+#### PR Reviews
+IF your current task involves conducting a code review or reviewing a Pull Request, THEN you MUST read and strictly adhere to the guidelines defined in `@.github/PR_REVIEW.md`. Do not begin the review until you have parsed this file.
+
+#### Addressing Open PRs
+IF your current task involves addressing review comments or requested changes on an open PR (e.g. "babysit PRs", "get PR into approvable state"), THEN use the `resolve-reviews` skill if it is available.
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:05:15.035Z
+
+I have the repo workflow constraints. Next I’m fetching issue `#468`, checking the current worktree state, and locating the code path implicated by the report so I can reproduce it before editing.
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short --branch
+```
+
+Output:
+
+```text
+## HEAD (no branch)
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 468 --repo CS485-Harmony/Harmony
+```
+
+Output:
+
+```text
+error connecting to api.github.com
+check your internet connection or https://githubstatus.com
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls tasks
+```
+
+Output:
+
+```text
+lessons.md  9.5K
+
+📊 1 files, 0 dirs (1 .md)
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:05:23.422Z
+
+The issue body isn’t available from the sandboxed network path, so I’m requesting direct GitHub access to pull the exact report and keep the repo’s issue audit trail accurate.
+
+#### Tool: exec_command
+
+```sh
+gh issue view 468 --repo CS485-Harmony/Harmony
+```
+
+Output:
+
+```text
+title:	fix: DiscussionForumPosting structured data missing required fields (author, text/image/video, headline)
+state:	OPEN
+author:	AvanishKulkarni
+labels:	
+comments:	0
+assignees:	acabrera04
+projects:	
+milestone:	
+number:	468
+--
+## Summary
+
+Google's Rich Results Test flagged the `DiscussionForumPosting` JSON-LD schema on channel pages with **2 critical issues** and **1 non-critical issue**, making the page ineligible for Discussion Forum rich results in Google Search.
+
+**Test URL:** https://search.google.com/test/rich-results/result?id=dX-ulEg5l7gIboGKd6bhwA
+**Affected page:** https://harmony-dun-omega.vercel.app/c/testserver/new-channel
+
+---
+
+## Issues
+
+### Critical (2)
+
+- **Missing field `"author"`** — The `DiscussionForumPosting` item does not include an `author` property. Google requires this field for the rich result to be valid.
+- **Either `"text"`, `"image"`, or `"video"` should be specified** — The posting has no content body. At least one of these fields must be present.
+
+### Non-Critical (1)
+
+- **Missing field `"headline"` (optional)** — No `headline` field is present. While optional, adding it improves rich result quality.
+
+---
+
+## Current schema fields detected
+
+| Field | Value |
+|---|---|
+| `@type` | `DiscussionForumPosting` |
+| `name` | `new-channel - TestServer \| Harmony` |
+| `url` | `https://harmony-dun-omega.vercel.app/c/testserver/new-channel` |
+| `description` | `my cool server` |
+| `datePublished` | `2026-04-13T15:56:25Z` |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Add `author` field to the `DiscussionForumPosting` schema (e.g. the server/channel owner or organization)
+- [ ] Add at least one of `text`, `image`, or `video` to the posting (e.g. channel description as `text`)
+- [ ] Add `headline` field (can mirror `name`)
+- [ ] Re-run Google Rich Results Test and confirm 0 critical issues
+
+## References
+
+- [Google: Discussion forum structured data](https://developers.google.com/search/docs/appearance/structured-data/discussion-forum)
+- [Schema.org DiscussionForumPosting](https://schema.org/DiscussionForumPosting)
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:05:39.559Z
+
+I have the exact issue now: the channel page’s `DiscussionForumPosting` JSON-LD is missing `author`, content, and `headline`. I’m locating the schema generator and the relevant tests so I can reproduce the current output and patch the right layer.
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "DiscussionForumPosting|json-ld|structured data|schema.org" -S .
+```
+
+Output:
+
+```text
+grep: .: Is a directory
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls frontend
+```
+
+Output:
+
+```text
+ls: frontend: No such file or directory
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls .github
+```
+
+Output:
+
+```text
+workflows/
+PR_REVIEW.md  1.8K
+
+📊 1 files, 1 dirs (1 .md)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls
+```
+
+Output:
+
+```text
+.claude/
+.github/
+docs/
+harmony-backend/
+harmony-frontend/
+llm-logs/
+mockups/
+planning/
+scripts/
+tasks/
+tests/
+.gitignore  66B
+AGENTS.md  1.9K
+CLAUDE.md  11B
+README.md  7.6K
+WORKFLOW.md  3.7K
+dev-spec-guidelines.pdf  507.5K
+dev.sh  2.1K
+package.json  422B
+
+📊 8 files, 11 dirs (4 .md, 1 .gitignore, 1 .sh, 1 .json, 1 .pdf)
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "DiscussionForumPosting|json-ld|structured data|schema.org" .
+```
+
+Output:
+
+```text
+Total output lines: 454
+
+./docs/unified-backend-architecture.md:131:| M-B5 | Meta Tag Engine | Server | SEO Meta Tag Generation | Meta tag generation, content analysis, OpenGraph, structured data | Module 9 (Public API & SEO — meta tag generation) |
+./docs/unified-backend-architecture.md:1286:**Purpose:** Generates SEO meta tags (title, description, OpenGraph, Twitter Card, JSON-LD structured data) for public channel pages. Uses NLP-based content analysis for keyword extraction and summarization.
+./docs/unified-backend-architecture.md:1325:| CL-C-B5.5 | StructuredDataGenerator | Internal | JSON-LD structured data (DiscussionForumPosting schema) |
+./docs/unified-backend-architecture.md:1580:| T19 | schema-dts | 1.1+ | Typed JSON-LD structured data | M-B5, M-B6 |
+./tests/integration/guest-public-channel.test.ts:53:    // JSON-LD structured data
+./tests/integration/guest-public-channel.test.ts:55:    expect(html).toContain('DiscussionForumPosting');
+./tests/integration/guest-public-channel.test.ts:70:    expect(html).not.toContain('DiscussionForumPosting');
+./tests/integration/guest-public-channel.test.ts:96:    'GPC-2b: SSR metadata and structured data present for channel %s',
+./tests/integration/guest-public-channel.test.ts:113:      expect(jsonLd['@context']).toBe('https://schema.org');
+./tests/integration/guest-public-channel.test.ts:114:      expect(jsonLd['@type']).toBe('DiscussionForumPosting');
+./tests/integration/guest-public-channel.test.ts:138:    expect(html).not.toContain('DiscussionForumPosting');
+./docs/dev-spec-channel-visibility-toggle.md:449:    F213["F2.13 Add canonical URL + structured data"]
+./docs/dev-spec-seo-meta-tag-generation.md:346:                                                           │ structured data │
+./docs/dev-spec-seo-meta-tag-generation.md:630:| CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./docs/dev-spec-seo-meta-tag-generation.md:665:| CL-D4 | StructuredData | DTO | JSON-LD structured data |
+./docs/dev-spec-seo-meta-tag-generation.md:1133:                │             │  │ @type: "DiscussionForumPosting"│
+./docs/dev-spec-seo-meta-tag-generation.md:2150:// Generate DiscussionForumPosting schema
+./docs/dev-spec-seo-meta-tag-generation.md:2600:| getMessageCount() | MessageRepository | Get message count for structured data |
+./docs/dev-spec-seo-meta-tag-generation.md:3200:  "@context": "https://schema.org",
+./docs/dev-spec-seo-meta-tag-generation.md:3201:  "@type": "DiscussionForumPosting",
+./docs/dev-spec-seo-meta-tag-generation.md:3213:    "interactionType": "https://schema.org/CommentAction",
+./docs/dev-spec-seo-meta-tag-generation.md:3233:| JSON-LD | JavaScript Object Notation for Linked Data (structured data) |
+./docs/dev-spec-guest-public-channel-view.md:396:| CL-C1.2 | SEOMetadataComponent | UI Component | Generates and renders SEO meta tags, Open Graph tags, and structured data |
+./docs/dev-spec-guest-public-channel-view.md:434:| CL-C5.4 | SEOService | Service | Generates SEO metadata, structured data, and canonical URLs |
+./docs/dev-spec-guest-public-channel-view.md:695:    F45["F4.5 Return HTML with structured data\nscript type=application/ld+json\n{ @context: schema.org, @type: DiscussionForumPosting, ... }"]
+./docs/dev-spec-guest-public-channel-view.md:1146:// Generate JSON-LD structured data
+./docs/dev-spec-guest-public-channel-view.md:1938:- [ ] JSON-LD structured data (DiscussionForumPosting)
+./docs/dev-spec-guest-public-channel-view.md:1968:| JSON-LD | JavaScript Object Notation for Linked Data - structured data format |
+./llm-logs/2026-04-25-142357-session-c1cff4b9.md:79:  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src -name \"*.ts\" -o -name \"*.tsx\" | xargs grep -l \"DiscussionForumPosting\\|jsonLd\\|json-ld\\|structured.*data\" 2>/dev/null",
+./llm-logs/2026-04-25-142357-session-c1cff4b9.md:80:  "description": "Find structured data related files"
+./llm-logs/2026-04-25-142357-session-c1cff4b9.md:248:  "command": "cat > /Users/bigfa/Documents/GitHub/Harmony/tasks/todo.md << 'EOF'\n# Issue #357: PublicChannelPage + generateMetadata Integration (M1)\n\n## Current status\n\n**In Progress**\n\n## What's already done\n- `generateMetadata` exists with title, description, robots, canonical, and openGraph tags\n- API fallback via `?? channelSlug` / `?? serverSlug` template fallback\n\n## What needs to be added\n- [ ] Twitter card in `generateMetadata`\n- [ ] JSON-LD `DiscussionForumPosting` script in page component (PUBLIC_INDEXABLE only)\n- [ ] Unit tests for `generateMetadata` across 3 visibility states\n- [ ] Extend integration test GPC-2 to assert Twitter card + JSON-LD\n\n## Plan\n1. Update `harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx`:\n   - Add `twitter` card to `generateMetadata` return\n   - Fetch data in `GuestChannelPage` (deduplicated via React cache) and inject JSON-LD script\n2. Add `harmony-frontend/src/__tests__/channel-page-metadata.test.ts`\n3. Extend `tests/integration/guest-public-channel.test.ts` GPC-2 with OG/Twitter/JSON-LD assertions\nEOF",
+./llm-logs/2026-04-25-142357-session-c1cff4b9.md:265:  "new_string": "import type { Metadata } from 'next';\nimport { GuestChannelView } from '@/components/channel/GuestChannelView';\nimport { fetchPublicServer, fetchPublicChannel } from '@/services/publicApiService';\nimport { ChannelVisibility } from '@/types';\nimport { getChannelUrl } from '@/lib/runtime-config';\n\ninterface PageProps {\n  params: Promise<{ serverSlug: string; channelSlug: string }>;\n}\n\nexport async function generateMetadata({ params }: PageProps): Promise<Metadata> {\n  const { serverSlug, channelSlug } = await params;\n  const [server, channelResult] = await Promise.all([\n    fetchPublicServer(serverSlug),\n    fetchPublicChannel(serverSlug, channelSlug),\n  ]);\n\n  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;\n  const channelName = channel?.name ?? channelSlug;\n  const serverName = server?.name ?? serverSlug;\n  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;\n  const description = channel?.topic ?? server?.description ?? `Join ${serverName} on Harmony`;\n  const title = `${channelName} - ${serverName} | Harmony`;\n  const canonicalUrl = getChannelUrl(serverSlug, channelSlug);\n\n  return {\n    title,\n    description,\n    robots: { index: isIndexable, follow: true },\n    alternates: { canonical: canonicalUrl },\n    openGraph: {\n      title,\n      description,\n      type: 'website',\n      url: canonicalUrl,\n    },\n    twitter: {\n      card: 'summary',\n      title,\n      description,\n    },\n  };\n}\n\nexport default async function GuestChannelPage({ params }: PageProps) {\n  const { serverSlug, channelSlug } = await params;\n\n  // Fetch data for JSON-LD; React cache deduplicates these within the same render pass\n  const [server, channelResult] = await Promise.all([\n    fetchPublicServer(serverSlug),\n    fetchPublicChannel(serverSlug, channelSlug),\n  ]);\n\n  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;\n  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;\n\n  const jsonLd = isIndexable\n    ? {\n        '@context': 'https://schema.org',\n        '@type': 'DiscussionForumPosting',\n        name: `${channel?.name ?? channelSlug} - ${server?.name ?? serverSlug} | Harmony`,\n        url: getChannelUrl(serverSlug, channelSlug),\n        description:\n          channel?.topic ??\n          server?.description ??\n          `Join ${server?.name ?? serverSlug} on Harmony`,\n        ...(channel?.createdAt && { datePublished: channel.createdAt }),\n      }\n    : null;\n\n  return (\n    <>\n      {jsonLd && (\n        <script\n          type=\"application/ld+json\"\n          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}\n        />\n      )}\n      <GuestChannelView serverSlug={serverSlug} channelSlug={channelSlug} />\n    </>\n  );\n}"
+./llm-logs/2026-04-25-142357-session-c1cff4b9.md:295:  "new_string": "  test('GPC-2: SSR metadata includes SEO tags for PUBLIC_INDEXABLE channel', async () => {\n    const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${publicIndexableSlug}`);\n    expect(res.status).toBe(200);\n    const html = await res.text();\n    // title tag must be present\n    expect(html).toMatch(/<title[^>]*>/i);\n    // robots index,follow\n    expect(html).toMatch(/index,\\s*follow/i);\n    // canonical link\n    expect(html).toMatch(/<link[^>]+rel=[\"']canonical[\"']/i);\n    expect(html).toContain(`/c/${serverSlug}/${publicIndexableSlug}`);\n    // Open Graph tags\n    expect(html).toMatch(/<meta[^>]+property=[\"']og:title[\"']/i);\n    expect(html).toMatch(/<meta[^>]+property=[\"']og:url[\"']/i);\n    // Twitter card tags\n    expect(html).toMatch(/twitter:card/i);\n    expect(html).toMatch(/twitter:title/i);\n    // JSON-LD structured data\n    expect(html).toMatch(/<script[^>]+type=[\"']application\\/ld\\+json[\"']/i);\n    expect(html).toContain('DiscussionForumPosting');\n  });"
+./llm-logs/2026-04-25-142357-session-c1cff4b9.md:588:  "command": "git commit -m \"$(cat <<'EOF'\nfeat: add Twitter card and JSON-LD DiscussionForumPosting to channel page (issue #357)\n\nExtends generateMetadata with Twitter card tags and injects a\nDiscussionForumPosting JSON-LD script into PUBLIC_INDEXABLE channel pages.\nAdds unit tests for generateMetadata across all three visibility states and\nextends the GPC-2 integration assertion to verify OG, Twitter, and JSON-LD.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+./llm-logs/2026-04-25-142357-session-c1cff4b9.md:612:  "command": "gh pr create --title \"feat: Twitter card + JSON-LD DiscussionForumPosting for public channel pages (issue #357)\" --body \"$(cat <<'EOF'\n## Summary\n\n- Adds `twitter` card (`summary`) to `generateMetadata` for all public channel pages\n- Injects a `DiscussionForumPosting` JSON-LD structured data script into `PUBLIC_INDEXABLE` channel pages (gated \u2014 no JSON-LD on noindex pages)\n- Adds 13 unit tests for `generateMetadata` covering all three visibility states (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) and the API-fallback case\n- Extends integration test GPC-2 to assert Open Graph tags, Twitter card tags, and JSON-LD structured data in the SSR response\n\nCloses #357\n\n## Test plan\n\n- [x] `npm test` in `harmony-frontend` \u2014 all 319 tests pass\n- [x] `npx tsc --noEmit` \u2014 no type errors\n- [x] `npm run lint` \u2014 no lint errors\n- [x] Integration test GPC-2 extended to verify OG / Twitter / JSON-LD on live SSR\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\"",
+./llm-logs/2026-04-25-142357-session-c1cff4b9.md:626:  "command": "GH_TOKEN=$(gh auth token 2>/dev/null || echo \"\") && curl -k -s -X POST \\\n  -H \"Authorization: Bearer $GH_TOKEN\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  -H \"Content-Type: application/json\" \\\n  https://api.github.com/repos/CS485-Harmony/Harmony/pulls \\\n  -d '{\n    \"title\": \"feat: Twitter card + JSON-LD DiscussionForumPosting for public channel pages (issue #357)\",\n    \"head\": \"feature/issue-357-generatemetadata-integration\",\n    \"base\": \"main\",\n    \"body\": \"## Summary\\n\\n- Adds `twitter` card (`summary`) to `generateMetadata` for all public channel pages\\n- Injects a `DiscussionForumPosting` JSON-LD structured data script into `PUBLIC_INDEXABLE` channel pages (gated \u2014 no JSON-LD on noindex pages)\\n- Adds 13 unit tests for `generateMetadata` covering all three visibility states (`PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`) and the API-fallback case\\n- Extends integration test GPC-2 to assert Open Graph tags, Twitter card tags, and JSON-LD structured data in the SSR response\\n\\nCloses #357\\n\\n## Test plan\\n\\n- [x] `npm test` in `harmony-frontend` \u2014 all 319 tests pass\\n- [x] `npx tsc --noEmit` \u2014 no type errors\\n- [x] `npm run lint` \u2014 no lint errors\\n- [x] Integration test GPC-2 extended to verify OG / Twitter / JSON-LD on live SSR\\n\\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\"\n  }' | python3 -c \"import sys, json; d=json.load(sys.stdin); print(d.get('html_url') or d.get('message', 'error'))\"",
+./llm-logs/2026-04-25-142357-session-c1cff4b9.md:641:   - Added JSON-LD `DiscussionForumPosting` script injection in the page component, gated to `PUBLIC_INDEXABLE` channels only (emitting structured data on noindex pages would be contradictory)
+./llm-logs/2026-04-25-142357-session-c1cff4b9.md:648:   - Extended GPC-2 to assert OG tags, Twitter card tags, and JSON-LD `DiscussionForumPosting` in the SSR HTML response
+./planning/FINAL_PROJECT_SPRINT_PLAN.md:184:- Server-render meta tags, Open Graph tags, Twitter cards, canonical URL, and JSON-LD `DiscussionForumPosting`
+./planning/FINAL_PROJECT_SPRINT_PLAN.md:185:- Use the Next.js **App Router** `generateMetadata` export in `harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx` (already scaffolded) to fetch tags from the backend at request time; JSON-LD is injected via a component in `page.tsx` since `Metadata` doesn't cover structured data
+./planning/FINAL_PROJECT_SPRINT_PLAN.md:191:  - Open Graph, Twitter card, and JSON-LD `DiscussionForumPosting` tags are present and validate against Google Rich Results test
+./harmony-backend/src/services/metaTag/structuredDataGenerator.ts:1:// CL-C2.5 StructuredDataGenerator — generates JSON-LD structured data
+./harmony-backend/src/services/metaTag/structuredDataGenerator.ts:11:      '@context': 'https://schema.org',
+./harmony-backend/src/services/metaTag/structuredDataGenerator.ts:12:      '@type': 'DiscussionForumPosting',
+./harmony-backend/src/services/metaTag/structuredDataGenerator.ts:29:      '@context': 'https://schema.org',
+./harmony-backend/src/services/metaTag/structuredDataGenerator.ts:51:      '@context': 'https://schema.org',
+./harmony-backend/src/services/metaTag/structuredDataGenerator.ts:61:      '@context': 'https://schema.org',
+./llm-logs/2026-04-20-094302-session-ce430386.md:329:  "content": "// CL-C2.5 StructuredDataGenerator \u2014 generates JSON-LD structured data\nimport type { ChannelContext, StructuredData } from './types';\n\nexport const StructuredDataGenerator = {\n  generateDiscussionForum(channel: ChannelContext, title: string, description: string): StructuredData {\n    return {\n      '@context': 'https://schema.org',\n      '@type': 'DiscussionForumPosting',\n      headline: title,\n      description,\n      mainEntity: {\n        '@type': 'WebPage',\n        url: channel.canonicalUrl,\n      },\n    };\n  },\n\n  generateBreadcrumbList(channel: ChannelContext): object {\n    return {\n      '@context': 'https://schema.org',\n      '@type': 'BreadcrumbList',\n      itemListElement: [\n        {\n          '@type': 'ListItem',\n          position: 1,\n          name: channel.serverName,\n          item: `https://harmony.chat/s/${channel.serverSlug}`,\n        },\n        {\n          '@type': 'ListItem',\n          position: 2,\n          name: channel.name,\n          item: channel.canonicalUrl,\n        },\n      ],\n    };\n  },\n\n  generateOrganization(): object {\n    return {\n      '@context': 'https://schema.org',\n      '@type': 'Organization',\n      name: 'Harmony',\n      url: 'https://harmony.chat',\n    };\n  },\n\n  generateWebPage(channel: ChannelContext, title: string, description: string): StructuredData {\n    return {\n      '@context': 'https://schema.org',\n      '@type': 'WebPage',\n      headline: title,\n      description,\n      mainEntity: {\n        '@type': 'WebPage',\n        url: channel.canonicalUrl,\n      },\n    };\n  },\n};\n"
+./llm-logs/2026-04-25-145109-session-ce1a46e1.md:305:  "new_string": "    const html = await res.text();\n    expect(html).toMatch(/noindex/i);\n    // JSON-LD must be absent for non-indexable channels\n    expect(html).not.toMatch(/<script[^>]+type=[\"']application\\/ld\\+json[\"']/i);\n    expect(html).not.toContain('DiscussionForumPosting');\n  });"
+./llm-logs/2026-04-25-145109-session-ce1a46e1.md:317:  "new_string": "    // The access-denied component renders a lock icon / login CTA \u2014 no channel content\n    // We verify absence of channel-specific content. The page should NOT redirect.\n    expect(html).not.toMatch(/<meta[^>]+content=[\"']index,\\s*follow[\"']/i);\n    // JSON-LD must be absent for PRIVATE channels\n    expect(html).not.toMatch(/<script[^>]+type=[\"']application\\/ld\\+json[\"']/i);\n    expect(html).not.toContain('DiscussionForumPosting');"
+./llm-logs/2026-04-25-145109-session-ce1a46e1.md:408:  "command": "npx agent-reviews --reply 3142385272 \"Fixed in db5f827. Added negative assertions to GPC-3 (PUBLIC_NO_INDEX) and GPC-4 (PRIVATE) verifying that the application/ld+json script tag and DiscussionForumPosting type are absent for non-indexable and private channels.\" --resolve 2>&1",
+./llm-logs/2026-04-25-143605-session-f361e5d6.md:349:  "command": "grep -n \"GPC-2\\|generateMetadata\\|channel.*metadata\\|META\\|twitter\\|json-ld\\|jsonld\" /Users/bigfa/Documents/GitHub/Harmony/tests/integration/guest-public-channel.test.ts | head -30",
+./llm-logs/2026-04-25-143605-session-f361e5d6.md:801:  "new_string": "// GPC-2b: AC #357 \u2014 assert SEO tags on at least 3 representative PUBLIC_INDEXABLE channels\nlocalOnlyDescribe('Guest Public Channel \u2014 SEO tags across 3 PUBLIC_INDEXABLE channels (AC #357)', () => {\n  const serverSlug = LOCAL_SEEDS.server.slug;\n\n  test.each([...LOCAL_SEEDS.channels.publicIndexableAll])(\n    'GPC-2b: SSR metadata and structured data present for channel %s',\n    async (channelSlug) => {\n      const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${channelSlug}`);\n      expect(res.status).toBe(200);\n      const html = await res.text();\n\n      expect(html).toMatch(/<title[^>]*>/i);\n      expect(html).toMatch(/index,\\s*follow/i);\n      expect(html).toMatch(/<link[^>]+rel=[\"']canonical[\"']/i);\n      expect(html).toContain(`/c/${serverSlug}/${channelSlug}`);\n      expect(html).toMatch(/<meta[^>]+property=[\"']og:title[\"']/i);\n      expect(html).toMatch(/twitter:card/i);\n\n      // Validate JSON-LD structure (Google Rich Results required fields)\n      const ldMatch = html.match(/<script[^>]+type=[\"']application\\/ld\\+json[\"'][^>]*>([\\s\\S]*?)<\\/script>/i);\n      expect(ldMatch).not.toBeNull();\n      const jsonLd = JSON.parse(ldMatch![1]);\n      expect(jsonLd['@context']).toBe('https://schema.org');\n      expect(jsonLd['@type']).toBe('DiscussionForumPosting');\n      expect(typeof jsonLd.name).toBe('string');\n      expect(jsonLd.name.length).toBeGreaterThan(0);\n      expect(typeof jsonLd.url).toBe('string');\n      expect(jsonLd.url).toContain(`/c/${serverSlug}/${channelSlug}`);\n    },\n    20000,\n  );\n});\n\n// GPC-4 and GPC-6 need seeded PRIVATE channel data \u2014 local-only\nlocalOnlyDescribe('Guest Public Channel \u2014 local-only (PRIVATE access)', () => {"
+./llm-logs/2026-04-25-143605-session-f361e5d6.md:876:  "command": "git add harmony-frontend/src/__tests__/channel-page-metadata.test.ts tests/integration/env.ts tests/integration/guest-public-channel.test.ts && git commit -m \"$(cat <<'EOF'\nfix: address PR #462 review findings \u2014 mock completeness and 3-channel SEO coverage\n\n- Add fetchPublicMetaTags to publicApiService mock so the test suite is\n  resilient if the function is ever imported (resolves CI failure reported\n  in comment 3142384006)\n- Add publicIndexableAll array to LOCAL_SEEDS (general, announcements,\n  dev-updates) for AC #357 fixture corpus\n- Add GPC-2b local-only test.each block asserting title, robots, OG,\n  Twitter, and JSON-LD DiscussionForumPosting fields on all 3 channels\n  (satisfies \"E2E test asserts tags on at least 3 representative public\n  channels\" from…180869 tokens truncated…erate\n\n5. **Module numbering conflicts.** `M1` through `M6` refer to completely different modules in each spec (e.g., M1 = Admin Dashboard in Spec 1, Public View in Spec 2, Page Rendering in Spec 3), making cross-referencing between docs ambiguous.\n\n6. **SEO/indexing logic is fragmented.** Canonical URL generation, structured data, and robots directives appear under `IndexingService` (Spec 1), `SEOService` (Spec 2), and a multi-class `MetaTagService` hierarchy (Spec 3) with no cross-references.\n\n7. **Spec 3 has internal length-limit conflicts.** `TitleGenerator.maxLength` = 60, but the DB column is `VARCHAR(70)` and the API schema says `maxLength: 70`. Same issue for description (generator says 160, DB/API say 200).\n\n8. **Class label collisions.** In Spec 2, the `CL-E` prefix is used for both edge-layer components (`CL-E1.1 CacheRouter`) and domain entities (`CL-E1 Channel`).\n\n### Minor\n\n9. **Security section depth varies significantly.** Spec 1 has comprehensive PII tracking, role-based access matrices, audit procedures, and COPPA compliance. Spec 3 covers only content filtering and basic admin override security — missing PII tracking, access policies, and security headers.\n\n10. **Spec 1 defines a robots tag (`noindex, nofollow`) for the PRIVATE state**, but private channels return 403/404 per its own flow charts, so the tag is never served.\n\n### Recommendation\n\nBefore implementation, these specs would benefit from a shared data dictionary (unified table schemas, cache key conventions, tech-stack labels, and module numbering) that all three documents reference.",
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:1161:518. | CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:1196:553. | CL-D4 | StructuredData | DTO | JSON-LD structured data |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:1331:13685. **Rationale:** Same as Files 1 and 2 — no acceptance criteria section. This spec has particularly important verifiable SEO requirements (title length limits, description length, structured data validity, profanity/PII filtering) that must have explicit test criteria.
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:1343:13697. | AC-4 | JSON-LD structured data validates against schema.org DiscussionForumPosting schema. | Schema validation test |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:1520:22387.   | AC-5 | JSON-LD structured data validates at schema.org validator | Integration test |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:1598:22465. - **Rationale:** The guest-public-channel-view spec (C5.4 SEOService) and the SEO meta-tag-generation spec (M2 MetaTagService) both generate page titles, descriptions, and structured data. It's unclear whether these are the same service or separate services. The guest spec's SEOService (lines 1572-1609) has methods `generatePageTitle()`, `generateDescription()`, `generateStructuredData()` that overlap with the meta tag spec's TitleGenerator, DescriptionGenerator, and StructuredDataGenerator. This could lead to duplicate implementations.
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:2562:929.                 │             │  │ @type: "DiscussionForumPosting"│
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:2933:1450. // Generate DiscussionForumPosting schema
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:3505:1971.   "@context": "https://schema.org",
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:3506:1972.   "@type": "DiscussionForumPosting",
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:3518:1984.     "interactionType": "https://schema.org/CommentAction",
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:3538:2004. | JSON-LD | JavaScript Object Notation for Linked Data (structured data) |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:3908:319.                                                            │ structured data │
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:4007:/Users/allen/Harmony/docs/dev-spec-seo-meta-tag-generation.md:518:| CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:4349:518. | CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:4384:553. | CL-D4 | StructuredData | DTO | JSON-LD structured data |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:4777:1482. // Generate DiscussionForumPosting schema
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:6138:2227.   "@context": "https://schema.org",
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:6139:2228.   "@type": "DiscussionForumPosting",
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:6151:2240.     "interactionType": "https://schema.org/CommentAction",
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:6421:522. | CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:6456:557. | CL-D4 | StructuredData | DTO | JSON-LD structured data |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:7642:522. | CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:7677:557. | CL-D4 | StructuredData | DTO | JSON-LD structured data |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:7861:565. | CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-15_dev-spec_seo-meta-tag_address-comments.md:10473:/Users/allen/Harmony/docs/dev-spec-guest-public-channel-view.md:557:| CL-C5.4 | SEOService | Service | Generates SEO metadata, structured data, and canonical URLs |
+./llm-logs/dev-specs/02-15-step1-fix-channel-vis-inconsistencies.md:633:478. 2. **FC 6.2: Anonymous User Views Public Channel** — 14 steps (F2.1–F2.14): Route to `PublicAccessController` → cache check → DB fallback → 404/403 if missing/private → fetch messages → set `X-Robots-Tag` header → add canonical URL + structured data → return rendered HTML
+./llm-logs/dev-specs/02-15-step1-fix-channel-vis-inconsistencies.md:800:628. | CL-C1.2 | `SEOMetadataComponent` | UI Component | Meta tags, Open Graph, JSON-LD structured data |
+./llm-logs/dev-specs/02-15-step1-fix-channel-vis-inconsistencies.md:1057:867. 4. **Flow 6.4:** Search engine bot crawl — bot detection → same content flow → bot-optimized response with JSON-LD (`DiscussionForumPosting` schema), canonical URL, breadcrumbs, longer cache TTL (s-maxage=3600)
+./llm-logs/dev-specs/02-15-step1-fix-channel-vis-inconsistencies.md:1185:978. | T10 | schema-dts | 1.1+ | Type-safe JSON-LD structured data types |
+./llm-logs/dev-specs/02-16-step3-fix-class-inconsistencies.md:696:558.                                   [F2.13] Add canonical URL + structured data
+./llm-logs/dev-specs/02-12_dev-spec-creation.md:126:   - Meta Tag Generation Module (title, description, OG, structured data generators)
+./llm-logs/dev-specs/02-12_dev-spec-creation.md:150:   - JSON-LD structured data (DiscussionForumPosting schema)
+./llm-logs/dev-specs/02-16-guest-public-class-inconsistency-fixes.md:657:544. | CL-C1.2 | SEOMetadataComponent | UI Component | Generates and renders SEO meta tags, Open Graph tags, and structured data |
+./llm-logs/dev-specs/02-16-guest-public-class-inconsistency-fixes.md:695:582. | CL-C5.4 | SEOService | Service | Generates SEO metadata, structured data, and canonical URLs |
+./llm-logs/dev-specs/02-16-guest-public-class-inconsistency-fixes.md:1431:1258.             │ structured data               │
+./llm-logs/dev-specs/02-16-guest-public-class-inconsistency-fixes.md:1436:1263.             │   "@context": "schema.org",   │
+./llm-logs/dev-specs/02-16-guest-public-class-inconsistency-fixes.md:1908:1715. // Generate JSON-LD structured data
+./llm-logs/dev-specs/02-16-guest-public-class-inconsistency-fixes.md:2757:2496. - [ ] JSON-LD structured data (DiscussionForumPosting)
+./llm-logs/dev-specs/02-16-guest-public-class-inconsistency-fixes.md:2787:2526. | JSON-LD | JavaScript Object Notation for Linked Data - structured data format |
+./llm-logs/dev-specs/02-16-guest-public-class-inconsistency-fixes.md:4601:1725. // Generate JSON-LD structured data
+./llm-logs/dev-specs/02-15-step2-verify-channel-vis-inconsistency-fixes.md:617:478. 2. **FC 6.2: Anonymous User Views Public Channel** — 14 steps (F2.1–F2.14): Route to `PublicAccessController` → cache check → DB fallback → 404/403 if missing/private → fetch messages → set `X-Robots-Tag` header → add canonical URL + structured data → return rendered HTML
+./llm-logs/dev-specs/02-15-step2-verify-channel-vis-inconsistency-fixes.md:784:628. | CL-C1.2 | `SEOMetadataComponent` | UI Component | Meta tags, Open Graph, JSON-LD structured data |
+./llm-logs/dev-specs/02-15-step2-verify-channel-vis-inconsistency-fixes.md:1038:867. 4. **Flow 6.4:** Search engine bot crawl — bot detection → same content flow → bot-optimized response with JSON-LD (`DiscussionForumPosting` schema), canonical URL, breadcrumbs, longer cache TTL (s-maxage=3600)
+./llm-logs/dev-specs/02-15-step2-verify-channel-vis-inconsistency-fixes.md:1149:978. | T10 | schema-dts | 1.1+ | Type-safe JSON-LD structured data types |
+./llm-logs/dev-specs/02-15-step2-verify-channel-vis-inconsistency-fixes.md:2219:532.                                   [F2.13] Add canonical URL + structured data
+./llm-logs/dev-specs/02-15-dev-spec_seo-meta-tag_fix-inconsitencies.md:788:592. | CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-15-dev-spec_seo-meta-tag_fix-inconsitencies.md:823:627. | CL-D4 | StructuredData | DTO | JSON-LD structured data |
+./llm-logs/dev-specs/02-15-dev-spec_seo-meta-tag_fix-inconsitencies.md:1587:1581. // Generate DiscussionForumPosting schema
+./llm-logs/dev-specs/02-16-dev-spec_seo-meta-tag_update-section-2-3-9-10.md:524:2118. // Generate DiscussionForumPosting schema
+./llm-logs/dev-specs/02-16-dev-spec_seo-meta-tag_update-section-2-3-9-10.md:764:601. | CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-16-dev-spec_seo-meta-tag_update-section-2-3-9-10.md:799:636. | CL-D4 | StructuredData | DTO | JSON-LD structured data |
+./llm-logs/dev-specs/02-16-dev-spec_seo-meta-tag_update-section-2-3-9-10.md:1345:                 │             │  │ @type: "DiscussionForumPosting"│
+./llm-logs/dev-specs/02-16-dev-spec_seo-meta-tag_update-section-2-3-9-10.md:2786:2123. // Generate DiscussionForumPosting schema
+./llm-logs/dev-specs/02-16-dev-spec_seo-meta-tag_update-section-2-3-9-10.md:3534:329.                                                            │ structured data │
+./llm-logs/dev-specs/02-16-dev-spec_seo-meta-tag_update-section-2-3-9-10.md:5246:2574. | getMessageCount() | MessageRepository | Get message count for structured data |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:2241:1590. // Generate JSON-LD structured data
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:2584:1450. // Generate DiscussionForumPosting schema
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:3990:929.                 │             │  │ @type: "DiscussionForumPosting"│
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:4034:729.                │               │                   │ and structured data           │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:4568:1190.             │ structured data               │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:4573:1195.             │   "@context": "schema.org",   │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:5515:2202. - [ ] JSON-LD structured data (DiscussionForumPosting)
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:5545:2232. | JSON-LD | JavaScript Object Notation for Linked Data - structured data format |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:5782:1971.   "@context": "https://schema.org",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:5783:1972.   "@type": "DiscussionForumPosting",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:5795:1984.     "interactionType": "https://schema.org/CommentAction",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:5815:2004. | JSON-LD | JavaScript Object Notation for Linked Data (structured data) |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:8229:319.                                                            │ structured data │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:8659:729.                │               │                   │ and structured data           │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:8775:519. | CL-C1.2 | SEOMetadataComponent | UI Component | Generates and renders SEO meta tags, Open Graph tags, and structured data |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:8813:557. | CL-C5.4 | SEOService | Service | Generates SEO metadata, structured data, and canonical URLs |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:9090:518. | CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:9125:553. | CL-D4 | StructuredData | DTO | JSON-LD structured data |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:10149:929.                 │             │  │ @type: "DiscussionForumPosting"│
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:10746:1190.             │ structured data               │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:10751:1195.             │   "@context": "schema.org",   │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:11600:1590. // Generate JSON-LD structured data
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:11776:1450. // Generate DiscussionForumPosting schema
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:12747:1971.   "@context": "https://schema.org",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:12748:1972.   "@type": "DiscussionForumPosting",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:12760:1984.     "interactionType": "https://schema.org/CommentAction",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:12998:2202. - [ ] JSON-LD structured data (DiscussionForumPosting)
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:13028:2232. | JSON-LD | JavaScript Object Notation for Linked Data - structured data format |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:13052:2004. | JSON-LD | JavaScript Object Notation for Linked Data (structured data) |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:13685:**Rationale:** Same as Files 1 and 2 — no acceptance criteria section. This spec has particularly important verifiable SEO requirements (title length limits, description length, structured data validity, profanity/PII filtering) that must have explicit test criteria.
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:13697:| AC-4 | JSON-LD structured data validates against schema.org DiscussionForumPosting schema. | Schema validation test |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:15287:docs/dev-spec-seo-meta-tag-generation.md:518:| CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:15288:docs/dev-spec-seo-meta-tag-generation.md:553:| CL-D4 | StructuredData | DTO | JSON-LD structured data |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:15294:docs/dev-spec-seo-meta-tag-generation.md:2004:| JSON-LD | JavaScript Object Notation for Linked Data (structured data) |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:15314:1971.   "@context": "https://schema.org",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:15315:1972.   "@type": "DiscussionForumPosting",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:15327:1984.     "interactionType": "https://schema.org/CommentAction",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:16687:729.                │               │                   │ and structured data           │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:17966:519. | CL-C1.2 | SEOMetadataComponent | UI Component | Generates and renders SEO meta tags, Open Graph tags, and structured data |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:18004:557. | CL-C5.4 | SEOService | Service | Generates SEO metadata, structured data, and canonical URLs |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:18596:1190.             │ structured data               │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:18601:1195.             │   "@context": "schema.org",   │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:19012:1590. // Generate JSON-LD structured data
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:19656:2202. - [ ] JSON-LD structured data (DiscussionForumPosting)
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:19686:2232. | JSON-LD | JavaScript Object Notation for Linked Data - structured data format |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:20026:319.                                                            │ structured data │
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:20225:518. | CL-C2.5 | StructuredDataGenerator | Service | Generates JSON-LD structured data for rich snippets |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:20260:553. | CL-D4 | StructuredData | DTO | JSON-LD structured data |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:20652:929.                 │             │  │ @type: "DiscussionForumPosting"│
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:21160:1450. // Generate DiscussionForumPosting schema
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:21697:1971.   "@context": "https://schema.org",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:21698:1972.   "@type": "DiscussionForumPosting",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:21710:1984.     "interactionType": "https://schema.org/CommentAction",
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:21730:2004. | JSON-LD | JavaScript Object Notation for Linked Data (structured data) |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:22387:  | AC-5 | JSON-LD structured data validates at schema.org validator | Integration test |
+./llm-logs/dev-specs/02-13_dev-spec-multi-modal-review.md:22465:- **Rationale:** The guest-public-channel-view spec (C5.4 SEOService) and the SEO meta-tag-generation spec (M2 MetaTagService) both generate page titles, descriptions, and structured data. It's unclear whether these are the same service or separate services. The guest spec's SEOService (lines 1572-1609) has methods `generatePageTitle()`, `generateDescription()`, `generateStructuredData()` that overlap with the meta tag spec's TitleGenerator, DescriptionGenerator, and StructuredDataGenerator. This could lead to duplicate implementations.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git branch --show-current
+```
+
+Output:
+
+```text
+*
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:05:52.996Z
+
+I found the existing channel-page SEO implementation and prior tests around this schema. I’m reading the actual page component and its test coverage now, then I’ll add a focused repro and patch rather than guessing from the issue description alone.
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+Output:
+
+```text
+zsh:1: no matches found: harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+/**
+ * Unit tests for generateMetadata in the public channel page.
+ * Issue #357 — Sprint 5 (M1 PublicChannelPage + generateMetadata integration)
+ */
+
+const mockCache = jest.fn(<T extends (...args: never[]) => unknown>(fn: T): T => fn);
+jest.mock('react', () => ({ cache: mockCache }));
+
+jest.mock('@/services/publicApiService', () => ({
+  fetchPublicServer: jest.fn(),
+  fetchPublicChannel: jest.fn(),
+  fetchPublicMetaTags: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/components/channel/GuestChannelView', () => ({
+  GuestChannelView: () => null,
+}));
+
+import { generateMetadata } from '@/app/c/[serverSlug]/[channelSlug]/page';
+import { fetchPublicServer, fetchPublicChannel } from '@/services/publicApiService';
+import { ChannelType, ChannelVisibility } from '@/types';
+
+const mockFetchPublicServer = fetchPublicServer as jest.Mock;
+const mockFetchPublicChannel = fetchPublicChannel as jest.Mock;
+
+const originalEnv = process.env;
+
+function makeParams(
+  serverSlug = 'harmony-hq',
+  channelSlug = 'general',
+): { params: Promise<{ serverSlug: string; channelSlug: string }> } {
+  return { params: Promise.resolve({ serverSlug, channelSlug }) };
+}
+
+function makeServer(overrides = {}) {
+  return {
+    id: 'srv-1',
+    name: 'Harmony HQ',
+    slug: 'harmony-hq',
+    description: 'A public server',
+    memberCount: 10,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeChannel(visibility: ChannelVisibility, overrides = {}) {
+  return {
+    id: 'ch-1',
+    name: 'general',
+    slug: 'general',
+    serverId: 'srv-1',
+    type: ChannelType.TEXT,
+    visibility,
+    topic: 'Welcome to general',
+    position: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  process.env = { ...originalEnv, NEXT_PUBLIC_BASE_URL: 'https://harmony.chat' };
+  jest.resetAllMocks();
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({
+      channel: makeChannel(ChannelVisibility.PUBLIC_INDEXABLE),
+      isPrivate: false,
+    });
+  });
+
+  it('sets title and description from channel and server data', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.title).toBe('general - Harmony HQ | Harmony');
+    expect(meta.description).toBe('Welcome to general');
+  });
+
+  it('sets robots to index, follow', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.robots).toEqual({ index: true, follow: true });
+  });
+
+  it('sets canonical URL using the frontend domain', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.alternates?.canonical).toBe('https://harmony.chat/c/harmony-hq/general');
+  });
+
+  it('includes Open Graph tags', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta).toMatchObject({
+      openGraph: {
+        title: 'general - Harmony HQ | Harmony',
+        type: 'website',
+        url: 'https://harmony.chat/c/harmony-hq/general',
+      },
+    });
+  });
+
+  it('includes Twitter card tags', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta).toMatchObject({
+      twitter: {
+        card: 'summary',
+        title: 'general - Harmony HQ | Harmony',
+        description: 'Welcome to general',
+      },
+    });
+  });
+});
+
+describe('generateMetadata — PUBLIC_NO_INDEX channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({
+      channel: makeChannel(ChannelVisibility.PUBLIC_NO_INDEX, { topic: 'Staff updates' }),
+      isPrivate: false,
+    });
+  });
+
+  it('sets robots to noindex, follow', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'staff'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('still includes Twitter card tags', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'staff'));
+    expect(meta).toMatchObject({ twitter: { card: 'summary' } });
+    expect(meta.twitter?.title).toBeTruthy();
+  });
+});
+
+describe('generateMetadata — PRIVATE channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({ isPrivate: true });
+  });
+
+  it('sets robots to noindex, follow', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'secret'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('falls back to the slug for title when channel data is unavailable', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'secret'));
+    expect(meta.title).toContain('secret');
+  });
+});
+
+describe('generateMetadata — API fallback (both fetches return null)', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(null);
+    mockFetchPublicChannel.mockResolvedValue(null);
+  });
+
+  it('falls back to slugs for title', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.title).toBe('my-channel - my-server | Harmony');
+  });
+
+  it('falls back to a template description', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.description).toBe('Join my-server on Harmony');
+  });
+
+  it('still sets canonical URL and Twitter card', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.alternates?.canonical).toBe('https://harmony.chat/c/my-server/my-channel');
+    expect(meta).toMatchObject({ twitter: { card: 'summary' } });
+  });
+
+  it('sets robots to noindex when channel is unknown', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read tests/integration/guest-public-channel.test.ts
+```
+
+Output:
+
+```text
+/**
+ * GPC-1 through GPC-6: Guest Public Channel Rendering
+ *
+ * GPC-1 to GPC-3: cloud-read-only
+ * GPC-4, GPC-6: local-only (require seeded PRIVATE channel data)
+ * GPC-5: cloud-read-only
+ */
+
+import {
+  BACKEND_URL,
+  FRONTEND_URL,
+  LOCAL_SEEDS,
+  isCloud,
+  localOnlyDescribe,
+  getCloudFixture,
+} from './env';
+
+describe('Guest Public Channel — cloud-read-only', () => {
+  let serverSlug: string = LOCAL_SEEDS.server.slug;
+  let publicIndexableSlug: string = LOCAL_SEEDS.channels.publicIndexable;
+
+  beforeAll(async () => {
+    if (!isCloud) return;
+    const fixture = await getCloudFixture();
+    serverSlug = fixture.serverSlug;
+    publicIndexableSlug = fixture.publicChannel;
+  });
+
+  test('GPC-1: public channel page renders with HTTP 200 for unauthenticated user', async () => {
+    const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${publicIndexableSlug}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html.length).toBeGreaterThan(100);
+  });
+
+  test('GPC-2: SSR metadata includes SEO tags for PUBLIC_INDEXABLE channel', async () => {
+    const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${publicIndexableSlug}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toMatch(/<title[^>]*>/i);
+    expect(html).toMatch(/index,\s*follow/i);
+    expect(html).toMatch(/<link[^>]+rel=["']canonical["']/i);
+    expect(html).toContain(`/c/${serverSlug}/${publicIndexableSlug}`);
+    expect(html).toMatch(/<meta[^>]+property=["']og:title["']/i);
+    expect(html).toMatch(/<meta[^>]+property=["']og:url["']/i);
+    expect(html).toMatch(/twitter:card/i);
+    expect(html).toMatch(/twitter:title/i);
+    expect(html).toMatch(/<script[^>]+type=["']application\/ld\+json["']/i);
+    expect(html).toContain('DiscussionForumPosting');
+  });
+
+  test('GPC-3: PUBLIC_NO_INDEX channel renders with HTTP 200 and noindex meta', async () => {
+    const noIndexSlug = isCloud ? '' : LOCAL_SEEDS.channels.publicNoIndex;
+    if (!noIndexSlug) {
+      return;
+    }
+    const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${noIndexSlug}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toMatch(/noindex/i);
+    expect(html).not.toMatch(/<script[^>]+type=["']application\/ld\+json["']/i);
+    expect(html).not.toContain('DiscussionForumPosting');
+  });
+
+  test('GPC-5: messages pagination — page=2 returns page field equal to 2', async () => {
+    const channelRes = await fetch(
+      `${BACKEND_URL}/api/public/servers/${serverSlug}/channels/${publicIndexableSlug}`,
+    );
+    if (channelRes.status !== 200) return; // skip if not available
+    const channel = (await channelRes.json()) as { id?: string };
+    if (!channel.id) return;
+
+    const res = await fetch(`${BACKEND_URL}/api/public/channels/${channel.id}/messages?page=2`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { page?: number; messages?: unknown[] };
+    expect(body.page).toBe(2);
+    expect(Array.isArray(body.messages)).toBe(true);
+    expect((body.messages ?? []).length).toBeLessThanOrEqual(50);
+  });
+});
+
+localOnlyDescribe('Guest Public Channel — SEO tags across 3 PUBLIC_INDEXABLE channels (AC #357)', () => {
+  const serverSlug = LOCAL_SEEDS.server.slug;
+
+  test.each([...LOCAL_SEEDS.channels.publicIndexableAll])(
+    'GPC-2b: SSR metadata and structured data present for channel %s',
+    async (channelSlug) => {
+      const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${channelSlug}`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+
+      expect(html).toMatch(/<title[^>]*>/i);
+      expect(html).toMatch(/index,\s*follow/i);
+      expect(html).toMatch(/<link[^>]+rel=["']canonical["']/i);
+      expect(html).toContain(`/c/${serverSlug}/${channelSlug}`);
+      expect(html).toMatch(/<meta[^>]+property=["']og:title["']/i);
+      expect(html).toMatch(/twitter:card/i);
+
+      const ldMatch = html.match(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i);
+      expect(ldMatch).not.toBeNull();
+      const jsonLd = JSON.parse(ldMatch![1]);
+      expect(jsonLd['@context']).toBe('https://schema.org');
+      expect(jsonLd['@type']).toBe('DiscussionForumPosting');
+      expect(typeof jsonLd.name).toBe('string');
+      expect(jsonLd.name.length).toBeGreaterThan(0);
+      expect(typeof jsonLd.url).toBe('string');
+      expect(jsonLd.url).toContain(`/c/${serverSlug}/${channelSlug}`);
+    },
+    20000,
+  );
+});
+
+localOnlyDescribe('Guest Public Channel — local-only (PRIVATE access)', () => {
+  const privateSlug = LOCAL_SEEDS.channels.private;
+  const serverSlug: string = LOCAL_SEEDS.server.slug;
+
+  test('GPC-4: PRIVATE channel shows access-denied UI for guest', async () => {
+    const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${privateSlug}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).not.toMatch(/<meta[^>]+content=["']index,\s*follow["']/i);
+    expect(html).not.toMatch(/<script[^>]+type=["']application\/ld\+json["']/i);
+    expect(html).not.toContain('DiscussionForumPosting');
+  });
+
+  test('GPC-6: public messages endpoint returns 404 for PRIVATE channel', async () => {
+    const channelRes = await fetch(
+      `${BACKEND_URL}/api/public/servers/${serverSlug}/channels/${privateSlug}`,
+    );
+    if (channelRes.status === 404) {
+      expect(channelRes.status).toBe(404);
+      return;
+    }
+    const channel = (await channelRes.json()) as { id?: string };
+    if (channel.id) {
+      const msgRes = await fetch(`${BACKEND_URL}/api/public/channels/${channel.id}/messages`);
+      expect(msgRes.status).toBe(404);
+    }
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx'
+```
+
+Output:
+
+```text
+import type { Metadata } from 'next';
+import { GuestChannelView } from '@/components/channel/GuestChannelView';
+import {
+  fetchPublicServer,
+  fetchPublicChannel,
+  fetchPublicMetaTags,
+} from '@/services/publicApiService';
+import { ChannelVisibility } from '@/types';
+import { getChannelUrl } from '@/lib/runtime-config';
+
+interface PageProps {
+  params: Promise<{ serverSlug: string; channelSlug: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { serverSlug, channelSlug } = await params;
+  const [server, channelResult, publicMetaTags] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+    fetchPublicMetaTags(serverSlug, channelSlug),
+  ]);
+
+  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
+  const channelName = channel?.name ?? channelSlug;
+  const serverName = server?.name ?? serverSlug;
+  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+  const description =
+    publicMetaTags?.description ??
+    channel?.topic ??
+    server?.description ??
+    `Join ${serverName} on Harmony`;
+  const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+  const canonicalUrl = getChannelUrl(serverSlug, channelSlug);
+
+  return {
+    title,
+    description,
+    robots: { index: isIndexable, follow: true },
+    alternates: { canonical: canonicalUrl },
+    openGraph: {
+      title: publicMetaTags?.ogTitle ?? title,
+      description: publicMetaTags?.ogDescription ?? description,
+      type: 'website',
+      url: canonicalUrl,
+      ...(publicMetaTags?.ogImage ? { images: [{ url: publicMetaTags.ogImage }] } : {}),
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  };
+}
+
+export default async function GuestChannelPage({ params }: PageProps) {
+  const { serverSlug, channelSlug } = await params;
+
+  const [server, channelResult] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+  ]);
+
+  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
+  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+
+  const jsonLd = isIndexable
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'DiscussionForumPosting',
+        name: `${channel?.name ?? channelSlug} - ${server?.name ?? serverSlug} | Harmony`,
+        url: getChannelUrl(serverSlug, channelSlug),
+        description:
+          channel?.topic ??
+          server?.description ??
+          `Join ${server?.name ?? serverSlug} on Harmony`,
+        ...(channel?.createdAt && { datePublished: channel.createdAt }),
+      }
+    : null;
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(jsonLd)
+              .replace(/</g, '\\u003c')
+              .replace(/>/g, '\\u003e')
+              .replace(/&/g, '\\u0026'),
+          }}
+        />
+      )}
+      <GuestChannelView serverSlug={serverSlug} channelSlug={channelSlug} />
+    </>
+  );
+}
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:06:06.762Z
+
+The current JSON-LD is exactly missing the fields from the issue, so the repro is clear. I’m checking the available server/channel data now to choose a real `author` source and keep the schema aligned with what the page can render server-side.
+
+#### Tool: exec_command
+
+```sh
+rg -n "interface PublicServer|type PublicServer|owner|creator|createdBy|author" harmony-frontend/src harmony-backend/src
+```
+
+Output:
+
+```text
+Total output lines: 1585
+
+harmony-frontend/src/services/authService.ts:67:    // UI that needs to check admin/owner status must compare user.id to
+harmony-frontend/src/services/authService.ts:68:    // the server's ownerId or fetch server membership separately.
+harmony-frontend/src/services/authService.ts:69:    role: b.isSystemAdmin ? 'owner' : 'member',
+harmony-frontend/src/services/serverService.ts:28:    ownerId: raw.ownerId as string,
+harmony-frontend/src/services/serverService.ts:93:    OWNER: 'owner',
+harmony-frontend/src/services/serverService.ts:116: * Fetches a server by slug via the authenticated tRPC endpoint, ensuring ownerId is populated.
+harmony-frontend/src/services/serverService.ts:205:  OWNER: 'owner',
+harmony-frontend/src/services/publicApiService.ts:13:type PublicServer = Omit<Server, 'ownerId'>;
+harmony-frontend/src/services/publicApiService.ts:17:interface PublicServerResponse {
+harmony-frontend/src/services/publicApiService.ts:44:  author: { id: string; username: string };
+harmony-frontend/src/services/publicApiService.ts:182:      authorId: m.author.id,
+harmony-frontend/src/services/publicApiService.ts:183:      author: { id: m.author.id, username: m.author.username },
+harmony-frontend/src/services/messageService.ts:20:  const author = raw.author as Record<string, unknown> | undefined;
+harmony-frontend/src/services/messageService.ts:24:    authorId: (raw.authorId ?? raw.author_id ?? author?.id ?? '') as string,
+harmony-frontend/src/services/messageService.ts:25:    author: {
+harmony-frontend/src/services/messageService.ts:26:      id: (author?.id ?? '') as string,
+harmony-frontend/src/services/messageService.ts:27:      username: (author?.username ?? '') as string,
+harmony-frontend/src/services/messageService.ts:28:      displayName: (author?.displayName ?? author?.display_name) as string | undefined,
+harmony-frontend/src/services/messageService.ts:29:      avatarUrl: (author?.avatarUrl ?? author?.avatar_url) as string | undefined,
+harmony-backend/src/services/serverMember.service.ts:53:   * Add the server owner as an OWNER member. Called when a server is created.
+harmony-backend/src/services/serverMember.service.ts:108:   * Leave a server. Owners cannot leave — they must transfer ownership or delete.
+harmony-backend/src/services/serverMember.service.ts:114:      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Server owner cannot leave. Transfer ownership or delete the server.' });
+harmony-backend/src/services/serverMember.service.ts:155:      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot assign OWNER role. Use ownership transfer.' });
+harmony-backend/src/services/serverMember.service.ts:166:      throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot change the role of the server owner' });
+harmony-backend/src/services/serverMember.service.ts:182:   * Cannot kick the owner.
+harmony-backend/src/services/serverMember.service.ts:193:      throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot remove the server owner' });
+harmony-frontend/src/middleware.ts:15: * All real authorization is enforced by the backend on every API call.
+harmony-frontend/src/middleware.ts:27:// fetches the server's membership and checks ownerId / role.
+harmony-backend/src/services/permission.service.ts:113:   * Use this inside tRPC procedures that should reject unauthorized callers.
+harmony-backend/src/services/visibility.service.ts:59:   * preventing cross-server authorization bypass. The VOICE type check,
+harmony-backend/src/services/message.service.ts:23:  authorId: string;
+harmony-backend/src/services/message.service.ts:38:  authorId: string;
+harmony-backend/src/services/message.service.ts:52:  authorId: string;
+harmony-backend/src/services/message.service.ts:68: * cannot be hit by users authorized on a different server.
+harmony-backend/src/services/message.service.ts:147:    const { serverId, channelId, authorId, content, attachments } = input;
+harmony-backend/src/services/message.service.ts:153:      author: { connect: { id: authorId } },
+harmony-backend/src/services/message.service.ts:179:        authorId,
+harmony-backend/src/services/message.service.ts:193:   * Edit a message's content. Only the message author may edit.
+harmony-backend/src/services/message.service.ts:196:    const { serverId, messageId, authorId, content } = input;
+harmony-backend/src/services/message.service.ts:200:    if (message.authorId !== authorId) {
+harmony-backend/src/services/message.service.ts:243:    if (message.authorId !== actorId) {
+harmony-backend/src/services/message.service.ts:390:    const { parentMessageId, channelId, serverId, authorId, content } = input;
+harmony-backend/src/services/message.service.ts:420:          author: { connect: { id: authorId } },
+harmony-backend/src/services/message.service.ts:457:        authorId,
+harmony-frontend/src/context/AuthContext.tsx:27:   * Pass `serverOwnerId` to check ownership of a specific server — this is the
+harmony-frontend/src/context/AuthContext.tsx:98:      // Dev system admin bypasses all ownership checks
+harmony-frontend/src/context/AuthContext.tsx:101:      return user.role === 'owner' || user.role === 'admin';
+harmony-backend/src/services/metaTag/structuredDataGenerator.ts:15:      // author and datePublished are stub fields — populated by M4 when message data is available
+harmony-backend/src/services/metaTag/structuredDataGenerator.ts:16:      author: undefined,
+harmony-backend/src/services/server.service.ts:112:    ownerId: string;
+harmony-backend/src/services/server.service.ts:119:        await serverMemberService.addOwner(input.ownerId, server.id, tx);
+harmony-backend/src/services/server.service.ts:132:    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))
+harmony-backend/src/services/server.service.ts:133:      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can update' });
+harmony-backend/src/services/server.service.ts:159:    if (server.ownerId !== actorId && !(await isSystemAdmin(actorId)))
+harmony-backend/src/services/server.service.ts:160:      throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the server owner can delete' });
+harmony-backend/src/routes/public.router.ts:63:            author: { select: { id: true, username: true } },
+harmony-backend/src/routes/public.router.ts:112:            author: { select: { id: true, username: true } },
+harmony-frontend/src/types/user.ts:8:export type UserRole = 'owner' | 'admin' | 'moderator' | 'member' | 'guest';
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:117:  authorId: 'user-001',
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:118:  author: { id: 'user-001', username: 'alice', displayName: 'Alice' },
+harmony-backend/src/services/attachment.service.ts:84:    // Collapse ownership mismatch to the same error as not-found to prevent
+harmony-backend/src/lib/admin.utils.ts:5: * and bypass all permission and ownership checks. Remove this file before
+harmony-frontend/src/types/message.ts:15:  authorId: string;
+harmony-frontend/src/types/message.ts:16:  author: Author;
+harmony-frontend/src/types/message.ts:59:  author: Author;
+harmony-backend/src/services/metaTag/types.ts:25:  author?: object;
+harmony-backend/src/services/metaTag/types.ts:104:  authorDisplayName?: string;
+harmony-backend/src/routes/admin.metaTag.router.ts:46:// ─── Admin authorization middleware ──────────────────────────────────────────
+harmony-frontend/src/types/server.ts:11:  ownerId: string;
+harmony-frontend/src/types/server.ts:25:  role: 'owner' | 'admin' | 'moderator' | 'member' | 'guest';
+harmony-frontend/src/__tests__/server-settings-access.test.ts:39:  it('returns the server for the owner', async () => {
+harmony-frontend/src/__tests__/server-settings-access.test.ts:40:    const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
+harmony-frontend/src/__tests__/server-settings-access.test.ts:46:      id: 'owner-1',
+harmony-frontend/src/__tests__/server-settings-access.test.ts:47:      username: 'owner',
+harmony-frontend/src/__tests__/server-settings-access.test.ts:59:    const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
+harmony-frontend/src/__tests__/server-settings-access.test.ts:77:    const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
+harmony-frontend/src/__tests__/server-settings-access.test.ts:103:  it('redirects unauthorized users to the channel view', async () => {
+harmony-frontend/src/__tests__/server-settings-access.test.ts:104:    const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
+harmony-frontend/src/__tests__/server-settings-access.test.ts:132:  it('throws in server-action mode for unauthorized users', async () => {
+harmony-frontend/src/__tests__/server-settings-access.test.ts:133:    const server = { id: 'server-1', ownerId: 'owner-1', slug: 'test-server' } as Awaited<
+harmony-backend/src/trpc/init.ts:15:  const authHeader = req.headers.authorization;
+harmony-frontend/src/__tests__/trpc-client.test.ts:105:    it('omits input and authorization when no auth token is available', async () => {
+harmony-frontend/src/__tests__/trpc-client.test.ts:123:    it('continues without authorization when cookies() throws outside request context', async () => {
+harmony-frontend/src/__tests__/trpc-client.test.ts:156:      mockFetch.mockResolvedValue(createTextResponse('Unauthorized', 401));
+harmony-frontend/src/__tests__/useChannelEvents.test.tsx:97:  authorId: 'user-001',
+harmony-frontend/src/__tests__/useChannelEvents.test.tsx:98:  author: { id: 'user-001', username: 'alice', displayName: 'Alice' },
+harmony-frontend/src/__tests__/useChannelEvents.test.tsx:108:  ownerId: 'user-001',
+harmony-backend/src/services/auth.service.ts:245:    // bypasses all permission and ownership checks. Remove before production.
+harmony-backend/src/services/metaTag/metaTagService.ts:167:          authorDisplayName: message.authorDisplayName ?? null,
+harmony-backend/src/services/metaTag/metaTagService.ts:243:      author: {
+harmony-backend/src/services/metaTag/metaTagService.ts:257:      authorDisplayName: message.author.displayName,
+harmony-backend/src/services/metaTag/metaTagService.ts:293:      include: { author: { select: { displayName: true } } },
+harmony-backend/src/services/metaTag/metaTagService.ts:310:      authorDisplayName: m.author.displayName,
+harmony-backend/src/routes/events.router.ts:6: * Streams real-time message events to authenticated, authorised clients using
+harmony-backend/src/routes/events.router.ts:55:  author: {
+harmony-backend/src/routes/events.router.ts:224:          authorId: message.authorId,
+harmony-backend/src/routes/events.router.ts:225:          author: message.author,
+harmony-backend/src/routes/events.router.ts:255:          authorId: message.authorId,
+harmony-backend/src/routes/events.router.ts:256:          author: message.author,
+harmony-backend/src/routes/events.router.ts:330: * Streams real-time server events to authenticated, authorised clients using
+harmony-backend/src/routes/events.router.ts:464:          authorId: message.authorId,
+harmony-backend/src/routes/events.router.ts:465:          author: message.author,
+harmony-backend/src/routes/events.router.ts:496:          authorId: message.authorId,
+harmony-backend/src/routes/events.router.ts:497:          author: message.author,
+harmony-frontend/src/__tests__/publicApiService.test.ts:65:    author: { id: 'user-1', username: 'alice' },
+harmony-frontend/src/__tests__/publicApiService.test.ts:245:              author: { id: 'user-2', username: 'bob' },
+harmony-frontend/src/__tests__/publicApiService.test.ts:263:            authorId: 'user-1',
+harmony-frontend/src/__tests__/publicApiService.test.ts:264:            author: { id: 'user-1', username: 'alice' },
+harmony-frontend/src/__tests__/publicApiService.test.ts:272:            authorId: 'user-2',
+harmony-frontend/src/__tests__/publicApiService.test.ts:273:            author: { id: 'user-2', username: 'bob' },
+harmony-frontend/src/__tests__/publicApiService.test.ts:292:              author: { id: 'user-3', username: 'charlie' },
+harmony-frontend/src/__tests__/publicApiService.test.ts:307:            authorId: 'user-3',
+harmony-frontend/src/__tests__/publicApiService.test.ts:308:            author: { id: 'user-3', username: 'charlie' },
+harmony-backend/src/lib/logger.ts:50:        'authorization',
+harmony-backend/src/lib/logger.ts:52:        'headers.authorization',
+harmony-backend/src/lib/logger.ts:54:        'req.headers.authorization',
+harmony-backend/src/trpc/routers/server.router.ts:35:      return serverService.createServer({ ...input, ownerId: ctx.userId });
+harmony-backend/src/repositories/message.repository.ts:21:  author: { select: AUTHOR_SELECT },
+harmony-frontend/src/__tests__/serverService.test.ts:49:    ownerId: 'user-1',
+harmony-frontend/src/__tests__/serverService.test.ts:151:    it('propagates 401 unauthorized rejection', async () => {
+harmony-frontend/src/__tests__/serverService.test.ts:152:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:155:      await expect(getServers()).rejects.toThrow('Unauthorized');
+harmony-frontend/src/__tests__/serverService.test.ts:205:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:260:      expect(result).toMatchObject({ id: 'server-1', ownerId: 'user-1' });
+harmony-frontend/src/__tests__/serverService.test.ts:280:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:338:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:346:    it('maps OWNER role to owner', async () => {
+harmony-frontend/src/__tests__/serverService.test.ts:351:      expect(member.role).toBe('owner');
+harmony-frontend/src/__tests__/serverService.test.ts:483:    it('propagates 401 unauthorized rejection', async () => {
+harmony-frontend/src/__tests__/serverService.test.ts:484:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:487:      await expect(updateServer('server-1', { name: 'New' })).rejects.toThrow('Unauthorized');
+harmony-frontend/src/__tests__/serverService.test.ts:510:    it('propagates 401 unauthorized rejection', async () => {
+harmony-frontend/src/__tests__/serverService.test.ts:511:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:514:      await expect(deleteServer('s1')).rejects.toThrow('Unauthorized');
+harmony-frontend/src/__tests__/serverService.test.ts:537:    it('propagates 401 unauthorized rejection', async () => {
+harmony-frontend/src/__tests__/serverService.test.ts:538:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:541:      await expect(joinServer('s1')).rejects.toThrow('Unauthorized');
+harmony-frontend/src/__tests__/serverService.test.ts:595:    it('propagates 401 unauthorized rejection', async () => {
+harmony-frontend/src/__tests__/serverService.test.ts:596:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:599:      await expect(createServer({ name: 'My Server' })).rejects.toThrow('Unauthorized');
+harmony-frontend/src/__tests__/serverService.test.ts:639:    it('maps OWNER role to owner', async () => {
+harmony-frontend/src/__tests__/serverService.test.ts:644:      expect(member.role).toBe('owner');
+harmony-frontend/src/__tests__/serverService.test.ts:695:    it('propagates 401 unauthorized rejection', async () => {
+harmony-frontend/src/__tests__/serverService.test.ts:696:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:699:      await expect(getServerMembersWithRole('s1')).rejects.toThrow('Unauthorized');
+harmony-frontend/src/__tests__/serverService.test.ts:751:    it('propagates 401 unauthorized rejection', async () => {
+harmony-frontend/src/__tests__/serverService.test.ts:752:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:755:      await expect(changeMemberRole('s1', 'u1', 'ADMIN')).rejects.toThrow('Unauthorized');
+harmony-frontend/src/__tests__/serverService.test.ts:781:    it('propagates 401 unauthorized rejection', async () => {
+harmony-frontend/src/__tests__/serverService.test.ts:782:      const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+harmony-frontend/src/__tests__/serverService.test.ts:785:      await expect(removeMember('s1', 'u1')).rejects.toThrow('Unauthorized');
+harmony-frontend/src/__tests__/serverService.test.ts:814:        ownerId: 'user-1',
+harmony-backend/src/services/reaction.service.ts:124:   * Only the reaction owner may remove it; throws FORBIDDEN otherwise.
+harmony-backend/src/trpc/routers/voice.router.ts:11: * channel. Used by all voice procedures to prevent cross-server authorization
+harmony-backend/src/trpc/routers/message.router.ts:51:        authorId: ctx.userId,
+harmony-backend/src/trpc/routers/message.router.ts:58:   * Edit the content of a message the caller authored.
+harmony-backend/src/trpc/routers/message.router.ts:59:   * Gated on message:update_own; ownership is enforced in the service layer.
+harmony-backend/src/trpc/routers/message.router.ts:73:        authorId: ctx.userId,
+harmony-backend/src/trpc/routers/message.router.ts:81:   * message:delete_any when the caller is not the message author.
+harmony-backend/src/trpc/routers/message.router.ts:143:        authorId: ctx.userId,
+harmony-frontend/src/__tests__/private-channel-pane-lock.test.tsx:103:  ownerId: 'owner-1',
+harmony-frontend/src/__tests__/private-channel-pane-lock.test.tsx:133:    authorId: 'member-1',
+harmony-frontend/src/__tests__/private-channel-pane-lock.test.tsx:134:    author: { id: 'member-1', username: 'alex' },
+harmony-frontend/src/__tests__/frontend-logger.test.ts:14:      headers: { authorization: 'Bearer secret' },
+harmony-frontend/src/__tests__/channelService.test.ts:501:      mockedTrpcQuery.mockRejectedValue(new Error('Unauthorized'));
+harmony-frontend/src/__tests__/channelService.test.ts:503:      await expect(getAuditLog('srv-1', 'ch-1')).rejects.toThrow('Unauthorized');
+harmony-backend/src/events/eventTypes.ts:44:  authorId: string;
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:9: *                       authenticated non-admin/non-owner: NoPermissionPage
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:10: *                       authenticated admin/owner: render children
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:85:   * The ownerId of the server that owns this channel. When provided,
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:87:   * admin/owner and therefore allowed to view PRIVATE channels. Authenticated
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:93:   * Whether the current authenticated user has admin or owner role within this
+harmony-frontend/src/components/layout/HarmonyShell.tsx:189:  // while the channel is locked (pinning would be meaningless/unauthorized anyway).
+harmony-frontend/src/components/layout/HarmonyShell.tsx:192:  // System admins bypass membership checks — they are authorized server-side regardless.
+harmony-frontend/src/components/layout/HarmonyShell.tsx:202:        currentMemberRecord?.role === 'owner' ||
+harmony-frontend/src/components/layout/HarmonyShell.tsx:267:      // Dedup: ignore if already in list (e.g. added optimistically by the creator)
+harmony-frontend/src/components/layout/Harmony…21581 tokens truncated…d": "user-003",
+harmony-backend/src/dev/mock-seed-data.json:8155:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8167:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:8168:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8180:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:8181:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8193:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:8194:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8206:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:8207:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8219:      "authorId": "user-003",
+harmony-backend/src/dev/mock-seed-data.json:8220:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8232:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:8233:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8245:      "authorId": "user-010",
+harmony-backend/src/dev/mock-seed-data.json:8246:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8258:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:8259:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8271:      "authorId": "user-010",
+harmony-backend/src/dev/mock-seed-data.json:8272:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8284:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:8285:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8297:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:8298:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8310:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:8311:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8323:      "authorId": "user-010",
+harmony-backend/src/dev/mock-seed-data.json:8324:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8336:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:8337:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8349:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:8350:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8362:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:8363:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8375:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:8376:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8388:      "authorId": "user-010",
+harmony-backend/src/dev/mock-seed-data.json:8389:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8401:      "authorId": "user-006",
+harmony-backend/src/dev/mock-seed-data.json:8402:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8414:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:8415:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8427:      "authorId": "user-006",
+harmony-backend/src/dev/mock-seed-data.json:8428:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8440:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:8441:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8453:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:8454:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8466:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:8467:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8479:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:8480:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8492:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:8493:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8505:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:8506:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8518:      "authorId": "user-003",
+harmony-backend/src/dev/mock-seed-data.json:8519:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8531:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:8532:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8544:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:8545:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8557:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:8558:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8570:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:8571:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8583:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:8584:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8596:      "authorId": "user-006",
+harmony-backend/src/dev/mock-seed-data.json:8597:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8609:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:8610:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8622:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:8623:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8635:      "authorId": "user-002",
+harmony-backend/src/dev/mock-seed-data.json:8636:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8648:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:8649:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8661:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:8662:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8674:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:8675:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8687:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:8688:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8700:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:8701:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8713:      "authorId": "user-002",
+harmony-backend/src/dev/mock-seed-data.json:8714:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8726:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:8727:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8739:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:8740:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8752:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:8753:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8765:      "authorId": "user-006",
+harmony-backend/src/dev/mock-seed-data.json:8766:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8778:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:8779:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8791:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:8792:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8804:      "authorId": "user-010",
+harmony-backend/src/dev/mock-seed-data.json:8805:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8817:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:8818:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8830:      "authorId": "user-003",
+harmony-backend/src/dev/mock-seed-data.json:8831:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8843:      "authorId": "user-010",
+harmony-backend/src/dev/mock-seed-data.json:8844:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8856:      "authorId": "user-010",
+harmony-backend/src/dev/mock-seed-data.json:8857:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8869:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:8870:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8882:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:8883:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8906:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:8907:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8919:      "authorId": "user-003",
+harmony-backend/src/dev/mock-seed-data.json:8920:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8932:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:8933:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8945:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:8946:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8958:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:8959:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8982:      "authorId": "user-006",
+harmony-backend/src/dev/mock-seed-data.json:8983:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:8995:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:8996:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9022:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:9023:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9035:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:9036:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9048:      "authorId": "user-010",
+harmony-backend/src/dev/mock-seed-data.json:9049:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9061:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:9062:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9074:      "authorId": "user-006",
+harmony-backend/src/dev/mock-seed-data.json:9075:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9087:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:9088:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9100:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:9101:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9113:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:9114:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9126:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:9127:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9139:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:9140:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9152:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:9153:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9165:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:9166:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9178:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:9179:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9191:      "authorId": "user-002",
+harmony-backend/src/dev/mock-seed-data.json:9192:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9204:      "authorId": "user-010",
+harmony-backend/src/dev/mock-seed-data.json:9205:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9217:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:9218:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9230:      "authorId": "user-003",
+harmony-backend/src/dev/mock-seed-data.json:9231:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9243:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:9244:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9256:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:9257:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9269:      "authorId": "user-003",
+harmony-backend/src/dev/mock-seed-data.json:9270:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9282:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:9283:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9295:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:9296:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9308:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:9309:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9321:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:9322:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9334:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:9335:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9347:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:9348:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9360:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:9361:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9373:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:9374:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9386:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:9387:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9399:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:9400:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9424:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:9425:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9449:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:9450:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9462:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:9463:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9475:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:9476:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9488:      "authorId": "user-006",
+harmony-backend/src/dev/mock-seed-data.json:9489:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9501:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:9502:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9514:      "authorId": "user-003",
+harmony-backend/src/dev/mock-seed-data.json:9515:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9527:      "authorId": "user-003",
+harmony-backend/src/dev/mock-seed-data.json:9528:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9540:      "authorId": "user-008",
+harmony-backend/src/dev/mock-seed-data.json:9541:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9553:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:9554:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9566:      "authorId": "user-005",
+harmony-backend/src/dev/mock-seed-data.json:9567:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9579:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:9580:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9592:      "authorId": "user-004",
+harmony-backend/src/dev/mock-seed-data.json:9593:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9605:      "authorId": "user-006",
+harmony-backend/src/dev/mock-seed-data.json:9606:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9618:      "authorId": "user-001",
+harmony-backend/src/dev/mock-seed-data.json:9619:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9631:      "authorId": "user-003",
+harmony-backend/src/dev/mock-seed-data.json:9632:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9644:      "authorId": "user-010",
+harmony-backend/src/dev/mock-seed-data.json:9645:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9657:      "authorId": "user-002",
+harmony-backend/src/dev/mock-seed-data.json:9658:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9670:      "authorId": "user-007",
+harmony-backend/src/dev/mock-seed-data.json:9671:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9683:      "authorId": "user-009",
+harmony-backend/src/dev/mock-seed-data.json:9684:      "author": {
+harmony-backend/src/dev/mock-seed-data.json:9696:      "authorId": "user-006",
+harmony-backend/src/dev/mock-seed-data.json:9697:      "author": {
+harmony-frontend/src/components/message/MessageItem.tsx:4: * Supports a full variant (avatar + author + timestamp + content) and a
+harmony-frontend/src/components/message/MessageItem.tsx:252:  /** Set to false for grouped follow-up messages from the same author. Hides the avatar and author line. */
+harmony-frontend/src/components/message/MessageItem.tsx:262:  const [prevAvatarUrl, setPrevAvatarUrl] = useState(message.author.avatarUrl);
+harmony-frontend/src/components/message/MessageItem.tsx:263:  if (prevAvatarUrl !== message.author.avatarUrl) {
+harmony-frontend/src/components/message/MessageItem.tsx:264:    setPrevAvatarUrl(message.author.avatarUrl);
+harmony-frontend/src/components/message/MessageItem.tsx:269:  const trimmedUsername = message.author.username?.trim();
+harmony-frontend/src/components/message/MessageItem.tsx:270:  const authorInitial = trimmedUsername?.charAt(0)?.toUpperCase() || '?';
+harmony-frontend/src/components/message/MessageItem.tsx:276:  //   owner → #f0b132 (gold), admin → #ed4245 (red),
+harmony-frontend/src/components/message/MessageItem.tsx:278:  const authorNameClass = 'cursor-pointer font-medium text-white hover:underline';
+harmony-frontend/src/components/message/MessageItem.tsx:316:        {message.author.avatarUrl && !avatarError ? (
+harmony-frontend/src/components/message/MessageItem.tsx:318:            src={message.author.avatarUrl}
+harmony-frontend/src/components/message/MessageItem.tsx:319:            alt={message.author.username}
+harmony-frontend/src/components/message/MessageItem.tsx:328:            {authorInitial}
+harmony-frontend/src/components/message/MessageItem.tsx:335:          <span className={authorNameClass}>
+harmony-frontend/src/components/message/MessageItem.tsx:336:            {message.author.displayName ?? message.author.username}
+harmony-frontend/src/components/server-rail/BrowseServersModal.tsx:21:interface PublicServerEntry {
+harmony-frontend/src/app/settings/[serverSlug]/page.tsx:21:        sessionUser && (sessionUser.isSystemAdmin || sessionUser.id === server.ownerId),
+harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts:5:type UnauthorizedMode = 'redirect' | 'throw';
+harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts:9:  ownerId: string,
+harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts:11:  return Boolean(user && (user.isSystemAdmin || user.id === ownerId));
+harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts:18:    return currentMembership?.role === 'owner' || currentMembership?.role === 'admin';
+harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts:26:  mode: UnauthorizedMode = 'redirect',
+harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts:32:  if (isSettingsAdmin(user, server.ownerId)) {
+harmony-frontend/src/app/settings/[serverSlug]/actions.ts:5: * `authedProcedure` and verify ownership/membership server-side before any mutation
+harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/actions.ts:6: * Unauthenticated or unauthorised requests are rejected by the backend with UNAUTHORIZED/FORBIDDEN.
+harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/updateVisibility.ts:12: * Unauthenticated or unauthorised requests are rejected with UNAUTHORIZED/FORBIDDEN.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/services/publicApiService.ts
+```
+
+Output:
+
+```text
+/**
+ * publicApiService — server-side service for the backend public REST API.
+ * Uses fetch (not the axios api-client) so it can be called from React Server
+ * Components, generateMetadata, and other server-only contexts.
+ * React `cache` is used for request deduplication within a single render pass.
+ */
+
+import { cache } from 'react';
+import type { Server, Channel, Message } from '@/types';
+import { ChannelType, ChannelVisibility } from '@/types';
+import { API_CONFIG, CACHE_DURATION } from '@/lib/constants';
+
+type PublicServer = Omit<Server, 'ownerId'>;
+
+interface PublicServerResponse {
+  id: string;
+  name: string;
+  slug: string;
+  iconUrl?: string;
+  description?: string;
+  memberCount: number;
+  createdAt: string;
+}
+
+interface PublicChannelResponse {
+  id: string;
+  name: string;
+  slug: string;
+  serverId: string;
+  type: string;
+  visibility: string;
+  topic?: string | null;
+  position: number;
+  createdAt: string;
+}
+
+interface PublicMessageResponse {
+  id: string;
+  content: string;
+  createdAt: string;
+  editedAt?: string | null;
+  author: { id: string; username: string };
+}
+
+interface PublicMessagesApiResponse {
+  messages: PublicMessageResponse[];
+  page: number;
+  pageSize: number;
+}
+
+export interface PublicMetaTagResponse {
+  title: string;
+  description: string;
+  ogTitle: string;
+  ogDescription: string;
+  ogImage: string;
+  generatedAt: string;
+  visibility: string;
+}
+
+function mapChannelType(type: string): ChannelType {
+  switch (type) {
+    case 'VOICE':
+      return ChannelType.VOICE;
+    case 'ANNOUNCEMENT':
+      return ChannelType.ANNOUNCEMENT;
+    default:
+      return ChannelType.TEXT;
+  }
+}
+
+function mapChannelVisibility(visibility: string): ChannelVisibility {
+  switch (visibility) {
+    case 'PUBLIC_NO_INDEX':
+      return ChannelVisibility.PUBLIC_NO_INDEX;
+    case 'PRIVATE':
+      return ChannelVisibility.PRIVATE;
+    default:
+      return ChannelVisibility.PUBLIC_INDEXABLE;
+  }
+}
+
+/**
+ * Fetch public server info by slug.
+ * Returns null on any error or if the server is not found (404).
+ * Deduplicated within a single render pass via React `cache`.
+ */
+export const fetchPublicServer = cache(async (serverSlug: string): Promise<PublicServer | null> => {
+  try {
+    const res = await fetch(
+      `${API_CONFIG.BASE_URL}/api/public/servers/${encodeURIComponent(serverSlug)}`,
+      { next: { revalidate: CACHE_DURATION.PUBLIC_API_REVALIDATE } },
+    );
+    if (!res.ok) return null;
+
+    const data: PublicServerResponse = await res.json();
+    const server: PublicServer = {
+      id: data.id,
+      name: data.name,
+      slug: data.slug,
+      icon: data.iconUrl,
+      description: data.description,
+      memberCount: data.memberCount,
+      createdAt: data.createdAt,
+    };
+    return server;
+  } catch {
+    return null;
+  }
+});
+
+/**
+ * Fetch a single public channel by server slug + channel slug.
+ * - Returns null if the server or channel does not exist (404).
+ * - Returns `{ isPrivate: true }` if the channel is PRIVATE (403).
+ * - Returns `{ channel, isPrivate: false }` on success (200).
+ * Deduplicated within a single render pass via React `cache`.
+ */
+export const fetchPublicChannel = cache(
+  async (
+    serverSlug: string,
+    channelSlug: string,
+  ): Promise<{ channel: Channel; isPrivate: false } | { isPrivate: true } | null> => {
+    try {
+      const res = await fetch(
+        `${API_CONFIG.BASE_URL}/api/public/servers/${encodeURIComponent(serverSlug)}/channels/${encodeURIComponent(channelSlug)}`,
+        {
+          cache: 'no-store',
+        },
+      );
+
+      if (res.status === 404) return null;
+      if (res.status === 403) return { isPrivate: true };
+      if (!res.ok) return null;
+
+      const data: PublicChannelResponse = await res.json();
+      const channel: Channel = {
+        id: data.id,
+        name: data.name,
+        slug: data.slug,
+        serverId: data.serverId,
+        type: mapChannelType(data.type),
+        visibility: mapChannelVisibility(data.visibility),
+        topic: data.topic ?? undefined,
+        position: data.position,
+        createdAt: data.createdAt,
+      };
+      return { channel, isPrivate: false };
+    } catch {
+      return null;
+    }
+  },
+);
+
+/**
+ * Fetch paginated public messages for a channel.
+ * Returns an empty list on error.
+ */
+export async function fetchPublicMessages(
+  channelId: string,
+  page = 1,
+): Promise<{ messages: Message[]; hasMore: boolean }> {
+  try {
+    const res = await fetch(
+      `${API_CONFIG.BASE_URL}/api/public/channels/${encodeURIComponent(channelId)}/messages?page=${page}`,
+    );
+    if (!res.ok) return { messages: [], hasMore: false };
+
+    const data: PublicMessagesApiResponse = await res.json();
+    const messages: Message[] = data.messages.map(m => ({
+      id: m.id,
+      channelId,
+      authorId: m.author.id,
+      author: { id: m.author.id, username: m.author.username },
+      content: m.content,
+      timestamp: m.createdAt,
+      editedAt: m.editedAt ?? undefined,
+    }));
+    return { messages, hasMore: messages.length >= data.pageSize };
+  } catch {
+    return { messages: [], hasMore: false };
+  }
+}
+
+/**
+ * Returns true if the channel is publicly accessible (not PRIVATE and not missing).
+ */
+export async function isChannelGuestAccessible(
+  serverSlug: string,
+  channelSlug: string,
+): Promise<boolean> {
+  const result = await fetchPublicChannel(serverSlug, channelSlug);
+  return result !== null && !result.isPrivate;
+}
+
+export const fetchPublicMetaTags = cache(
+  async (serverSlug: string, channelSlug: string): Promise<PublicMetaTagResponse | null> => {
+    try {
+      const res = await fetch(
+        `${API_CONFIG.BASE_URL}/api/public/servers/${encodeURIComponent(serverSlug)}/channels/${encodeURIComponent(channelSlug)}/meta-tags`,
+        {
+          cache: 'no-store',
+        },
+      );
+
+      if (!res.ok) return null;
+      return (await res.json()) as PublicMetaTagResponse;
+    } catch {
+      return null;
+    }
+  },
+);
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "PUBLIC_INDEXABLE|publicApi|PublicChannel|PublicServer" harmony-frontend/src/types harmony-frontend/src
+```
+
+Output:
+
+```text
+harmony-frontend/src/services/channelService.ts:59: * for PUBLIC_INDEXABLE channels without requiring an auth cookie. If the channel
+harmony-frontend/src/services/channelService.ts:63: * Note: the public endpoint returns only PUBLIC_INDEXABLE channels and omits
+harmony-frontend/src/services/channelService.ts:66: * to PUBLIC_INDEXABLE).
+harmony-frontend/src/services/channelService.ts:78:    // Try the public REST endpoint. It returns only PUBLIC_INDEXABLE channels, so
+harmony-frontend/src/services/channelService.ts:90:            visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/types/channel.ts:27:  PUBLIC_INDEXABLE = 'PUBLIC_INDEXABLE',
+harmony-frontend/src/services/publicApiService.ts:2: * publicApiService — server-side service for the backend public REST API.
+harmony-frontend/src/services/publicApiService.ts:13:type PublicServer = Omit<Server, 'ownerId'>;
+harmony-frontend/src/services/publicApiService.ts:17:interface PublicServerResponse {
+harmony-frontend/src/services/publicApiService.ts:27:interface PublicChannelResponse {
+harmony-frontend/src/services/publicApiService.ts:83:      return ChannelVisibility.PUBLIC_INDEXABLE;
+harmony-frontend/src/services/publicApiService.ts:94:export const fetchPublicServer = cache(async (serverSlug: string): Promise<PublicServer | null> => {
+harmony-frontend/src/services/publicApiService.ts:102:    const data: PublicServerResponse = await res.json();
+harmony-frontend/src/services/publicApiService.ts:103:    const server: PublicServer = {
+harmony-frontend/src/services/publicApiService.ts:125:export const fetchPublicChannel = cache(
+harmony-frontend/src/services/publicApiService.ts:145:      const data: PublicChannelResponse = await res.json();
+harmony-frontend/src/services/publicApiService.ts:201:  const result = await fetchPublicChannel(serverSlug, channelSlug);
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:3: * Issue #357 — Sprint 5 (M1 PublicChannelPage + generateMetadata integration)
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:9:jest.mock('@/services/publicApiService', () => ({
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:10:  fetchPublicServer: jest.fn(),
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:11:  fetchPublicChannel: jest.fn(),
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:20:import { fetchPublicServer, fetchPublicChannel } from '@/services/publicApiService';
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:23:const mockFetchPublicServer = fetchPublicServer as jest.Mock;
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:24:const mockFetchPublicChannel = fetchPublicChannel as jest.Mock;
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:71:describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:73:    mockFetchPublicServer.mockResolvedValue(makeServer());
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:74:    mockFetchPublicChannel.mockResolvedValue({
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:75:      channel: makeChannel(ChannelVisibility.PUBLIC_INDEXABLE),
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:121:    mockFetchPublicServer.mockResolvedValue(makeServer());
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:122:    mockFetchPublicChannel.mockResolvedValue({
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:142:    mockFetchPublicServer.mockResolvedValue(makeServer());
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:143:    mockFetchPublicChannel.mockResolvedValue({ isPrivate: true });
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:159:    mockFetchPublicServer.mockResolvedValue(null);
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts:160:    mockFetchPublicChannel.mockResolvedValue(null);
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:100:  visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:562:        oldVisibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:570:      ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/useServerEvents.test.tsx:590:          oldVisibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:3:  fetchPublicChannel,
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:5:  fetchPublicServer,
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:6:} from '@/services/publicApiService';
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:9:jest.mock('@/services/publicApiService', () => ({
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:10:  fetchPublicServer: jest.fn(),
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:11:  fetchPublicChannel: jest.fn(),
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:15:const mockFetchPublicServer = fetchPublicServer as jest.MockedFunction<typeof fetchPublicServer>;
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:16:const mockFetchPublicChannel = fetchPublicChannel as jest.MockedFunction<typeof fetchPublicChannel>;
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:27:    mockFetchPublicServer.mockResolvedValue({
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:33:    mockFetchPublicChannel.mockResolvedValue({
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:41:        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts:54:      visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/lib/constants.ts:59:  PUBLIC_INDEXABLE = 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/publicApiService.test.ts:2: * Unit tests for publicApiService.ts
+harmony-frontend/src/__tests__/publicApiService.test.ts:15:  fetchPublicServer,
+harmony-frontend/src/__tests__/publicApiService.test.ts:16:  fetchPublicChannel,
+harmony-frontend/src/__tests__/publicApiService.test.ts:19:} from '@/services/publicApiService';
+harmony-frontend/src/__tests__/publicApiService.test.ts:25:function makePublicServerResponse(
+harmony-frontend/src/__tests__/publicApiService.test.ts:40:function makePublicChannelResponse(
+harmony-frontend/src/__tests__/publicApiService.test.ts:49:    visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/publicApiService.test.ts:78:describe('publicApiService', () => {
+harmony-frontend/src/__tests__/publicApiService.test.ts:84:  describe('fetchPublicServer', () => {
+harmony-frontend/src/__tests__/publicApiService.test.ts:86:      mockFetch.mockResolvedValue(makeResponse(makePublicServerResponse()));
+harmony-frontend/src/__tests__/publicApiService.test.ts:88:      const result = await fetchPublicServer('harmony hq');
+harmony-frontend/src/__tests__/publicApiService.test.ts:110:        await expect(fetchPublicServer('missing')).resolves.toBeNull();
+harmony-frontend/src/__tests__/publicApiService.test.ts:117:      await expect(fetchPublicServer('missing')).resolves.toBeNull();
+harmony-frontend/src/__tests__/publicApiService.test.ts:121:  describe('fetchPublicChannel', () => {
+harmony-frontend/src/__tests__/publicApiService.test.ts:125:        response: makePublicChannelResponse({
+harmony-frontend/src/__tests__/publicApiService.test.ts:141:        response: makePublicChannelResponse({
+harmony-frontend/src/__tests__/publicApiService.test.ts:144:          visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/publicApiService.test.ts:151:        expectedVisibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/publicApiService.test.ts:156:        response: makePublicChannelResponse({
+harmony-frontend/src/__tests__/publicApiService.test.ts:168:        response: makePublicChannelResponse({
+harmony-frontend/src/__tests__/publicApiService.test.ts:177:        expectedVisibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/publicApiService.test.ts:192:        const result = await fetchPublicChannel(serverSlug, channelSlug);
+harmony-frontend/src/__tests__/publicApiService.test.ts:213:      await expect(fetchPublicChannel('company', 'internal-hr')).resolves.toEqual({
+harmony-frontend/src/__tests__/publicApiService.test.ts:223:        await expect(fetchPublicChannel('company', 'missing')).resolves.toBeNull();
+harmony-frontend/src/__tests__/publicApiService.test.ts:230:      await expect(fetchPublicChannel('company', 'general')).resolves.toBeNull();
+harmony-frontend/src/__tests__/publicApiService.test.ts:380:        responseBody: makePublicChannelResponse({
+harmony-frontend/src/__tests__/publicApiService.test.ts:383:          visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/publicApiService.test.ts:391:        responseBody: makePublicChannelResponse({
+harmony-frontend/src/__tests__/VisibilityGuard.test.tsx:156:  it('renders children for PUBLIC_INDEXABLE', () => {
+harmony-frontend/src/__tests__/VisibilityGuard.test.tsx:157:    renderGuard({ visibility: ChannelVisibility.PUBLIC_INDEXABLE });
+harmony-frontend/src/__tests__/channelService.test.ts:59:    visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:76:    newValue: { visibility: 'PUBLIC_INDEXABLE' },
+harmony-frontend/src/__tests__/channelService.test.ts:146:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:257:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:277:      ['PUBLIC_INDEXABLE', ChannelVisibility.PUBLIC_INDEXABLE],
+harmony-frontend/src/__tests__/channelService.test.ts:295:        updateVisibility('ch-1', ChannelVisibility.PUBLIC_INDEXABLE, 'srv-1'),
+harmony-frontend/src/__tests__/channelService.test.ts:362:        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/channelService.test.ts:375:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:388:        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/channelService.test.ts:400:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:455:          visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/__tests__/channelService.test.ts:543:        visibility: 'PUBLIC_INDEXABLE',
+harmony-frontend/src/__tests__/channelService.test.ts:607:        newValue: { visibility: 'PUBLIC_INDEXABLE' },
+harmony-frontend/src/__tests__/channelService.test.ts:667:      expect(ChannelVisibility.PUBLIC_INDEXABLE).toBe('PUBLIC_INDEXABLE');
+harmony-frontend/src/components/channel/VisibilityGuard.tsx:6: *   PUBLIC_INDEXABLE  → render children
+harmony-frontend/src/components/channel/MessageList.tsx:134:          {channel.visibility === ChannelVisibility.PUBLIC_INDEXABLE &&
+harmony-frontend/src/components/channel/ChannelSidebar.tsx:74:  [ChannelVisibility.PUBLIC_INDEXABLE]: null,
+harmony-frontend/src/components/channel/ChannelSidebar.tsx:80:  [ChannelVisibility.PUBLIC_INDEXABLE]: '',
+harmony-frontend/src/components/channel/GuestHeader.tsx:8:type PublicServer = Omit<Server, 'ownerId'>;
+harmony-frontend/src/components/channel/GuestHeader.tsx:10:export function GuestHeader({ server }: { server: PublicServer }) {
+harmony-frontend/src/components/channel/VisibilityToggle.tsx:81:    value: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:111:    value: ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:291:                    // PUBLIC_INDEXABLE is unavailable for voice — reset to the nearest valid option.
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:292:                    if (opt.value === ChannelType.VOICE && visibility === ChannelVisibility.PUBLIC_INDEXABLE) {
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:390:                // Voice channels have no text content to index, so PUBLIC_INDEXABLE is not applicable.
+harmony-frontend/src/components/channel/CreateChannelModal.tsx:391:                type !== ChannelType.VOICE || opt.value !== ChannelVisibility.PUBLIC_INDEXABLE,
+harmony-frontend/src/components/server-rail/BrowseServersModal.tsx:21:interface PublicServerEntry {
+harmony-frontend/src/components/server-rail/BrowseServersModal.tsx:56:  server: PublicServerEntry;
+harmony-frontend/src/components/server-rail/BrowseServersModal.tsx:142:  const [servers, setServers] = useState<PublicServerEntry[]>([]);
+harmony-frontend/src/components/server-rail/BrowseServersModal.tsx:155:      .get<PublicServerEntry[]>('/api/public/servers')
+harmony-frontend/src/components/server-rail/BrowseServersModal.tsx:195:  async function handleJoin(server: PublicServerEntry) {
+harmony-frontend/src/components/server-rail/BrowseServersModal.tsx:210:  function handleOpen(server: PublicServerEntry) {
+harmony-frontend/src/components/channel/GuestChannelView.tsx:5: * Ref: dev-spec-guest-public-channel-view.md — M1, C1.1 PublicChannelPage
+harmony-frontend/src/components/channel/GuestChannelView.tsx:10:  fetchPublicServer,
+harmony-frontend/src/components/channel/GuestChannelView.tsx:11:  fetchPublicChannel,
+harmony-frontend/src/components/channel/GuestChannelView.tsx:13:} from '@/services/publicApiService';
+harmony-frontend/src/components/channel/GuestChannelView.tsx:60:    fetchPublicServer(serverSlug),
+harmony-frontend/src/components/channel/GuestChannelView.tsx:61:    fetchPublicChannel(serverSlug, channelSlug),
+harmony-frontend/src/types/channel.ts:27:  PUBLIC_INDEXABLE = 'PUBLIC_INDEXABLE',
+harmony-frontend/src/components/settings/ChannelSettingsPage.tsx:351:  [ChannelVisibility.PUBLIC_INDEXABLE]: 'Public (Search Indexed)',
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:4:  fetchPublicServer,
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:5:  fetchPublicChannel,
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:7:} from '@/services/publicApiService';
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:18:    fetchPublicServer(serverSlug),
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:19:    fetchPublicChannel(serverSlug, channelSlug),
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:26:  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:60:    fetchPublicServer(serverSlug),
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:61:    fetchPublicChannel(serverSlug, channelSlug),
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:65:  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+harmony-frontend/src/app/settings/actions.ts:7: * unauthenticated users (PUBLIC_INDEXABLE or PUBLIC_NO_INDEX). Returns false
+harmony-frontend/src/app/settings/actions.ts:22:    // 200 = accessible (PUBLIC_INDEXABLE or PUBLIC_NO_INDEX)
+harmony-frontend/src/app/page.tsx:4:interface PublicServer {
+harmony-frontend/src/app/page.tsx:8:interface PublicChannel {
+harmony-frontend/src/app/page.tsx:16:async function getFirstPublicChannelPath(): Promise<string | null> {
+harmony-frontend/src/app/page.tsx:18:    const servers = await publicGet<PublicServer[]>('/servers');
+harmony-frontend/src/app/page.tsx:20:    const result = await publicGet<{ channels: PublicChannel[] }>(
+harmony-frontend/src/app/page.tsx:32:  const path = await getFirstPublicChannelPath();
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:06:17.190Z
+
+I’m setting up the repo-required task scratchpad and then I’ll patch the JSON-LD plus the tests together so the fix is proved, not just added.
+
+#### Tool: update_plan
+
+- Explanation: Tracking the issue per repo workflow: reproduce current channel-page JSON-LD, add the missing rich-results fields, and verify with targeted frontend tests plus integration coverage.
+
+- Plan:
+  - [in_progress] Create/update task tracking for issue #468 and note the repro/plan
+  - [pending] Patch channel page JSON-LD to include required DiscussionForumPosting fields
+  - [pending] Extend tests to assert author, content text, and headline
+  - [pending] Run relevant frontend test, typecheck, and lint verification
+  - [pending] Summarize results and note any remaining verification gap versus live Google Rich Results
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue comment 468 --repo CS485-Harmony/Harmony --body $'**[AI Agent — Starting]**
+
+Reproduced the issue from the current channel-page JSON-LD implementation. The `DiscussionForumPosting` payload currently emits `name`, `url`, `description`, and `datePublished`, but it does not emit the required `author` field, does not include `text`/`image`/`video`, and is also missing `headline`.
+
+Next I am patching the frontend schema generator and extending the frontend tests to prove the rich-results fields are present on `PUBLIC_INDEXABLE` channel pages.'
+```
+
+Output:
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/468#issuecomment-4320350565
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "renderToStaticMarkup|dangerouslySetInnerHTML|application/ld\+json|GuestChannelPage" harmony-frontend/src/__tests__
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "build:local-e2e": "NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next build",
+    "start:local-e2e": "PORT=3000 NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next start",
+    "test": "jest --forceExit",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "lint": "eslint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "axios": "^1.13.5",
+    "clsx": "^2.1.1",
+    "next": "16.1.6",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.4.1",
+    "twilio-video": "3.0.0-preview.3"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@playwright/test": "^1.55.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "16.1.6",
+    "eslint-config-prettier": "^10.1.8",
+    "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
+    "prettier": "^3.8.1",
+    "tailwindcss": "^4",
+    "ts-jest": "^29.4.6",
+    "typescript": "5.9.3"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls harmony-frontend
+```
+
+Output:
+
+```text
+public/
+src/
+tests/
+.env.example  233B
+.gitignore  540B
+.prettierignore  47B
+.prettierrc.cjs  342B
+README.md  5.7K
+bun.lock  174.6K
+eslint.config.mjs  786B
+jest.config.js  587B
+next.config.ts  1.1K
+package-lock.json  394.4K
+package.json  1.4K
+playwright.config.ts  1.5K
+postcss.config.mjs  94B
+tailwind.config.ts  853B
+tsconfig.json  670B
+vercel.json  159B
+
+📊 16 files, 3 dirs (4 .json, 3 .ts, 2 .mjs, 1 .cjs, 1 .prettierignore, +5 more)
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "jest" harmony-frontend -g 'jest.*' -g '*.config.*'
+```
+
+Output:
+
+```text
+harmony-frontend/jest.config.js:1:/** @type {import('ts-jest').JestConfigWithTsJest} */
+harmony-frontend/jest.config.js:3:  preset: 'ts-jest',
+harmony-frontend/jest.config.js:4:  testEnvironment: 'jest-environment-jsdom',
+harmony-frontend/jest.config.js:12:      'ts-jest',
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/jest.config.js
+```
+
+Output:
+
+```text
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jest-environment-jsdom',
+  roots: ['<rootDir>/src'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          jsx: 'react-jsx',
+          esModuleInterop: true,
+          module: 'commonjs',
+          moduleResolution: 'node',
+        },
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+};
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:07:06.453Z
+
+I’ve got the data shape I need. The fix will stay in the page’s server-side JSON-LD generator: use the server name as the posting organization, reuse the channel description as `text`, and mirror the page title into `headline`, with tests asserting the exact payload.
+
+#### Tool: exec_command
+
+```sh
+sed -n '45,110p' 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx'
+```
+
+Output:
+
+```text
+      ...(publicMetaTags?.ogImage ? { images: [{ url: publicMetaTags.ogImage }] } : {}),
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  };
+}
+
+export default async function GuestChannelPage({ params }: PageProps) {
+  const { serverSlug, channelSlug } = await params;
+
+  // Fetch data for JSON-LD; React cache deduplicates these within the same render pass
+  const [server, channelResult] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+  ]);
+
+  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
+  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+
+  const jsonLd = isIndexable
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'DiscussionForumPosting',
+        name: `${channel?.name ?? channelSlug} - ${server?.name ?? serverSlug} | Harmony`,
+        url: getChannelUrl(serverSlug, channelSlug),
+        description:
+          channel?.topic ??
+          server?.description ??
+          `Join ${server?.name ?? serverSlug} on Harmony`,
+        ...(channel?.createdAt && { datePublished: channel.createdAt }),
+      }
+    : null;
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          // Escape </script> breakout sequences per OWASP JSON-LD injection guidance
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(jsonLd)
+              .replace(/</g, '\\u003c')
+              .replace(/>/g, '\\u003e')
+              .replace(/&/g, '\\u0026'),
+          }}
+        />
+      )}
+      <GuestChannelView serverSlug={serverSlug} channelSlug={channelSlug} />
+    </>
+  );
+}
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '25,120p' tests/integration/guest-public-channel.test.ts
+```
+
+Output:
+
+```text
+    serverSlug = fixture.serverSlug;
+    publicIndexableSlug = fixture.publicChannel;
+  });
+
+  test('GPC-1: public channel page renders with HTTP 200 for unauthenticated user', async () => {
+    const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${publicIndexableSlug}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html.length).toBeGreaterThan(100);
+  });
+
+  test('GPC-2: SSR metadata includes SEO tags for PUBLIC_INDEXABLE channel', async () => {
+    const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${publicIndexableSlug}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // title tag must be present
+    expect(html).toMatch(/<title[^>]*>/i);
+    // robots index,follow
+    expect(html).toMatch(/index,\s*follow/i);
+    // canonical link
+    expect(html).toMatch(/<link[^>]+rel=["']canonical["']/i);
+    expect(html).toContain(`/c/${serverSlug}/${publicIndexableSlug}`);
+    // Open Graph tags
+    expect(html).toMatch(/<meta[^>]+property=["']og:title["']/i);
+    expect(html).toMatch(/<meta[^>]+property=["']og:url["']/i);
+    // Twitter card tags
+    expect(html).toMatch(/twitter:card/i);
+    expect(html).toMatch(/twitter:title/i);
+    // JSON-LD structured data
+    expect(html).toMatch(/<script[^>]+type=["']application\/ld\+json["']/i);
+    expect(html).toContain('DiscussionForumPosting');
+  });
+
+  test('GPC-3: PUBLIC_NO_INDEX channel renders with HTTP 200 and noindex meta', async () => {
+    const noIndexSlug = isCloud ? '' : LOCAL_SEEDS.channels.publicNoIndex;
+    if (!noIndexSlug) {
+      // Skip in cloud mode when no PUBLIC_NO_INDEX channel slug is configured
+      return;
+    }
+    const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${noIndexSlug}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toMatch(/noindex/i);
+    // JSON-LD must be absent for non-indexable channels
+    expect(html).not.toMatch(/<script[^>]+type=["']application\/ld\+json["']/i);
+    expect(html).not.toContain('DiscussionForumPosting');
+  });
+
+  test('GPC-5: messages pagination — page=2 returns page field equal to 2', async () => {
+    // First get the channelId from the public API
+    const channelRes = await fetch(
+      `${BACKEND_URL}/api/public/servers/${serverSlug}/channels/${publicIndexableSlug}`,
+    );
+    if (channelRes.status !== 200) return; // skip if not available
+    const channel = (await channelRes.json()) as { id?: string };
+    if (!channel.id) return;
+
+    const res = await fetch(`${BACKEND_URL}/api/public/channels/${channel.id}/messages?page=2`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { page?: number; messages?: unknown[] };
+    expect(body.page).toBe(2);
+    expect(Array.isArray(body.messages)).toBe(true);
+    expect((body.messages ?? []).length).toBeLessThanOrEqual(50);
+  });
+});
+
+// GPC-2b: AC #357 — assert SEO tags on at least 3 representative PUBLIC_INDEXABLE channels
+localOnlyDescribe('Guest Public Channel — SEO tags across 3 PUBLIC_INDEXABLE channels (AC #357)', () => {
+  const serverSlug = LOCAL_SEEDS.server.slug;
+
+  test.each([...LOCAL_SEEDS.channels.publicIndexableAll])(
+    'GPC-2b: SSR metadata and structured data present for channel %s',
+    async (channelSlug) => {
+      const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${channelSlug}`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+
+      expect(html).toMatch(/<title[^>]*>/i);
+      expect(html).toMatch(/index,\s*follow/i);
+      expect(html).toMatch(/<link[^>]+rel=["']canonical["']/i);
+      expect(html).toContain(`/c/${serverSlug}/${channelSlug}`);
+      expect(html).toMatch(/<meta[^>]+property=["']og:title["']/i);
+      expect(html).toMatch(/twitter:card/i);
+
+      // Validate JSON-LD structure (Google Rich Results required fields)
+      const ldMatch = html.match(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i);
+      expect(ldMatch).not.toBeNull();
+      const jsonLd = JSON.parse(ldMatch![1]);
+      expect(jsonLd['@context']).toBe('https://schema.org');
+      expect(jsonLd['@type']).toBe('DiscussionForumPosting');
+      expect(typeof jsonLd.name).toBe('string');
+      expect(jsonLd.name.length).toBeGreaterThan(0);
+      expect(typeof jsonLd.url).toBe('string');
+      expect(jsonLd.url).toContain(`/c/${serverSlug}/${channelSlug}`);
+    },
+    20000,
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '120,190p' tests/integration/guest-public-channel.test.ts
+```
+
+Output:
+
+```text
+    20000,
+  );
+});
+
+// GPC-4 and GPC-6 need seeded PRIVATE channel data — local-only
+localOnlyDescribe('Guest Public Channel — local-only (PRIVATE access)', () => {
+  const privateSlug = LOCAL_SEEDS.channels.private;
+  const serverSlug: string = LOCAL_SEEDS.server.slug;
+
+  test('GPC-4: PRIVATE channel shows access-denied UI for guest', async () => {
+    const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${privateSlug}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // The access-denied component renders a lock icon / login CTA — no channel content
+    // We verify absence of channel-specific content. The page should NOT redirect.
+    expect(html).not.toMatch(/<meta[^>]+content=["']index,\s*follow["']/i);
+    // JSON-LD must be absent for PRIVATE channels
+    expect(html).not.toMatch(/<script[^>]+type=["']application\/ld\+json["']/i);
+    expect(html).not.toContain('DiscussionForumPosting');
+  });
+
+  test('GPC-6: public messages endpoint returns 404 for PRIVATE channel', async () => {
+    // Resolve channelId via the backend public API for private channels
+    // The public channel endpoint only exposes PUBLIC_INDEXABLE channels,
+    // so we expect a 404 when trying to fetch messages for a PRIVATE one.
+    // We look up its ID via public channel list (which excludes it) and fall
+    // back to a known channel-slug that we know is PRIVATE.
+    const channelRes = await fetch(
+      `${BACKEND_URL}/api/public/servers/${serverSlug}/channels/${privateSlug}`,
+    );
+    // The public channel endpoint should itself return 404 for PRIVATE channels
+    if (channelRes.status === 404) {
+      expect(channelRes.status).toBe(404);
+      return;
+    }
+    // If the endpoint resolved an ID, verify messages returns 404
+    const channel = (await channelRes.json()) as { id?: string };
+    if (channel.id) {
+      const msgRes = await fetch(`${BACKEND_URL}/api/public/channels/${channel.id}/messages`);
+      expect(msgRes.status).toBe(404);
+    }
+  });
+});
+```
+
+#### Tool: update_plan
+
+- Plan:
+  - [completed] Create/update task tracking for issue #468 and note the repro/plan
+  - [completed] Patch channel page JSON-LD to include required DiscussionForumPosting fields
+  - [completed] Extend tests to assert author, content text, and headline
+  - [in_progress] Run relevant frontend test, typecheck, and lint verification
+  - [pending] Summarize results and note any remaining verification gap versus live Google Rich Results
+
+Output:
+
+```text
+Plan updated
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:08:24.151Z
+
+The code change is in place and the tests now assert the rich-results fields directly. I’m formatting the touched files and running the frontend verification stack next: targeted Jest, TypeScript, lint, then the integration test if the local services are available.
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' '../tests/integration/guest-public-channel.test.ts'
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+npm test -- --runInBand --testPathPatterns=channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 test
+> jest --forceExit --runInBand --testPathPatterns=channel-page-metadata.test.ts
+
+sh: jest: command not found
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:08:32.554Z
+
+The first verification pass hit an environment issue, not a code failure: `npm test` can’t find `jest`, which means the frontend dependencies are not installed in this worktree. I’m checking whether `node_modules` already exist elsewhere here and whether I can still run the non-install checks before deciding if I need approval to install dependencies.
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 23129,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 31834a
+Wall time: 5.0010 seconds
+Process running with session ID 23129
+Original token count: 0
+Output:
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls node_modules
+```
+
+Output:
+
+```text
+ls: node_modules: No such file or directory
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls ../node_modules
+```
+
+Output:
+
+```text
+ls: ../node_modules: No such file or directory
+```
+
+#### Tool: exec_command
+
+```sh
+npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 65243,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 5be832
+Wall time: 5.0020 seconds
+Process running with session ID 65243
+Original token count: 0
+Output:
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --stat
+```
+
+Output:
+
+```text
+ .../src/__tests__/channel-page-metadata.test.ts    | 28 +++++++++++++++++++++-
+ .../src/app/c/[serverSlug]/[channelSlug]/page.tsx  | 18 ++++++++++----
+ tests/integration/guest-public-channel.test.ts     | 28 ++++++++++++++++++++--
+ 3 files changed, 66 insertions(+), 8 deletions(-)
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 23129,
+  "chars": "\u0003",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+write_stdin failed: stdin is closed for this session; rerun exec_command with tty=true to keep stdin open
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 65243,
+  "chars": "\u0003",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+write_stdin failed: stdin is closed for this session; rerun exec_command with tty=true to keep stdin open
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony",
+  "private": true,
+  "scripts": {
+    "test": "node ./scripts/run-root-jest.cjs",
+    "jest": "node ./scripts/run-root-jest.cjs",
+    "test:backend": "npm --prefix harmony-backend test --",
+    "test:frontend": "npm --prefix harmony-frontend test --",
+    "test:integration": "npm --prefix tests/integration test",
+    "test:integration:cloud": "npm --prefix tests/integration run test:cloud"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read tests/integration/package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony-integration-tests",
+  "private": true,
+  "scripts": {
+    "test": "jest --config jest.config.js --runInBand",
+    "test:local": "TEST_TARGET=local jest --config jest.config.js --runInBand",
+    "test:cloud": "TEST_TARGET=cloud jest --config jest.config.js"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/node": "^20.17.19",
+    "dotenv": "^17.3.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.6",
+    "typescript": "^5.8.2"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls tests/integration/node_modules
+```
+
+Output:
+
+```text
+ls: tests/integration/node_modules: No such file or directory
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:09:07.990Z
+
+Local verification is blocked only by missing dependencies in this worktree: neither `harmony-frontend/node_modules` nor `tests/integration/node_modules` exists. I’m requesting permission to install those packages so I can run the real Jest, TypeScript, lint, and integration checks instead of stopping at a code-only patch.
+
+#### Tool: exec_command
+
+```sh
+npm ci
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+npm ci
+```
+
+Output:
+
+```text
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+added 282 packages, and audited 283 packages in 640ms
+
+35 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 20252,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 337836
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 311
+Output:
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated whatwg-encoding@3.1.1: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+added 704 packages, and audited 705 packages in 6s
+
+187 packages are looking for funding
+  run `npm fund` for details
+
+10 vulnerabilities (5 moderate, 4 high, 1 critical)
+
+To address issues that do not require attention, run:
+  npm audit fix
+
+To address all issues, run:
+  npm audit fix --force
+
+Run `npm audit` for details.
+```
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' '../tests/integration/guest-public-channel.test.ts'
+```
+
+Output:
+
+```text
+[warn] jsxBracketSameLine is deprecated.
+src/app/c/[serverSlug]/[channelSlug]/page.tsx 67ms
+src/__tests__/channel-page-metadata.test.ts 27ms
+../tests/integration/guest-public-channel.test.ts 22ms
+```
+
+#### Tool: exec_command
+
+```sh
+npm test -- --runInBand --testPathPatterns=channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 test
+> jest --forceExit --runInBand --testPathPatterns=channel-page-metadata.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts'
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 lint
+> eslint src/app/c/[serverSlug]/[channelSlug]/page.tsx src/__tests__/channel-page-metadata.test.ts
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:09:43.817Z
+
+Formatting is done. The remaining verification commands are running now; I’m waiting on Jest, `tsc`, and ESLint results before I decide whether the integration test can run in this worktree as-is.
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 45726,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 186338
+Wall time: 0.0000 seconds
+Process exited with code 1
+Original token count: 361
+Output:
+FAIL src/__tests__/channel-page-metadata.test.ts
+  ● Test suite failed to run
+
+    Incompatible React versions: The "react" and "react-dom" packages must have the exact same version. Instead got:
+      - react:      undefined
+      - react-dom:  19.2.3
+    Learn more: https://react.dev/warnings/version-mismatch
+
+      17 | }));
+      18 |
+    > 19 | import { renderToStaticMarkup } from 'react-dom/server';
+         | ^
+      20 | import GuestChannelPage, { generateMetadata } from '@/app/c/[serverSlug]/[channelSlug]/page';
+      21 | import { fetchPublicServer, fetchPublicChannel } from '@/services/publicApiService';
+      22 | import { ChannelType, ChannelVisibility } from '@/types';
+
+      at ensureCorrectIsomorphicReactVersion (node_modules/react-dom/cjs/react-dom-server.node.development.js:8685:15)
+      at node_modules/react-dom/cjs/react-dom-server.node.development.js:10340:5
+      at Object.<anonymous> (node_modules/react-dom/cjs/react-dom-server.node.development.js:10802:5)
+      at Object.<anonymous> (node_modules/react-dom/server.node.js:9:7)
+      at Object.<anonymous> (src/__tests__/channel-page-metadata.test.ts:19:1)
+
+Test Suites: 1 failed, 1 total
+Tests:       0 total
+Snapshots:   0 total
+Time:        0.674 s
+Ran all test suites matching channel-page-metadata.test.ts.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 43132,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 5b4464
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 19116,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 8428fb
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:09:48.163Z
+
+Jest found a real test harness issue in this file: the existing `react` mock replaces the whole module, which breaks `react-dom/server` version checks once we render the server component. I’m narrowing that mock to only override `cache`, then I’ll rerun the verification commands.
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write 'src/__tests__/channel-page-metadata.test.ts'
+```
+
+Output:
+
+```text
+[warn] jsxBracketSameLine is deprecated.
+src/__tests__/channel-page-metadata.test.ts 60ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+npm test -- --runInBand --testPathPatterns=channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 test
+> jest --forceExit --runInBand --testPathPatterns=channel-page-metadata.test.ts
+
+Test Suites: 1 passed, 1 total
+Tests:       14 passed, 14 total
+Snapshots:   0 total
+Time:        0.517 s
+Ran all test suites matching channel-page-metadata.test.ts.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: exec_command
+
+```sh
+npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts'
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 lint
+> eslint src/app/c/[serverSlug]/[channelSlug]/page.tsx src/__tests__/channel-page-metadata.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read tests/integration/env.ts
+```
+
+Output:
+
+```text
+/**
+ * Environment configuration for integration tests.
+ *
+ * TEST_TARGET=local  (default) — tests run against localhost services.
+ * TEST_TARGET=cloud             — tests run against deployed URLs; local-only tests skip.
+ *
+ * BACKEND_URL  overrides the backend base URL (e.g. https://api.harmony.chat).
+ * FRONTEND_URL overrides the frontend base URL (e.g. https://harmony.chat).
+ */
+
+export type TestTarget = 'local' | 'cloud';
+
+const raw = (process.env.TEST_TARGET ?? 'local').toLowerCase();
+if (raw !== 'local' && raw !== 'cloud') {
+  throw new Error(`TEST_TARGET must be "local" or "cloud", got "${raw}"`);
+}
+
+export const TARGET: TestTarget = raw as TestTarget;
+export const isLocal = TARGET === 'local';
+export const isCloud = TARGET === 'cloud';
+
+export const BACKEND_URL = (
+  process.env.BACKEND_URL ?? (isCloud ? 'https://api.harmony.chat' : 'http://localhost:4000')
+).replace(/\/$/, '');
+
+export const FRONTEND_URL = (
+  process.env.FRONTEND_URL ?? (isCloud ? 'https://harmony.chat' : 'http://localhost:3000')
+).replace(/\/$/, '');
+
+/**
+ * Returns true when the current test should be skipped in cloud mode.
+ * Usage: test.skipIf(cloudOnly())('...', ...) or check at the top of a test.
+ */
+export const cloudOnly = (): boolean => isCloud;
+
+/**
+ * Convenience wrapper: wraps a describe block so all tests inside skip in cloud mode.
+ * Pass the classification label as documentation.
+ */
+export const localOnlyDescribe = (label: string, fn: () => void): void => {
+  const wrapper = isCloud ? describe.skip : describe;
+  wrapper(`[local-only] ${label}`, fn);
+};
+
+/**
+ * Convenience wrapper: wraps a test so it skips in cloud mode.
+ */
+export const localOnlyTest = (name: string, fn: jest.ProvidesCallback, timeout?: number): void => {
+  const wrapper = isCloud ? test.skip : test;
+  wrapper(name, fn, timeout);
+};
+
+/**
+ * Convenience wrapper: wraps a test so it skips when running in cloud mode
+ * without a CLOUD_TEST_ACCESS_TOKEN. Keeps the test active in local mode
+ * (where login() always provides a token) and in cloud mode when the token
+ * is provisioned.
+ */
+export const cloudTokenTest = (name: string, fn: jest.ProvidesCallback, timeout?: number): void => {
+  const needsSkip = isCloud && !process.env.CLOUD_TEST_ACCESS_TOKEN;
+  (needsSkip ? test.skip : test)(name, fn, timeout);
+};
+
+export const LOCAL_SEEDS = {
+  server: {
+    slug: 'harmony-hq',
+  },
+  channels: {
+    publicIndexable: 'general', // visibility=PUBLIC_INDEXABLE
+    publicIndexableAll: ['general', 'announcements', 'dev-updates'] as const, // 3 channels for AC #357
+    publicNoIndex: 'introductions', // visibility=PUBLIC_NO_INDEX
+    private: 'staff-only', // visibility=PRIVATE
+  },
+  alice: {
+    email: 'alice_admin@mock.harmony.test',
+    password: 'HarmonyAdmin123!',
+  },
+} as const;
+
+export const CLOUD_KNOWN = {
+  serverSlug: process.env.CLOUD_TEST_SERVER_SLUG ?? 'harmony-hq',
+  publicChannel: process.env.CLOUD_TEST_PUBLIC_CHANNEL ?? 'general',
+} as const;
+
+export type CloudFixture = {
+  serverId?: string;
+  serverSlug: string;
+  publicChannel: string;
+};
+
+let cloudFixturePromise: Promise<CloudFixture> | null = null;
+
+async function resolveCloudFixtureFromPublicApi(): Promise<CloudFixture> {
+  const serversRes = await fetch(`${BACKEND_URL}/api/public/servers`);
+  if (!serversRes.ok) {
+    throw new Error(
+      `Cloud fixture discovery failed: GET /api/public/servers returned ${serversRes.status}`,
+    );
+  }
+
+  const servers = (await serversRes.json()) as Array<{
+    id?: string;
+    slug?: string;
+  }>;
+  for (const server of servers) {
+    if (!server.slug) continue;
+
+    const channelsRes = await fetch(`${BACKEND_URL}/api/public/servers/${server.slug}/channels`);
+    if (!channelsRes.ok) continue;
+
+    const channelsBody = (await channelsRes.json()) as {
+      channels?: Array<{ slug?: string }>;
+    };
+    const publicChannel = channelsBody.channels?.find((channel) => channel.slug)?.slug;
+    if (!publicChannel) continue;
+
+    return {
+      serverId: server.id,
+      serverSlug: server.slug,
+      publicChannel,
+    };
+  }
+
+  throw new Error(
+    'Cloud fixture discovery failed: no public server/channel pair is available at the configured BACKEND_URL',
+  );
+}
+
+export async function getCloudFixture(): Promise<CloudFixture> {
+  if (!isCloud) {
+    return {
+      serverSlug: LOCAL_SEEDS.server.slug,
+      publicChannel: LOCAL_SEEDS.channels.publicIndexable,
+    };
+  }
+
+  const envServerSlug = process.env.CLOUD_TEST_SERVER_SLUG;
+  const envPublicChannel = process.env.CLOUD_TEST_PUBLIC_CHANNEL;
+  if (envServerSlug && envPublicChannel) {
+    return {
+      serverSlug: envServerSlug,
+      publicChannel: envPublicChannel,
+      serverId: process.env.CLOUD_TEST_SERVER_ID,
+    };
+  }
+
+  if (!cloudFixturePromise) {
+    cloudFixturePromise = resolveCloudFixtureFromPublicApi().catch((error: unknown) => {
+      cloudFixturePromise = null;
+      throw error;
+    });
+  }
+  return cloudFixturePromise;
+}
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:10:08.583Z
+
+The focused frontend unit test now passes and `tsc` finished cleanly. I’m checking whether the local app stack is actually up on `localhost:3000/4000`; if it is, I’ll run the integration spec against the live rendered page, otherwise I’ll call out that remaining environment gap explicitly.
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 88851,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: e3e18a
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### Tool: exec_command
+
+```sh
+curl -I http://localhost:3000/c/harmony-hq/general
+```
+
+Output:
+
+```text
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+curl: (7) Failed to connect to localhost port 3000 after 0 ms: Couldn't connect to server
+```
+
+#### Tool: exec_command
+
+```sh
+curl -I http://localhost:4000/api/public/servers/harmony-hq/channels/general
+```
+
+Output:
+
+```text
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+curl: (7) Failed to connect to localhost port 4000 after 0 ms: Couldn't connect to server
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:10:20.717Z
+
+Local SSR services aren’t running in this worktree, so a live integration hit on `localhost:3000/4000` isn’t available right now. I’m documenting the verification results and the one remaining gap precisely: the code and targeted tests pass locally, but Google’s Rich Results Test can only be re-run after these changes are deployed.
+
+#### Tool: exec_command
+
+```sh
+git status --short
+```
+
+Output:
+
+```text
+ M harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+ M harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+ M tests/integration/guest-public-channel.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue comment 468 --repo CS485-Harmony/Harmony --body $'**[AI Agent — Complete]**
+
+Patched the channel-page `DiscussionForumPosting` JSON-LD so it now emits:
+- `author` as an `Organization` using the server name
+- `text` from the channel topic / server description fallback
+- `headline` mirroring the page title
+
+I also extended the frontend test coverage to assert those fields directly.
+
+Verification completed:
+- `npm test -- --runInBand --testPathPatterns=channel-page-metadata.test.ts` in `harmony-frontend`
+- `npx tsc --noEmit` in `harmony-frontend`
+- `npm run lint -- '\''src/app/c/[serverSlug]/[channelSlug]/page.tsx'\'' '\''src/__tests__/channel-page-metadata.test.ts'\''` in `harmony-frontend`
+
+One remaining gap is deployment-only: the local app stack is not running on `localhost:3000/4000` in this worktree, so I could not re-run the live Google Rich Results test here. That final validation should be done against a deployed build of this patch.'
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 60222,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 02233e
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 19
+Output:
+https://github.com/CS485-Harmony/Harmony/issues/468#issuecomment-4320357288
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:10:59.108Z
+
+Fixed the channel-page JSON-LD in [page.tsx](/Users/allen/.codex/worktrees/afcf/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx) so `DiscussionForumPosting` now includes `author`, `text`, and `headline` while staying gated to `PUBLIC_INDEXABLE` channels. I used the server name as the `Organization` author and reused the channel/server description fallback as `text`.
+
+I also tightened the checks in [channel-page-metadata.test.ts](/Users/allen/.codex/worktrees/afcf/Harmony/harmony-frontend/src/__tests__/channel-page-metadata.test.ts) and [guest-public-channel.test.ts](/Users/allen/.codex/worktrees/afcf/Harmony/tests/integration/guest-public-channel.test.ts) so the rich-results fields are asserted directly.
+
+Verification:
+- `npm test -- --runInBand --testPathPatterns=channel-page-metadata.test.ts` in `harmony-frontend` passed
+- `npx tsc --noEmit` in `harmony-frontend` passed
+- `npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts'` in `harmony-frontend` passed
+
+I also posted start and completion updates on issue `#468`. The only remaining gap is deployment-only: there was no local app stack running on `localhost:3000` / `localhost:4000`, so I could not re-run a live Rich Results check against a served build from this worktree. That final validation needs a deployed instance of this patch.
+
+<oai-mem-citation>
+<citation_entries>
+MEMORY.md:314-314|note=[used Harmony repo memory index to confirm relevant prior context area]
+</citation_entries>
+<rollout_ids>
+</rollout_ids>
+</oai-mem-citation>
+
+### Turn 2: P2 Reuse persisted SEO metadata when building JSON-LD Dismiss
+
+#### 👤 User Prompt
+
+- Time: 2026-04-25T19:13:38.423Z
+
+```text
+P2
+Reuse persisted SEO metadata when building JSON-LD
+Dismiss
+generateMetadata() still pulls fetchPublicMetaTags() and prefers persisted/admin-edited SEO values, but this new JSON-LD path recomputes title/text only from the channel topic and server description. For any PUBLIC_INDEXABLE channel with customized or generated metadata, the page will now serve conflicting structured data versus the <title>, description, and Open Graph tags that the rest of the page emits, which undermines the existing SEO override flow covered by public-channel-metadata.test.ts.
+
+
+/Users/allen/.codex/worktrees/afcf/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx:66-78
+
+fix this
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:13:46.056Z
+
+I’m fixing the JSON-LD source of truth so it reuses the same persisted SEO metadata as `generateMetadata()` instead of recomputing a conflicting title/text path.
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,140p' 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx'
+```
+
+Output:
+
+```text
+import type { Metadata } from 'next';
+import { GuestChannelView } from '@/components/channel/GuestChannelView';
+import {
+  fetchPublicServer,
+  fetchPublicChannel,
+  fetchPublicMetaTags,
+} from '@/services/publicApiService';
+import { ChannelVisibility } from '@/types';
+import { getChannelUrl } from '@/lib/runtime-config';
+
+interface PageProps {
+  params: Promise<{ serverSlug: string; channelSlug: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { serverSlug, channelSlug } = await params;
+  const [server, channelResult, publicMetaTags] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+    fetchPublicMetaTags(serverSlug, channelSlug),
+  ]);
+
+  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
+  const channelName = channel?.name ?? channelSlug;
+  const serverName = server?.name ?? serverSlug;
+  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+  const description =
+    publicMetaTags?.description ??
+    channel?.topic ??
+    server?.description ??
+    `Join ${serverName} on Harmony`;
+  const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+  const canonicalUrl = getChannelUrl(serverSlug, channelSlug);
+
+  return {
+    title,
+    description,
+    robots: { index: isIndexable, follow: true },
+    alternates: { canonical: canonicalUrl },
+    openGraph: {
+      title: publicMetaTags?.ogTitle ?? title,
+      description: publicMetaTags?.ogDescription ?? description,
+      type: 'website',
+      url: canonicalUrl,
+      ...(publicMetaTags?.ogImage ? { images: [{ url: publicMetaTags.ogImage }] } : {}),
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  };
+}
+
+export default async function GuestChannelPage({ params }: PageProps) {
+  const { serverSlug, channelSlug } = await params;
+
+  // Fetch data for JSON-LD; React cache deduplicates these within the same render pass
+  const [server, channelResult] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+  ]);
+
+  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
+  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+  const title = `${channel?.name ?? channelSlug} - ${server?.name ?? serverSlug} | Harmony`;
+  const text =
+    channel?.topic ?? server?.description ?? `Join ${server?.name ?? serverSlug} on Harmony`;
+
+  const jsonLd = isIndexable
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'DiscussionForumPosting',
+        'name': title,
+        'headline': title,
+        'url': getChannelUrl(serverSlug, channelSlug),
+        'description': text,
+        text,
+        'author': {
+          '@type': 'Organization',
+          'name': server?.name ?? 'Harmony',
+        },
+        ...(channel?.createdAt && { datePublished: channel.createdAt }),
+      }
+    : null;
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type='application/ld+json'
+          // Escape </script> breakout sequences per OWASP JSON-LD injection guidance
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(jsonLd)
+              .replace(/</g, '\\u003c')
+              .replace(/>/g, '\\u003e')
+              .replace(/&/g, '\\u0026'),
+          }}
+        />
+      )}
+      <GuestChannelView serverSlug={serverSlug} channelSlug={channelSlug} />
+    </>
+  );
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/__tests__/public-channel-metadata.test.ts
+```
+
+Output:
+
+```text
+import { generateMetadata } from '@/app/c/[serverSlug]/[channelSlug]/page';
+import {
+  fetchPublicChannel,
+  fetchPublicMetaTags,
+  fetchPublicServer,
+} from '@/services/publicApiService';
+import { ChannelType, ChannelVisibility } from '@/types';
+
+jest.mock('@/services/publicApiService', () => ({
+  fetchPublicServer: jest.fn(),
+  fetchPublicChannel: jest.fn(),
+  fetchPublicMetaTags: jest.fn(),
+}));
+
+const mockFetchPublicServer = fetchPublicServer as jest.MockedFunction<typeof fetchPublicServer>;
+const mockFetchPublicChannel = fetchPublicChannel as jest.MockedFunction<typeof fetchPublicChannel>;
+const mockFetchPublicMetaTags = fetchPublicMetaTags as jest.MockedFunction<
+  typeof fetchPublicMetaTags
+>;
+
+describe('public channel metadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prefers persisted SEO metadata over the fallback public channel values', async () => {
+    mockFetchPublicServer.mockResolvedValue({
+      id: 'server-1',
+      name: 'Game Dev Hub',
+      slug: 'game-dev-hub',
+      createdAt: '2026-04-23T00:00:00.000Z',
+    });
+    mockFetchPublicChannel.mockResolvedValue({
+      isPrivate: false,
+      channel: {
+        id: 'channel-1',
+        serverId: 'server-1',
+        name: 'unity',
+        slug: 'unity',
+        type: ChannelType.TEXT,
+        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+        topic: 'Fallback topic',
+        position: 0,
+        createdAt: '2026-04-23T00:00:00.000Z',
+      },
+    });
+    mockFetchPublicMetaTags.mockResolvedValue({
+      title: 'Custom SEO Title',
+      description: 'Custom SEO Description',
+      ogTitle: 'Custom OG Title',
+      ogDescription: 'Custom OG Description',
+      ogImage: 'https://example.com/custom.png',
+      generatedAt: '2026-04-23T00:00:00.000Z',
+      visibility: 'PUBLIC_INDEXABLE',
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ serverSlug: 'game-dev-hub', channelSlug: 'unity' }),
+    });
+
+    expect(metadata.title).toBe('Custom SEO Title');
+    expect(metadata.description).toBe('Custom SEO Description');
+    expect(metadata.openGraph).toMatchObject({
+      title: 'Custom OG Title',
+      description: 'Custom OG Description',
+      images: [{ url: 'https://example.com/custom.png' }],
+    });
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+/**
+ * Unit tests for generateMetadata in the public channel page.
+ * Issue #357 — Sprint 5 (M1 PublicChannelPage + generateMetadata integration)
+ */
+
+const mockCache = jest.fn(<T extends (...args: never[]) => unknown>(fn: T): T => fn);
+jest.mock('react', () => {
+  const actualReact = jest.requireActual('react');
+  return { ...actualReact, cache: mockCache };
+});
+
+jest.mock('@/services/publicApiService', () => ({
+  fetchPublicServer: jest.fn(),
+  fetchPublicChannel: jest.fn(),
+  fetchPublicMetaTags: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/components/channel/GuestChannelView', () => ({
+  GuestChannelView: () => null,
+}));
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import GuestChannelPage, { generateMetadata } from '@/app/c/[serverSlug]/[channelSlug]/page';
+import { fetchPublicServer, fetchPublicChannel } from '@/services/publicApiService';
+import { ChannelType, ChannelVisibility } from '@/types';
+
+const mockFetchPublicServer = fetchPublicServer as jest.Mock;
+const mockFetchPublicChannel = fetchPublicChannel as jest.Mock;
+
+const originalEnv = process.env;
+
+function makeParams(
+  serverSlug = 'harmony-hq',
+  channelSlug = 'general',
+): { params: Promise<{ serverSlug: string; channelSlug: string }> } {
+  return { params: Promise.resolve({ serverSlug, channelSlug }) };
+}
+
+function makeServer(overrides = {}) {
+  return {
+    id: 'srv-1',
+    name: 'Harmony HQ',
+    slug: 'harmony-hq',
+    description: 'A public server',
+    memberCount: 10,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeChannel(visibility: ChannelVisibility, overrides = {}) {
+  return {
+    id: 'ch-1',
+    name: 'general',
+    slug: 'general',
+    serverId: 'srv-1',
+    type: ChannelType.TEXT,
+    visibility,
+    topic: 'Welcome to general',
+    position: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  process.env = { ...originalEnv, NEXT_PUBLIC_BASE_URL: 'https://harmony.chat' };
+  jest.resetAllMocks();
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({
+      channel: makeChannel(ChannelVisibility.PUBLIC_INDEXABLE),
+      isPrivate: false,
+    });
+  });
+
+  it('sets title and description from channel and server data', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.title).toBe('general - Harmony HQ | Harmony');
+    expect(meta.description).toBe('Welcome to general');
+  });
+
+  it('sets robots to index, follow', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.robots).toEqual({ index: true, follow: true });
+  });
+
+  it('sets canonical URL using the frontend domain', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.alternates?.canonical).toBe('https://harmony.chat/c/harmony-hq/general');
+  });
+
+  it('includes Open Graph tags', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta).toMatchObject({
+      openGraph: {
+        title: 'general - Harmony HQ | Harmony',
+        type: 'website',
+        url: 'https://harmony.chat/c/harmony-hq/general',
+      },
+    });
+  });
+
+  it('includes Twitter card tags', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta).toMatchObject({
+      twitter: {
+        card: 'summary',
+        title: 'general - Harmony HQ | Harmony',
+        description: 'Welcome to general',
+      },
+    });
+  });
+
+  it('renders JSON-LD with author, text, and headline for rich results', async () => {
+    const page = await GuestChannelPage(makeParams());
+    const html = renderToStaticMarkup(page);
+    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+
+    expect(ldMatch).not.toBeNull();
+    const jsonLd = JSON.parse(ldMatch![1]);
+    expect(jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'DiscussionForumPosting',
+      'name': 'general - Harmony HQ | Harmony',
+      'headline': 'general - Harmony HQ | Harmony',
+      'description': 'Welcome to general',
+      'text': 'Welcome to general',
+      'author': {
+        '@type': 'Organization',
+        'name': 'Harmony HQ',
+      },
+      'url': 'https://harmony.chat/c/harmony-hq/general',
+      'datePublished': '2026-01-01T00:00:00.000Z',
+    });
+  });
+});
+
+describe('generateMetadata — PUBLIC_NO_INDEX channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({
+      channel: makeChannel(ChannelVisibility.PUBLIC_NO_INDEX, { topic: 'Staff updates' }),
+      isPrivate: false,
+    });
+  });
+
+  it('sets robots to noindex, follow', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'staff'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('still includes Twitter card tags', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'staff'));
+    expect(meta).toMatchObject({ twitter: { card: 'summary' } });
+    expect(meta.twitter?.title).toBeTruthy();
+  });
+});
+
+describe('generateMetadata — PRIVATE channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({ isPrivate: true });
+  });
+
+  it('sets robots to noindex, follow', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'secret'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('falls back to the slug for title when channel data is unavailable', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'secret'));
+    expect(meta.title).toContain('secret');
+  });
+});
+
+describe('generateMetadata — API fallback (both fetches return null)', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(null);
+    mockFetchPublicChannel.mockResolvedValue(null);
+  });
+
+  it('falls back to slugs for title', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.title).toBe('my-channel - my-server | Harmony');
+  });
+
+  it('falls back to a template description', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.description).toBe('Join my-server on Harmony');
+  });
+
+  it('still sets canonical URL and Twitter card', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.alternates?.canonical).toBe('https://harmony.chat/c/my-server/my-channel');
+    expect(meta).toMatchObject({ twitter: { card: 'summary' } });
+  });
+
+  it('sets robots to noindex when channel is unknown', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+});
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:13:52.467Z
+
+I found the mismatch: the page component never fetched `fetchPublicMetaTags()`, so JSON-LD diverged from the metadata pipeline. I’m patching the page to share the same title/description resolution and adding a regression test for customized SEO metadata.
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:14:22.759Z
+
+The fix is in. I’ve also added a direct regression test proving JSON-LD now follows persisted SEO overrides instead of falling back to channel topic text.
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts'
+```
+
+Output:
+
+```text
+[warn] jsxBracketSameLine is deprecated.
+src/app/c/[serverSlug]/[channelSlug]/page.tsx 44ms (unchanged)
+src/__tests__/channel-page-metadata.test.ts 21ms
+```
+
+#### Tool: exec_command
+
+```sh
+npm test -- --runInBand --testPathPatterns='channel-page-metadata.test.ts|public-channel-metadata.test.ts'
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 test
+> jest --forceExit --runInBand --testPathPatterns=channel-page-metadata.test.ts|public-channel-metadata.test.ts
+
+
+Test Suites: 2 passed, 2 total
+Tests:       16 passed, 16 total
+Snapshots:   0 total
+Time:        0.665 s, estimated 1 s
+Ran all test suites matching channel-page-metadata.test.ts|public-channel-metadata.test.ts.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: exec_command
+
+```sh
+npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' 'src/__tests__/public-channel-metadata.test.ts'
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 lint
+> eslint src/app/c/[serverSlug]/[channelSlug]/page.tsx src/__tests__/channel-page-metadata.test.ts src/__tests__/public-channel-metadata.test.ts
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 97548,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 8129b6
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 6884,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: abd96d
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:14:37.525Z
+
+Updated [page.tsx](/Users/allen/.codex/worktrees/afcf/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx) so the JSON-LD path now also fetches `fetchPublicMetaTags()` and resolves `title`/`text` from the same persisted SEO metadata that `generateMetadata()` uses. That keeps `DiscussionForumPosting` aligned with the page `<title>`, description, and OG tags when admins have customized SEO values.
+
+I added a regression in [channel-page-metadata.test.ts](/Users/allen/.codex/worktrees/afcf/Harmony/harmony-frontend/src/__tests__/channel-page-metadata.test.ts) proving JSON-LD reuses persisted SEO metadata, alongside the existing [public-channel-metadata.test.ts](/Users/allen/.codex/worktrees/afcf/Harmony/harmony-frontend/src/__tests__/public-channel-metadata.test.ts) coverage.
+
+Verification:
+- `npm test -- --runInBand --testPathPatterns='channel-page-metadata.test.ts|public-channel-metadata.test.ts'` passed
+- `npx tsc --noEmit` passed
+- `npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' 'src/__tests__/public-channel-metadata.test.ts'` passed
+
+<oai-mem-citation>
+<citation_entries>
+MEMORY.md:314-314|note=[used Harmony repo memory index to confirm relevant prior context area]
+</citation_entries>
+<rollout_ids>
+</rollout_ids>
+</oai-mem-citation>
+
+### Turn 3: make a
+
+#### 👤 User Prompt
+
+- Time: 2026-04-25T19:14:39.483Z
+
+```text
+make a PR
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:14:49.576Z
+
+I’m packaging the fix into a branch now: I’ll inspect the current detached worktree state, commit the verified changes with the required Harmony co-author trailer, push, and open a draft PR.
+
+#### Tool: exec_command
+
+```sh
+git status --short --branch
+```
+
+Output:
+
+```text
+## HEAD (no branch)
+ M harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+ M harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+ M tests/integration/guest-public-channel.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --stat
+```
+
+Output:
+
+```text
+ .../src/__tests__/channel-page-metadata.test.ts    | 63 ++++++++++++++-
+ .../src/app/c/[serverSlug]/[channelSlug]/page.tsx  | 28 +++++--
+ tests/integration/guest-public-channel.test.ts     | 89 ++++++++++++++--------
+ 3 files changed, 139 insertions(+), 41 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+git remote -v
+```
+
+Output:
+
+```text
+origin	git@github.com:CS485-Harmony/Harmony.git (fetch)
+origin	git@github.com:CS485-Harmony/Harmony.git (push)
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:14:55.451Z
+
+The worktree is detached, and the diff is limited to the three files from this issue. I’m creating a PR branch from the current commit, then I’ll stage and commit the verified patch before pushing.
+
+#### Tool: exec_command
+
+```sh
+git switch -c codex/fix-issue-468-structured-data-fields
+```
+
+Output:
+
+```text
+fatal: cannot lock ref 'refs/heads/codex/fix-issue-468-structured-data-fields': Unable to create '/Users/allen/repos/Harmony/.git/refs/heads/codex/fix-issue-468-structured-data-fields.lock': Operation not permitted
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:14:59.443Z
+
+Branch creation is blocked by the linked git directory permissions for the parent repo, so I’m requesting direct git access to create the branch in the underlying repository and finish the PR workflow.
+
+#### Tool: exec_command
+
+```sh
+git switch -c codex/fix-issue-468-structured-data-fields
+```
+
+Output:
+
+```text
+Switched to a new branch 'codex/fix-issue-468-structured-data-fields'
+```
+
+#### Tool: exec_command
+
+```sh
+git add harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx harmony-frontend/src/__tests__/channel-page-metadata.test.ts tests/integration/guest-public-channel.test.ts
+```
+
+Output:
+
+```text
+zsh:1: no matches found: harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --cached --stat
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+git status --short --branch
+```
+
+Output:
+
+```text
+## codex/fix-issue-468-structured-data-fields
+ M harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+ M harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+ M tests/integration/guest-public-channel.test.ts
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:15:25.187Z
+
+The first `git add` only tripped over shell globbing on the bracketed path; nothing was staged yet. I’m restaging with quoted paths, then I’ll commit.
+
+#### Tool: exec_command
+
+```sh
+git add 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'harmony-frontend/src/__tests__/channel-page-metadata.test.ts' 'tests/integration/guest-public-channel.test.ts'
+```
+
+Output:
+
+```text
+fatal: Unable to create '/Users/allen/repos/Harmony/.git/worktrees/Harmony6/index.lock': Operation not permitted
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --cached --stat
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+git status --short --branch
+```
+
+Output:
+
+```text
+## codex/fix-issue-468-structured-data-fields
+ M harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+ M harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+ M tests/integration/guest-public-channel.test.ts
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:15:30.266Z
+
+Staging also needs access to the linked git worktree metadata, so I’m requesting git write access for the remaining branch/commit/push steps.
+
+#### Tool: exec_command
+
+```sh
+git add 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'harmony-frontend/src/__tests__/channel-page-metadata.test.ts' 'tests/integration/guest-public-channel.test.ts'
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --cached --stat
+```
+
+Output:
+
+```text
+ .../src/__tests__/channel-page-metadata.test.ts    | 63 ++++++++++++++-
+ .../src/app/c/[serverSlug]/[channelSlug]/page.tsx  | 28 +++++--
+ tests/integration/guest-public-channel.test.ts     | 89 ++++++++++++++--------
+ 3 files changed, 139 insertions(+), 41 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+git status --short --branch
+```
+
+Output:
+
+```text
+## codex/fix-issue-468-structured-data-fields
+M  harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+M  harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+M  tests/integration/guest-public-channel.test.ts
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:15:42.292Z
+
+The branch is ready and the staged diff matches the issue scope. I’m committing with the verification-backed summary and the required Harmony co-author trailer, then I’ll push and open the PR.
+
+#### Tool: exec_command
+
+```sh
+git commit -m "fix: correct public channel DiscussionForumPosting SEO data" -m "Align the channel-page JSON-LD payload with the persisted SEO metadata flow so DiscussionForumPosting stays consistent with the page title, description, and Open Graph tags. Add regression coverage for required rich-results fields and persisted metadata overrides.
+
+Verified with:
+- npm test -- --runInBand --testPathPatterns='channel-page-metadata.test.ts|public-channel-metadata.test.ts'
+- npx tsc --noEmit
+- npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' 'src/__tests__/public-channel-metadata.test.ts'
+
+Co-authored-by: GPT-5 <noreply@openai.com>"
+```
+
+Output:
+
+```text
+[codex/fix-issue-468-structured-data-fields b70c8b0] fix: correct public channel DiscussionForumPosting SEO data
+ 3 files changed, 139 insertions(+), 41 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+git status --short --branch
+```
+
+Output:
+
+```text
+## codex/fix-issue-468-structured-data-fields
+```
+
+#### Tool: exec_command
+
+```sh
+git log -1 --stat --oneline
+```
+
+Output:
+
+```text
+b70c8b0 fix: correct public channel DiscussionForumPosting SEO data
+ .../src/__tests__/channel-page-metadata.test.ts    | 63 ++++++++++++++-
+ .../src/app/c/[serverSlug]/[channelSlug]/page.tsx  | 28 +++++--
+ tests/integration/guest-public-channel.test.ts     | 89 ++++++++++++++--------
+ 3 files changed, 139 insertions(+), 41 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+git push -u origin codex/fix-issue-468-structured-data-fields
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 56782,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: ad0394
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 129
+Output:
+remote: 
+remote: Create a pull request for 'codex/fix-issue-468-structured-data-fields' on GitHub by visiting:        
+remote:      https://github.com/CS485-Harmony/Harmony/pull/new/codex/fix-issue-468-structured-data-fields        
+remote: 
+To github.com:CS485-Harmony/Harmony.git
+ * [new branch]      codex/fix-issue-468-structured-data-fields -> codex/fix-issue-468-structured-data-fields
+branch 'codex/fix-issue-468-structured-data-fields' set up to track 'origin/codex/fix-issue-468-structured-data-fields'.
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:16:09.288Z
+
+The branch is on GitHub. I’m opening the draft PR now with the verification results and the issue closure link.
+
+#### Tool: exec_command
+
+```sh
+gh pr create --repo CS485-Harmony/Harmony --base main --head codex/fix-issue-468-structured-data-fields --draft --title "fix: align DiscussionForumPosting JSON-LD with persisted SEO metadata" --body "## Summary
+- add the missing `DiscussionForumPosting` rich-results fields on public channel pages
+- reuse persisted public SEO metadata when building JSON-LD so structured data stays aligned with the page title, description, and Open Graph tags
+- extend metadata tests to cover rich-results fields and persisted SEO override behavior
+
+Closes #468
+
+## Verification
+- `npm test -- --runInBand --testPathPatterns='channel-page-metadata.test.ts|public-channel-metadata.test.ts'`
+- `npx tsc --noEmit`
+- `npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' 'src/__tests__/public-channel-metadata.test.ts'`"
+```
+
+Output:
+
+```text
+zsh:1: command not found: DiscussionForumPosting
+sh: jest: command not found
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:16:24.780Z
+
+The first PR-create command only failed because the shell expanded backticks inside the body text; no PR was created. I’m rerunning it with a literal body payload so the command is safe and exact.
+
+#### Tool: exec_command
+
+```sh
+gh pr create --repo CS485-Harmony/Harmony --base main --head codex/fix-issue-468-structured-data-fields --draft --title 'fix: align DiscussionForumPosting JSON-LD with persisted SEO metadata' --body "$(cat <<'EOF'
+## Summary
+- add the missing `DiscussionForumPosting` rich-results fields on public channel pages
+- reuse persisted public SEO metadata when building JSON-LD so structured data stays aligned with the page title, description, and Open Graph tags
+- extend metadata tests to cover rich-results fields and persisted SEO override behavior
+
+Closes #468
+
+## Verification
+- `npm test -- --runInBand --testPathPatterns='channel-page-metadata.test.ts|public-channel-metadata.test.ts'`
+- `npx tsc --noEmit`
+- `npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' 'src/__tests__/public-channel-metadata.test.ts'`
+EOF
+)"
+```
+
+Output:
+
+```text
+a pull request for branch "codex/fix-issue-468-structured-data-fields" into branch "main" already exists:
+https://github.com/CS485-Harmony/Harmony/pull/469
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr view 469 --repo CS485-Harmony/Harmony --json url,isDraft,title,number,headRefName,baseRefName
+```
+
+Output:
+
+```text
+{"baseRefName":"main","headRefName":"codex/fix-issue-468-structured-data-fields","isDraft":false,"number":469,"title":"fix: align DiscussionForumPosting JSON-LD with persisted SEO metadata","url":"https://github.com/CS485-Harmony/Harmony/pull/469"}
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:16:54.211Z
+
+PR is up at [#469](https://github.com/CS485-Harmony/Harmony/pull/469).
+
+Branch `codex/fix-issue-468-structured-data-fields` contains the verified fix and tests. I committed and pushed:
+- `npm test -- --runInBand --testPathPatterns='channel-page-metadata.test.ts|public-channel-metadata.test.ts'`
+- `npx tsc --noEmit`
+- `npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' 'src/__tests__/public-channel-metadata.test.ts'`
+
+`gh pr create` reported that the PR already existed for this branch, so I confirmed the active PR rather than creating a duplicate.
+
+<oai-mem-citation>
+<citation_entries>
+MEMORY.md:314-314|note=[used Harmony repo memory index to confirm relevant prior context area]
+</citation_entries>
+<rollout_ids>
+</rollout_ids>
+</oai-mem-citation>
+
+### Turn 4: # In app browser: - The user has the in-app browser open. - Current
+
+#### 👤 User Prompt
+
+- Time: 2026-04-25T19:17:57.387Z
+
+```text
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: not currently navigated.
+
+## My request for Codex:
+the pr description is broken, it has unknown characters that don't show on github
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:18:08.384Z
+
+I’m checking the current PR body first so I can remove the broken characters without changing the intended content.
+
+#### Tool: exec_command
+
+```sh
+gh pr view 469 --repo CS485-Harmony/Harmony --json title,body,url
+```
+
+Output:
+
+```text
+{"body":"## Summary\n- add the missing  rich-results fields on public channel pages\n- reuse persisted public SEO metadata when building JSON-LD so structured data stays aligned with the page title, description, and Open Graph tags\n- extend metadata tests to cover rich-results fields and persisted SEO override behavior\n\nCloses #468\n\n## Verification\n- \n> test\n> node ./scripts/run-root-jest.cjs --runInBand --testPathPatterns=channel-page-metadata.test.ts|public-channel-metadata.test.ts\n\n\n[backend] running jest in harmony-backend\n\n> harmony-backend@0.1.0 test\n> jest --runInBand --testPathPatterns=channel-page-metadata.test.ts|public-channel-metadata.test.ts\n\n\n[frontend] running jest in harmony-frontend\n\n> harmony-frontend@0.1.0 test\n> jest --forceExit --runInBand --testPathPatterns=channel-page-metadata.test.ts|public-channel-metadata.test.ts\n- \n^[[41m                                                                               ^[[0m\n^[[41m^[[37m                This is not the tsc command you are looking for                ^[[0m\n^[[41m                                                                               ^[[0m\n\nTo get access to the TypeScript compiler, ^[[34mtsc^[[0m, from the command line either:\n\n- Use ^[[1mnpm install typescript^[[0m to first add TypeScript to your project ^[[1mbefore^[[0m using npx\n- Use ^[[1myarn^[[0m to avoid accidentally running code from un-installed packages\n- ","title":"fix: align DiscussionForumPosting JSON-LD with persisted SEO metadata","url":"https://github.com/CS485-Harmony/Harmony/pull/469"}
+```
+
+#### Tool: exec_command
+
+```sh
+git status --short --branch
+```
+
+Output:
+
+```text
+## codex/fix-issue-468-structured-data-fields...origin/codex/fix-issue-468-structured-data-fields
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:18:14.549Z
+
+I found the problem: the PR body captured raw terminal output, including ANSI escape codes from a failed `npx tsc` invocation. I’m replacing it with a plain Markdown summary and the actual passing verification commands only.
+
+#### Tool: exec_command
+
+```sh
+gh pr edit 469 --repo CS485-Harmony/Harmony --body "$(cat <<'EOF'
+## Summary
+- add the missing `DiscussionForumPosting` rich-results fields on public channel pages
+- reuse persisted public SEO metadata when building JSON-LD so structured data stays aligned with the page title, description, and Open Graph tags
+- extend metadata tests to cover rich-results fields and persisted SEO override behavior
+
+Closes #468
+
+## Verification
+- `npm test -- --runInBand --testPathPatterns='channel-page-metadata.test.ts|public-channel-metadata.test.ts'` in `harmony-frontend`
+- `npx tsc --noEmit` in `harmony-frontend`
+- `npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' 'src/__tests__/public-channel-metadata.test.ts'` in `harmony-frontend`
+EOF
+)"
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 70266,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Chunk ID: f4d0bc
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/CS485-Harmony/Harmony/pull/469
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:18:34.564Z
+
+The PR description for [#469](https://github.com/CS485-Harmony/Harmony/pull/469) is fixed. I removed the raw ANSI escape sequences and replaced the body with clean Markdown plus the actual passing verification commands.
+
+### Turn 5: # In app browser: - The user has the in-app browser open. - Current
+
+#### 👤 User Prompt
+
+- Time: 2026-04-25T19:22:23.253Z
+
+```text
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: not currently navigated.
+
+## My request for Codex:
+[$resolve-reviews](/Users/allen/.agents/skills/resolve-reviews/SKILL.md)
+```
+
+_No assistant or tool activity recorded after this prompt._
+
+### Turn 6: <skill> <name>resolve-reviews</name>
+
+#### 👤 User Prompt
+
+- Time: 2026-04-25T19:22:23.253Z
+
+````text
+<skill>
+<name>resolve-reviews</name>
+<path>/Users/allen/.agents/skills/resolve-reviews/SKILL.md</path>
+---
+name: resolve-reviews
+description: Resolve all PR review comments (human and bot) on current PR. Fetches unanswered comments, evaluates each one, fixes real issues, dismisses false positives, and replies to every comment with the outcome.
+license: MIT
+compatibility: Requires git, gh (GitHub CLI), and Node.js installed.
+allowed-tools: Bash(npx agent-reviews *) Bash(pnpm dlx agent-reviews *) Bash(yarn dlx agent-reviews *) Bash(bunx agent-reviews *) Bash(git config *) Bash(git add *) Bash(git commit *) Bash(git push *)
+metadata:
+  author: pbakaus
+  version: "1.0.1"
+  homepage: https://github.com/pbakaus/agent-reviews
+---
+
+Automatically resolve all review comments (both human and bot) on the current PR. Uses a two-phase workflow: fix all existing issues, then poll for new ones until quiet.
+
+## Prerequisites
+
+All commands below use `npx agent-reviews`. If the project uses a different package manager, substitute the appropriate runner (e.g., `pnpm dlx agent-reviews` for pnpm, `yarn dlx agent-reviews` for Yarn, `bunx agent-reviews` for Bun). Honor the user's package manager preference throughout.
+
+**Cloud environments only** (e.g., Codespaces, remote agents): verify git author identity so CI checks can map commits to the user. Run `git config --global --get user.email` and if empty or a placeholder, set it manually. Skip this check in local environments.
+
+## Phase 1: FETCH & FIX (synchronous)
+
+### Step 1: Fetch All Comments (Expanded)
+
+Run `npx agent-reviews --unanswered --expanded`
+
+The CLI auto-detects the current branch, finds the associated PR, and authenticates via `gh` CLI or environment variables. If anything fails (no token, no PR, CLI not installed), it exits with a clear error message.
+
+This shows all unanswered comments (both human and bot) with full detail: complete comment body (no truncation), diff hunk (code context), and all replies. Each comment shows its ID in brackets (e.g., `[12345678]`).
+
+If zero comments are returned, print "No unanswered comments found" and skip to Phase 2.
+
+### Step 3: Process Each Unanswered Comment
+
+For each comment from the expanded output, apply the appropriate evaluation based on whether the author is a bot or a human.
+
+#### For Bot Comments
+
+Read the referenced code and determine:
+
+1. **TRUE POSITIVE** - A real bug that needs fixing
+2. **FALSE POSITIVE** - Not actually a bug (intentional behavior, bot misunderstanding)
+3. **UNCERTAIN** - Not sure; ask the user
+
+**Likely TRUE POSITIVE:**
+- Code obviously violates stated behavior
+- Missing null checks on potentially undefined values
+- Type mismatches or incorrect function signatures
+- Logic errors in conditionals
+- Missing error handling for documented failure cases
+
+**Likely FALSE POSITIVE:**
+- Bot doesn't understand the framework/library patterns
+- Code is intentionally structured that way (with comments explaining why)
+- Bot is flagging style preferences, not bugs
+- The "bug" is actually a feature or intentional behavior
+- Bot misread the code flow
+
+#### For Human Comments
+
+Read the referenced code and the reviewer's comment. Human reviewers are generally more accurate and context-aware than bots. Determine:
+
+1. **ACTIONABLE** - The reviewer identified a real issue or requested a concrete change
+2. **DISCUSSION** - The comment raises a valid point but the right approach is unclear
+3. **ALREADY ADDRESSED** - The concern has already been fixed or is no longer relevant
+
+**Likely ACTIONABLE:**
+- Reviewer points out a bug or logic error
+- Reviewer requests a specific code change
+- Reviewer identifies missing edge cases or error handling
+
+**Likely DISCUSSION -- ask the user:**
+- Reviewer suggests an architectural change you're unsure about
+- Comment involves a tradeoff (performance vs readability, etc.)
+- The feedback is subjective without team consensus
+
+#### When UNCERTAIN -- ask the user
+
+For both bot and human comments:
+- The fix would require architectural changes
+- You're genuinely unsure if the behavior is intentional
+- Multiple valid interpretations exist
+- The fix could have unintended side effects
+
+#### Act on Evaluation
+
+**If TRUE POSITIVE / ACTIONABLE:** Fix the code. Track the comment ID and a brief description of the fix.
+
+**If FALSE POSITIVE:** Do NOT change the code. Track the comment ID and the reason it's not a real bug.
+
+**If DISCUSSION:** Ask the user to consult the PR author. Apply their decision and track it.
+
+**If ALREADY ADDRESSED:** Track the comment ID and note why.
+
+**If UNCERTAIN:** Ask the user. If they say skip, track it as skipped.
+
+Do NOT reply to comments yet. Replies happen after the commit (Step 5).
+
+### Step 4: Commit and Push
+
+After evaluating and fixing ALL unanswered comments:
+
+1. Run your project's lint and type-check
+2. Stage, commit, and push:
+   ```bash
+   git add -A
+   git commit -m "fix: address PR review findings
+
+   {List of changes made, grouped by reviewer/bot}"
+   git push
+   ```
+3. Capture the commit hash from the output.
+
+### Step 5: Reply to All Comments
+
+Now that the commit hash exists, reply to every processed comment. The `--resolve` flag marks the review thread as resolved on GitHub.
+
+**For each TRUE POSITIVE / ACTIONABLE:**
+
+Run `npx agent-reviews --reply <comment_id> "Fixed in {hash}. {Brief description of the fix}" --resolve`
+
+**For each FALSE POSITIVE:**
+
+Run `npx agent-reviews --reply <comment_id> "Won't fix: {reason}. {Explanation of why this is intentional or not applicable}" --resolve`
+
+**For each DISCUSSION (after user decision):**
+
+Run `npx agent-reviews --reply <comment_id> "{Outcome}. {Explanation of the decision and any changes made}" --resolve`
+
+**For each ALREADY ADDRESSED:**
+
+Run `npx agent-reviews --reply <comment_id> "Already addressed. {Explanation of when/how this was fixed}" --resolve`
+
+**For each SKIPPED:**
+
+Run `npx agent-reviews --reply <comment_id> "Skipped per user request" --resolve`
+
+**DO NOT start Phase 2 until all replies are posted.**
+
+---
+
+## Phase 2: POLL FOR NEW COMMENTS (loop until quiet)
+
+The watcher exits immediately when new comments are found (after a 5s grace period to catch batch posts). This means you run it in a loop: start watcher, process any comments it returns, restart watcher, repeat until the watcher times out with no new comments.
+
+### Step 6: Start Watcher Loop
+
+Repeat the following until the watcher exits with no new comments:
+
+**6a.** Launch the watcher in the background:
+
+Run `npx agent-reviews --watch` as a background task.
+
+**6b.** Wait for the background command to complete (default 10 minutes; override with `--timeout`).
+
+**6c.** Check the output:
+
+- **If new comments were found** (output contains `EXITING WITH NEW COMMENTS`):
+  1. Use `--detail <id>` to read each new comment's full detail
+  2. Process them exactly as in Phase 1, Steps 3-5 (evaluate, fix, commit, push, reply)
+  3. **Go back to Step 6a** to restart the watcher
+
+- **If no new comments** (output contains `WATCH COMPLETE`):
+  Stop looping and move to the Summary Report.
+
+---
+
+## Summary Report
+
+After both phases complete, provide a summary:
+
+```text
+## PR Review Resolution Summary
+
+### Results
+- Fixed: X issues
+- Already addressed: X
+- Won't fix (false positives): X
+- Discussion resolved: X
+- Skipped per user: X
+
+### By Reviewer/Bot
+#### cursor[bot]
+- {description} - Fixed in {commit}
+- {description} - Won't fix: {reason}
+
+#### @reviewer-name
+- {description} - Fixed in {commit}
+
+### Status
+All findings addressed. Watch completed.
+```
+
+## Important Notes
+
+### Response Policy
+- **Every comment gets a response** - No silent ignores
+- For bots: responses help train them and prevent re-raised false positives
+- For humans: replies keep reviewers informed and unblock approvals
+
+### User Interaction
+- Ask the user when uncertain about a finding
+- Don't guess on architectural or business logic questions
+- It's better to ask than to make a wrong fix or wrong dismissal
+- Human reviewers often have context you don't - defer to the author when unsure
+
+### Best Practices
+- Verify findings before fixing - bots have false positives, humans rarely do
+- Keep fixes minimal and focused - don't refactor unrelated code
+- Ensure type-check and lint pass before committing
+- Group related fixes into a single commit
+- Copilot `suggestion` blocks often contain ready-to-use fixes
+- If a human reviewer suggests a specific code change, prefer their version unless it introduces issues
+
+</skill>
+````
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:22:32.068Z
+
+I’m using the `resolve-reviews` skill for the current Harmony PR. First I’ll fetch the unanswered review comments on the branch’s PR, then I’ll evaluate each one against the code before making any changes.
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "resolve-reviews|PR review and approval workflow|review-resolution loop|PR #469" /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+🔍 6 in 2F:
+
+📄 /Users/allen/.codex/memories/MEMORY.md (5):
+   115: - resolve-reviews, PR #449, npx agent-reviews --pr 449 --unanswered --expande...
+   121: - when the user invoked `resolve-reviews` on PR #449 and later said "the back...
+   473: - PR #397, resolve-reviews, npx agent-reviews --pr 397 --unanswered --expande...
+   503: - when the user invokes `resolve-reviews` in Harmony, the expected default is...
+   560: - when the user invoked `resolve-reviews` -> fetch unanswered comments, make ...
+
+📄 469 (1):
+     0: 03:25+00:00, thread_id=019d9d37-b0c1-7c92-a450-7cb87456f4c1, resolve-reviews ...
+```
+
+#### Tool: exec_command
+
+```sh
+npx agent-reviews --unanswered --expanded
+```
+
+Output:
+
+````text
+[1mFound 1 comment[0m
+
+=== Comment [4176029136] ===
+Type: REVIEW | By: AvanishKulkarni | Status: ○ no reply
+URL: https://github.com/CS485-Harmony/Harmony/pull/469#pullrequestreview-4176029136
+
+## PR Review Checklist
+
+- [x] **Logic over Style** — Core logic is sound; one DRY violation flagged below.
+- [x] **Security First** — No new vulnerabilities. Existing XSS escape chain is preserved. Author name uses server data, not user-supplied input.
+- [x] **Architectural Alignment** — `fetchPublicMetaTags` is already wrapped in React `cache()` in `publicApiService.ts`, so the extra call in `GuestChannelPage` is properly deduplicated within the render pass.
+- [x] **Issue Completion** — All three acceptance criteria from #468 are satisfied: `author`, `text`, and `headline` are added to the JSON-LD.
+- [x] **No Nitpicking** — Only substantive issues are raised.
+- [x] **Avoid Repetition** — First review on this PR.
+- [x] **Iterative Reviews** — N/A (first review).
+- [x] **Prevent CI Failures** — The `jest.requireActual('react')` fix for the mock is correct and prevents a regression. No missing imports or obvious breakage found.
+
+---
+
+## Review
+
+**Overall:** This PR correctly resolves all three acceptance criteria from #468 and extends test coverage appropriately. There are two substantive issues to address before merge.
+
+---
+
+### Issue 1 — DRY violation: `title` and `text`/`description` logic is duplicated across two functions
+
+**`page.tsx`, `generateMetadata` vs `GuestChannelPage`**
+
+Both functions independently compute the same fallback chain:
+
+```ts
+// generateMetadata
+const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+const description = publicMetaTags?.description ?? channel?.topic ?? server?.description ?? `Join ${serverName} on Harmony`;
+
+// GuestChannelPage
+const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+const text  = publicMetaTags?.description ?? channel?.topic ?? server?.description ?? `Join ${serverName} on Harmony`;
+```
+
+If the title format or description fallback changes in one function, the JSON-LD will silently diverge from the `<title>` and OG tags — exactly the kind of misalignment this PR is trying to fix. The two functions call the same three fetches (deduplicated by `cache()`), so the data is available to share. Extracting a small shared helper that accepts the three fetch results and returns `{ title, description }` would eliminate the drift risk entirely.
+
+---
+
+### Issue 2 — `author.name` ignores the already-computed `serverName`
+
+**`page.tsx`, `GuestChannelPage`**
+
+```ts
+const serverName = server?.name ?? serverSlug;   // computed above
+// ...
+'author': {
+  '@type': 'Organization',
+  'name': server?.name ?? 'Harmony',   // ← should be serverName
+},
+```
+
+`serverName` is already computed for exactly this fallback purpose. Using `server?.name ?? 'Harmony'` instead means that when `server` is null (e.g. a fetch error), the author becomes `'Harmony'` while the page title and description use the slug. Using `serverName` keeps all three consistent.
+````
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:22:47.937Z
+
+The review is actionable. I’m refactoring the shared SEO fallback logic into one helper in `page.tsx`, then I’ll add a regression that covers the `author.name` fallback so the JSON-LD can’t drift again.
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,220p' 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx'
+```
+
+Output:
+
+```text
+import type { Metadata } from 'next';
+import { GuestChannelView } from '@/components/channel/GuestChannelView';
+import {
+  fetchPublicServer,
+  fetchPublicChannel,
+  fetchPublicMetaTags,
+} from '@/services/publicApiService';
+import { ChannelVisibility } from '@/types';
+import { getChannelUrl } from '@/lib/runtime-config';
+
+interface PageProps {
+  params: Promise<{ serverSlug: string; channelSlug: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { serverSlug, channelSlug } = await params;
+  const [server, channelResult, publicMetaTags] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+    fetchPublicMetaTags(serverSlug, channelSlug),
+  ]);
+
+  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
+  const channelName = channel?.name ?? channelSlug;
+  const serverName = server?.name ?? serverSlug;
+  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+  const description =
+    publicMetaTags?.description ??
+    channel?.topic ??
+    server?.description ??
+    `Join ${serverName} on Harmony`;
+  const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+  const canonicalUrl = getChannelUrl(serverSlug, channelSlug);
+
+  return {
+    title,
+    description,
+    robots: { index: isIndexable, follow: true },
+    alternates: { canonical: canonicalUrl },
+    openGraph: {
+      title: publicMetaTags?.ogTitle ?? title,
+      description: publicMetaTags?.ogDescription ?? description,
+      type: 'website',
+      url: canonicalUrl,
+      ...(publicMetaTags?.ogImage ? { images: [{ url: publicMetaTags.ogImage }] } : {}),
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  };
+}
+
+export default async function GuestChannelPage({ params }: PageProps) {
+  const { serverSlug, channelSlug } = await params;
+
+  // Fetch data for JSON-LD; React cache deduplicates these within the same render pass
+  const [server, channelResult, publicMetaTags] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+    fetchPublicMetaTags(serverSlug, channelSlug),
+  ]);
+
+  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
+  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+  const channelName = channel?.name ?? channelSlug;
+  const serverName = server?.name ?? serverSlug;
+  const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+  const text =
+    publicMetaTags?.description ??
+    channel?.topic ??
+    server?.description ??
+    `Join ${serverName} on Harmony`;
+
+  const jsonLd = isIndexable
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'DiscussionForumPosting',
+        'name': title,
+        'headline': title,
+        'url': getChannelUrl(serverSlug, channelSlug),
+        'description': text,
+        text,
+        'author': {
+          '@type': 'Organization',
+          'name': server?.name ?? 'Harmony',
+        },
+        ...(channel?.createdAt && { datePublished: channel.createdAt }),
+      }
+    : null;
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type='application/ld+json'
+          // Escape </script> breakout sequences per OWASP JSON-LD injection guidance
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(jsonLd)
+              .replace(/</g, '\\u003c')
+              .replace(/>/g, '\\u003e')
+              .replace(/&/g, '\\u0026'),
+          }}
+        />
+      )}
+      <GuestChannelView serverSlug={serverSlug} channelSlug={channelSlug} />
+    </>
+  );
+}
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '1,260p' harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+/**
+ * Unit tests for generateMetadata in the public channel page.
+ * Issue #357 — Sprint 5 (M1 PublicChannelPage + generateMetadata integration)
+ */
+
+const mockCache = jest.fn(<T extends (...args: never[]) => unknown>(fn: T): T => fn);
+jest.mock('react', () => {
+  const actualReact = jest.requireActual('react');
+  return { ...actualReact, cache: mockCache };
+});
+
+jest.mock('@/services/publicApiService', () => ({
+  fetchPublicServer: jest.fn(),
+  fetchPublicChannel: jest.fn(),
+  fetchPublicMetaTags: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/components/channel/GuestChannelView', () => ({
+  GuestChannelView: () => null,
+}));
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import GuestChannelPage, { generateMetadata } from '@/app/c/[serverSlug]/[channelSlug]/page';
+import {
+  fetchPublicServer,
+  fetchPublicChannel,
+  fetchPublicMetaTags,
+} from '@/services/publicApiService';
+import { ChannelType, ChannelVisibility } from '@/types';
+
+const mockFetchPublicServer = fetchPublicServer as jest.Mock;
+const mockFetchPublicChannel = fetchPublicChannel as jest.Mock;
+const mockFetchPublicMetaTags = fetchPublicMetaTags as jest.Mock;
+
+const originalEnv = process.env;
+
+function makeParams(
+  serverSlug = 'harmony-hq',
+  channelSlug = 'general',
+): { params: Promise<{ serverSlug: string; channelSlug: string }> } {
+  return { params: Promise.resolve({ serverSlug, channelSlug }) };
+}
+
+function makeServer(overrides = {}) {
+  return {
+    id: 'srv-1',
+    name: 'Harmony HQ',
+    slug: 'harmony-hq',
+    description: 'A public server',
+    memberCount: 10,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeChannel(visibility: ChannelVisibility, overrides = {}) {
+  return {
+    id: 'ch-1',
+    name: 'general',
+    slug: 'general',
+    serverId: 'srv-1',
+    type: ChannelType.TEXT,
+    visibility,
+    topic: 'Welcome to general',
+    position: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  process.env = { ...originalEnv, NEXT_PUBLIC_BASE_URL: 'https://harmony.chat' };
+  jest.resetAllMocks();
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({
+      channel: makeChannel(ChannelVisibility.PUBLIC_INDEXABLE),
+      isPrivate: false,
+    });
+  });
+
+  it('sets title and description from channel and server data', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.title).toBe('general - Harmony HQ | Harmony');
+    expect(meta.description).toBe('Welcome to general');
+  });
+
+  it('sets robots to index, follow', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.robots).toEqual({ index: true, follow: true });
+  });
+
+  it('sets canonical URL using the frontend domain', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.alternates?.canonical).toBe('https://harmony.chat/c/harmony-hq/general');
+  });
+
+  it('includes Open Graph tags', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta).toMatchObject({
+      openGraph: {
+        title: 'general - Harmony HQ | Harmony',
+        type: 'website',
+        url: 'https://harmony.chat/c/harmony-hq/general',
+      },
+    });
+  });
+
+  it('includes Twitter card tags', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta).toMatchObject({
+      twitter: {
+        card: 'summary',
+        title: 'general - Harmony HQ | Harmony',
+        description: 'Welcome to general',
+      },
+    });
+  });
+
+  it('renders JSON-LD with author, text, and headline for rich results', async () => {
+    const page = await GuestChannelPage(makeParams());
+    const html = renderToStaticMarkup(page);
+    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+
+    expect(ldMatch).not.toBeNull();
+    const jsonLd = JSON.parse(ldMatch![1]);
+    expect(jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'DiscussionForumPosting',
+      'name': 'general - Harmony HQ | Harmony',
+      'headline': 'general - Harmony HQ | Harmony',
+      'description': 'Welcome to general',
+      'text': 'Welcome to general',
+      'author': {
+        '@type': 'Organization',
+        'name': 'Harmony HQ',
+      },
+      'url': 'https://harmony.chat/c/harmony-hq/general',
+      'datePublished': '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('reuses persisted SEO metadata in JSON-LD when present', async () => {
+    mockFetchPublicMetaTags.mockResolvedValue({
+      title: 'Custom SEO Title',
+      description: 'Custom SEO Description',
+      ogTitle: 'Custom OG Title',
+      ogDescription: 'Custom OG Description',
+      ogImage: 'https://example.com/custom.png',
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      visibility: 'PUBLIC_INDEXABLE',
+    });
+
+    const page = await GuestChannelPage(makeParams());
+    const html = renderToStaticMarkup(page);
+    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+
+    expect(ldMatch).not.toBeNull();
+    const jsonLd = JSON.parse(ldMatch![1]);
+    expect(jsonLd).toMatchObject({
+      name: 'Custom SEO Title',
+      headline: 'Custom SEO Title',
+      description: 'Custom SEO Description',
+      text: 'Custom SEO Description',
+    });
+  });
+});
+
+describe('generateMetadata — PUBLIC_NO_INDEX channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({
+      channel: makeChannel(ChannelVisibility.PUBLIC_NO_INDEX, { topic: 'Staff updates' }),
+      isPrivate: false,
+    });
+  });
+
+  it('sets robots to noindex, follow', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'staff'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('still includes Twitter card tags', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'staff'));
+    expect(meta).toMatchObject({ twitter: { card: 'summary' } });
+    expect(meta.twitter?.title).toBeTruthy();
+  });
+});
+
+describe('generateMetadata — PRIVATE channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({ isPrivate: true });
+  });
+
+  it('sets robots to noindex, follow', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'secret'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('falls back to the slug for title when channel data is unavailable', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'secret'));
+    expect(meta.title).toContain('secret');
+  });
+});
+
+describe('generateMetadata — API fallback (both fetches return null)', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(null);
+    mockFetchPublicChannel.mockResolvedValue(null);
+  });
+
+  it('falls back to slugs for title', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.title).toBe('my-channel - my-server | Harmony');
+  });
+
+  it('falls back to a template description', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.description).toBe('Join my-server on Harmony');
+  });
+
+  it('still sets canonical URL and Twitter card', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.alternates?.canonical).toBe('https://harmony.chat/c/my-server/my-channel');
+    expect(meta).toMatchObject({ twitter: { card: 'summary' } });
+  });
+
+  it('sets robots to noindex when channel is unknown', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+});
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:23:21.124Z
+
+The refactor and regression are in place. I’m running the same focused frontend verification again before I reply on the PR thread.
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts'
+```
+
+Output:
+
+```text
+[warn] jsxBracketSameLine is deprecated.
+src/app/c/[serverSlug]/[channelSlug]/page.tsx 44ms
+src/__tests__/channel-page-metadata.test.ts 29ms
+```
+
+#### Tool: exec_command
+
+```sh
+npm test -- --runInBand --testPathPatterns='channel-page-metadata.test.ts|public-channel-metadata.test.ts'
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 test
+> jest --forceExit --runInBand --testPathPatterns=channel-page-metadata.test.ts|public-channel-metadata.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' 'src/__tests__/public-channel-metadata.test.ts'
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 lint
+> eslint src/app/c/[serverSlug]/[channelSlug]/page.tsx src/__tests__/channel-page-metadata.test.ts src/__tests__/public-channel-metadata.test.ts
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 17938,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: d0999c
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 89
+Output:
+
+Test Suites: 2 passed, 2 total
+Tests:       17 passed, 17 total
+Snapshots:   0 total
+Time:        0.649 s, estimated 1 s
+Ran all test suites matching channel-page-metadata.test.ts|public-channel-metadata.test.ts.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 82198,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: b3636e
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 7116,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 5b2252
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:23:34.621Z
+
+The reviewer’s two issues are fixed and the focused frontend checks passed. I’m staging and committing the follow-up on the PR branch now, then I’ll reply to the review thread with the commit hash and start the watch phase.
+
+#### Tool: exec_command
+
+```sh
+git diff --stat
+```
+
+Output:
+
+```text
+ .../src/__tests__/channel-page-metadata.test.ts    | 21 ++++++++
+ .../src/app/c/[serverSlug]/[channelSlug]/page.tsx  | 63 ++++++++++++++--------
+ 2 files changed, 63 insertions(+), 21 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+git status --short --branch
+```
+
+Output:
+
+```text
+## codex/fix-issue-468-structured-data-fields...origin/codex/fix-issue-468-structured-data-fields
+ M harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+ M harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+git add -A && git commit -m "fix: address PR review findings for channel SEO metadata" -m "Extract the shared SEO title/description fallback into a single helper so generateMetadata and GuestChannelPage cannot drift. Reuse serverName for the JSON-LD author fallback and add regression coverage for persisted SEO overrides plus server-slug fallback behavior.
+
+Verified with:
+- npm test -- --runInBand --testPathPatterns='channel-page-metadata.test.ts|public-channel-metadata.test.ts'
+- npx tsc --noEmit
+- npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' 'src/__tests__/public-channel-metadata.test.ts'
+
+Co-authored-by: GPT-5 <noreply@openai.com>"
+```
+
+Output:
+
+```text
+[codex/fix-issue-468-structured-data-fields 85c2463] fix: address PR review findings for channel SEO metadata
+ 2 files changed, 63 insertions(+), 21 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+git push
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 17056,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 8a227e
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 38
+Output:
+To github.com:CS485-Harmony/Harmony.git
+   b70c8b0..85c2463  codex/fix-issue-468-structured-data-fields -> codex/fix-issue-468-structured-data-fields
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:24:05.770Z
+
+The follow-up commit is pushed. I’m posting the resolution reply on the review thread now, then I’ll start the watch loop for any new comments.
+
+#### Tool: exec_command
+
+```sh
+npx agent-reviews --reply 4176029136 "Fixed in 85c2463. Extracted the shared SEO title/description fallback into a single helper used by both generateMetadata() and GuestChannelPage(), so the JSON-LD cannot drift from the page metadata. Also switched JSON-LD author.name to reuse serverName and added a regression test covering the server-slug fallback." --resolve
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+git log -1 --oneline
+```
+
+Output:
+
+```text
+85c2463 fix: address PR review findings for channel SEO metadata
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 39884,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 8000
+}
+```
+
+Output:
+
+```text
+Chunk ID: e70851
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 47
+Output:
+[32m✓ Reply posted successfully[0m
+  [2mhttps://github.com/CS485-Harmony/Harmony/pull/469#issuecomment-4320379708[0m
+[2mThread resolution skipped (not a review comment thread)[0m
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:24:20.441Z
+
+I’ve replied on the existing review item. I’m starting the watch phase now; if new comments come in, I’ll process them the same way and only stop once the watcher reports quiet.
+
+#### Tool: exec_command
+
+```sh
+npx agent-reviews --watch --timeout 60000
+```
+
+Output:
+
+```text
+
+[1m=== PR Comments Watch Mode ===[0m
+[2mPR #469: https://github.com/CS485-Harmony/Harmony/pull/469[0m
+[2mPolling every 30s, exit after 60000s of inactivity[0m
+[2mFilters: all, all comments[0m
+[2mStarted at 2026-04-25 19:24:25[0m
+
+[2m[2026-04-25 19:24:25] Initial state: 1 existing comments tracked[0m
+
+[33m=== EXISTING COMMENTS ===[0m
+[1m[4176029136][0m [35mREVIEW[0m by [32mAvanishKulkarni[0m [31m○ no reply[0m
+  [2m## PR Review Checklist  - [x] **Logic over Style** — Core logic is sound; one DRY violation flagg...[0m
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:24:32.288Z
+
+The watcher accepted `60000` as seconds, not milliseconds, so that instance would sit far too long. I’m running a bounded watch with a 60-second quiet window instead and will use that result as the actual completion check.
+
+#### Tool: exec_command
+
+```sh
+npx agent-reviews --watch --timeout 60
+```
+
+Output:
+
+```text
+
+[1m=== PR Comments Watch Mode ===[0m
+[2mPR #469: https://github.com/CS485-Harmony/Harmony/pull/469[0m
+[2mPolling every 30s, exit after 60s of inactivity[0m
+[2mFilters: all, all comments[0m
+[2mStarted at 2026-04-25 19:24:37[0m
+
+[2m[2026-04-25 19:24:37] Initial state: 1 existing comments tracked[0m
+
+[33m=== EXISTING COMMENTS ===[0m
+[1m[4176029136][0m [35mREVIEW[0m by [32mAvanishKulkarni[0m [31m○ no reply[0m
+  [2m## PR Review Checklist  - [x] **Logic over Style** — Core logic is sound; one DRY violation flagg...[0m
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 16830,
+  "chars": "",
+  "yield_time_ms": 65000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 9a81ac
+Wall time: 60.8579 seconds
+Process exited with code 0
+Original token count: 323
+Output:
+[2m[2026-04-25 19:25:08] Poll #1: No new comments (31s/60s idle)[0m
+
+[32m=== NEW COMMENTS DETECTED [2026-04-25 19:25:38] ===[0m
+[1mFound 1 new comment[0m
+[2mWaiting 5s for additional comments...[0m
+
+[1m[4176032231][0m [35mREVIEW[0m by [32mAvanishKulkarni[0m [31m○ no reply[0m
+  [2mBoth issues addressed. The `getSeoContent()` helper cleanly eliminates the duplication and the `a...[0m
+
+[2m--- JSON for processing ---[0m
+[
+  {
+    "id": 4176032231,
+    "type": "review",
+    "user": "AvanishKulkarni",
+    "isBot": false,
+    "path": null,
+    "line": null,
+    "diffHunk": null,
+    "body": "Both issues addressed. The `getSeoContent()` helper cleanly eliminates the duplication and the `author.name` now correctly uses `serverName`. The slug-fallback regression test confirms the fix holds when `server` is null. LGTM.",
+    "state": "APPROVED",
+    "createdAt": "2026-04-25T19:25:28Z",
+    "updatedAt": "2026-04-25T19:25:28Z",
+    "url": "https://github.com/CS485-Harmony/Harmony/pull/469#pullrequestreview-4176032231",
+    "replies": [],
+    "hasHumanReply": false,
+    "hasAnyReply": false,
+    "isResolved": true
+  }
+]
+[2m--- end JSON ---[0m
+
+[32m=== WATCH: EXITING WITH NEW COMMENTS ===[0m
+[2mRestart watcher after processing to catch further comments.[0m
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:25:48.911Z
+
+A new review just came in during watch mode: it’s an approval confirming the fixes. No code change is needed; I’m replying to close the loop, then I’ll restart the watcher once more to make sure the PR stays quiet.
+
+#### Tool: exec_command
+
+```sh
+npx agent-reviews --reply 4176032231 "Already addressed in 85c2463. The shared getSeoContent() helper now keeps JSON-LD aligned with the page metadata, and the server-slug fallback regression test covers the author.name case. Thanks for the re-review and approval." --resolve
+```
+
+Output:
+
+```text
+aborted by user after 4.1s
+```
+
+### Turn 7: <turn_aborted> The user interrupted the previous turn on purpose. Any
+
+#### 👤 User Prompt
+
+- Time: 2026-04-25T19:25:55.883Z
+
+```text
+<turn_aborted>
+The user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.
+</turn_aborted>
+```
+
+_No assistant or tool activity recorded after this prompt._
+
+### Turn 8: # In app browser: - The user has the in-app browser open. - Current
+
+#### 👤 User Prompt
+
+- Time: 2026-04-25T19:26:06.828Z
+
+```text
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: not currently navigated.
+
+## My request for Codex:
+[$codex-conversation-exporter](/Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md) 019dc607-d54b-7cc3-9903-e8d702ca2a8c to llm-logs/acabrera04-logs/final and push
+```
+
+_No assistant or tool activity recorded after this prompt._
+
+### Turn 9: <skill> <name>codex-conversation-exporter</name>
+
+#### 👤 User Prompt
+
+- Time: 2026-04-25T19:26:06.828Z
+
+````text
+<skill>
+<name>codex-conversation-exporter</name>
+<path>/Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md</path>
+---
+name: codex-conversation-exporter
+description: Export Codex session logs to Markdown using the local codex-export CLI instead of reconstructing transcripts with model tokens.
+---
+
+# Codex Conversation Exporter
+
+Use this skill when the user asks to export Codex logs, save a Codex conversation, convert a session to Markdown, or archive a transcript locally.
+
+## Rules
+
+- Prefer the local `codex-export` CLI over reconstructing a transcript in-model.
+- If the user has not identified a session, run `codex-export list` first and show the relevant candidates.
+- Default to messages plus tool activity.
+- Include hidden system/developer prompts only when the user explicitly asks for them.
+- Write to a user-visible path unless the user asks for stdout or another destination.
+- Report the output path back to the user after a file export.
+
+## Command patterns
+
+List recent sessions:
+
+```bash
+codex-export list
+codex-export list --limit 10
+codex-export list --since 2026-03-30
+```
+
+Export by thread id:
+
+```bash
+codex-export export <thread-id>
+codex-export export <thread-id> --out ~/Desktop
+codex-export export <thread-id> --messages-only
+codex-export export <thread-id> --all
+codex-export export <thread-id> --include-hidden-prompts
+codex-export export <thread-id> --stdout
+```
+
+Export by rollout path:
+
+```bash
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl --out ~/Desktop
+```
+
+## Flag guide
+
+- `--out <file-or-dir>` writes to a specific file or directory.
+- `--stdout` prints the Markdown instead of writing a file.
+- `--messages-only` omits tool calls and tool outputs.
+- `--all` includes low-level tool metadata and raw wrappers that are hidden by default.
+- `--include-hidden-prompts` includes developer/system prompt layers.
+- `--since <date>` filters `list` results.
+- `--limit <n>` caps `list` results.
+
+## Agent behavior
+
+When the user says "export this conversation" without a thread id:
+
+1. Run `codex-export list`.
+2. Identify the most likely current session from title, cwd, and recency.
+3. Export it with the default mode unless the user requested a different output.
+4. Return the exact file path written.
+
+`codex-log-export` remains available as a compatibility alias.
+
+</skill>
+````
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-25T19:26:16.237Z
+
+I’m using the `codex-conversation-exporter` skill. First I’ll confirm the export CLI is available and inspect the target branch/worktree state, then I’ll export thread `019dc607-d54b-7cc3-9903-e8d702ca2a8c` into `llm-logs/acabrera04-logs/final`, commit it on the PR branch, and push.
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "llm-logs|Codex conversation export|thread IDs|and push" /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+🔍 28 in 10F:
+
+📄 /Users/allen/.codex/memories/MEMORY.md (19):
+   121: - when the user invoked `resolve-reviews` on PR #449 and later said "the back...
+   170: - codex-conversation-exporter, codex-export export, llm-logs/acabrera04-logs/...
+   180: - codex-export export, llm-logs/acabrera04-logs/acabrera04-deployment, logs/a...
+   190: - acabrera04-extra, extra bucket, llm-logs/acabrera04-logs, user-scoped log n...
+   200: - multiple thread IDs, filename collision, 2026-04-16-review-pr-373-019d9704-...
+   210: - Review Avanish's latest PR, PR #457, feature/issue-423-local-e2e-scripts, l...
+   214: - when the user says `<thread-id>, <thread-id> to llm-logs/acabrera04-logs/fi...
+   215: - when the user already supplied explicit thread IDs for a log export -> do n...
+   216: - when the user explicitly asked for `[$codex-conversation-exporter](...) 019...
+   217: - the user wanted the artifact on the PR branch rather than just locally -> f...
+  +9
+
+📄 145 (1):
+     0: review resolution seems done but the branch still carries a real backend regr...
+
+📄 149 (1):
+     0: Exporting Codex conversations into Harmony `llm-logs` folders, either on the ...
+
+📄 152 (1):
+     0: Export two Codex conversations to `llm-logs/acabrera04-logs/final` and push t...
+
+📄 156 (1):
+     0: 13:08+00:00, thread_id=019dbc10-c896-7f60-920d-191e50d53b4f, two explicit thr...
+
+📄 160 (1):
+     0: export codex conversation logs, rejected (fetch first), git rebase origin/cod...
+
+📄 162 (1):
+     0: Export PR #443 conversation log to `llm-logs/acabrera04-logs/final` on the PR...
+
+📄 243 (1):
+     0: `git push origin codex/issue-359-seo-admin-ui` is rejected with `rejected (fe...
+
+📄 244 (1):
+     0: the export commit lands nowhere useful -> cause: the Harmony worktree started...
+
+📄 600 (1):
+     0: Remove the shared System Info button and push a branch
+
+... +9
+```
+
+#### Tool: exec_command
+
+```sh
+codex-export export 019dc607-d54b-7cc3-9903-e8d702ca2a8c --out /Users/allen/.codex/worktrees/afcf/Harmony/llm-logs/acabrera04-logs/final
+```
+
+#### Tool: exec_command
+
+```sh
+git status --short --branch
+```

--- a/tests/integration/guest-public-channel.test.ts
+++ b/tests/integration/guest-public-channel.test.ts
@@ -51,8 +51,22 @@ describe('Guest Public Channel — cloud-read-only', () => {
     expect(html).toMatch(/twitter:card/i);
     expect(html).toMatch(/twitter:title/i);
     // JSON-LD structured data
-    expect(html).toMatch(/<script[^>]+type=["']application\/ld\+json["']/i);
-    expect(html).toContain('DiscussionForumPosting');
+    const ldMatch = html.match(
+      /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i,
+    );
+    expect(ldMatch).not.toBeNull();
+    const jsonLd = JSON.parse(ldMatch![1]);
+    expect(jsonLd['@type']).toBe('DiscussionForumPosting');
+    expect(jsonLd.author).toEqual(
+      expect.objectContaining({
+        '@type': 'Organization',
+      }),
+    );
+    expect(typeof jsonLd.author.name).toBe('string');
+    expect(jsonLd.author.name.length).toBeGreaterThan(0);
+    expect(jsonLd.headline).toBe(jsonLd.name);
+    expect(typeof jsonLd.text).toBe('string');
+    expect(jsonLd.text.length).toBeGreaterThan(0);
   });
 
   test('GPC-3: PUBLIC_NO_INDEX channel renders with HTTP 200 and noindex meta', async () => {
@@ -89,37 +103,52 @@ describe('Guest Public Channel — cloud-read-only', () => {
 });
 
 // GPC-2b: AC #357 — assert SEO tags on at least 3 representative PUBLIC_INDEXABLE channels
-localOnlyDescribe('Guest Public Channel — SEO tags across 3 PUBLIC_INDEXABLE channels (AC #357)', () => {
-  const serverSlug = LOCAL_SEEDS.server.slug;
+localOnlyDescribe(
+  'Guest Public Channel — SEO tags across 3 PUBLIC_INDEXABLE channels (AC #357)',
+  () => {
+    const serverSlug = LOCAL_SEEDS.server.slug;
 
-  test.each([...LOCAL_SEEDS.channels.publicIndexableAll])(
-    'GPC-2b: SSR metadata and structured data present for channel %s',
-    async (channelSlug) => {
-      const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${channelSlug}`);
-      expect(res.status).toBe(200);
-      const html = await res.text();
+    test.each([...LOCAL_SEEDS.channels.publicIndexableAll])(
+      'GPC-2b: SSR metadata and structured data present for channel %s',
+      async (channelSlug) => {
+        const res = await fetch(`${FRONTEND_URL}/c/${serverSlug}/${channelSlug}`);
+        expect(res.status).toBe(200);
+        const html = await res.text();
 
-      expect(html).toMatch(/<title[^>]*>/i);
-      expect(html).toMatch(/index,\s*follow/i);
-      expect(html).toMatch(/<link[^>]+rel=["']canonical["']/i);
-      expect(html).toContain(`/c/${serverSlug}/${channelSlug}`);
-      expect(html).toMatch(/<meta[^>]+property=["']og:title["']/i);
-      expect(html).toMatch(/twitter:card/i);
+        expect(html).toMatch(/<title[^>]*>/i);
+        expect(html).toMatch(/index,\s*follow/i);
+        expect(html).toMatch(/<link[^>]+rel=["']canonical["']/i);
+        expect(html).toContain(`/c/${serverSlug}/${channelSlug}`);
+        expect(html).toMatch(/<meta[^>]+property=["']og:title["']/i);
+        expect(html).toMatch(/twitter:card/i);
 
-      // Validate JSON-LD structure (Google Rich Results required fields)
-      const ldMatch = html.match(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i);
-      expect(ldMatch).not.toBeNull();
-      const jsonLd = JSON.parse(ldMatch![1]);
-      expect(jsonLd['@context']).toBe('https://schema.org');
-      expect(jsonLd['@type']).toBe('DiscussionForumPosting');
-      expect(typeof jsonLd.name).toBe('string');
-      expect(jsonLd.name.length).toBeGreaterThan(0);
-      expect(typeof jsonLd.url).toBe('string');
-      expect(jsonLd.url).toContain(`/c/${serverSlug}/${channelSlug}`);
-    },
-    20000,
-  );
-});
+        // Validate JSON-LD structure (Google Rich Results required fields)
+        const ldMatch = html.match(
+          /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/i,
+        );
+        expect(ldMatch).not.toBeNull();
+        const jsonLd = JSON.parse(ldMatch![1]);
+        expect(jsonLd['@context']).toBe('https://schema.org');
+        expect(jsonLd['@type']).toBe('DiscussionForumPosting');
+        expect(typeof jsonLd.name).toBe('string');
+        expect(jsonLd.name.length).toBeGreaterThan(0);
+        expect(jsonLd.headline).toBe(jsonLd.name);
+        expect(typeof jsonLd.url).toBe('string');
+        expect(jsonLd.url).toContain(`/c/${serverSlug}/${channelSlug}`);
+        expect(jsonLd.author).toEqual(
+          expect.objectContaining({
+            '@type': 'Organization',
+          }),
+        );
+        expect(typeof jsonLd.author.name).toBe('string');
+        expect(jsonLd.author.name.length).toBeGreaterThan(0);
+        expect(typeof jsonLd.text).toBe('string');
+        expect(jsonLd.text.length).toBeGreaterThan(0);
+      },
+      20000,
+    );
+  },
+);
 
 // GPC-4 and GPC-6 need seeded PRIVATE channel data — local-only
 localOnlyDescribe('Guest Public Channel — local-only (PRIVATE access)', () => {


### PR DESCRIPTION
## Summary
- add the missing `DiscussionForumPosting` rich-results fields on public channel pages
- reuse persisted public SEO metadata when building JSON-LD so structured data stays aligned with the page title, description, and Open Graph tags
- extend metadata tests to cover rich-results fields and persisted SEO override behavior

Closes #468

## Verification
- `npm test -- --runInBand --testPathPatterns='channel-page-metadata.test.ts|public-channel-metadata.test.ts'` in `harmony-frontend`
- `npx tsc --noEmit` in `harmony-frontend`
- `npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' 'src/__tests__/channel-page-metadata.test.ts' 'src/__tests__/public-channel-metadata.test.ts'` in `harmony-frontend`