### PR TITLE
fix(security): enforce isPublic filter on public server slug endpoints (CWE-862)

### DIFF
--- a/harmony-backend/src/routes/public.router.ts
+++ b/harmony-backend/src/routes/public.router.ts
@@ -169,7 +169,7 @@ export function createPublicRouter(store?: Store) {
   router.get('/servers/:serverSlug', async (req: Request, res: Response) => {
     try {
       const server = await prisma.server.findUnique({
-        where: { slug: req.params.serverSlug },
+        where: { slug: req.params.serverSlug, isPublic: true },
         select: {
           id: true,
           name: true,
@@ -224,7 +224,7 @@ export function createPublicRouter(store?: Store) {
   router.get('/servers/:serverSlug/channels', async (req: Request, res: Response) => {
     try {
       const server = await prisma.server.findUnique({
-        where: { slug: req.params.serverSlug },
+        where: { slug: req.params.serverSlug, isPublic: true },
         select: { id: true },
       });
 
@@ -276,7 +276,7 @@ export function createPublicRouter(store?: Store) {
   router.get('/servers/:serverSlug/channels/:channelSlug', async (req: Request, res: Response) => {
     try {
       const server = await prisma.server.findUnique({
-        where: { slug: req.params.serverSlug },
+        where: { slug: req.params.serverSlug, isPublic: true },
         select: { id: true },
       });
 

--- a/harmony-backend/tests/public.router.test.ts
+++ b/harmony-backend/tests/public.router.test.ts
@@ -148,6 +148,19 @@ describe('GET /api/public/servers/:serverSlug', () => {
     expect(res.status).toBe(404);
     expect(res.body).toHaveProperty('error');
   });
+
+  it('CWE-862: returns 404 for a private server slug (isPublic filter enforced)', async () => {
+    // Prisma returns null because isPublic: true is in the where clause and server is private
+    mockPrisma.server.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/public/servers/private-server');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error', 'Server not found');
+    expect(mockPrisma.server.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ isPublic: true }) }),
+    );
+  });
 });
 
 // ─── GET /api/public/servers/:serverSlug/channels ────────────────────────────
@@ -195,6 +208,18 @@ describe('GET /api/public/servers/:serverSlug/channels', () => {
 
     expect(res.status).toBe(404);
     expect(res.body).toHaveProperty('error');
+  });
+
+  it('CWE-862: returns 404 for a private server (isPublic filter enforced on channels endpoint)', async () => {
+    mockPrisma.server.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/public/servers/private-server/channels');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error', 'Server not found');
+    expect(mockPrisma.server.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ isPublic: true }) }),
+    );
   });
 });
 
@@ -788,6 +813,18 @@ describe('GET /api/public/servers/:serverSlug/channels/:channelSlug', () => {
 
     expect(res.status).toBe(404);
     expect(res.body).toHaveProperty('error', 'Server not found');
+  });
+
+  it('CWE-862: returns 404 for a private server on channel slug lookup (isPublic filter enforced)', async () => {
+    mockPrisma.server.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/public/servers/private-server/channels/general');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error', 'Server not found');
+    expect(mockPrisma.server.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ isPublic: true }) }),
+    );
   });
 
   it('PR-45: returns 404 when the channel slug does not exist within the server', async () => {

--- a/llm-logs/2026-04-25-170228-session-be5a895c.md
+++ b/llm-logs/2026-04-25-170228-session-be5a895c.md
@@ -1,0 +1,372 @@
+# Session Log 2026-04-25-170228
+
+## User
+
+complete https://github.com/CS485-Harmony/Harmony/issues/464 and open a PR
+
+## Assistant
+
+Let me fetch the issue details first.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 464 --repo CS485-Harmony/Harmony"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/routes/public.router.ts"
+}
+```
+
+## Assistant
+
+Now let me check the existing tests for this router.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests -name \"*public*\" | head -20"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/public.router.test.ts"
+}
+```
+
+## Assistant
+
+Now I have a clear picture. The fix is simple: add `isPublic: true` to the `where` clause in all three routes that look up a server by slug without checking visibility. Let me also add regression tests.
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/routes/public.router.ts",
+  "old_string": "  router.get('/servers/:serverSlug', async (req: Request, res: Response) => {\n    try {\n      const server = await prisma.server.findUnique({\n        where: { slug: req.params.serverSlug },",
+  "new_string": "  router.get('/servers/:serverSlug', async (req: Request, res: Response) => {\n    try {\n      const server = await prisma.server.findUnique({\n        where: { slug: req.params.serverSlug, isPublic: true },"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/routes/public.router.ts",
+  "old_string": "  router.get('/servers/:serverSlug/channels', async (req: Request, res: Response) => {\n    try {\n      const server = await prisma.server.findUnique({\n        where: { slug: req.params.serverSlug },",
+  "new_string": "  router.get('/servers/:serverSlug/channels', async (req: Request, res: Response) => {\n    try {\n      const server = await prisma.server.findUnique({\n        where: { slug: req.params.serverSlug, isPublic: true },"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/routes/public.router.ts",
+  "old_string": "  router.get('/servers/:serverSlug/channels/:channelSlug', async (req: Request, res: Response) => {\n    try {\n      const server = await prisma.server.findUnique({\n        where: { slug: req.params.serverSlug },",
+  "new_string": "  router.get('/servers/:serverSlug/channels/:channelSlug', async (req: Request, res: Response) => {\n    try {\n      const server = await prisma.server.findUnique({\n        where: { slug: req.params.serverSlug, isPublic: true },"
+}
+```
+
+## Assistant
+
+Now add regression tests to the test file:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/public.router.test.ts",
+  "old_string": "describe('GET /api/public/servers/:serverSlug', () => {\n  it('returns 200 with server info when the server exists', async () => {\n    mockPrisma.server.findUnique.mockResolvedValue(SERVER);\n\n    const res = await request(app).get(`/api/public/servers/${SERVER.slug}`);\n\n    expect(res.status).toBe(200);\n    expect(res.body).toMatchObject({\n      id: SERVER.id,\n      name: SERVER.name,\n      slug: SERVER.slug,\n      memberCount: SERVER.memberCount,\n    });\n  });\n\n  it('returns 404 when the server slug does not exist', async () => {\n    mockPrisma.server.findUnique.mockResolvedValue(null);\n\n    const res = await request(app).get('/api/public/servers/does-not-exist');\n\n    expect(res.status).toBe(404);\n    expect(res.body).toHaveProperty('error');\n  });\n});",
+  "new_string": "describe('GET /api/public/servers/:serverSlug', () => {\n  it('returns 200 with server info when the server exists', async () => {\n    mockPrisma.server.findUnique.mockResolvedValue(SERVER);\n\n    const res = await request(app).get(`/api/public/servers/${SERVER.slug}`);\n\n    expect(res.status).toBe(200);\n    expect(res.body).toMatchObject({\n      id: SERVER.id,\n      name: SERVER.name,\n      slug: SERVER.slug,\n      memberCount: SERVER.memberCount,\n    });\n  });\n\n  it('returns 404 when the server slug does not exist', async () => {\n    mockPrisma.server.findUnique.mockResolvedValue(null);\n\n    const res = await request(app).get('/api/public/servers/does-not-exist');\n\n    expect(res.status).toBe(404);\n    expect(res.body).toHaveProperty('error');\n  });\n\n  it('CWE-862: returns 404 for a private server slug (isPublic filter enforced)', async () => {\n    // Prisma returns null because isPublic: true is in the where clause and server is private\n    mockPrisma.server.findUnique.mockResolvedValue(null);\n\n    const res = await request(app).get('/api/public/servers/private-server');\n\n    expect(res.status).toBe(404);\n    expect(res.body).toHaveProperty('error', 'Server not found');\n    expect(mockPrisma.server.findUnique).toHaveBeenCalledWith(\n      expect.objectContaining({ where: expect.objectContaining({ isPublic: true }) }),\n    );\n  });\n});"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/public.router.test.ts",
+  "old_string": "  it('returns 404 when the server slug does not exist', async () => {\n    mockPrisma.server.findUnique.mockResolvedValue(null);\n\n    const res = await request(app).get('/api/public/servers/does-not-exist/channels');\n\n    expect(res.status).toBe(404);\n    expect(res.body).toHaveProperty('error');\n  });\n});",
+  "new_string": "  it('returns 404 when the server slug does not exist', async () => {\n    mockPrisma.server.findUnique.mockResolvedValue(null);\n\n    const res = await request(app).get('/api/public/servers/does-not-exist/channels');\n\n    expect(res.status).toBe(404);\n    expect(res.body).toHaveProperty('error');\n  });\n\n  it('CWE-862: returns 404 for a private server (isPublic filter enforced on channels endpoint)', async () => {\n    mockPrisma.server.findUnique.mockResolvedValue(null);\n\n    const res = await request(app).get('/api/public/servers/private-server/channels');\n\n    expect(res.status).toBe(404);\n    expect(res.body).toHaveProperty('error', 'Server not found');\n    expect(mockPrisma.server.findUnique).toHaveBeenCalledWith(\n      expect.objectContaining({ where: expect.objectContaining({ isPublic: true }) }),\n    );\n  });\n});"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/public.router.test.ts",
+  "old_string": "  it('PR-44: returns 404 when the server slug does not exist', async () => {\n    mockPrisma.server.findUnique.mockResolvedValue(null);\n\n    const res = await request(app).get('/api/public/servers/no-such-server/channels/general');\n\n    expect(res.status).toBe(404);\n    expect(res.body).toHaveProperty('error', 'Server not found');\n  });",
+  "new_string": "  it('PR-44: returns 404 when the server slug does not exist', async () => {\n    mockPrisma.server.findUnique.mockResolvedValue(null);\n\n    const res = await request(app).get('/api/public/servers/no-such-server/channels/general');\n\n    expect(res.status).toBe(404);\n    expect(res.body).toHaveProperty('error', 'Server not found');\n  });\n\n  it('CWE-862: returns 404 for a private server on channel slug lookup (isPublic filter enforced)', async () => {\n    mockPrisma.server.findUnique.mockResolvedValue(null);\n\n    const res = await request(app).get('/api/public/servers/private-server/channels/general');\n\n    expect(res.status).toBe(404);\n    expect(res.body).toHaveProperty('error', 'Server not found');\n    expect(mockPrisma.server.findUnique).toHaveBeenCalledWith(\n      expect.objectContaining({ where: expect.objectContaining({ isPublic: true }) }),\n    );\n  });"
+}
+```
+
+## Assistant
+
+Now run the backend tests to confirm everything passes:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npm test -- --testPathPattern=\"public.router\" --no-coverage 2>&1",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All 55 tests pass. Now let me post the opening comment on the issue and create the PR.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 464 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Starting]**\n\nFixing the missing authorization check on public server endpoints (CWE-862).\n\n**Plan:**\n- Add \\`isPublic: true\\` to the \\`where\\` clause in three routes inside \\`harmony-backend/src/routes/public.router.ts\\`:\n  - \\`GET /api/public/servers/:serverSlug\\`\n  - \\`GET /api/public/servers/:serverSlug/channels\\`\n  - \\`GET /api/public/servers/:serverSlug/channels/:channelSlug\\`\n- Add regression tests verifying each endpoint returns 404 for private server slugs and that the query includes \\`isPublic: true\\`.\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b fix/issue-464-private-server-public-endpoint-leak"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add harmony-backend/src/routes/public.router.ts harmony-backend/tests/public.router.test.ts && git status"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git add harmony-backend/src/routes/public.router.ts harmony-backend/tests/public.router.test.ts && git status"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git commit -m \"$(cat <<'EOF'\nfix(security): enforce isPublic filter on public server slug endpoints (CWE-862, #464)\n\nAdd isPublic: true to the Prisma where clause for GET /api/public/servers/:serverSlug,\n/servers/:serverSlug/channels, and /servers/:serverSlug/channels/:channelSlug so private\nservers cannot be enumerated or their metadata disclosed by unauthenticated callers.\nAdds regression tests asserting each endpoint returns 404 for private server slugs.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/issue-464-private-server-public-endpoint-leak"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --repo CS485-Harmony/Harmony --title \"fix(security): enforce isPublic filter on public server slug endpoints (CWE-862)\" --body \"$(cat <<'EOF'\n## Summary\n\nCloses #464\n\n- `GET /api/public/servers/:serverSlug` was querying by slug alone, allowing unauthenticated callers to retrieve metadata for private servers.\n- Same gap existed in `GET /api/public/servers/:serverSlug/channels` and `GET /api/public/servers/:serverSlug/channels/:channelSlug`.\n- Fix: added `isPublic: true` to the Prisma `where` clause in all three routes so Prisma returns `null` (\u2192 404) for any private server, preventing enumeration and metadata disclosure.\n\n## Test plan\n\n- [x] Added `CWE-862` regression test for each affected route asserting that a private server slug returns 404 and that `findUnique` is called with `isPublic: true` in the where clause.\n- [x] All 55 existing `public.router.test.ts` tests still pass (`npm test -- --testPathPattern=\"public.router\"`).\nEOF\n)\""
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 464 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Complete]**\n\nFix is merged into PR #470.\n\n**Changes made:**\n- \\`harmony-backend/src/routes/public.router.ts\\`: added \\`isPublic: true\\` to the Prisma \\`where\\` clause in all three server-slug lookup routes (\\`/servers/:serverSlug\\`, \\`/servers/:serverSlug/channels\\`, \\`/servers/:serverSlug/channels/:channelSlug\\`)\n- \\`harmony-backend/tests/public.router.test.ts\\`: added three \\`CWE-862\\` regression tests (one per route) asserting 404 is returned for private server slugs and that the query includes \\`isPublic: true\\`\n\nAll 55 tests pass.\""
+}
+```
+
+## Assistant
+
+PR is open at https://github.com/CS485-Harmony/Harmony/pull/470.
+
+**What changed:** Added `isPublic: true` to the Prisma `where` clause in three routes in `public.router.ts` — the server-by-slug lookup, the server channels listing, and the channel-by-slug lookup. Without this, any unauthenticated caller who guessed a private server's slug could retrieve its metadata. Also added three `CWE-862` regression tests (one per route) verifying the filter is enforced. All 55 tests pass.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 /tmp/harmony_export_logs.py 2>&1 || true"
+}
+```
+


### PR DESCRIPTION
## Summary

Closes #464

- `GET /api/public/servers/:serverSlug` was querying by slug alone, allowing unauthenticated callers to retrieve metadata for private servers.
- Same gap existed in `GET /api/public/servers/:serverSlug/channels` and `GET /api/public/servers/:serverSlug/channels/:channelSlug`.
- Fix: added `isPublic: true` to the Prisma `where` clause in all three routes so Prisma returns `null` (→ 404) for any private server, preventing enumeration and metadata disclosure.

## Test plan

- [x] Added `CWE-862` regression test for each affected route asserting that a private server slug returns 404 and that `findUnique` is called with `isPublic: true` in the where clause.
- [x] All 55 existing `public.router.test.ts` tests still pass (`npm test -- --testPathPattern="public.router"`).