### PR TITLE
fix: block reserved admin email/username at registration (#466)

### DIFF
--- a/harmony-backend/src/lib/admin.utils.ts
+++ b/harmony-backend/src/lib/admin.utils.ts
@@ -10,14 +10,22 @@ import { prisma } from '../db/prisma';
 
 export const ADMIN_EMAIL = 'admin@harmony.dev';
 
+/** Lowercase emails that must not be claimable via public registration. */
+export const RESERVED_EMAILS = new Set<string>([ADMIN_EMAIL]);
+
+/** Lowercase usernames that must not be claimable via public registration. */
+export const RESERVED_USERNAMES = new Set<string>(['admin']);
+
 /** Cached admin user ID to avoid repeated DB lookups. */
 let _adminUserId: string | null = null;
 
 /**
  * Returns true if the given userId belongs to the system admin account.
+ * Never returns true in production — this utility is dev/test only.
  * Caches the result after the first positive lookup.
  */
 export async function isSystemAdmin(userId: string): Promise<boolean> {
+  if (process.env.NODE_ENV === 'production') return false;
   if (_adminUserId === userId) return true;
   const user = await prisma.user.findUnique({
     where: { id: userId },

--- a/harmony-backend/src/services/auth.service.ts
+++ b/harmony-backend/src/services/auth.service.ts
@@ -4,7 +4,7 @@ import crypto from 'crypto';
 import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import { serverMemberService } from './serverMember.service';
-import { ADMIN_EMAIL } from '../lib/admin.utils';
+import { ADMIN_EMAIL, RESERVED_EMAILS, RESERVED_USERNAMES } from '../lib/admin.utils';
 import { userRepository } from '../repositories/user.repository';
 import { serverRepository } from '../repositories/server.repository';
 import { serverMemberRepository } from '../repositories/serverMember.repository';
@@ -187,6 +187,14 @@ export const authService = {
     passwordSalt: string,
     passwordVerifier: string,
   ): Promise<AuthTokens> {
+    if (RESERVED_EMAILS.has(email.toLowerCase())) {
+      throw new TRPCError({ code: 'FORBIDDEN', message: 'This email address is reserved' });
+    }
+
+    if (RESERVED_USERNAMES.has(username.toLowerCase())) {
+      throw new TRPCError({ code: 'FORBIDDEN', message: 'This username is reserved' });
+    }
+
     const existingEmail = await userRepository.findByEmail(email);
     if (existingEmail) {
       throw new TRPCError({ code: 'CONFLICT', message: 'Email already in use' });

--- a/harmony-backend/tests/admin.utils.test.ts
+++ b/harmony-backend/tests/admin.utils.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression tests for admin.utils — Issue #466
+ *
+ * Verifies that isSystemAdmin is gated by NODE_ENV so a user whose email
+ * matches ADMIN_EMAIL cannot escalate privileges in production.
+ */
+
+import { isSystemAdmin, ADMIN_EMAIL, RESERVED_EMAILS, RESERVED_USERNAMES } from '../src/lib/admin.utils';
+
+const ADMIN_USER_ID = '00000000-0000-0000-0000-000000000099';
+
+jest.mock('../src/db/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '../src/db/prisma';
+const mockPrisma = prisma as unknown as { user: { findUnique: jest.Mock } };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('isSystemAdmin — production env guard (issue #466)', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: originalEnv, writable: true });
+  });
+
+  it('returns false in production even when the user email matches ADMIN_EMAIL', async () => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', writable: true });
+    mockPrisma.user.findUnique.mockResolvedValue({ email: ADMIN_EMAIL });
+
+    const result = await isSystemAdmin(ADMIN_USER_ID);
+
+    expect(result).toBe(false);
+    expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns true in test env when the user email matches ADMIN_EMAIL', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({ email: ADMIN_EMAIL });
+
+    const result = await isSystemAdmin(ADMIN_USER_ID);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false in test env when the user email does not match ADMIN_EMAIL', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({ email: 'attacker@example.com' });
+
+    const result = await isSystemAdmin('attacker-id');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('RESERVED_EMAILS and RESERVED_USERNAMES sets (issue #466)', () => {
+  it('includes the admin email (lowercase)', () => {
+    expect(RESERVED_EMAILS.has(ADMIN_EMAIL)).toBe(true);
+  });
+
+  it('includes the username "admin"', () => {
+    expect(RESERVED_USERNAMES.has('admin')).toBe(true);
+  });
+});

--- a/harmony-backend/tests/auth.test.ts
+++ b/harmony-backend/tests/auth.test.ts
@@ -164,6 +164,53 @@ describe('POST /api/auth/register', () => {
   });
 });
 
+describe('POST /api/auth/register — reserved identities (issue #466)', () => {
+  it('rejects registration with the reserved admin email', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'admin@harmony.dev',
+        username: 'notadmin',
+        passwordSalt: PASSWORD_SALT,
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/reserved/i);
+  });
+
+  it('rejects registration with the reserved admin email regardless of case', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'Admin@Harmony.Dev',
+        username: 'notadmin',
+        passwordSalt: PASSWORD_SALT,
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/reserved/i);
+  });
+
+  it('rejects registration with the reserved username "admin"', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'someone@example.com',
+        username: 'admin',
+        passwordSalt: PASSWORD_SALT,
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/reserved/i);
+  });
+});
+
 describe('POST /api/auth/login/challenge', () => {
   it('returns the stored password salt for existing users', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(mockUser);

--- a/llm-logs/2026-04-25-211145-session-784aaade.md
+++ b/llm-logs/2026-04-25-211145-session-784aaade.md
@@ -1,0 +1,517 @@
+# Session Log 2026-04-25-211145
+
+## User
+
+complete https://github.com/CS485-Harmony/Harmony/issues/466 and open a PR
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 466 --repo CS485-Harmony/Harmony",
+  "description": "View GitHub issue 466"
+}
+```
+
+## Assistant
+
+Let me read the relevant files to understand the current state.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/lib/admin.utils.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/routes/auth.router.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auth.service.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/permission.service.ts"
+}
+```
+
+## Assistant
+
+Now let me check existing tests to understand the test patterns.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests -name \"*.test.ts\" | head -20",
+  "description": "Find backend test files"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/auth.test.ts"
+}
+```
+
+## Assistant
+
+Now I have a clear picture. Let me call the advisor before implementing.
+
+## Assistant
+
+Good advice. Let me check email handling and `tasks/lessons.md` before writing code.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"findByEmail\\|findByUsername\\|email\\|toLowerCase\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/user.repository.ts | head -30",
+  "description": "Check email normalization in user repository"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cat /Users/bigfa/Documents/GitHub/Harmony/tasks/lessons.md 2>/dev/null | head -50; cat /Users/bigfa/Documents/GitHub/Harmony/tasks/todo.md 2>/dev/null | head -20",
+  "description": "Check lessons and todo files"
+}
+```
+
+## Assistant
+
+Now I'll create a branch, implement the fix, and add tests.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b fix/466-reserved-admin-email-registration",
+  "description": "Create fix branch for issue 466"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 466 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Starting]**\n\nStarting work on this issue. Plan:\n\n1. Block reserved email \\`admin@harmony.dev\\` (case-insensitive) at registration in \\`auth.service.ts\\`\n2. Block reserved username \\`admin\\` at registration\n3. Add \\`NODE_ENV === 'production'\\` guard to \\`isSystemAdmin\\` in \\`admin.utils.ts\\` as defense-in-depth\n4. Add regression tests covering reserved-email/username registration rejection and the production env guard\"",
+  "description": "Post opening comment on issue 466"
+}
+```
+
+## Assistant
+
+Now I'll implement the three changes:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/lib/admin.utils.ts",
+  "old_string": "/**\n * Temporary dev-only system admin utilities.\n *\n * The admin override lets a developer log in as admin@harmony.dev / admin\n * and bypass all permission and ownership checks. Remove this file before\n * deploying to production.\n */\n\nimport { prisma } from '../db/prisma';\n\nexport const ADMIN_EMAIL = 'admin@harmony.dev';\n\n/** Cached admin user ID to avoid repeated DB lookups. */\nlet _adminUserId: string | null = null;\n\n/**\n * Returns true if the given userId belongs to the system admin account.\n * Caches the result after the first positive lookup.\n */\nexport async function isSystemAdmin(userId: string): Promise<boolean> {\n  if (_adminUserId === userId) return true;\n  const user = await prisma.user.findUnique({\n    where: { id: userId },\n    select: { email: true },\n  });\n  if (user?.email === ADMIN_EMAIL) {\n    _adminUserId = userId;\n    return true;\n  }\n  return false;\n}",
+  "new_string": "/**\n * Temporary dev-only system admin utilities.\n *\n * The admin override lets a developer log in as admin@harmony.dev / admin\n * and bypass all permission and ownership checks. Remove this file before\n * deploying to production.\n */\n\nimport { prisma } from '../db/prisma';\n\nexport const ADMIN_EMAIL = 'admin@harmony.dev';\n\n/** Cached admin user ID to avoid repeated DB lookups. */\nlet _adminUserId: string | null = null;\n\n/**\n * Returns true if the given userId belongs to the system admin account.\n * Never returns true in production \u2014 this utility is dev/test only.\n * Caches the result after the first positive lookup.\n */\nexport async function isSystemAdmin(userId: string): Promise<boolean> {\n  if (process.env.NODE_ENV === 'production') return false;\n  if (_adminUserId === userId) return true;\n  const user = await prisma.user.findUnique({\n    where: { id: userId },\n    select: { email: true },\n  });\n  if (user?.email === ADMIN_EMAIL) {\n    _adminUserId = userId;\n    return true;\n  }\n  return false;\n}"
+}
+```
+
+## Assistant
+
+Now update `auth.service.ts` to block reserved emails and usernames:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auth.service.ts",
+  "old_string": "import { ADMIN_EMAIL } from '../lib/admin.utils';",
+  "new_string": "import { ADMIN_EMAIL, RESERVED_EMAILS, RESERVED_USERNAMES } from '../lib/admin.utils';"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/auth.service.ts",
+  "old_string": "    const existingEmail = await userRepository.findByEmail(email);\n    if (existingEmail) {\n      throw new TRPCError({ code: 'CONFLICT', message: 'Email already in use' });\n    }\n\n    const existingUsername = await userRepository.findByUsername(username);\n    if (existingUsername) {\n      throw new TRPCError({ code: 'CONFLICT', message: 'Username already taken' });\n    }",
+  "new_string": "    if (RESERVED_EMAILS.has(email.toLowerCase())) {\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'This email address is reserved' });\n    }\n\n    if (RESERVED_USERNAMES.has(username.toLowerCase())) {\n      throw new TRPCError({ code: 'FORBIDDEN', message: 'This username is reserved' });\n    }\n\n    const existingEmail = await userRepository.findByEmail(email);\n    if (existingEmail) {\n      throw new TRPCError({ code: 'CONFLICT', message: 'Email already in use' });\n    }\n\n    const existingUsername = await userRepository.findByUsername(username);\n    if (existingUsername) {\n      throw new TRPCError({ code: 'CONFLICT', message: 'Username already taken' });\n    }"
+}
+```
+
+## Assistant
+
+Now add the exported sets to `admin.utils.ts`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/lib/admin.utils.ts",
+  "old_string": "export const ADMIN_EMAIL = 'admin@harmony.dev';",
+  "new_string": "export const ADMIN_EMAIL = 'admin@harmony.dev';\n\n/** Lowercase emails that must not be claimable via public registration. */\nexport const RESERVED_EMAILS = new Set<string>([ADMIN_EMAIL]);\n\n/** Lowercase usernames that must not be claimable via public registration. */\nexport const RESERVED_USERNAMES = new Set<string>(['admin']);"
+}
+```
+
+## Assistant
+
+Now add regression tests to `auth.test.ts`:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/auth.test.ts",
+  "old_string": "describe('POST /api/auth/login/challenge', () => {",
+  "new_string": "describe('POST /api/auth/register \u2014 reserved identities (issue #466)', () => {\n  it('rejects registration with the reserved admin email', async () => {\n    const res = await request(app)\n      .post('/api/auth/register')\n      .set('Origin', 'http://localhost:3000')\n      .send({\n        email: 'admin@harmony.dev',\n        username: 'notadmin',\n        passwordSalt: PASSWORD_SALT,\n        passwordVerifier: derivePasswordVerifier('password123'),\n      });\n\n    expect(res.status).toBe(403);\n    expect(res.body.error).toMatch(/reserved/i);\n  });\n\n  it('rejects registration with the reserved admin email regardless of case', async () => {\n    const res = await request(app)\n      .post('/api/auth/register')\n      .set('Origin', 'http://localhost:3000')\n      .send({\n        email: 'Admin@Harmony.Dev',\n        username: 'notadmin',\n        passwordSalt: PASSWORD_SALT,\n        passwordVerifier: derivePasswordVerifier('password123'),\n      });\n\n    expect(res.status).toBe(403);\n    expect(res.body.error).toMatch(/reserved/i);\n  });\n\n  it('rejects registration with the reserved username \"admin\"', async () => {\n    const res = await request(app)\n      .post('/api/auth/register')\n      .set('Origin', 'http://localhost:3000')\n      .send({\n        email: 'someone@example.com',\n        username: 'admin',\n        passwordSalt: PASSWORD_SALT,\n        passwordVerifier: derivePasswordVerifier('password123'),\n      });\n\n    expect(res.status).toBe(403);\n    expect(res.body.error).toMatch(/reserved/i);\n  });\n});\n\ndescribe('POST /api/auth/login/challenge', () => {"
+}
+```
+
+## Assistant
+
+Now add a test for `isSystemAdmin` in production. Let me check if there's a good place to add it or if I should create a new file:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "ls /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/ | grep admin",
+  "description": "Check for existing admin test files"
+}
+```
+
+## Assistant
+
+I'll add the `isSystemAdmin` production-guard test as a new file:
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/admin.utils.test.ts",
+  "content": "/**\n * Regression tests for admin.utils \u2014 Issue #466\n *\n * Verifies that isSystemAdmin is gated by NODE_ENV so a user whose email\n * matches ADMIN_EMAIL cannot escalate privileges in production.\n */\n\nimport { isSystemAdmin, ADMIN_EMAIL, RESERVED_EMAILS, RESERVED_USERNAMES } from '../src/lib/admin.utils';\n\nconst ADMIN_USER_ID = '00000000-0000-0000-0000-000000000099';\n\njest.mock('../src/db/prisma', () => ({\n  prisma: {\n    user: {\n      findUnique: jest.fn(),\n    },\n  },\n}));\n\nimport { prisma } from '../src/db/prisma';\nconst mockPrisma = prisma as unknown as { user: { findUnique: jest.Mock } };\n\nbeforeEach(() => {\n  jest.clearAllMocks();\n});\n\ndescribe('isSystemAdmin \u2014 production env guard (issue #466)', () => {\n  const originalEnv = process.env.NODE_ENV;\n\n  afterEach(() => {\n    Object.defineProperty(process.env, 'NODE_ENV', { value: originalEnv, writable: true });\n  });\n\n  it('returns false in production even when the user email matches ADMIN_EMAIL', async () => {\n    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', writable: true });\n    mockPrisma.user.findUnique.mockResolvedValue({ email: ADMIN_EMAIL });\n\n    const result = await isSystemAdmin(ADMIN_USER_ID);\n\n    expect(result).toBe(false);\n    expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();\n  });\n\n  it('returns true in test env when the user email matches ADMIN_EMAIL', async () => {\n    mockPrisma.user.findUnique.mockResolvedValue({ email: ADMIN_EMAIL });\n\n    const result = await isSystemAdmin(ADMIN_USER_ID);\n\n    expect(result).toBe(true);\n  });\n\n  it('returns false in test env when the user email does not match ADMIN_EMAIL', async () => {\n    mockPrisma.user.findUnique.mockResolvedValue({ email: 'attacker@example.com' });\n\n    const result = await isSystemAdmin('attacker-id');\n\n    expect(result).toBe(false);\n  });\n});\n\ndescribe('RESERVED_EMAILS and RESERVED_USERNAMES sets (issue #466)', () => {\n  it('includes the admin email (lowercase)', () => {\n    expect(RESERVED_EMAILS.has(ADMIN_EMAIL)).toBe(true);\n  });\n\n  it('includes the username \"admin\"', () => {\n    expect(RESERVED_USERNAMES.has('admin')).toBe(true);\n  });\n});\n"
+}
+```
+
+## Assistant
+
+Now let's run the tests to verify everything passes:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npm test -- --testPathPattern=\"auth.test|admin.utils.test\" --no-coverage 2>&1 | tail -50",
+  "description": "Run auth and admin.utils tests",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All 22 tests pass. Let me also run the full backend test suite to check for regressions:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test --no-coverage 2>&1 | tail -30",
+  "description": "Run full backend test suite",
+  "timeout": 120000
+}
+```
+
+## Assistant
+
+The failures are all Redis/DB connection errors (Docker not running locally) — pre-existing infrastructure issues unrelated to my changes. Let me verify by running only the non-infrastructure tests:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test -- --testPathPattern=\"auth.test|admin.utils|app.test|permission|schema|rate-limit\" --no-coverage 2>&1 | tail -20",
+  "description": "Run non-infrastructure tests to verify no regressions",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test -- --testPathPattern=\"auth.test|admin.utils|app.test|schema\" --no-coverage 2>&1 | grep -E \"PASS|FAIL|Tests:|Test Suites:\"",
+  "description": "Check pass/fail summary for relevant tests",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test -- --testPathPattern=\"schema.test\" --no-coverage 2>&1 | grep -E \"\u25cf|FAIL\" | head -10",
+  "description": "Check schema test failures",
+  "timeout": 30000
+}
+```
+
+## Assistant
+
+Those are all DB-connection failures (Docker not running), not related to my changes. The auth and admin.utils tests all pass. Now let me commit and create the PR:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git diff --stat",
+  "description": "Show changed files"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add harmony-backend/src/lib/admin.utils.ts harmony-backend/src/services/auth.service.ts harmony-backend/tests/auth.test.ts harmony-backend/tests/admin.utils.test.ts && git commit -m \"$(cat <<'EOF'\nfix: block reserved admin email/username registration and add production env guard (#466)\n\n- Reject registration with `admin@harmony.dev` (case-insensitive) and\n  username `admin` via RESERVED_EMAILS/RESERVED_USERNAMES sets exported\n  from admin.utils, preventing privilege escalation via the public\n  registration path\n- Guard `isSystemAdmin` with a `NODE_ENV === 'production'` early-return\n  as defense-in-depth so the email-based check is never reachable in prod\n- Add regression tests for reserved-email/username rejection (including\n  mixed-case), and for the production env guard in isSystemAdmin\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit security fix"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/466-reserved-admin-email-registration",
+  "description": "Push branch to remote"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --repo CS485-Harmony/Harmony --title \"fix: block reserved admin email/username at registration (#466)\" --body \"$(cat <<'EOF'\n## Summary\n\nFixes #466 \u2014 privilege escalation via public registration claiming `admin@harmony.dev`.\n\n- **Block reserved emails at registration**: `auth.service.ts` now rejects any email in `RESERVED_EMAILS` (case-insensitive) with HTTP 403 before the DB is consulted. `admin@harmony.dev` and any future reserved addresses can be added to the set in `admin.utils.ts`.\n- **Block reserved usernames at registration**: Similarly rejects username `admin` (and future reserved names) so the dev-admin bootstrap path in `ensureAdminUser` can never be blocked by a pre-claimed username.\n- **Production env guard on `isSystemAdmin`**: Returns `false` immediately when `NODE_ENV === 'production'`, ensuring the email-based admin check is never reachable in production even if another write path bypasses the registration block.\n\n## Test plan\n\n- [ ] `POST /api/auth/register` with `admin@harmony.dev` \u2192 403 Reserved\n- [ ] `POST /api/auth/register` with `Admin@Harmony.Dev` (mixed case) \u2192 403 Reserved\n- [ ] `POST /api/auth/register` with username `admin` \u2192 403 Reserved\n- [ ] `isSystemAdmin` returns `false` in production env even for a user whose email matches `ADMIN_EMAIL`\n- [ ] `isSystemAdmin` still returns `true` in test/dev env for the admin user\n- [ ] Existing auth flow tests (register, login, logout, refresh) continue to pass\n- [ ] Run `npm test` in `harmony-backend` \u2014 all non-infrastructure tests pass\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\"",
+  "description": "Create pull request"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 466 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Complete]**\n\nAll changes landed in PR #471.\n\n**What was done:**\n- \\`harmony-backend/src/lib/admin.utils.ts\\`: Added \\`RESERVED_EMAILS\\` and \\`RESERVED_USERNAMES\\` sets; added \\`NODE_ENV === 'production'\\` early-return to \\`isSystemAdmin\\` as defense-in-depth\n- \\`harmony-backend/src/services/auth.service.ts\\`: Checks both sets (case-insensitive) at the top of \\`register()\\` and throws 403 FORBIDDEN before any DB lookup\n- \\`harmony-backend/tests/auth.test.ts\\`: Regression tests for reserved email (exact + mixed-case) and reserved username rejection\n- \\`harmony-backend/tests/admin.utils.test.ts\\`: New test file verifying the production env guard on \\`isSystemAdmin\\`\"",
+  "description": "Post completion comment on issue 466"
+}
+```
+
+## Assistant
+
+PR is open at https://github.com/CS485-Harmony/Harmony/pull/471. Here's what was done:
+
+**3 files changed, 1 new test file created:**
+
+1. **`admin.utils.ts`** — Added `RESERVED_EMAILS` and `RESERVED_USERNAMES` sets (extensible for future reserved identifiers), and added a `NODE_ENV === 'production'` early-return to `isSystemAdmin` as defense-in-depth.
+
+2. **`auth.service.ts`** — `register()` now checks both sets (case-insensitively) before touching the database and throws 403 FORBIDDEN for reserved emails/usernames.
+
+3. **`auth.test.ts`** — Regression tests for `admin@harmony.dev`, `Admin@Harmony.Dev` (mixed case), and username `admin`.
+
+4. **`admin.utils.test.ts`** (new) — Tests that `isSystemAdmin` returns `false` in production even when the user's email matches `ADMIN_EMAIL`, and still returns `true` in dev/test.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 /tmp/harmony_export_logs.py 2>&1 || true",
+  "description": "Check if export script already exists"
+}
+```
+


### PR DESCRIPTION
## Summary

Fixes #466 — privilege escalation via public registration claiming `admin@harmony.dev`.

- **Block reserved emails at registration**: `auth.service.ts` now rejects any email in `RESERVED_EMAILS` (case-insensitive) with HTTP 403 before the DB is consulted. `admin@harmony.dev` and any future reserved addresses can be added to the set in `admin.utils.ts`.
- **Block reserved usernames at registration**: Similarly rejects username `admin` (and future reserved names) so the dev-admin bootstrap path in `ensureAdminUser` can never be blocked by a pre-claimed username.
- **Production env guard on `isSystemAdmin`**: Returns `false` immediately when `NODE_ENV === 'production'`, ensuring the email-based admin check is never reachable in production even if another write path bypasses the registration block.

## Test plan

- [ ] `POST /api/auth/register` with `admin@harmony.dev` → 403 Reserved
- [ ] `POST /api/auth/register` with `Admin@Harmony.Dev` (mixed case) → 403 Reserved
- [ ] `POST /api/auth/register` with username `admin` → 403 Reserved
- [ ] `isSystemAdmin` returns `false` in production env even for a user whose email matches `ADMIN_EMAIL`
- [ ] `isSystemAdmin` still returns `true` in test/dev env for the admin user
- [ ] Existing auth flow tests (register, login, logout, refresh) continue to pass
- [ ] Run `npm test` in `harmony-backend` — all non-infrastructure tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)