### PR TITLE
fix: bind channel.getChannel lookup to authorized serverId (issue #463)

### DIFF
--- a/harmony-backend/src/services/channel.service.ts
+++ b/harmony-backend/src/services/channel.service.ts
@@ -43,6 +43,16 @@ export const channelService = {
     return channel;
   },
 
+  // Resolves by the authorized serverId directly — used by the authed tRPC endpoint
+  // so the authorization scope and resource lookup are bound to the same server.
+  async getChannelByServerId(serverId: string, channelSlug: string) {
+    const channel = await channelRepository.findByServerAndSlug(serverId, channelSlug);
+    if (!channel) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found' });
+    }
+    return channel;
+  },
+
   async createChannel(input: CreateChannelInput, tx?: Prisma.TransactionClient) {
     const { serverId, name, slug, type, visibility, topic, position = 0 } = input;
 

--- a/harmony-backend/src/trpc/routers/channel.router.ts
+++ b/harmony-backend/src/trpc/routers/channel.router.ts
@@ -15,8 +15,8 @@ export const channelRouter = router({
 
   /** Requires channel:read — prevents leaking PRIVATE channel metadata to non-members. */
   getChannel: withPermission('channel:read')
-    .input(z.object({ serverId: z.string().uuid(), serverSlug: z.string(), channelSlug: z.string() }))
-    .query(({ input }) => channelService.getChannelBySlug(input.serverSlug, input.channelSlug)),
+    .input(z.object({ serverId: z.string().uuid(), channelSlug: z.string() }))
+    .query(({ input }) => channelService.getChannelByServerId(input.serverId, input.channelSlug)),
 
   createChannel: withPermission('channel:create')
     .input(

--- a/harmony-backend/tests/channel.service.test.ts
+++ b/harmony-backend/tests/channel.service.test.ts
@@ -189,6 +189,37 @@ describe('channelService.getChannelBySlug', () => {
   });
 });
 
+// ─── CS-5a, CS-5b, CS-5c: getChannelByServerId ───────────────────────────────
+// Verifies the fix for issue #463: authorization scope and resource lookup are
+// bound to the same server (no cross-server bypass via slug).
+
+describe('channelService.getChannelByServerId', () => {
+  it('CS-5a: returns channel when serverId and channelSlug match', async () => {
+    const result = await channelService.getChannelByServerId(serverId, channelSlug);
+
+    expect(result.id).toBe(channelId);
+    expect(result.serverId).toBe(serverId);
+  });
+
+  it('CS-5b: throws NOT_FOUND when channelSlug does not exist in the given server', async () => {
+    await expect(
+      channelService.getChannelByServerId(serverId, 'no-such-channel'),
+    ).rejects.toThrow(
+      expect.objectContaining({ code: 'NOT_FOUND', message: 'Channel not found' }),
+    );
+  });
+
+  it('CS-5c: throws NOT_FOUND when serverId does not own the channel (cross-server guard)', async () => {
+    // channelSlug belongs to `serverId`, but we pass `emptyServerId` as the authorized server.
+    // This simulates an attacker supplying a different serverId than the one that owns the channel.
+    await expect(
+      channelService.getChannelByServerId(emptyServerId, channelSlug),
+    ).rejects.toThrow(
+      expect.objectContaining({ code: 'NOT_FOUND', message: 'Channel not found' }),
+    );
+  });
+});
+
 // ─── CS-6 through CS-13: createChannel ───────────────────────────────────────
 
 describe('channelService.createChannel', () => {

--- a/harmony-frontend/src/__tests__/channelService.test.ts
+++ b/harmony-frontend/src/__tests__/channelService.test.ts
@@ -166,7 +166,6 @@ describe('channelService', () => {
 
       expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getChannel', {
         serverId: 'srv-1',
-        serverSlug: 'my-server',
         channelSlug: 'general',
       });
       expect(result).toMatchObject({ id: 'ch-1', visibility: 'PRIVATE' });

--- a/harmony-frontend/src/services/channelService.ts
+++ b/harmony-frontend/src/services/channelService.ts
@@ -101,7 +101,6 @@ export const getChannel = cache(
     try {
       const data = await trpcQuery<Record<string, unknown>>('channel.getChannel', {
         serverId,
-        serverSlug,
         channelSlug,
       });
       if (!data) return null;

--- a/llm-logs/2026-04-25-212531-session-07a8cfe1.md
+++ b/llm-logs/2026-04-25-212531-session-07a8cfe1.md
@@ -1,0 +1,621 @@
+# Session Log 2026-04-25-212531
+
+## User
+
+complete https://github.com/CS485-Harmony/Harmony/issues/463 and open a PR
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue view 463 --repo CS485-Harmony/Harmony",
+  "description": "View issue #463"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/WORKFLOW.md",
+  "limit": 20
+}
+```
+
+## Assistant
+
+Let me read the affected files to understand the vulnerability.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"getChannel\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/trpc/routers/channel.router.ts | head -40",
+  "description": "Find getChannel in channel router"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"withPermission\\|serverId\\|serverSlug\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/trpc/init.ts | head -40",
+  "description": "Find withPermission in trpc init"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/trpc/routers/channel.router.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"getChannelBySlug\\|getChannel\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/channel.service.ts | head -30",
+  "description": "Find getChannelBySlug in channel service"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/channel.service.ts",
+  "limit": 80
+}
+```
+
+## Assistant
+
+Let me check how `getChannelBySlug` is used elsewhere and look at the tests.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -rn \"getChannelBySlug\\|getChannel\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/ --include=\"*.ts\" | grep -v \"router\\|service\" | head -20",
+  "description": "Find all usages of getChannelBySlug"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -rn \"getChannel\\b\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/ --include=\"*.ts\" --include=\"*.tsx\" | head -20",
+  "description": "Find frontend usages of getChannel"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"getChannel\\|serverId\\|serverSlug\\|channelSlug\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/channelService.ts | head -50",
+  "description": "View channelService frontend"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -rn \"getChannelBySlug\\|getChannelById\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/ --include=\"*.ts\" | head -20",
+  "description": "Find all uses of getChannelBySlug in backend"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"findByServerAndSlug\\|findByServerId\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/channel.repository.ts | head -20",
+  "description": "Check channel repository methods"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/repositories/channel.repository.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -rn \"getChannelBySlug\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/ --include=\"*.ts\"",
+  "description": "Check all usages of getChannelBySlug"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/channel.service.test.ts",
+  "limit": 220,
+  "offset": 160
+}
+```
+
+## Assistant
+
+Let me look at the frontend test and service files to understand the full scope of changes.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/channelService.test.ts",
+  "limit": 230,
+  "offset": 125
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/channelService.ts",
+  "limit": 140
+}
+```
+
+## Assistant
+
+Now I have a complete picture of the vulnerability and the fix needed. Let me post a comment to the issue and implement the fix.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 463 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Starting]**\n\nFixing the cross-server authorization bypass in \\`channel.getChannel\\`.\n\n**Root cause**: \\`withPermission\\` checks the caller's membership in \\`input.serverId\\`, but the actual channel lookup uses \\`serverSlug\\` to independently resolve a (possibly different) server. An attacker in Server A can supply Server B's \\`serverSlug\\` to read Server B's channel data.\n\n**Fix approach** (\\\"resolve by serverId + channelSlug\\\"):\n1. Add \\`getChannelByServerId(serverId, channelSlug)\\` to the service \u2014 uses \\`channelRepository.findByServerAndSlug\\` (already takes \\`serverId\\`) so no extra DB work\n2. Remove \\`serverSlug\\` from the \\`getChannel\\` router input \u2014 it is no longer needed\n3. Update the frontend \\`channelService\\` to not pass \\`serverSlug\\` in the tRPC call\n4. Add backend service tests for the new method\n5. Update frontend test expectations\"",
+  "description": "Post opening comment to issue 463"
+}
+```
+
+## Assistant
+
+Now let me implement the fix. I'll make all changes:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git checkout -b fix/463-channel-getChannel-cross-server-auth-bypass",
+  "description": "Create fix branch"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/services/channel.service.ts",
+  "old_string": "  async getChannelBySlug(serverSlug: string, channelSlug: string) {\n    const server = await serverRepository.findBySlug(serverSlug);\n    if (!server) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n    }\n\n    const channel = await channelRepository.findByServerAndSlug(server.id, channelSlug);\n    if (!channel) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found' });\n    }\n\n    return channel;\n  },",
+  "new_string": "  async getChannelBySlug(serverSlug: string, channelSlug: string) {\n    const server = await serverRepository.findBySlug(serverSlug);\n    if (!server) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });\n    }\n\n    const channel = await channelRepository.findByServerAndSlug(server.id, channelSlug);\n    if (!channel) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found' });\n    }\n\n    return channel;\n  },\n\n  // Resolves by the authorized serverId directly \u2014 used by the authed tRPC endpoint\n  // so the authorization scope and resource lookup are bound to the same server.\n  async getChannelByServerId(serverId: string, channelSlug: string) {\n    const channel = await channelRepository.findByServerAndSlug(serverId, channelSlug);\n    if (!channel) {\n      throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found' });\n    }\n    return channel;\n  },"
+}
+```
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/trpc/routers/channel.router.ts",
+  "old_string": "  /** Requires channel:read \u2014 prevents leaking PRIVATE channel metadata to non-members. */\n  getChannel: withPermission('channel:read')\n    .input(z.object({ serverId: z.string().uuid(), serverSlug: z.string(), channelSlug: z.string() }))\n    .query(({ input }) => channelService.getChannelBySlug(input.serverSlug, input.channelSlug)),",
+  "new_string": "  /** Requires channel:read \u2014 prevents leaking PRIVATE channel metadata to non-members. */\n  getChannel: withPermission('channel:read')\n    .input(z.object({ serverId: z.string().uuid(), channelSlug: z.string() }))\n    .query(({ input }) => channelService.getChannelByServerId(input.serverId, input.channelSlug)),"
+}
+```
+
+## Assistant
+
+Now update the frontend to remove `serverSlug` from the tRPC call:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/services/channelService.ts",
+  "old_string": "      const data = await trpcQuery<Record<string, unknown>>('channel.getChannel', {\n        serverId,\n        serverSlug,\n        channelSlug,\n      });",
+  "new_string": "      const data = await trpcQuery<Record<string, unknown>>('channel.getChannel', {\n        serverId,\n        channelSlug,\n      });"
+}
+```
+
+## Assistant
+
+Now update the frontend test to match the new call signature:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/__tests__/channelService.test.ts",
+  "old_string": "      expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getChannel', {\n        serverId: 'srv-1',\n        serverSlug: 'my-server',\n        channelSlug: 'general',\n      });",
+  "new_string": "      expect(mockedTrpcQuery).toHaveBeenCalledWith('channel.getChannel', {\n        serverId: 'srv-1',\n        channelSlug: 'general',\n      });"
+}
+```
+
+## Assistant
+
+Now add backend tests for the new `getChannelByServerId` method. Let me see the test file structure around line 165-190:
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/channel.service.test.ts",
+  "limit": 30,
+  "offset": 185
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/channel.service.test.ts",
+  "limit": 90,
+  "offset": 1
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/channel.service.test.ts",
+  "limit": 75,
+  "offset": 90
+}
+```
+
+## Assistant
+
+Now I'll add tests for `getChannelByServerId` right after the `getChannelBySlug` tests:
+
+## Assistant
+
+**Tool call: `Edit`**
+```json
+{
+  "replace_all": false,
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/tests/channel.service.test.ts",
+  "old_string": "  it('CS-5: throws NOT_FOUND when channel slug does not match any channel in the server', async () => {\n    await expect(\n      channelService.getChannelBySlug(serverSlug, 'no-such-channel'),\n    ).rejects.toThrow(\n      expect.objectContaining({ code: 'NOT_FOUND', message: 'Channel not found' }),\n    );\n  });\n});\n\n// \u2500\u2500\u2500 CS-6 through CS-13: createChannel \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+  "new_string": "  it('CS-5: throws NOT_FOUND when channel slug does not match any channel in the server', async () => {\n    await expect(\n      channelService.getChannelBySlug(serverSlug, 'no-such-channel'),\n    ).rejects.toThrow(\n      expect.objectContaining({ code: 'NOT_FOUND', message: 'Channel not found' }),\n    );\n  });\n});\n\n// \u2500\u2500\u2500 CS-5a, CS-5b, CS-5c: getChannelByServerId \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n// Verifies the fix for issue #463: authorization scope and resource lookup are\n// bound to the same server (no cross-server bypass via slug).\n\ndescribe('channelService.getChannelByServerId', () => {\n  it('CS-5a: returns channel when serverId and channelSlug match', async () => {\n    const result = await channelService.getChannelByServerId(serverId, channelSlug);\n\n    expect(result.id).toBe(channelId);\n    expect(result.serverId).toBe(serverId);\n  });\n\n  it('CS-5b: throws NOT_FOUND when channelSlug does not exist in the given server', async () => {\n    await expect(\n      channelService.getChannelByServerId(serverId, 'no-such-channel'),\n    ).rejects.toThrow(\n      expect.objectContaining({ code: 'NOT_FOUND', message: 'Channel not found' }),\n    );\n  });\n\n  it('CS-5c: throws NOT_FOUND when serverId does not own the channel (cross-server guard)', async () => {\n    // channelSlug belongs to `serverId`, but we pass `emptyServerId` as the authorized server.\n    // This simulates an attacker supplying a different serverId than the one that owns the channel.\n    await expect(\n      channelService.getChannelByServerId(emptyServerId, channelSlug),\n    ).rejects.toThrow(\n      expect.objectContaining({ code: 'NOT_FOUND', message: 'Channel not found' }),\n    );\n  });\n});\n\n// \u2500\u2500\u2500 CS-6 through CS-13: createChannel \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500"
+}
+```
+
+## Assistant
+
+Now let's run the tests to verify everything works:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npm test -- --testPathPattern=\"channel.service\" --no-coverage 2>&1 | tail -40",
+  "description": "Run channel service tests",
+  "timeout": 90000
+}
+```
+
+## Assistant
+
+Database isn't running locally — let me verify correctness with a TypeScript type check instead:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx tsc --noEmit 2>&1 | head -30",
+  "description": "TypeScript type check backend",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend && npx tsc --noEmit 2>&1 | head -30",
+  "description": "TypeScript type check frontend",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+Both type check clean. Now let me run the frontend tests which don't need a database:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npm test -- --testPathPattern=\"channelService\" --no-coverage 2>&1 | tail -30",
+  "description": "Run frontend channel service tests",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "npx jest --testPathPatterns=\"channelService\" --no-coverage 2>&1 | tail -30",
+  "description": "Run frontend channel service tests",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+All 41 frontend tests pass. Now let me also run the backend lint check:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony/harmony-backend && npm run lint 2>&1 | tail -20",
+  "description": "Lint backend",
+  "timeout": 60000
+}
+```
+
+## Assistant
+
+No new errors — the existing warning is pre-existing and unrelated. Now commit and push:
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "cd /Users/bigfa/Documents/GitHub/Harmony && git diff --stat",
+  "description": "Show changed files"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git add harmony-backend/src/services/channel.service.ts harmony-backend/src/trpc/routers/channel.router.ts harmony-backend/tests/channel.service.test.ts harmony-frontend/src/__tests__/channelService.test.ts harmony-frontend/src/services/channelService.ts && git commit -m \"$(cat <<'EOF'\nfix: bind channel.getChannel lookup to authorized serverId (issue #463)\n\nAuthorization via withPermission checked input.serverId, but the\nresource was resolved by serverSlug \u2014 allowing a caller to supply\na valid serverId for Server A while fetching a channel from Server B.\n\nFix: add getChannelByServerId(serverId, channelSlug) to the service so\nboth authorization and lookup use the same server identity. Remove\nserverSlug from the getChannel input schema and update the frontend\ntRPC call accordingly. Add CS-5a/5b/5c tests covering the cross-server\nguard.\n\nCloses #463\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\"",
+  "description": "Commit the fix"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "git push -u origin fix/463-channel-getChannel-cross-server-auth-bypass",
+  "description": "Push branch to remote"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr create --repo CS485-Harmony/Harmony --title \"fix: bind channel.getChannel lookup to authorized serverId (issue #463)\" --body \"$(cat <<'EOF'\n## Summary\n\n- **Root cause (CWE-639)**: `channel.getChannel` authorized via `input.serverId` but resolved the channel via `serverSlug`, letting an attacker supply Server A's `serverId` (authorized) while fetching data from Server B via its slug.\n- **Fix**: Added `getChannelByServerId(serverId, channelSlug)` to the channel service, which queries the DB directly by `serverId + channelSlug` using the existing `findByServerAndSlug` repository method. The router now uses this method and drops `serverSlug` from the input schema entirely.\n- **Frontend**: Removed the now-unnecessary `serverSlug` from the `channel.getChannel` tRPC call.\n- **Tests**: Added CS-5a/5b/5c backend service tests \u2014 including CS-5c which explicitly verifies the cross-server guard (wrong `serverId` returns NOT_FOUND).\n\n## Changed files\n\n| File | Change |\n|------|--------|\n| `harmony-backend/src/services/channel.service.ts` | Added `getChannelByServerId(serverId, channelSlug)` |\n| `harmony-backend/src/trpc/routers/channel.router.ts` | Removed `serverSlug` from input, use new service method |\n| `harmony-backend/tests/channel.service.test.ts` | Added CS-5a/5b/5c tests for the new method |\n| `harmony-frontend/src/services/channelService.ts` | Removed `serverSlug` from tRPC call |\n| `harmony-frontend/src/__tests__/channelService.test.ts` | Updated expectation to match new call shape |\n\n## Test plan\n\n- [x] `npx tsc --noEmit` passes on both backend and frontend\n- [x] Frontend Jest suite (`channelService`) \u2014 41 tests pass\n- [x] Backend lint \u2014 no new errors\n- [ ] Backend integration tests (require live DB \u2014 verified by CI)\n\nCloses #463\n\n\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\"",
+  "description": "Open PR for issue 463"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh issue comment 463 --repo CS485-Harmony/Harmony --body \"**[AI Agent \u2014 Complete]**\n\nFix is implemented and PR opened: https://github.com/CS485-Harmony/Harmony/pull/473\n\n**Changes made:**\n- Added \\`getChannelByServerId(serverId, channelSlug)\\` to the channel service \u2014 queries by \\`serverId + channelSlug\\` directly, binding authorization scope and resource lookup to the same server\n- Updated \\`channel.router.ts\\`: removed \\`serverSlug\\` from the \\`getChannel\\` input schema; now calls the new service method\n- Updated frontend \\`channelService.ts\\`: removed \\`serverSlug\\` from the tRPC call\n- Added CS-5a/5b/5c backend tests including a cross-server guard test (CS-5c)\n\n**Verification:** TypeScript passes clean on both backend and frontend; 41/41 frontend Jest tests pass; backend lint clean.\"",
+  "description": "Post completion comment to issue 463"
+}
+```
+
+## Assistant
+
+PR opened at https://github.com/CS485-Harmony/Harmony/pull/473.
+
+**What was done:**
+
+The bug: `channel.getChannel` authorized via `input.serverId` (Server A) but resolved the channel via `serverSlug` — which could silently point at a different Server B.
+
+**Fix (5 files):**
+- **`channel.service.ts`** — Added `getChannelByServerId(serverId, channelSlug)` that queries by `serverId + channelSlug` directly, so authorization and lookup are bound to the same server
+- **`channel.router.ts`** — Removed `serverSlug` from the `getChannel` input schema; calls the new service method
+- **`channelService.ts` (frontend)** — Removed `serverSlug` from the tRPC call
+- **`channel.service.test.ts`** — Added CS-5a/5b/5c tests, including CS-5c which explicitly verifies the cross-server guard
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+


### PR DESCRIPTION
## Summary

- **Root cause (CWE-639)**: `channel.getChannel` authorized via `input.serverId` but resolved the channel via `serverSlug`, letting an attacker supply Server A's `serverId` (authorized) while fetching data from Server B via its slug.
- **Fix**: Added `getChannelByServerId(serverId, channelSlug)` to the channel service, which queries the DB directly by `serverId + channelSlug` using the existing `findByServerAndSlug` repository method. The router now uses this method and drops `serverSlug` from the input schema entirely.
- **Frontend**: Removed the now-unnecessary `serverSlug` from the `channel.getChannel` tRPC call.
- **Tests**: Added CS-5a/5b/5c backend service tests — including CS-5c which explicitly verifies the cross-server guard (wrong `serverId` returns NOT_FOUND).

## Changed files

| File | Change |
|------|--------|
| `harmony-backend/src/services/channel.service.ts` | Added `getChannelByServerId(serverId, channelSlug)` |
| `harmony-backend/src/trpc/routers/channel.router.ts` | Removed `serverSlug` from input, use new service method |
| `harmony-backend/tests/channel.service.test.ts` | Added CS-5a/5b/5c tests for the new method |
| `harmony-frontend/src/services/channelService.ts` | Removed `serverSlug` from tRPC call |
| `harmony-frontend/src/__tests__/channelService.test.ts` | Updated expectation to match new call shape |

## Test plan

- [x] `npx tsc --noEmit` passes on both backend and frontend
- [x] Frontend Jest suite (`channelService`) — 41 tests pass
- [x] Backend lint — no new errors
- [ ] Backend integration tests (require live DB — verified by CI)

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)