### PR TITLE
fix(#446): keep message input focused after send

### DIFF
--- a/harmony-frontend/src/__tests__/issue-238-message-input-aria-label.test.tsx
+++ b/harmony-frontend/src/__tests__/issue-238-message-input-aria-label.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@/app/actions/sendMessage', () => ({
 // ─── Imports ──────────────────────────────────────────────────────────────────
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MessageInput } from '../components/channel/MessageInput';
 
@@ -70,5 +70,33 @@ describe('Issue #238 — MessageInput: textarea aria-label accessibility', () =>
     // Read-only view shows a permission notice, no textarea
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     expect(screen.getByText(/do not have permission/i)).toBeInTheDocument();
+  });
+
+  it('keeps focus on textarea after sending a message with Enter', async () => {
+    mockSendMessageAction.mockResolvedValueOnce({
+      id: 'm-1',
+      content: 'hello world',
+      channelId: 'ch-1',
+      authorId: 'u-1',
+      createdAt: new Date().toISOString(),
+      editedAt: null,
+      deletedAt: null,
+      author: { id: 'u-1', username: 'tester' },
+      reactions: [],
+      replyCount: 0,
+      attachments: [],
+    });
+
+    render(<MessageInput {...defaultProps} />);
+
+    const textarea = screen.getByRole('textbox', { name: 'Message #general' });
+    textarea.focus();
+    fireEvent.change(textarea, { target: { value: 'hello world' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', charCode: 13 });
+
+    await waitFor(() => {
+      expect(mockSendMessageAction).toHaveBeenCalledTimes(1);
+      expect(textarea).toHaveFocus();
+    });
   });
 });

--- a/harmony-frontend/src/__tests__/issue-238-message-input-aria-label.test.tsx
+++ b/harmony-frontend/src/__tests__/issue-238-message-input-aria-label.test.tsx
@@ -99,4 +99,21 @@ describe('Issue #238 — MessageInput: textarea aria-label accessibility', () =>
       expect(textarea).toHaveFocus();
     });
   });
+
+  it('restores textarea focus after send failure', async () => {
+    mockSendMessageAction.mockRejectedValueOnce(new Error('network failure'));
+
+    render(<MessageInput {...defaultProps} />);
+
+    const textarea = screen.getByRole('textbox', { name: 'Message #general' });
+    textarea.focus();
+    fireEvent.change(textarea, { target: { value: 'hello world' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', charCode: 13 });
+
+    await waitFor(() => {
+      expect(mockSendMessageAction).toHaveBeenCalledTimes(1);
+      expect(textarea).toHaveFocus();
+      expect(screen.getByRole('alert')).toHaveTextContent(/failed to send message/i);
+    });
+  });
 });

--- a/harmony-frontend/src/components/channel/MessageInput.tsx
+++ b/harmony-frontend/src/components/channel/MessageInput.tsx
@@ -64,6 +64,7 @@ export function MessageInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const emojiPickerRef = useRef<HTMLDivElement>(null);
+  const shouldRefocusTextareaRef = useRef(false);
 
   // On channel switch: clear draft, clear attachments, clear any send error, and autofocus
   useEffect(() => {
@@ -93,6 +94,14 @@ export function MessageInput({
     el.style.height = 'auto';
     el.style.height = `${Math.min(el.scrollHeight, 240)}px`;
   }, [value]);
+
+  // Refocus only after controls have re-enabled; focusing while disabled is ignored by the browser.
+  useEffect(() => {
+    if (!isSending && !isUploading && shouldRefocusTextareaRef.current) {
+      textareaRef.current?.focus();
+      shouldRefocusTextareaRef.current = false;
+    }
+  }, [isSending, isUploading]);
 
   const handleAttachClick = () => {
     fileInputRef.current?.click();
@@ -174,6 +183,7 @@ export function MessageInput({
     if ((!trimmed && !pendingAttachments.length) || isSending || isUploading || isReadOnly) return;
     setIsSending(true);
     setSendError(null);
+    shouldRefocusTextareaRef.current = true;
     try {
       let msg: Message;
       if (replyingTo) {
@@ -202,7 +212,6 @@ export function MessageInput({
       setSendError('Failed to send message. Please try again.');
     } finally {
       setIsSending(false);
-      textareaRef.current?.focus();
     }
   }, [
     value,

--- a/harmony-frontend/src/components/channel/MessageInput.tsx
+++ b/harmony-frontend/src/components/channel/MessageInput.tsx
@@ -72,6 +72,7 @@ export function MessageInput({
     setSendError(null);
     setPendingAttachments([]);
     setShowEmojiPicker(false);
+    shouldRefocusTextareaRef.current = false;
     textareaRef.current?.focus();
   }, [channelId]);
 
@@ -116,6 +117,7 @@ export function MessageInput({
 
     setIsUploading(true);
     setSendError(null);
+    shouldRefocusTextareaRef.current = true;
 
     try {
       const formData = new FormData();
@@ -146,7 +148,6 @@ export function MessageInput({
       setSendError('Upload failed. Please try again.');
     } finally {
       setIsUploading(false);
-      textareaRef.current?.focus();
     }
   }, []);
 

--- a/llm-logs/2026-04-27-114026-session-180e1f62.md
+++ b/llm-logs/2026-04-27-114026-session-180e1f62.md
@@ -1,0 +1,334 @@
+# Session Log 2026-04-27-114026
+
+## User
+
+<command-message>review</command-message>
+<command-name>/review</command-name>
+<command-args>485</command-args>
+
+## User
+
+You are an expert code reviewer. Follow these steps:
+
+      1. If no PR number is provided in the args, run `gh pr list` to show open PRs
+      2. If a PR number is provided, run `gh pr view <number>` to get PR details
+      3. Run `gh pr diff <number>` to get the diff
+      4. Analyze the changes and provide a thorough code review that includes:
+         - Overview of what the PR does
+         - Analysis of code quality and style
+         - Specific suggestions for improvements
+         - Any potential issues or risks
+
+      Keep your review concise but thorough. Focus on:
+      - Code correctness
+      - Following project conventions
+      - Performance implications
+      - Test coverage
+      - Security considerations
+
+      Format your review with clear sections and bullet points.
+
+      PR number: 485
+
+## Assistant
+
+I'll fetch the PR details and diff for review.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 485 && echo \"---DIFF---\" && gh pr diff 485",
+  "description": "Fetch PR #485 details and diff"
+}
+```
+
+## Assistant
+
+Let me also check the full MessageInput component for broader context.
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/channel/MessageInput.tsx"
+}
+```
+
+## Assistant
+
+Now I have enough context to write a thorough review.
+
+---
+
+## PR #485 Review — `fix(#446): keep message input focused after send`
+
+**Author:** Declan | **Additions:** 39 | **Deletions:** 2
+
+---
+
+### Overview
+
+Fixes the focus-loss race condition in `MessageInput` where calling `textareaRef.current?.focus()` inside the `finally` block was a no-op because the browser silently ignores `.focus()` calls on disabled elements. The fix defers the refocus until React re-renders after `isSending` is cleared.
+
+---
+
+### Code Quality
+
+**The core approach is correct and well-reasoned.**
+
+```tsx
+// MessageInput.tsx — new useEffect
+useEffect(() => {
+  if (!isSending && !isUploading && shouldRefocusTextareaRef.current) {
+    textareaRef.current?.focus();
+    shouldRefocusTextareaRef.current = false;
+  }
+}, [isSending, isUploading]);
+```
+
+Positives:
+- Using a `ref` (not `useState`) for `shouldRefocusTextareaRef` is the right call — avoids a spurious re-render just to track intent.
+- The comment `// Refocus only after controls have re-enabled; focusing while disabled is ignored by the browser.` explains the *why*, which is non-obvious.
+- Dependency array `[isSending, isUploading]` is correct — the effect needs to re-check when either state clears.
+
+---
+
+### Issues
+
+**1. Inconsistency: upload path still uses the old direct-focus pattern**
+
+`handleFileChange` still has `textareaRef.current?.focus()` in its `finally` block (line 118–119 in the full file). This is *not* a regression introduced by this PR — it predates it — and it happens to be safe because the textarea's `disabled` prop is only tied to `isSending`, not `isUploading`. But for consistency and correctness the two paths should use the same pattern. If `isUploading` is ever wired to `disabled`, this will silently break again.
+
+**Recommendation:** Set `shouldRefocusTextareaRef.current = true` before the upload try-block and remove the direct `.focus()` from `handleFileChange`'s finally block, mirroring the send path.
+
+**2. Refocus fires even if the user navigated away mid-send**
+
+`shouldRefocusTextareaRef.current` is set to `true` synchronously before the `await`, so if the user switches channels during a slow send, the channel-switch effect fires `.focus()` (line 55), then when `isSending` clears the deferred effect also fires `.focus()` — potentially stealing focus from wherever the user is now. Low probability but worth a note.
+
+**3. Test plan is narrow**
+
+The test plan only specifies running a single test file:
+```
+npm test -- --runInBand src/__tests__/issue-238-message-input-aria-label.test.tsx
+```
+PRs should verify the full frontend test suite (`npm test`) passes. A reviewer cannot tell from this plan that no other tests were broken.
+
+---
+
+### Test Coverage
+
+The new test is sound:
+
+```tsx
+it('keeps focus on textarea after sending a message with Enter', async () => {
+  // ...
+  fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', charCode: 13 });
+  await waitFor(() => {
+    expect(mockSendMessageAction).toHaveBeenCalledTimes(1);
+    expect(textarea).toHaveFocus();
+  });
+});
+```
+
+- Covers the most common path (Enter-to-send).
+- The `mockResolvedValueOnce` response shape matches the `Message` type.
+- Missing: test for the error path — does focus still restore if `sendMessageAction` rejects? Currently `shouldRefocusTextareaRef.current` is set to `true` before the try, but if the error path also sets `setIsSending(false)`, the refocus effect will still fire, which is the correct behavior. A test confirming this would add confidence.
+
+---
+
+### Summary
+
+| Area | Assessment |
+|---|---|
+| Core fix correctness | ✅ Correct approach, solves the race condition cleanly |
+| Code style/conventions | ✅ Matches existing patterns |
+| Minimal impact | ✅ Only touches what's necessary |
+| Consistency | ⚠️ Upload path left on old pattern |
+| Test coverage | ⚠️ Happy path only; test plan doesn't run full suite |
+| Security | ✅ No concerns |
+
+**Verdict:** Approve with minor comments. The core fix is correct and the code is clean. The upload-path inconsistency and narrow test plan are worth flagging but are not blockers.
+
+## User
+
+request changes for now, we want to keep as much as jank out as possible
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr review 485 --request-changes --body \"$(cat <<'EOF'\n## Review: Request Changes\n\nThe core fix is correct \u2014 deferring refocus to a `useEffect` that waits for controls to re-enable is the right approach. A few issues need to be addressed before merge.\n\n### Required\n\n**1. Upload path inconsistency**\n\n`handleFileChange` still uses the old direct-focus pattern in its `finally` block:\n\n```tsx\n} finally {\n  setIsUploading(false);\n  textareaRef.current?.focus(); // \u2190 old pattern\n}\n```\n\nThe textarea's `disabled` prop is currently only tied to `isSending`, so this is not broken today \u2014 but if `isUploading` is ever added to `disabled`, this will silently regress. Both paths should use the same deferred pattern for consistency. Please set `shouldRefocusTextareaRef.current = true` before the upload try-block and remove the direct `.focus()` from `handleFileChange`'s finally.\n\n**2. Test plan runs only one file**\n\nThe test plan specifies:\n```\nnpm test -- --runInBand src/__tests__/issue-238-message-input-aria-label.test.tsx\n```\n\nPlease verify and document that the full frontend test suite (`cd harmony-frontend && npm test`) passes.\n\n### Suggested\n\n**3. Missing test: focus restores on send error**\n\n`shouldRefocusTextareaRef.current` is set before the try-block, so the refocus effect should fire even when `sendMessageAction` rejects. A test confirming this edge case would add confidence and prevent future regressions.\n\n**4. Potential focus-steal on channel switch mid-send**\n\n`shouldRefocusTextareaRef.current = true` is set synchronously before the `await`, so if a user switches channels during a slow send, the channel-switch effect fires `.focus()` and then the deferred effect fires a second time when `isSending` clears \u2014 potentially stealing focus. Consider clearing `shouldRefocusTextareaRef.current` inside the channel-switch effect to guard against this.\nEOF\n)\"\n",
+  "description": "Submit request-changes review on PR #485"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 485 --json reviewDecision,reviews --jq '{decision: .reviewDecision, reviews: [.reviews[] | {author: .author.login, state: .state}]}'",
+  "description": "Verify review was submitted"
+}
+```
+
+## Assistant
+
+Review submitted. PR #485 is now in **Changes Requested** state. The four points sent to Declan:
+
+1. **Required** — Unify the upload path to use the deferred refocus pattern, not the old direct `.focus()` in `finally`.
+2. **Required** — Confirm the full `npm test` suite passes, not just the one test file.
+3. **Suggested** — Add a test for the send-error path (focus should still restore on failure).
+4. **Suggested** — Clear `shouldRefocusTextareaRef.current` in the channel-switch effect to avoid a double-focus if the user navigates away mid-send.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "python3 - <<'PYEOF'\nimport os, glob, json\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\nPYEOF",
+  "description": "Run export script inline"
+}
+```
+


### PR DESCRIPTION
## Summary
- close the focus-loss race by deferring textarea refocus until send/upload controls are re-enabled
- keep the existing send flow intact while making post-send typing seamless
- add a frontend regression test that verifies Enter-to-send keeps focus in the message textarea

Closes #446

## Test plan
- [x] `cd harmony-frontend && npm test -- --runInBand src/__tests__/issue-238-message-input-aria-label.test.tsx`

Made with [Cursor](https://cursor.com)