### PR TITLE
[codex] Implement lease-based presence tracking

### DIFF
--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -10,11 +10,13 @@ import { authRouter } from './routes/auth.router';
 import { createPublicRouter } from './routes/public.router';
 import { seoRouter } from './routes/seo.router';
 import { eventsRouter } from './routes/events.router';
+import { presenceRouter } from './routes/presence.router';
 import { attachmentRouter } from './routes/attachment.router';
 import { adminMetaTagRouter } from './routes/admin.metaTag.router';
 import { instanceId } from './lib/instance-identity';
 import { createLogger } from './lib/logger';
 import { redis } from './db/redis';
+import { presenceService } from './services/presence.service';
 
 const logger = createLogger({ component: 'app', instanceId });
 
@@ -56,6 +58,8 @@ export interface CreateAppOptions {
 }
 
 export function createApp(options: CreateAppOptions = {}) {
+  presenceService.startSweeper();
+
   const isE2E = process.env.NODE_ENV === 'e2e';
   // Each limiter calls makeStore() independently so it gets its own instance.
   const makeStore = (prefix: string): Store | undefined =>
@@ -154,6 +158,9 @@ export function createApp(options: CreateAppOptions = {}) {
 
   // Real-time SSE endpoints
   app.use('/api/events', eventsRouter);
+
+  // Presence updates from authenticated browser clients
+  app.use('/api/presence', presenceRouter);
 
   // Attachment upload + file serving
   app.use('/api/attachments', attachmentRouter);

--- a/harmony-backend/src/routes/presence.router.ts
+++ b/harmony-backend/src/routes/presence.router.ts
@@ -1,0 +1,59 @@
+import { NextFunction, Router, Request, Response } from 'express';
+import { UserStatus } from '@prisma/client';
+import { z } from 'zod';
+import { authService } from '../services/auth.service';
+import { presenceService } from '../services/presence.service';
+
+export const presenceRouter = Router();
+
+const PresenceStatusSchema = z.enum([UserStatus.ONLINE, UserStatus.IDLE]);
+const PresenceBodySchema = z.object({ status: PresenceStatusSchema });
+type ActivePresenceStatus = z.infer<typeof PresenceStatusSchema>;
+
+function getBearerToken(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+}
+
+function verifyToken(token: string): string | null {
+  try {
+    return authService.verifyAccessToken(token).sub;
+  } catch {
+    return null;
+  }
+}
+
+async function updatePresence(
+  userId: string,
+  status: ActivePresenceStatus,
+  res: Response,
+): Promise<void> {
+  await presenceService.renewLease(userId, status);
+  res.status(204).send();
+}
+
+presenceRouter.post('/status', async (req: Request, res: Response, next: NextFunction) => {
+  const token = getBearerToken(req);
+  if (!token) {
+    res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    return;
+  }
+
+  const userId = verifyToken(token);
+  if (!userId) {
+    res.status(401).json({ error: 'Invalid or expired access token' });
+    return;
+  }
+
+  const parsed = PresenceBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+    return;
+  }
+
+  try {
+    await updatePresence(userId, parsed.data.status, res);
+  } catch (err) {
+    next(err);
+  }
+});

--- a/harmony-backend/src/routes/presence.router.ts
+++ b/harmony-backend/src/routes/presence.router.ts
@@ -1,59 +1,29 @@
 import { NextFunction, Router, Request, Response } from 'express';
 import { UserStatus } from '@prisma/client';
 import { z } from 'zod';
-import { authService } from '../services/auth.service';
+import { AuthenticatedRequest, requireAuth } from '../middleware/auth.middleware';
 import { presenceService } from '../services/presence.service';
 
 export const presenceRouter = Router();
 
 const PresenceStatusSchema = z.enum([UserStatus.ONLINE, UserStatus.IDLE]);
 const PresenceBodySchema = z.object({ status: PresenceStatusSchema });
-type ActivePresenceStatus = z.infer<typeof PresenceStatusSchema>;
 
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
-}
+presenceRouter.post(
+  '/status',
+  requireAuth,
+  async (req: Request, res: Response, next: NextFunction) => {
+    const parsed = PresenceBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+      return;
+    }
 
-function verifyToken(token: string): string | null {
-  try {
-    return authService.verifyAccessToken(token).sub;
-  } catch {
-    return null;
-  }
-}
-
-async function updatePresence(
-  userId: string,
-  status: ActivePresenceStatus,
-  res: Response,
-): Promise<void> {
-  await presenceService.renewLease(userId, status);
-  res.status(204).send();
-}
-
-presenceRouter.post('/status', async (req: Request, res: Response, next: NextFunction) => {
-  const token = getBearerToken(req);
-  if (!token) {
-    res.status(401).json({ error: 'Missing or invalid Authorization header' });
-    return;
-  }
-
-  const userId = verifyToken(token);
-  if (!userId) {
-    res.status(401).json({ error: 'Invalid or expired access token' });
-    return;
-  }
-
-  const parsed = PresenceBodySchema.safeParse(req.body);
-  if (!parsed.success) {
-    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
-    return;
-  }
-
-  try {
-    await updatePresence(userId, parsed.data.status, res);
-  } catch (err) {
-    next(err);
-  }
-});
+    try {
+      await presenceService.renewLease((req as AuthenticatedRequest).userId, parsed.data.status);
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+);

--- a/harmony-backend/src/services/presence.service.ts
+++ b/harmony-backend/src/services/presence.service.ts
@@ -1,0 +1,76 @@
+import { UserStatus } from '@prisma/client';
+import { redis } from '../db/redis';
+import { createLogger } from '../lib/logger';
+import { userRepository } from '../repositories/user.repository';
+import { userService } from './user.service';
+
+const PRESENCE_LEASE_SET = 'presence:leases';
+export const PRESENCE_LEASE_TTL_MS = 75_000;
+const PRESENCE_SWEEP_INTERVAL_MS = 15_000;
+
+const logger = createLogger({ component: 'presence-service' });
+let sweeper: ReturnType<typeof setInterval> | null = null;
+type ActivePresenceStatus = Extract<UserStatus, 'ONLINE' | 'IDLE'>;
+
+async function updateUserStatusIfChanged(userId: string, status: UserStatus): Promise<void> {
+  const user = await userRepository.findSelf(userId);
+  if (!user || user.status !== status) {
+    await userService.updateUser(userId, { status });
+  }
+}
+
+export const presenceService = {
+  async renewLease(userId: string, status: ActivePresenceStatus): Promise<void> {
+    const expiresAt = Date.now() + PRESENCE_LEASE_TTL_MS;
+    await redis.zadd(PRESENCE_LEASE_SET, expiresAt, userId);
+    await updateUserStatusIfChanged(userId, status);
+  },
+
+  async expireStaleLeases(now = Date.now()): Promise<number> {
+    const expiredUserIds = await redis.zrangebyscore(PRESENCE_LEASE_SET, 0, now);
+    let expiredCount = 0;
+
+    for (const userId of expiredUserIds) {
+      const removed = await redis.eval(
+        `
+          local score = redis.call("ZSCORE", KEYS[1], ARGV[1])
+          if score and tonumber(score) <= tonumber(ARGV[2]) then
+            return redis.call("ZREM", KEYS[1], ARGV[1])
+          end
+          return 0
+        `,
+        1,
+        PRESENCE_LEASE_SET,
+        userId,
+        String(now),
+      );
+      if (removed !== 1) continue;
+
+      try {
+        await updateUserStatusIfChanged(userId, UserStatus.OFFLINE);
+        expiredCount += 1;
+      } catch (err) {
+        logger.warn({ err, userId }, 'Failed to expire stale presence lease');
+      }
+    }
+
+    return expiredCount;
+  },
+
+  startSweeper(): void {
+    if (sweeper !== null || process.env.NODE_ENV === 'test') return;
+
+    sweeper = setInterval(() => {
+      presenceService
+        .expireStaleLeases()
+        .catch((err) => logger.warn({ err }, 'Presence lease sweep failed'));
+    }, PRESENCE_SWEEP_INTERVAL_MS);
+    sweeper.unref?.();
+  },
+
+  stopSweeper(): void {
+    if (sweeper === null) return;
+    clearInterval(sweeper);
+    sweeper = null;
+  },
+};

--- a/harmony-backend/src/services/presence.service.ts
+++ b/harmony-backend/src/services/presence.service.ts
@@ -14,7 +14,9 @@ type ActivePresenceStatus = Extract<UserStatus, 'ONLINE' | 'IDLE'>;
 
 async function updateUserStatusIfChanged(userId: string, status: UserStatus): Promise<void> {
   const user = await userRepository.findSelf(userId);
-  if (!user || user.status !== status) {
+  if (!user) return;
+
+  if (user.status !== status) {
     await userService.updateUser(userId, { status });
   }
 }

--- a/harmony-backend/tests/presence.router.test.ts
+++ b/harmony-backend/tests/presence.router.test.ts
@@ -1,0 +1,81 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+import { authService } from '../src/services/auth.service';
+import { presenceService } from '../src/services/presence.service';
+
+jest.mock('../src/services/auth.service', () => ({
+  authService: {
+    verifyAccessToken: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/presence.service', () => ({
+  presenceService: {
+    renewLease: jest.fn().mockResolvedValue(undefined),
+    startSweeper: jest.fn(),
+  },
+}));
+
+jest.mock('../src/middleware/rate-limit.middleware', () => ({
+  createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const app = createApp();
+const mockVerifyAccessToken = authService.verifyAccessToken as jest.Mock;
+const mockRenewLease = presenceService.renewLease as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerifyAccessToken.mockReturnValue({ sub: 'user-1' });
+  mockRenewLease.mockResolvedValue(undefined);
+});
+
+describe('POST /api/presence/status', () => {
+  it('updates authenticated users to ONLINE', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'ONLINE' });
+
+    expect(res.status).toBe(204);
+    expect(mockVerifyAccessToken).toHaveBeenCalledWith('valid-token');
+    expect(mockRenewLease).toHaveBeenCalledWith('user-1', 'ONLINE');
+  });
+
+  it('updates authenticated users to IDLE', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'IDLE' });
+
+    expect(res.status).toBe(204);
+    expect(mockRenewLease).toHaveBeenCalledWith('user-1', 'IDLE');
+  });
+
+  it('rejects DND because automatic presence only owns online and idle leases', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'DND' });
+
+    expect(res.status).toBe(400);
+    expect(mockRenewLease).not.toHaveBeenCalled();
+  });
+
+  it('rejects explicit OFFLINE updates because stale leases expire server-side', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'OFFLINE' });
+
+    expect(res.status).toBe(400);
+    expect(mockRenewLease).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing bearer token', async () => {
+    const res = await request(app).post('/api/presence/status').send({ status: 'ONLINE' });
+
+    expect(res.status).toBe(401);
+    expect(mockRenewLease).not.toHaveBeenCalled();
+  });
+});

--- a/harmony-backend/tests/presence.router.test.ts
+++ b/harmony-backend/tests/presence.router.test.ts
@@ -78,4 +78,18 @@ describe('POST /api/presence/status', () => {
     expect(res.status).toBe(401);
     expect(mockRenewLease).not.toHaveBeenCalled();
   });
+
+  it('rejects invalid bearer token', async () => {
+    mockVerifyAccessToken.mockImplementation(() => {
+      throw new Error('expired');
+    });
+
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer expired-token')
+      .send({ status: 'ONLINE' });
+
+    expect(res.status).toBe(401);
+    expect(mockRenewLease).not.toHaveBeenCalled();
+  });
 });

--- a/harmony-backend/tests/presence.service.test.ts
+++ b/harmony-backend/tests/presence.service.test.ts
@@ -1,0 +1,89 @@
+import { UserStatus } from '@prisma/client';
+import { presenceService, PRESENCE_LEASE_TTL_MS } from '../src/services/presence.service';
+import { redis } from '../src/db/redis';
+import { userRepository } from '../src/repositories/user.repository';
+import { userService } from '../src/services/user.service';
+
+jest.mock('../src/db/redis', () => ({
+  redis: {
+    zadd: jest.fn(),
+    zrangebyscore: jest.fn(),
+    eval: jest.fn(),
+  },
+}));
+
+jest.mock('../src/repositories/user.repository', () => ({
+  userRepository: {
+    findSelf: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/user.service', () => ({
+  userService: {
+    updateUser: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+const mockRedis = redis as unknown as {
+  zadd: jest.Mock;
+  zrangebyscore: jest.Mock;
+  eval: jest.Mock;
+};
+const mockFindSelf = userRepository.findSelf as jest.Mock;
+const mockUpdateUser = userService.updateUser as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(Date, 'now').mockReturnValue(1_000);
+  mockFindSelf.mockResolvedValue({ id: 'user-1', status: UserStatus.OFFLINE });
+  mockUpdateUser.mockResolvedValue({});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('presenceService.renewLease', () => {
+  it('stores a shared Redis lease and updates status when it changed', async () => {
+    await presenceService.renewLease('user-1', UserStatus.ONLINE);
+
+    expect(mockRedis.zadd).toHaveBeenCalledWith(
+      'presence:leases',
+      1_000 + PRESENCE_LEASE_TTL_MS,
+      'user-1',
+    );
+    expect(mockUpdateUser).toHaveBeenCalledWith('user-1', { status: UserStatus.ONLINE });
+  });
+
+  it('does not rebroadcast when renewing the same status', async () => {
+    mockFindSelf.mockResolvedValue({ id: 'user-1', status: UserStatus.ONLINE });
+
+    await presenceService.renewLease('user-1', UserStatus.ONLINE);
+
+    expect(mockRedis.zadd).toHaveBeenCalled();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('presenceService.expireStaleLeases', () => {
+  it('marks users offline after winning conditional lease removal', async () => {
+    mockRedis.zrangebyscore.mockResolvedValue(['user-1']);
+    mockRedis.eval.mockResolvedValue(1);
+    mockFindSelf.mockResolvedValue({ id: 'user-1', status: UserStatus.ONLINE });
+
+    const expiredCount = await presenceService.expireStaleLeases(2_000);
+
+    expect(expiredCount).toBe(1);
+    expect(mockUpdateUser).toHaveBeenCalledWith('user-1', { status: UserStatus.OFFLINE });
+  });
+
+  it('does not mark offline when another replica renewed the lease first', async () => {
+    mockRedis.zrangebyscore.mockResolvedValue(['user-1']);
+    mockRedis.eval.mockResolvedValue(0);
+
+    const expiredCount = await presenceService.expireStaleLeases(2_000);
+
+    expect(expiredCount).toBe(0);
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+});

--- a/harmony-backend/tests/presence.service.test.ts
+++ b/harmony-backend/tests/presence.service.test.ts
@@ -63,6 +63,15 @@ describe('presenceService.renewLease', () => {
     expect(mockRedis.zadd).toHaveBeenCalled();
     expect(mockUpdateUser).not.toHaveBeenCalled();
   });
+
+  it('does not update status when the user no longer exists', async () => {
+    mockFindSelf.mockResolvedValue(null);
+
+    await presenceService.renewLease('deleted-user', UserStatus.ONLINE);
+
+    expect(mockRedis.zadd).toHaveBeenCalled();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
 });
 
 describe('presenceService.expireStaleLeases', () => {

--- a/harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+++ b/harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePresenceTracker } from '../hooks/usePresenceTracker';
+
+jest.mock('../lib/api-client', () => ({
+  getAccessToken: jest.fn(() => 'mock-token'),
+}));
+
+const API_URL = 'http://localhost:4000';
+const mockFetch = jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_API_URL = API_URL;
+  Object.defineProperty(global, 'fetch', { writable: true, value: mockFetch });
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe('usePresenceTracker', () => {
+  it('posts ONLINE when enabled', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer mock-token' }),
+        body: JSON.stringify({ status: 'ONLINE' }),
+      }),
+    );
+  });
+
+  it('does not post when disabled', () => {
+    renderHook(() => usePresenceTracker(false));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('posts IDLE after five minutes of inactivity', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000);
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        body: JSON.stringify({ status: 'IDLE' }),
+      }),
+    );
+  });
+
+  it('returns to ONLINE after activity while idle', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        body: JSON.stringify({ status: 'ONLINE' }),
+      }),
+    );
+  });
+
+  it('renews the current presence status on a heartbeat interval', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      jest.advanceTimersByTime(30 * 1000);
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        body: JSON.stringify({ status: 'ONLINE' }),
+      }),
+    );
+  });
+
+  it('does not mark OFFLINE on pagehide because the backend lease handles disconnects', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      window.dispatchEvent(new PageTransitionEvent('pagehide'));
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+++ b/harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
@@ -72,6 +72,24 @@ describe('usePresenceTracker', () => {
     );
   });
 
+  it('does not throttle the IDLE to ONLINE transition', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      jest.advanceTimersByTime(29 * 1000);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+      jest.advanceTimersByTime(5 * 60 * 1000);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'b' }));
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        body: JSON.stringify({ status: 'ONLINE' }),
+      }),
+    );
+  });
+
   it('renews the current presence status on a heartbeat interval', () => {
     renderHook(() => usePresenceTracker(true));
 

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -23,6 +23,7 @@ import { VoiceProvider } from '@/contexts/VoiceContext';
 import { BrowseServersModal } from '@/components/server-rail/BrowseServersModal';
 import { useServerEvents } from '@/hooks/useServerEvents';
 import { useServerListSync } from '@/hooks/useServerListSync';
+import { usePresenceTracker } from '@/hooks/usePresenceTracker';
 import { ChannelType, ChannelVisibility, UserStatus } from '@/types';
 import { useRouter } from 'next/navigation';
 import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
@@ -164,15 +165,6 @@ export function HarmonyShell({
     isAdmin: checkIsAdmin,
   } = useAuth();
 
-  // Fallback for guest/unauthenticated view
-  const currentUser: User = authUser ?? {
-    id: 'guest',
-    username: 'Guest',
-    displayName: 'Guest',
-    status: 'online',
-    role: 'guest',
-  };
-
   const router = useRouter();
   const [isCreateServerOpen, setIsCreateServerOpen] = useState(false);
   const [isBrowseServersOpen, setIsBrowseServersOpen] = useState(false);
@@ -185,15 +177,31 @@ export function HarmonyShell({
 
   const { notifyServerCreated, notifyServerJoined } = useServerListSync();
 
+  const currentMemberRecord = useMemo(
+    () => localMembers.find(m => m.id === authUser?.id),
+    [localMembers, authUser?.id],
+  );
+
+  // Fallback for guest/unauthenticated view.
+  const currentUser: User = authUser
+    ? {
+        ...authUser,
+        status: currentMemberRecord?.status ?? authUser.status,
+        role: currentMemberRecord?.role ?? authUser.role,
+      }
+    : {
+        id: 'guest',
+        username: 'Guest',
+        displayName: 'Guest',
+        status: 'online',
+        role: 'guest',
+      };
+
   // Show the pin UI only to users with MODERATOR+ server-scoped role, and never
   // while the channel is locked (pinning would be meaningless/unauthorized anyway).
   // localMembers is populated by toFrontendMember() in serverService.ts, which maps
   // the backend ServerMember.role field (server-scoped) to User.role.
   // System admins bypass membership checks — they are authorized server-side regardless.
-  const currentMemberRecord = useMemo(
-    () => localMembers.find(m => m.id === authUser?.id),
-    [localMembers, authUser?.id],
-  );
   const canPin = useMemo(
     () =>
       isAuthenticated &&
@@ -375,6 +383,8 @@ export function HarmonyShell({
     enabled: isAuthenticated,
   });
 
+  usePresenceTracker(isAuthenticated);
+
   // #c10/#c23: single global Ctrl+K / Cmd+K handler — SearchModal no longer needs its own
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -497,7 +507,7 @@ export function HarmonyShell({
               />
             )}
             <MembersSidebar
-              members={members}
+              members={localMembers}
               isOpen={isMembersOpen}
               onClose={() => setIsMembersOpen(false)}
             />

--- a/harmony-frontend/src/hooks/usePresenceTracker.ts
+++ b/harmony-frontend/src/hooks/usePresenceTracker.ts
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { getAccessToken } from '@/lib/api-client';
+import { createFrontendLogger } from '@/lib/frontend-logger';
+import { getApiBaseUrl } from '@/lib/runtime-config';
+
+type PresenceStatus = 'ONLINE' | 'IDLE';
+
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const ACTIVE_THROTTLE_MS = 30_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const ACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll', 'focus'];
+
+const logger = createFrontendLogger({ component: 'presence-tracker' });
+
+function postPresence(status: PresenceStatus): void {
+  const token = getAccessToken();
+  if (!token) return;
+
+  fetch(`${getApiBaseUrl()}/api/presence/status`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ status }),
+  }).catch(error => {
+    logger.warn('Presence update failed', {
+      feature: 'presence',
+      event: 'status_update_failed',
+      method: 'POST',
+      route: '/api/presence/status',
+      error,
+    });
+  });
+}
+
+export function usePresenceTracker(enabled: boolean): void {
+  const statusRef = useRef<PresenceStatus>('ONLINE');
+  const lastActivePostRef = useRef(0);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return;
+
+    const clearIdleTimer = () => {
+      if (idleTimerRef.current) {
+        clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+    };
+    const clearHeartbeatTimer = () => {
+      if (heartbeatTimerRef.current) {
+        clearInterval(heartbeatTimerRef.current);
+        heartbeatTimerRef.current = null;
+      }
+    };
+
+    const setPresence = (status: PresenceStatus, force = false) => {
+      const now = Date.now();
+      if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) {
+        return;
+      }
+      if (!force && statusRef.current === status) return;
+
+      statusRef.current = status;
+      if (status === 'ONLINE') lastActivePostRef.current = now;
+      postPresence(status);
+    };
+
+    const armIdleTimer = () => {
+      clearIdleTimer();
+      idleTimerRef.current = setTimeout(() => {
+        setPresence('IDLE', true);
+      }, IDLE_TIMEOUT_MS);
+    };
+
+    const markActive = () => {
+      setPresence('ONLINE');
+      armIdleTimer();
+    };
+
+    setPresence('ONLINE', true);
+    armIdleTimer();
+    heartbeatTimerRef.current = setInterval(() => {
+      postPresence(statusRef.current);
+    }, HEARTBEAT_INTERVAL_MS);
+    for (const event of ACTIVITY_EVENTS) {
+      window.addEventListener(event, markActive, { passive: true });
+    }
+
+    return () => {
+      clearIdleTimer();
+      clearHeartbeatTimer();
+      for (const event of ACTIVITY_EVENTS) {
+        window.removeEventListener(event, markActive);
+      }
+    };
+  }, [enabled]);
+}

--- a/harmony-frontend/src/hooks/usePresenceTracker.ts
+++ b/harmony-frontend/src/hooks/usePresenceTracker.ts
@@ -8,8 +8,7 @@ import { getApiBaseUrl } from '@/lib/runtime-config';
 type PresenceStatus = 'ONLINE' | 'IDLE';
 
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
-const ACTIVE_THROTTLE_MS = 30_000;
-const HEARTBEAT_INTERVAL_MS = 30_000;
+const PRESENCE_INTERVAL_MS = 30_000;
 const ACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll', 'focus'];
 
 const logger = createFrontendLogger({ component: 'presence-tracker' });
@@ -60,10 +59,10 @@ export function usePresenceTracker(enabled: boolean): void {
 
     const setPresence = (status: PresenceStatus, force = false) => {
       const now = Date.now();
-      if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) {
+      if (!force && statusRef.current === status) return;
+      if (!force && status === 'ONLINE' && now - lastActivePostRef.current < PRESENCE_INTERVAL_MS) {
         return;
       }
-      if (!force && statusRef.current === status) return;
 
       statusRef.current = status;
       if (status === 'ONLINE') lastActivePostRef.current = now;
@@ -86,7 +85,7 @@ export function usePresenceTracker(enabled: boolean): void {
     armIdleTimer();
     heartbeatTimerRef.current = setInterval(() => {
       postPresence(statusRef.current);
-    }, HEARTBEAT_INTERVAL_MS);
+    }, PRESENCE_INTERVAL_MS);
     for (const event of ACTIVITY_EVENTS) {
       window.addEventListener(event, markActive, { passive: true });
     }

--- a/llm-logs/2026-04-28-152847-session-36d96c92.md
+++ b/llm-logs/2026-04-28-152847-session-36d96c92.md
@@ -1,0 +1,482 @@
+# Session Log 2026-04-28-152847
+
+## User
+
+<command-message>review</command-message>
+<command-name>/review</command-name>
+<command-args>510</command-args>
+
+## User
+
+You are an expert code reviewer. Follow these steps:
+
+      1. If no PR number is provided in the args, run `gh pr list` to show open PRs
+      2. If a PR number is provided, run `gh pr view <number>` to get PR details
+      3. Run `gh pr diff <number>` to get the diff
+      4. Analyze the changes and provide a thorough code review that includes:
+         - Overview of what the PR does
+         - Analysis of code quality and style
+         - Specific suggestions for improvements
+         - Any potential issues or risks
+
+      Keep your review concise but thorough. Focus on:
+      - Code correctness
+      - Following project conventions
+      - Performance implications
+      - Test coverage
+      - Security considerations
+
+      Format your review with clear sections and bullet points.
+
+      PR number: 510
+
+## Assistant
+
+I'll fetch the PR details and diff for PR #510.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 510",
+  "description": "Get PR #510 details"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr diff 510",
+  "description": "Get PR #510 diff"
+}
+```
+
+## Assistant
+
+Now let me check the existing auth middleware to understand the convention being deviated from.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "find /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/middleware -name \"*.ts\" | head -10",
+  "description": "List backend middleware files"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"verifyAccessToken\\|getBearerToken\\|authMiddleware\\|requireAuth\" /Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/middleware/auth.middleware.ts 2>/dev/null | head -30",
+  "description": "Check existing auth middleware pattern"
+}
+```
+
+## Assistant
+
+**Tool call: `Read`**
+```json
+{
+  "file_path": "/Users/bigfa/Documents/GitHub/Harmony/harmony-backend/src/middleware/auth.middleware.ts"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "grep -n \"localMembers\\|members\\b\" /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/HarmonyShell.tsx | head -20",
+  "description": "Check localMembers vs members usage in HarmonyShell"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "sed -n '440,450p' /Users/bigfa/Documents/GitHub/Harmony/harmony-frontend/src/components/layout/HarmonyShell.tsx",
+  "description": "Check what uses members={members} at line 444"
+}
+```
+
+## Assistant
+
+Good, that's a different component (a menu). Now I have enough context for a thorough review.
+
+---
+
+## Code Review: PR #510 — Lease-Based Presence Tracking
+
+### Overview
+
+This PR implements a Redis sorted-set lease model for online/idle/offline presence. The frontend polls with heartbeats every 30s; the backend sweeper expires stale leases every 15s after a 75s TTL. The overall design is sound — it avoids false offline signals from tab-switching and handles multi-replica deployment via a Lua atomic-remove race. The `MembersSidebar` is also wired to `localMembers` (SSE-updated) rather than the stale prop.
+
+---
+
+### Issues
+
+#### 1. Duplicates `requireAuth` middleware (significant)
+
+`presence.router.ts` re-implements `getBearerToken` + `verifyToken` inline, but an identical `requireAuth` middleware already exists in `auth.middleware.ts`. This is dead duplication.
+
+```ts
+// presence.router.ts — these two helpers duplicate requireAuth exactly
+function getBearerToken(req: Request): string | null { ... }
+function verifyToken(token: string): string | null { ... }
+```
+
+The router should instead apply `requireAuth` and read `(req as AuthenticatedRequest).userId`:
+
+```ts
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth.middleware';
+
+presenceRouter.post('/status', requireAuth, async (req, res, next) => {
+  const userId = (req as AuthenticatedRequest).userId;
+  // ...
+});
+```
+
+This eliminates ~20 lines and stays consistent with every other authenticated route.
+
+#### 2. `setPresence` throttle can suppress IDLE→ONLINE transition (bug)
+
+In `usePresenceTracker.ts`, the ONLINE throttle check fires before the status-change check:
+
+```ts
+if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) return; // ← runs first
+if (!force && statusRef.current === status) return;
+```
+
+Scenario: user becomes active at t=0 (ONLINE posted, `lastActivePost=0`), the idle timer fires at t=5min (IDLE posted, `lastActivePost` unchanged). User moves mouse at t=5min+5s. The first guard fires: `status='ONLINE'`, `now - lastActivePost = 5m+5s > 30s` → passes, so no bug here *in this case*. But consider: user is active (t=0, ONLINE posted), goes idle immediately (e.g., rapid timer manipulation in tests or a very short custom timeout), then moves mouse at t=10s. `now - lastActivePost = 10s < 30s` → returns early. `statusRef` stays `IDLE`, no ONLINE posted. Status remains stale for up to 30s.
+
+The guard order should be inverted — a status *transition* (IDLE→ONLINE) should always fire regardless of throttle:
+
+```ts
+if (!force && statusRef.current === status) return;  // same-status dedup first
+if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) return;
+```
+
+#### 3. `updateUserStatusIfChanged` updates even when user not found
+
+```ts
+async function updateUserStatusIfChanged(userId: string, status: UserStatus): Promise<void> {
+  const user = await userRepository.findSelf(userId);
+  if (!user || user.status !== status) {   // ← if !user, still calls updateUser
+    await userService.updateUser(userId, { status });
+  }
+}
+```
+
+If `findSelf` returns `null` (deleted/deactivated user), it still calls `updateUser` with a non-existent ID. The condition should be:
+
+```ts
+if (!user) return;
+if (user.status !== status) {
+  await userService.updateUser(userId, { status });
+}
+```
+
+#### 4. Sweeper started in `createApp` — affects module-level singleton
+
+`presenceService.startSweeper()` is called at the top of `createApp()`. Since `sweeper` is module-level state, if the app module is re-imported across test suites the sweeper may leak across test boundaries. The guard `process.env.NODE_ENV === 'test'` prevents this, but it's worth noting `NODE_ENV=e2e` does *not* suppress the sweeper. This may be intentional (sweeper should run in e2e), but it should be documented.
+
+---
+
+### Minor / Style
+
+- **`updatePresence` helper in router**: The `async function updatePresence(userId, status, res)` wrapper that calls `renewLease` then `res.status(204).send()` adds indirection for trivial logic. It can be inlined.
+
+- **Missing router test for invalid token**: `presence.router.test.ts` tests a missing Authorization header but not the case where the header is present but the token is invalid (verifyAccessToken throws). The `401` path in `verifyToken` goes untested.
+
+- **`ACTIVE_THROTTLE_MS === HEARTBEAT_INTERVAL_MS`**: Both are `30_000`. Consider extracting a single named constant (`PRESENCE_INTERVAL_MS`) to make the intentional coupling explicit.
+
+---
+
+### Positives
+
+- Lua atomic-remove correctly handles the multi-replica race in `expireStaleLeases`.
+- `sweeper.unref?.()` prevents the interval from blocking process exit — good defensive call.
+- `MembersSidebar` correctly moved to `localMembers` (SSE live state) so status badges update without reload.
+- `currentUser` now derives `status`/`role` from `currentMemberRecord` — fixes the stale auth snapshot.
+- Test coverage is solid for the happy paths and the key edge cases (race condition, DND rejection, heartbeat).
+
+---
+
+### Summary
+
+The architecture is correct. Three issues warrant attention before merge: (1) duplicate auth logic should use `requireAuth`, (2) the throttle/transition order bug in `setPresence`, and (3) the null-user guard in `updateUserStatusIfChanged`. The rest are minor.
+
+## User
+
+post it
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr review 510 --comment --body \"$(cat <<'EOF'\n## Code Review: PR #510 \u2014 Lease-Based Presence Tracking\n\n### Overview\n\nThe overall design is sound \u2014 a Redis sorted-set lease model is a good fit here. It avoids false offline signals from tab-switching, handles multi-replica deployment via a Lua atomic-remove race, and the `MembersSidebar` is correctly wired to `localMembers` (SSE-updated) rather than the stale prop. Three issues warrant attention before merge.\n\n---\n\n### Issues\n\n#### 1. Duplicates `requireAuth` middleware (significant)\n\n`presence.router.ts` re-implements `getBearerToken` + `verifyToken` inline, but an identical `requireAuth` middleware already exists in `auth.middleware.ts`. This duplicates ~20 lines and diverges from every other authenticated route.\n\nThe router should use `requireAuth` directly:\n\n```ts\nimport { requireAuth, AuthenticatedRequest } from '../middleware/auth.middleware';\n\npresenceRouter.post('/status', requireAuth, async (req, res, next) => {\n  const userId = (req as AuthenticatedRequest).userId;\n  // ...\n});\n```\n\n#### 2. `setPresence` throttle can suppress IDLE\u2192ONLINE transition (bug)\n\nIn `usePresenceTracker.ts`, the ONLINE throttle check fires before the status-change check:\n\n```ts\nif (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) return; // \u2190 runs first\nif (!force && statusRef.current === status) return;\n```\n\nScenario: user is active (ONLINE posted at t=0), goes idle at t=4m59s (via the idle timer), immediately moves mouse at t=5m+5s. `now - lastActivePost = 5m+5s > 30s` \u2014 fine. But if the gap is shorter (e.g., ONLINE posted at t=28s ago, then IDLE fires at t=29s, user moves mouse at t=30s), the throttle fires first and swallows the IDLE\u2192ONLINE transition. `statusRef` stays `IDLE` for up to another 30s.\n\nFix: dedup same-status first, *then* throttle:\n\n```ts\nif (!force && statusRef.current === status) return;\nif (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) return;\n```\n\n#### 3. `updateUserStatusIfChanged` updates even when user is not found\n\n```ts\nconst user = await userRepository.findSelf(userId);\nif (!user || user.status !== status) {   // \u2190 calls updateUser even when user is null\n  await userService.updateUser(userId, { status });\n}\n```\n\nIf `findSelf` returns `null` (deleted/deactivated user), `updateUser` is still called with a non-existent ID. Should be:\n\n```ts\nif (!user) return;\nif (user.status !== status) {\n  await userService.updateUser(userId, { status });\n}\n```\n\n---\n\n### Minor\n\n- **`updatePresence` helper in router**: The wrapper that calls `renewLease` then `res.status(204).send()` adds indirection for trivial logic \u2014 can be inlined.\n- **Missing router test for invalid token**: Tests cover a missing Authorization header but not a present-but-invalid token (where `verifyAccessToken` throws). The 401 branch in `verifyToken` is untested.\n- **`ACTIVE_THROTTLE_MS === HEARTBEAT_INTERVAL_MS`**: Both are `30_000`. A single named constant (e.g. `PRESENCE_INTERVAL_MS`) would make the intentional coupling explicit.\n\n---\n\n### Positives\n\n- Lua atomic-remove correctly handles the multi-replica race in `expireStaleLeases`.\n- `sweeper.unref?.()` prevents the interval from blocking process exit.\n- `currentUser` now derives `status`/`role` from `currentMemberRecord` \u2014 fixes the stale auth snapshot in the shell.\n- Test coverage is solid for happy paths and key edge cases (race condition, DND rejection, pagehide no-op, heartbeat).\nEOF\n)\"\n",
+  "description": "Post review comment on PR #510"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 510 --comments | tail -20",
+  "description": "Verify the comment was posted"
+}
+```
+
+## Assistant
+
+Review posted on PR #510. Three items to address before merge: use `requireAuth` middleware instead of duplicating it, fix the throttle/transition ordering bug in `setPresence`, and guard against null users in `updateUserStatusIfChanged`.
+
+## User
+
+<local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.</local-command-caveat>
+
+## User
+
+<bash-input>git fetch</bash-input>
+
+## User
+
+<bash-stdout>From https://github.com/CS485-Harmony/Harmony
+   b6fec37..5a2c1b2  codex/issue-490-presence -> origin/codex/issue-490-presence
+ * [new branch]      codex/issue-484-sanitize-channel-title -> origin/codex/issue-484-sanitize-channel-title</bash-stdout><bash-stderr></bash-stderr>
+
+## User
+
+<local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.</local-command-caveat>
+
+## User
+
+<bash-input>git pull</bash-input>
+
+## User
+
+<bash-stdout>Updating b6fec37..5a2c1b2
+Fast-forward
+ harmony-backend/src/routes/presence.router.ts      | 68 ++++++----------------
+ harmony-backend/src/services/presence.service.ts   |  4 +-
+ harmony-backend/tests/presence.router.test.ts      | 14 +++++
+ harmony-backend/tests/presence.service.test.ts     |  9 +++
+ .../src/__tests__/usePresenceTracker.test.tsx      | 18 ++++++
+ harmony-frontend/src/hooks/usePresenceTracker.ts   |  9 ++-
+ 6 files changed, 67 insertions(+), 55 deletions(-)</bash-stdout><bash-stderr></bash-stderr>
+
+## User
+
+verify the review was address completely and then approve or reject
+
+## Assistant
+
+Let me pull the updated diff and check each issue.
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr diff 510",
+  "description": "Get updated PR #510 diff"
+}
+```
+
+## Assistant
+
+All review items have been addressed. Verifying each:
+
+| Issue | Status |
+|---|---|
+| Duplicate auth logic | Fixed — router now uses `requireAuth` + `AuthenticatedRequest` directly |
+| `setPresence` throttle/transition order bug | Fixed — same-status dedup runs first, throttle second |
+| `updateUserStatusIfChanged` null-user guard | Fixed — early return when `!user` |
+| `updatePresence` wrapper indirection | Fixed — inlined into the route handler |
+| Missing invalid-token router test | Fixed — `rejects invalid bearer token` test added |
+| `ACTIVE_THROTTLE_MS === HEARTBEAT_INTERVAL_MS` duplication | Fixed — merged into `PRESENCE_INTERVAL_MS` |
+| Missing service test for null user | Fixed — `does not update status when the user no longer exists` added |
+| Missing frontend throttle-transition test | Fixed — `does not throttle the IDLE to ONLINE transition` test added |
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr review 510 --approve --body \"All review items addressed. The router now uses `requireAuth` correctly, the `setPresence` guard order is fixed (status-change dedup before throttle), the null-user guard is in place, and test coverage fills the gaps called out. Good to merge.\"",
+  "description": "Approve PR #510"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr review 510 --approve --body 'All review items addressed. The router now uses requireAuth correctly, the setPresence guard order is fixed (status-change dedup before throttle), the null-user guard is in place, and test coverage fills the gaps called out. Good to merge.'",
+  "description": "Approve PR #510"
+}
+```
+
+## Assistant
+
+**Tool call: `Bash`**
+```json
+{
+  "command": "gh pr view 510 --json reviewDecision,reviews --jq '{decision: .reviewDecision, reviews: [.reviews[] | {author: .author.login, state: .state}]}'",
+  "description": "Verify approval was recorded"
+}
+```
+
+## Assistant
+
+PR #510 is approved. Every issue from the review was resolved — the three bugs fixed, the minor style items cleaned up, and new tests added for all the uncovered paths.
+
+## User
+
+<command-message>export-logs</command-message>
+<command-name>/export-logs</command-name>
+
+## User
+
+Base directory for this skill: /Users/bigfa/Documents/GitHub/Harmony/.claude/skills/export-logs
+
+Export the current session's conversation log to `llm-logs/` with a timestamp filename, then commit and push it.
+
+## Steps
+
+### Step 1: Write the export script to a temp file
+
+Write the following content exactly to `/tmp/harmony_export_logs.py`:
+
+```python
+import os, glob, json, subprocess
+from datetime import datetime
+
+cwd = os.getcwd()
+project_key = cwd.replace('/', '-').replace('.', '-')
+project_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')
+
+if not os.path.isdir(project_dir):
+    print(f'ERROR: project dir not found: {project_dir}')
+    exit(1)
+
+files = glob.glob(os.path.join(project_dir, '*.jsonl'))
+if not files:
+    print('ERROR: no session JSONL files found')
+    exit(1)
+
+latest = max(files, key=os.path.getmtime)
+session_id = os.path.splitext(os.path.basename(latest))[0]
+short_id = session_id[:8]
+
+now = datetime.now()
+date_str = now.strftime('%Y-%m-%d')
+time_str = now.strftime('%H%M%S')
+outfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'
+
+os.makedirs('llm-logs', exist_ok=True)
+
+lines = []
+with open(latest) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+md = [f'# Session Log {date_str}-{time_str}\n']
+
+for entry in lines:
+    t = entry.get('type')
+    if t == 'user':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            content = '\n'.join(texts)
+        if content.strip():
+            md.append(f'## User\n\n{content.strip()}\n')
+    elif t == 'assistant':
+        msg = entry.get('message', {})
+        content = msg.get('content', '')
+        if isinstance(content, list):
+            parts = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get('type') == 'text':
+                    parts.append(b.get('text', ''))
+                elif b.get('type') == 'tool_use':
+                    name = b.get('name', 'tool')
+                    inp = b.get('input', {})
+                    inp_str = json.dumps(inp, indent=2) if inp else ''
+                    parts.append(f'**Tool call: `{name}`**\n```json\n{inp_str}\n```')
+                elif b.get('type') == 'tool_result':
+                    result_content = b.get('content', '')
+                    if isinstance(result_content, list):
+                        result_content = '\n'.join(
+                            r.get('text', '') for r in result_content if isinstance(r, dict)
+                        )
+                    parts.append(f'**Tool result:**\n```\n{str(result_content)[:2000]}\n```')
+            content = '\n\n'.join(p for p in parts if p.strip())
+        if content.strip():
+            md.append(f'## Assistant\n\n{content.strip()}\n')
+
+with open(outfile, 'w') as f:
+    f.write('\n'.join(md) + '\n')
+
+print(f'OUTFILE={outfile}')
+```
+
+### Step 2: Run the script
+
+```bash
+python3 /tmp/harmony_export_logs.py
+```
+
+Capture `OUTFILE` from the output (the line starting with `OUTFILE=`). If the script exits with an error, report it and stop.
+
+### Step 3: Commit and push
+
+Stage only the new log file, commit with the canonical message, and push:
+
+```bash
+git add "$OUTFILE"
+git commit -m "chore: add llm logs"
+git push
+```
+
+If `git push` fails because the remote branch does not exist yet, re-run with `-u origin HEAD`.
+
+### Step 4: Report
+
+Tell the user:
+- The log file path that was written
+- The commit hash
+- Whether the push succeeded
+
+## Assistant
+
+**Tool call: `Write`**
+```json
+{
+  "file_path": "/tmp/harmony_export_logs.py",
+  "content": "import os, glob, json, subprocess\nfrom datetime import datetime\n\ncwd = os.getcwd()\nproject_key = cwd.replace('/', '-').replace('.', '-')\nproject_dir = os.path.expanduser(f'~/.claude/projects/{project_key}')\n\nif not os.path.isdir(project_dir):\n    print(f'ERROR: project dir not found: {project_dir}')\n    exit(1)\n\nfiles = glob.glob(os.path.join(project_dir, '*.jsonl'))\nif not files:\n    print('ERROR: no session JSONL files found')\n    exit(1)\n\nlatest = max(files, key=os.path.getmtime)\nsession_id = os.path.splitext(os.path.basename(latest))[0]\nshort_id = session_id[:8]\n\nnow = datetime.now()\ndate_str = now.strftime('%Y-%m-%d')\ntime_str = now.strftime('%H%M%S')\noutfile = f'llm-logs/{date_str}-{time_str}-session-{short_id}.md'\n\nos.makedirs('llm-logs', exist_ok=True)\n\nlines = []\nwith open(latest) as f:\n    for line in f:\n        line = line.strip()\n        if not line:\n            continue\n        try:\n            lines.append(json.loads(line))\n        except json.JSONDecodeError:\n            continue\n\nmd = [f'# Session Log {date_str}-{time_str}\\n']\n\nfor entry in lines:\n    t = entry.get('type')\n    if t == 'user':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']\n            content = '\\n'.join(texts)\n        if content.strip():\n            md.append(f'## User\\n\\n{content.strip()}\\n')\n    elif t == 'assistant':\n        msg = entry.get('message', {})\n        content = msg.get('content', '')\n        if isinstance(content, list):\n            parts = []\n            for b in content:\n                if not isinstance(b, dict):\n                    continue\n                if b.get('type') == 'text':\n                    parts.append(b.get('text', ''))\n                elif b.get('type') == 'tool_use':\n                    name = b.get('name', 'tool')\n                    inp = b.get('input', {})\n                    inp_str = json.dumps(inp, indent=2) if inp else ''\n                    parts.append(f'**Tool call: `{name}`**\\n```json\\n{inp_str}\\n```')\n                elif b.get('type') == 'tool_result':\n                    result_content = b.get('content', '')\n                    if isinstance(result_content, list):\n                        result_content = '\\n'.join(\n                            r.get('text', '') for r in result_content if isinstance(r, dict)\n                        )\n                    parts.append(f'**Tool result:**\\n```\\n{str(result_content)[:2000]}\\n```')\n            content = '\\n\\n'.join(p for p in parts if p.strip())\n        if content.strip():\n            md.append(f'## Assistant\\n\\n{content.strip()}\\n')\n\nwith open(outfile, 'w') as f:\n    f.write('\\n'.join(md) + '\\n')\n\nprint(f'OUTFILE={outfile}')\n"
+}
+```
+

--- a/llm-logs/acabrera04-logs/final/2026-04-28-pr-510-presence-019dd560.md
+++ b/llm-logs/acabrera04-logs/final/2026-04-28-pr-510-presence-019dd560.md
@@ -1,0 +1,13052 @@
+# Codex Conversation Export
+
+## Metadata
+
+- Thread ID: 019dd560-58ad-7053-a6cf-bf4a7384f242
+- Timestamp: 2026-04-28T18:35:54.417Z
+- CWD: /Users/allen/.codex/worktrees/7aee/Harmony
+- Source: vscode
+- Model Provider: openai
+- Model: gpt-5.5
+- Reasoning Effort: low
+- Rollout Path: /Users/allen/.codex/sessions/2026/04/28/rollout-2026-04-28T14-35-54-019dd560-58ad-7053-a6cf-bf4a7384f242.jsonl
+
+## Transcript
+
+### Turn 1: https://github.com/CS485-Harmony/Harmony/issues/490 Implement this
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T18:35:58.327Z
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/490 Implement this feature
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:36:06.258Z
+
+I’ll pull the repo workflow and the issue context first, then I’ll implement against the existing patterns and verify with the project’s commands.
+
+#### Tool: exec_command
+
+```sh
+rtk read WORKFLOW.md
+```
+
+Output:
+
+````text
+## Workflow Orchestration
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean 
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop 
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests - then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+This project uses a **hybrid approach**: `tasks/todo.md` for AI context, GitHub Issues as the canonical tracker on the Harmony Project Board (course requirement).
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items (local scratch pad for AI context)
+2. **Identify the Issue**: If the task maps to an existing GitHub Issue, note the issue number at the top of `tasks/todo.md`
+3. **Announce Start**: Post an opening comment to the issue — `gh issue comment <number> --body "..."` — describing what will be done
+4. **Track Progress**: Mark items complete in `tasks/todo.md` as you go; post a comment to the issue at meaningful milestones (e.g., after a major step or when blocked)
+5. **Explain Changes**: High-level summary at each step
+6. **Document Results**: Add a review section to `tasks/todo.md` and post a final summary comment to the issue when complete
+7. **Capture Lessons**: Update `tasks/lessons.md` after corrections. Post the new lessons learned as a comment to the issue.
+
+### Issue Comment Format
+Use this structure for issue comments to keep the audit trail readable:
+
+```
+**[AI Agent — <Step>]**
+
+<What was done or decided>
+
+<Any blockers, decisions, or next steps>
+```
+
+Example steps: `Starting`, `In Progress`, `Blocked`, `Complete`
+
+## Core Principles
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
+- **Lean Context Files**: Keep AGENTS.md and similar files to only non-obvious, non-discoverable essentials. Research shows context file bloat decreases task success rates and increases inference cost by 20%+ with 2–4 extra steps per task (Gloaguen et al., 2026).
+
+#### Taken from https://x.com/mdancho84/status/2023738764841894352
+
+Gloaguen, T., Mündler, N., Müller, M., Raychev, V., & Vechev, M. (2026, February 12). Evaluating AGENTS.MD: Are Repository-Level context Files helpful for coding agents? arXiv.org. https://arxiv.org/abs/2602.11988
+````
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ok ✓
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "490|issue #490|Issue 490" .
+```
+
+Output:
+
+```text
+Total output lines: 281
+
+./llm-logs/2026-04-16-134033-session-15e32eb5.md:780:  "command": "npx agent-reviews --reply 3090774878 \"Fixed in 991999b. Added explicit Server[] type annotation and narrowed the catch to TrpcHttpError status 401 only \u2014 non-auth errors rethrow instead of silently redirecting to login.\" --resolve 2>&1 && \\\nnpx agent-reviews --reply 3090774890 \"Fixed in 991999b. Added explicit Server[] and Channel[] type annotations and narrowed both catches to TrpcHttpError status 401, so network/5xx errors are not masked as auth failures.\" --resolve 2>&1 && \\\nnpx agent-reviews --reply 3090774900 \"Fixed in 991999b. Added a sidebarChannels filter before passing to EmptyShell: when showNoAccessMessage is true, PRIVATE text/announcement channels are excluded from the sidebar while voice channels are preserved, so members only see channels they can interact with.\" --resolve 2>&1",
+./llm-logs/2026-04-16-133946-session-15e32eb5.md:780:  "command": "npx agent-reviews --reply 3090774878 \"Fixed in 991999b. Added explicit Server[] type annotation and narrowed the catch to TrpcHttpError status 401 only \u2014 non-auth errors rethrow instead of silently redirecting to login.\" --resolve 2>&1 && \\\nnpx agent-reviews --reply 3090774890 \"Fixed in 991999b. Added explicit Server[] and Channel[] type annotations and narrowed both catches to TrpcHttpError status 401, so network/5xx errors are not masked as auth failures.\" --resolve 2>&1 && \\\nnpx agent-reviews --reply 3090774900 \"Fixed in 991999b. Added a sidebarChannels filter before passing to EmptyShell: when showNoAccessMessage is true, PRIVATE text/announcement channels are excluded from the sidebar while voice channels are preserved, so members only see channels they can interact with.\" --resolve 2>&1",
+./llm-logs/acabrera04-logs/acabrera04-tests/2026-04-03-review-this-pr-and-post-the-review-on-it-https-github-com-ac-019d53fe.md:1585:   490	        timestamp: '2025-06-01T12:00:00.000Z',
+./llm-logs/acabrera04-logs/acabrera04-tests/2026-04-03-review-this-pr-and-post-the-review-on-it-https-github-com-ac-019d53fe.md:3748:019d45fc-54a2-7841-bb04-16f7c04904d4	2026-03-31T22:20:57.000Z	Generate E2E tests	/Users/allen/.codex/worktrees/373a/Harmony	/Users/allen/.codex/sessions/2026/03/31/rollout-2026-03-31T18-20-57-019d45fc-54a2-7841-bb04-16f7c04904d4.jsonl
+./llm-logs/acabrera04-logs/acabrera04-tests/2026-04-03-review-this-pr-and-post-the-review-on-it-https-github-com-ac-019d53fe.md:3750:019d4574-0b75-71a1-8158-649028606463	2026-03-31T19:52:06.000Z	Why are my tests failing when I'm running it on my local machine?	/Users/allen/repos/Harmony/harmony-backend	/Users/allen/.codex/sessions/2026/03/31/rollout-2026-03-31T15-52-06-019d4574-0b75-71a1-8158-649028606463.jsonl
+./llm-logs/frontend/03-01-issue-39.md:2075:            <path d='M5.88657 21C5.57547 21 5.3399 20.7189 5.39427 20.4126L6.00001 17H2.59511C2.28449 17 2.04905 16.7198 2.10259 16.4138L2.27759 15.4138C2.31946 15.1746 2.52722 15 2.77011 15H6.35001L7.41001 9H4.00511C3.69449 9 3.45905 8.71977 3.51259 8.41381L3.68759 7.41381C3.72946 7.17456 3.93722 7 4.18011 7H7.76001L8.39677 3.41262C8.43914 3.17391 8.64664 3 8.88907 3H9.87344C10.1845 3 10.4201 3.28107 10.3657 3.58738L9.76001 7H15.76L16.3968 3.41262C16.4391 3.17391 16.6466 3 16.8891 3H17.8734C18.1845 3 18.4201 3.28107 18.3657 3.58738L17.76 7H21.1649C21.4755 7 21.711 7.28023 21.6574 7.58619L21.4824 8.58619C21.4406 8.82544 21.2328 9 20.9899 9H17.41L16.35 15H19.7549C20.0655 15 20.301 15.2802 20.2474 15.5862L20.0724 16.5862C20.0306 16.8254 19.8228 17 19.5799 17H16L15.3632 20.5874C15.3209 20.8261 15.1134 21 14.871 21H13.8866C13.5755 21 13.3399 20.7189 13.3943 20.4126L14 17H8.00001L7.36325 20.5874C7.32088 20.8261 7.11337 21 6.87094 21H5.88657ZM9.41001 9L8.35001 15H14.35L15.41 9H9.41001Z' />
+./llm-logs/frontend/03-01-issue-39.md:4038:124.             <path d='M5.88657 21C5.57547 21 5.3399 20.7189 5.39427 20.4126L6.00001 17H2.59511C2.28449 17 2.04905 16.7198 2.10259 16.4138L2.27759 15.4138C2.31946 15.…260144 tokens truncated… app used by\n // backend-api. The worker has no user-facing HTTP surface and should never\n@@ -49,22 +49,29 @@ const healthServer = http.createServer((req, res) => {\n });\n \n healthServer.on('error', (err: NodeJS.ErrnoException) => {\n-  console.error(\n-    `[worker] health server error instance=${instanceId} host=${HOST} port=${PORT} code=${err.code ?? 'unknown'} errno=${err.errno ?? 'unknown'} syscall=${err.syscall ?? 'unknown'}`,\n-    err,\n+  logger.error(\n+    {\n+      err,\n+      host: HOST,\n+      port: PORT,\n+      code: err.code ?? 'unknown',\n+      errno: err.errno ?? 'unknown',\n+      syscall: err.syscall ?? 'unknown',\n+    },\n+    'Worker health server error',\n   );\n   process.exit(1);\n });\n \n healthServer.listen(PORT, HOST, () => {\n-  console.log(`[worker] health endpoint listening on http://${HOST}:${PORT}/health`);\n+  logger.info({ host: HOST, port: PORT }, 'Worker health endpoint listening');\n });\n \n cacheInvalidator\n   .start()\n-  .then(() => console.log('[worker] cacheInvalidator subscriptions ready'))\n+  .then(() => logger.info('Cache invalidator subscriptions ready'))\n   .catch((err) => {\n-    console.error('[worker] cacheInvalidator start failed:', err);\n+    logger.error({ err }, 'Cache invalidator startup failed');\n     // Fail fast so Railway restarts us into a clean state rather than running\n     // a half-initialized worker that silently drops events.\n     process.exit(1);\n@@ -74,7 +81,7 @@ let shuttingDown = false;\n const shutdown = async (signal: string) => {\n   if (shuttingDown) return;\n   shuttingDown = true;\n-  console.log(`[worker] ${signal} received, shutting down instance=${instanceId}`);\n+  logger.info({ signal }, 'Shutdown signal received');\n   const timer = setTimeout(() => process.exit(1), 10_000);\n   let exitCode = 0;\n ","numLines":600,"startLine":1300,"totalLines":2051}},"sourceToolAssistantUUID":"3bf46e93-0474-4dab-898a-307e6f039829","userType":"external","entrypoint":"claude-desktop","cwd":"/Users/bigfa/Documents/GitHub/Harmony/.claude/worktrees/hardcore-mcnulty","sessionId":"d8774727-9f33-48ba-a00c-ce636ceebce2","version":"2.1.101","gitBranch":"claude/hardcore-mcnulty","slug":"velvety-marinating-truffle"}
+./llm-logs/backend/04-14-pr344-review.jsonl:64:{"parentUuid":"91e7f90e-7a61-4eed-a057-7b312de775b3","isSidechain":false,"message":{"model":"claude-sonnet-4-6","id":"msg_019acpsoquwdFj1Lz2yms3SQ","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_015RZLB7EMsc1hDm9FfMxSp1","name":"Bash","input":{"command":"gh pr view 344 --json commits | python3 -c \"import sys,json; data=json.load(sys.stdin); [print(c['oid'][:8], c['messageHeadline']) for c in data['commits']]\"","description":"List commits on PR 344"},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":1,"cache_creation_input_tokens":180,"cache_read_input_tokens":69437,"output_tokens":131,"server_tool_use":{"web_search_requests":0,"web_fetch_requests":0},"service_tier":"standard","cache_creation":{"ephemeral_1h_input_tokens":180,"ephemeral_5m_input_tokens":0},"inference_geo":"","iterations":[{"input_tokens":1,"output_tokens":131,"cache_read_input_tokens":69437,"cache_creation_input_tokens":180,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":180},"type":"message"}],"speed":"standard"}},"requestId":"req_011Ca4eLQ5h2teKh7APnuKMi","type":"assistant","uuid":"040dfef9-8abd-4fe2-a4f8-8db0c2a5390f","timestamp":"2026-04-15T00:54:32.490Z","advisorModel":"claude-opus-4-6","userType":"external","entrypoint":"claude-desktop","cwd":"/Users/bigfa/Documents/GitHub/Harmony/.claude/worktrees/hardcore-mcnulty","sessionId":"d8774727-9f33-48ba-a00c-ce636ceebce2","version":"2.1.101","gitBranch":"claude/hardcore-mcnulty","slug":"velvety-marinating-truffle"}
+./llm-logs/backend/03-05-pr131.md:420:     2745134654/job/65967214490
+./llm-logs/backend/03-05-pr131.md:427:     2745134654/job/65967214490
+```
+
+#### Tool: exec_command
+
+```sh
+rg -n "Harmony PR review|issue #490|490" /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+399:- rollout_summaries/2026-03-31T19-52-06-QkbV-local_test_failures_prisma_db_redis.md (cwd=/Users/allen/repos/Harmony/harmony-backend, rollout_path=/Users/allen/.codex/sessions/2026/03/31/rollout-2026-03-31T15-52-06-019d4574-0b75-71a1-8158-649028606463.jsonl, updated_at=2026-03-31T19:55:23+00:00, thread_id=019d4574-0b75-71a1-8158-649028606463, local infra diagnosis rather than code fix)
+478:# Task Group: Harmony PR review and review-resolution workflow
+480:applies_to: cwd=/Users/allen/.codex/worktrees/*/Harmony; reuse_rule=safe for Harmony PR review tasks that follow the repo's `WORKFLOW.md` and `.github/PR_REVIEW.md`; verify current remote/worktree before assuming repo names or branch refs.
+513:- Harmony PR review, .github/PR_REVIEW.md, WORKFLOW.md, bundled review, single bundled review, checklist of 8 guidelines, gh pr view, gh pr diff, gh pr review, gh api, file_comments expected objects not strings, acabrera04/Harmony, EmptyShell, VoiceProvider, system admin bypass, useChannelEvents, useServerEvents, SSE reconnect
+585:- In Harmony PR reviews, load `WORKFLOW.md` and `.github/PR_REVIEW.md` first. The durable pattern is checklist first, then one bundled review with line-specific findings or a clear approval if the updated head is good [Task 1][Task 2][Task 3][Task 4][Task 6]
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:36:14.318Z
+
+The worktree is clean. I’ve loaded the repo workflow; next I’m fetching issue #490 and mapping it to the relevant frontend/backend area before editing.
+
+#### Tool: exec_command
+
+```sh
+rtk gh issue view 490 --repo CS485-Harmony/Harmony --comments
+```
+
+Output:
+
+```text
+error connecting to api.github.com
+check your internet connection or https://githubstatus.com
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls
+```
+
+Output:
+
+```text
+.claude/
+.github/
+docs/
+harmony-backend/
+harmony-frontend/
+llm-logs/
+mockups/
+planning/
+scripts/
+tasks/
+tests/
+.gitignore  66B
+AGENTS.md  1.9K
+CLAUDE.md  11B
+README.md  13.7K
+WORKFLOW.md  3.7K
+dev-spec-guidelines.pdf  507.5K
+dev.sh  2.1K
+package.json  422B
+
+📊 8 files, 11 dirs (4 .md, 1 .gitignore, 1 .pdf, 1 .sh, 1 .json)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read tasks/todo.md
+```
+
+Output:
+
+```text
+Error: Failed to read file: tasks/todo.md
+
+Caused by:
+    No such file or directory (os error 2)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read tasks/lessons.md
+```
+
+Output:
+
+```text
+# Lessons Learned
+
+Shared knowledge base for the Harmony team. Add an entry whenever a mistake is caught, a better approach is discovered, or an AI agent is corrected.
+
+---
+
+## Template
+
+**Date:** YYYY-MM-DD  
+**Caught by:** [Human: @username] or [AI Agent: Copilot/Cursor]  
+**Related Issue:** #<number> (optional)  
+**Mistake / Situation:** One sentence describing what went wrong or what was unclear.  
+**Rule / Fix:** The actionable rule derived — written so it prevents the same mistake next time.
+
+---
+
+## Log
+
+<!-- Most recent entries at the top -->
+
+**Date:** 2026-04-23  
+**Caught by:** [Human: user]  
+**Related Issue:** #354  
+**Mistake / Situation:** I changed the GitHub issue and PR scope to defer acceptance criteria instead of implementing the missing worker-consumer path that the issue explicitly required.  
+**Rule / Fix:** When a Harmony issue's acceptance criteria are still technically feasible on the active PR branch, do not narrow scope or create a follow-up issue without explicit user approval; implement the missing work on the branch first and treat scope changes as an escalation path, not a default solution.
+
+**Date:** 2026-04-11  
+**Caught by:** [Human: user]  
+**Related Issue:** #313  
+**Mistake / Situation:** I changed the password verifier flow but left backend-only PBKDF2 helpers and E2E bootstrap code deriving with the literal hex salt string instead of decoded salt bytes, so browser auth and E2E diverged from local service tests.  
+**Rule / Fix:** When introducing a client/server crypto contract, centralize or explicitly mirror the byte-level encoding rules across backend helpers, tests, seed data, and E2E bootstraps; verify at least one browser-facing path, not just service-level tests.
+
+**Date:** 2026-04-11  
+**Caught by:** [Human: user]  
+**Related Issue:** #313  
+**Mistake / Situation:** I updated auth-related tests for the new verifier contract but missed another backend suite that still called `authService.register` with the old 3-argument signature, which broke CI.  
+**Rule / Fix:** After changing any shared service contract, grep the full repo for old call sites and run at least the affected package typecheck before pushing so stale compile-time usages do not escape to CI.
+
+**Date:** 2026-04-11  
+**Caught by:** [Human: user]  
+**Related Issue:** #313  
+**Mistake / Situation:** I began patching the auth implementation in the same pass as test creation instead of first proving the security regression with a failing test run.  
+**Rule / Fix:** For every non-trivial Harmony code change, especially security work, do strict red-green-refactor: write or update the regression tests first, run them to capture the red state, and only then modify implementation.
+
+**Date:** 2026-04-04  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I assumed serial CI workers and relaxed auth throttles were enough, but the WebKit-only auth flake was still tied to running the Next frontend in dev mode inside GitHub Actions.  
+**Rule / Fix:** For browser E2E in CI, prefer production-style frontend serving (`build + start`) over `next dev`; dev-mode tooling can introduce non-product flakiness that hides the real signal of the suite.
+
+**Date:** 2026-04-04  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I kept a browser matrix in the PR-gating CI path even after reproducing that only WebKit was flaky under CI-mode E2E, which blocked the suite without proving a product defect.  
+**Rule / Fix:** Keep every-PR E2E checks focused on the stable smoke browser for this repo, and move additional browser coverage like WebKit to non-blocking or follow-up coverage until the browser-specific flake has a rooted product cause.
+
+**Date:** 2026-04-01  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The new E2E suite passed locally but still failed in CI because production-style auth rate limits and full worker parallelism interacted badly with concurrent browser runs.  
+**Rule / Fix:** When adding full-stack E2E to CI, review backend throttles and shared-state assumptions explicitly; either relax them for `NODE_ENV=e2e` or reduce CI concurrency so auth/setup traffic cannot invalidate the suite.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The E2E suite mixed selector expectations based on route slugs with UI labels rendered from channel display names, and one startup preflight used a one-shot auth check while the rest of setup retried.  
+**Rule / Fix:** E2E assertions must target the exact accessibility text the UI renders, not adjacent seed identifiers, and all backend readiness checks should share the same retry semantics so cold-start timing does not create false failures.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** E2E preflight initially verified seeded content but skipped critical auth assumptions, and the shared E2E helper encoded environment defaults too implicitly.  
+**Rule / Fix:** E2E preconditions must verify every special-case fixture the suite depends on, including auth overrides, and shared test helpers should avoid hidden runtime defaults like hardcoded `NODE_ENV`.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The first true-E2E pass duplicated stack constants across TS and Node launcher files and allowed local server reuse, which made reruns stateful and brittle.  
+**Rule / Fix:** For stateful E2E stacks, keep shared ports/URLs/test credentials in one cross-runtime JS module and force the backend launcher to restart/reset locally unless there is an explicit reason to preserve state.
+**Date:** 2026-03-31  
+**Caught by:** [Human: user]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I left brittle expectations inside integration-test helpers, used a vacuous exclusion assertion in a membership-scoping test, hardcoded a slug-collision suffix, and missed unauthenticated plus join/leave coverage in the server lifecycle suite.  
+**Rule / Fix:** In Harmony integration tests, keep helpers assertion-light with descriptive failures, avoid vacuous negatives by asserting the response shape/status first, never hardcode collision suffixes when uniqueness is data-dependent, and cover both unauthenticated access and core membership transitions for authenticated server flows.
+
+**Date:** 2026-03-31  
+**Caught by:** [Human: user]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I initially called a mocked page-level test an integration test and also let a backend integration suite depend on state created in a prior `it` block.  
+**Rule / Fix:** In this repo, only call a test "integration" when it crosses real module boundaries without mocking application internals, and keep each integration test self-contained so it does not rely on execution order across `it` blocks.
+**Date:** 2026-04-03  
+**Caught by:** [Human: user]  
+**Mistake / Situation:** I renamed the branch and PR for a log export when the user meant to rename the exported log file itself.  
+**Rule / Fix:** When a user asks to "rename it" during log-export/PR work, confirm whether the target is the file, branch, PR, or commit before changing GitHub metadata; if context strongly points to the artifact path, rename the file first.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Related Issue:** #331  
+**Mistake / Situation:** I described the preferred custom-domain deployment contract too prominently in the root README when the user wanted the current live Vercel and Railway hostnames treated as the actual deployment URLs.  
+**Rule / Fix:** In Harmony deployment docs, present the currently serving hostnames as the source of truth unless the task is explicitly about future domain setup; mention custom domains only as preferred future state when they are not actually configured.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Related Issue:** #331  
+**Mistake / Situation:** I documented `npm run dev` and `npm run dev:worker` as if the worker would naturally stay on `4100`, but the backend `.env.example` sets `PORT=4000`, so both processes collide unless the worker port is overridden explicitly.  
+**Rule / Fix:** When documenting split-process local startup in Harmony, verify how `.env` values interact with entrypoint defaults; if a shared `PORT` variable exists, either force the worker dev script to `4100` or document an explicit `PORT=4100` override instead of relying on fallback defaults.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Related Issue:** #331  
+**Mistake / Situation:** I wrote a chained `cd` sequence in the README that ended with `cd ..` after entering `tests/integration`, which only returns to `tests/` rather than the repository root.  
+**Rule / Fix:** When documenting multi-step shell navigation in Harmony, trace the working directory after each `cd` and prefer exact return paths like `cd ../..` when the instructions are meant to end back at the repo root.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Mistake / Situation:** I documented `npm run test:integration` from the repo root without verifying the actual root script invocation. The root script was forwarding an extra `--config jest.config.js` even though the integration package already sets its own config, which breaks Jest argument parsing.  
+**Rule / Fix:** For Harmony root wrapper scripts, always execute the command once from the repo root before documenting it. If the delegated package already owns its config flags, the root wrapper should forward cleanly instead of duplicating CLI options.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk gh issue view 490 --repo CS485-Harmony/Harmony --comments
+```
+
+Output:
+
+```text
+🟢 Issue #490: feat: Real-time presence status (online, idle, dnd, offline)
+  Author: @acabrera04
+  Status: OPEN
+  URL: https://github.com/CS485-Harmony/Harmony/issues/490
+
+  Description:
+    ## Summary
+    Implement automatic presence tracking that detects user activity and broadcasts status changes in real-time via SSE.
+    
+    ## Expected Behavior
+    - User status automatically updates to ONLINE when active
+    - Status changes to IDLE after 5 minutes of inactivity
+    - Status changes to OFFLINE when user closes browser
+    - Status changes broadcast to all connected peers in real-time
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:36:33.609Z
+
+Issue #490 is real-time presence: active users go `ONLINE`, idle after 5 minutes, offline on browser close, and changes broadcast over SSE. I’m going to trace the existing user/session/SSE plumbing now so the implementation fits the repo instead of adding a parallel channel.
+
+#### Tool: exec_command
+
+```sh
+rtk tree harmony-backend/src -L 3
+```
+
+Output:
+
+```text
+Error: tree command not found. Install it first:
+- macOS: brew install tree
+- Ubuntu/Debian: sudo apt install tree
+- Fedora/RHEL: sudo dnf install tree
+- Arch: sudo pacman -S tree
+```
+
+#### Tool: exec_command
+
+```sh
+rtk tree harmony-frontend/src -L 3
+```
+
+Output:
+
+```text
+Error: tree command not found. Install it first:
+- macOS: brew install tree
+- Ubuntu/Debian: sudo apt install tree
+- Fedora/RHEL: sudo dnf install tree
+- Arch: sudo pacman -S tree
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep "SSE|EventSource|presence|status|online|idle|offline" harmony-backend/src harmony-frontend/src
+```
+
+Output:
+
+```text
+🔍 579 in 79F:
+
+📄 harmony-backend/src/app.ts (6):
+   134: status: 'ok',
+   155: // Real-time SSE endpoints
+   181: res.status(404).json({ error: 'Not found' });
+   187: const status = isCorsError ? 403 : 500;
+   190: logger.error({ err, status }, 'Unhandled Express error');
+   192: res.status(status).json({ error: message });
+
+📄 harmony-backend/src/dev/mock-seed-data.json (19):
+     8: "status": "online",
+    16: "status": "online",
+    24: "status": "idle",
+    32: "status": "online",
+    40: "status": "dnd",
+    48: "status": "offline",
+    56: "status": "idle",
+    64: "status": "online",
+    72: "status": "online",
+    80: "status": "offline",
+  +9
+
+📄 harmony-backend/src/dev/mockSeed.ts (1):
+    10: status: string;
+
+📄 harmony-backend/src/events/eventBus.ts (2):
+    36: // MaxListenersExceededWarning under concurrent SSE connections.
+    58: // ioredis emitter's listener count at 1 regardless of how many SSE connectio...
+
+📄 harmony-backend/src/events/eventTypes.ts (2):
+   133: /** Prisma UserStatus enum value; normalized to lowercase before emitting ove...
+   134: status: 'ONLINE' | 'IDLE' | 'DND' | 'OFFLINE';
+
+📄 harmony-backend/src/middleware/auth.middleware.ts (2):
+    15: res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    25: res.status(401).json({ error: 'Invalid or expired access token' });
+
+📄 harmony-backend/src/middleware/cache.middleware.ts (1):
+    72: if (res.statusCode >= 200 && res.statusCode < 300) {
+
+📄 harmony-backend/.../repositories/serverMember.repository.ts (1):
+    40: select: { id: true, username: true, displayName: true, avatarUrl: true, statu...
+
+📄 harmony-backend/.../repositories/user.repository.ts (2):
+    12: status: true,
+    23: status: true,
+
+📄 harmony-backend/src/routes/admin.metaTag.router.ts (17):
+    66: res.status(404).json({ error: 'Channel not found' });
+    78: res.status(403).json({ error: 'Server admin role required' });
+    86: res.status(500).json({ error: 'Internal server error' });
+   145: res.status(404).json({ error: 'Meta tags not found for this channel' });
+   152: res.status(500).json({ error: 'Internal server error' });
+   169: res.status(422).json({
+   191: res.status(404).json({ error: 'Meta tags not found for this channel' });
+   221: res.status(500).json({ error: 'Internal server error' });
+   254: res.status(202).json({
+   256: status: 'deduplicated',
+  +7
+
+📄 harmony-backend/src/routes/attachment.router.ts (7):
+    44: res.status(400).json({ error: 'No file provided. Use field name "file".' });
+    55: res.status(400).json({ error: err.message });
+    70: res.status(400).json({
+    88: res.status(201).json({
+    97: res.status(500).json({ error: 'Internal server error' });
+   112: const status = err.code === 'LIMIT_FILE_SIZE' ? 413 : 400;
+   113: res.status(status).json({ error: err.message });
+
+📄 harmony-backend/src/routes/auth.router.ts (14):
+    72: res.status(trpcCodeToHttp(err.code)).json({ error: err.message });
+    76: res.status(400).json({ error: 'Validation failed', details: err.errors });
+    80: res.status(500).json({ error: 'Internal server error' });
+    90: res.status(200).json({ passwordSalt: authService.generatePasswordSalt() });
+   100: res.status(400).json({ error: 'Validation failed', details: parsed.error.erro...
+   107: res.status(201).json(tokens);
+  +4
+
+... +529
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony",
+  "private": true,
+  "scripts": {
+    "test": "node ./scripts/run-root-jest.cjs",
+    "jest": "node ./scripts/run-root-jest.cjs",
+    "test:backend": "npm --prefix harmony-backend test --",
+    "test:frontend": "npm --prefix harmony-frontend test --",
+    "test:integration": "npm --prefix tests/integration test",
+    "test:integration:cloud": "npm --prefix tests/integration run test:cloud"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony-backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "dev:worker": "PORT=4100 tsx watch src/worker.ts",
+    "dev:e2e": "NODE_ENV=e2e PORT=4000 tsx src/index.ts",
+    "dev:e2e:worker": "NODE_ENV=e2e PORT=4100 tsx src/worker.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "start:api": "node dist/index.js",
+    "start:worker": "node dist/worker.js",
+    "lint": "eslint src tests",
+    "test": "jest",
+    "db:seed:mock": "prisma db seed",
+    "db:seed:demo": "tsx src/dev/demoSeed.ts"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.1030.0",
+    "@prisma/client": "^5.22.0",
+    "@trpc/server": "^11.0.0",
+    "bcryptjs": "^3.0.3",
+    "bullmq": "^5.75.2",
+    "cors": "^2.8.5",
+    "express": "^4.21.2",
+    "express-rate-limit": "^8.3.0",
+    "file-type": "^21.3.2",
+    "helmet": "^8.1.0",
+    "ioredis": "^5.10.0",
+    "jsonwebtoken": "^9.0.3",
+    "multer": "^2.1.1",
+    "pino": "^10.3.1",
+    "rate-limit-redis": "^4.3.1",
+    "serverless-http": "^3.2.0",
+    "twilio": "^5.13.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/ioredis": "^4.28.10",
+    "@types/jest": "^29.5.14",
+    "@types/jsonwebtoken": "^9.0.10",
+    "@types/multer": "^2.1.0",
+    "@types/node": "^20.17.19",
+    "@types/supertest": "^6.0.2",
+    "@typescript-eslint/eslint-plugin": "^8.26.0",
+    "@typescript-eslint/parser": "^8.26.0",
+    "dotenv": "^17.3.1",
+    "eslint": "^9.22.0",
+    "eslint-config-prettier": "^10.1.1",
+    "jest": "^29.7.0",
+    "pino-pretty": "^13.1.3",
+    "prettier": "^3.5.3",
+    "prisma": "^5.22.0",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.6",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "build:local-e2e": "NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next build",
+    "start:local-e2e": "PORT=3000 NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next start",
+    "test": "jest --forceExit",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "lint": "eslint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "axios": "^1.13.5",
+    "clsx": "^2.1.1",
+    "next": "16.1.6",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.4.1",
+    "twilio-video": "3.0.0-preview.3"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@playwright/test": "^1.55.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "16.1.6",
+    "eslint-config-prettier": "^10.1.8",
+    "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
+    "prettier": "^3.8.1",
+    "tailwindcss": "^4",
+    "ts-jest": "^29.4.6",
+    "typescript": "5.9.3"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rg --files harmony-backend/src | sed -n '1,200p'
+```
+
+Output:
+
+```text
+harmony-backend/src/worker.ts
+harmony-backend/src/services/cache.service.ts
+harmony-backend/src/services/serverMember.service.ts
+harmony-backend/src/services/voice.service.ts
+harmony-backend/src/services/cacheInvalidator.service.ts
+harmony-backend/src/services/visibility.service.ts
+harmony-backend/src/services/contentAnalysis/index.ts
+harmony-backend/src/services/contentAnalysis/types.ts
+harmony-backend/src/services/contentAnalysis/keywordExtractor.ts
+harmony-backend/src/services/contentAnalysis/contentAnalyzer.ts
+harmony-backend/src/services/contentAnalysis/topicClassifier.ts
+harmony-backend/src/services/contentAnalysis/textSummarizer.ts
+harmony-backend/src/services/contentAnalysis/stopWords.ts
+harmony-backend/src/services/user.service.ts
+harmony-backend/src/services/metaTag/structuredDataGenerator.ts
+harmony-backend/src/services/metaTag/descriptionGenerator.ts
+harmony-backend/src/services/metaTag/types.ts
+harmony-backend/src/services/metaTag/metaTagService.ts
+harmony-backend/src/services/metaTag/titleGenerator.ts
+harmony-backend/src/services/metaTag/contentFilter.ts
+harmony-backend/src/services/metaTag/metaTagCache.ts
+harmony-backend/src/services/metaTag/openGraphGenerator.ts
+harmony-backend/src/services/indexing.service.ts
+harmony-backend/src/services/permission.service.ts
+harmony-backend/src/services/server.service.ts
+harmony-backend/src/services/attachment.service.ts
+harmony-backend/src/services/auth.service.ts
+harmony-backend/src/services/reaction.service.ts
+harmony-backend/src/services/channel.service.ts
+harmony-backend/src/services/auditLog.service.ts
+harmony-backend/src/services/message.service.ts
+harmony-backend/src/routes/public.router.ts
+harmony-backend/src/routes/admin.metaTag.router.ts
+harmony-backend/src/routes/events.router.ts
+harmony-backend/src/routes/auth.router.ts
+harmony-backend/src/routes/seo.router.ts
+harmony-backend/src/routes/attachment.router.ts
+harmony-backend/src/events/eventTypes.ts
+harmony-backend/src/events/eventBus.ts
+harmony-backend/src/index.ts
+harmony-backend/src/workers/metaTagUpdate.queue.ts
+harmony-backend/src/workers/metaTagUpdate.runtime.ts
+harmony-backend/src/workers/metaTagUpdate.pipeline.ts
+harmony-backend/src/workers/metaTagUpdate.worker.ts
+harmony-backend/src/workers/eventListener.ts
+harmony-backend/src/dev/demoSeed.ts
+harmony-backend/src/dev/mockSeed.ts
+harmony-backend/src/dev/mock-seed-data.json
+harmony-backend/src/db/redis.ts
+harmony-backend/src/db/prisma.ts
+harmony-backend/src/lib/parsePortEnv.ts
+harmony-backend/src/lib/admin.utils.ts
+harmony-backend/src/lib/instance-identity.ts
+harmony-backend/src/lib/logger.ts
+harmony-backend/src/lib/storage/local.provider.ts
+harmony-backend/src/lib/storage/index.ts
+harmony-backend/src/lib/storage/mime-types.ts
+harmony-backend/src/lib/storage/storage.interface.ts
+harmony-backend/src/lib/storage/s3.provider.ts
+harmony-backend/src/lib/mime-detect.ts
+harmony-backend/src/lambda.ts
+harmony-backend/src/repositories/channel.repository.ts
+harmony-backend/src/repositories/message.repository.ts
+harmony-backend/src/repositories/metaTag.repository.ts
+harmony-backend/src/repositories/serverMember.repository.ts
+harmony-backend/src/repositories/user.repository.ts
+harmony-backend/src/repositories/auditLog.repository.ts
+harmony-backend/src/repositories/reaction.repository.ts
+harmony-backend/src/repositories/server.repository.ts
+harmony-backend/src/repositories/attachment.repository.ts
+harmony-backend/src/repositories/refreshToken.repository.ts
+harmony-backend/src/app.ts
+harmony-backend/src/trpc/router.ts
+harmony-backend/src/trpc/init.ts
+harmony-backend/src/trpc/routers/user.router.ts
+harmony-backend/src/trpc/routers/voice.router.ts
+harmony-backend/src/trpc/routers/message.router.ts
+harmony-backend/src/trpc/routers/reaction.router.ts
+harmony-backend/src/trpc/routers/channel.router.ts
+harmony-backend/src/trpc/routers/server.router.ts
+harmony-backend/src/trpc/routers/attachment.router.ts
+harmony-backend/src/trpc/routers/serverMember.router.ts
+harmony-backend/src/middleware/rate-limit.middleware.ts
+harmony-backend/src/middleware/auth.middleware.ts
+harmony-backend/src/middleware/cors.ts
+harmony-backend/src/middleware/cache.middleware.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rg --files harmony-frontend/src | sed -n '1,240p'
+```
+
+Output:
+
+```text
+harmony-frontend/src/services/index.ts
+harmony-frontend/src/services/channelService.ts
+harmony-frontend/src/services/authService.ts
+harmony-frontend/src/services/serverService.ts
+harmony-frontend/src/services/publicApiService.ts
+harmony-frontend/src/services/metaTagAdminService.ts
+harmony-frontend/src/services/messageService.ts
+harmony-frontend/src/lib/runtime-config.ts
+harmony-frontend/src/lib/trpc-client.ts
+harmony-frontend/src/lib/constants.ts
+harmony-frontend/src/lib/auth-constants.ts
+harmony-frontend/src/lib/sitemap-response.ts
+harmony-frontend/src/lib/frontend-logger.ts
+harmony-frontend/src/lib/passwordAuth.ts
+harmony-frontend/src/lib/seo-sitemap.ts
+harmony-frontend/src/lib/utils.ts
+harmony-frontend/src/lib/trpc-errors.ts
+harmony-frontend/src/lib/api-client.ts
+harmony-frontend/src/hooks/useServerListSync.ts
+harmony-frontend/src/hooks/useAuth.ts
+harmony-frontend/src/hooks/useServerEvents.ts
+harmony-frontend/src/hooks/useChannelEvents.ts
+harmony-frontend/src/hooks/useToast.ts
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+harmony-frontend/src/__tests__/useServerEvents.test.tsx
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts
+harmony-frontend/src/__tests__/server-settings-access.test.ts
+harmony-frontend/src/__tests__/SeoPreviewSection.test.tsx
+harmony-frontend/src/__tests__/publicApiService.test.ts
+harmony-frontend/src/__tests__/trpc-client.test.ts
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx
+harmony-frontend/src/__tests__/useChannelEvents.test.tsx
+harmony-frontend/src/__tests__/VisibilityGuard.test.tsx
+harmony-frontend/src/__tests__/private-channel-pane-lock.test.tsx
+harmony-frontend/src/__tests__/channelService.test.ts
+harmony-frontend/src/__tests__/authService.test.ts
+harmony-frontend/src/__tests__/middleware.test.ts
+harmony-frontend/src/__tests__/seo-routes.test.ts
+harmony-frontend/src/__tests__/runtime-config.test.ts
+harmony-frontend/src/__tests__/issue-238-message-input-aria-label.test.tsx
+harmony-frontend/src/__tests__/serverService.test.ts
+harmony-frontend/src/__tests__/metaTagAdminService.test.ts
+harmony-frontend/src/__tests__/useServerListSync.test.tsx
+harmony-frontend/src/__tests__/frontend-logger.test.ts
+harmony-frontend/src/__tests__/utils.test.ts
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts
+harmony-frontend/src/components/channel/VisibilityGuard.tsx
+harmony-frontend/src/components/channel/ChannelSidebar.tsx
+harmony-frontend/src/components/channel/MessageCard.tsx
+harmony-frontend/src/components/channel/GuestPromoBanner.tsx
+harmony-frontend/src/components/channel/MembersSidebar.tsx
+harmony-frontend/src/components/channel/PinnedMessagesPanel.tsx
+harmony-frontend/src/components/channel/AuthRedirect.tsx
+harmony-frontend/src/components/channel/SearchModal.tsx
+harmony-frontend/src/components/channel/NoServersView.tsx
+harmony-frontend/src/components/channel/CreateChannelModal.tsx
+harmony-frontend/src/components/channel/NoChannelsContent.tsx
+harmony-frontend/src/components/channel/UserStatusBar.tsx
+harmony-frontend/src/components/channel/MessageList.tsx
+harmony-frontend/src/components/channel/NoServersContent.tsx
+harmony-frontend/src/components/channel/VisibilityToggle.tsx
+harmony-frontend/src/components/channel/GuestChannelView.tsx
+harmony-frontend/src/components/channel/GuestHeader.tsx
+harmony-frontend/src/components/channel/TopBar.tsx
+harmony-frontend/src/components/channel/PrivateChannelLockedPane.tsx
+harmony-frontend/src/components/channel/ChannelPageContent.tsx
+harmony-frontend/src/components/channel/MessageInput.tsx
+harmony-frontend/src/components/README.md
+harmony-frontend/src/components/server/ServerSidebar.tsx
+harmony-frontend/src/components/message/MessageItem.tsx
+harmony-frontend/src/components/layout/HarmonyShell.tsx
+harmony-frontend/src/components/layout/EmptyShell.tsx
+harmony-frontend/src/components/settings/SeoPreviewSection.tsx
+harmony-frontend/src/components/settings/VisibilitySection.tsx
+harmony-frontend/src/components/settings/UserSettingsPage.tsx
+harmony-frontend/src/components/settings/MembersSection.tsx
+harmony-frontend/src/components/settings/ChannelSettingsPage.tsx
+harmony-frontend/src/components/settings/ServerSettingsPage.tsx
+harmony-frontend/src/components/ui/Toast.tsx
+harmony-frontend/src/components/ui/Button.tsx
+harmony-frontend/src/components/ui/TailwindTest.tsx
+harmony-frontend/src/components/ui/Card.tsx
+harmony-frontend/src/components/server-rail/CreateServerModal.tsx
+harmony-frontend/src/components/server-rail/ServerRail.tsx
+harmony-frontend/src/components/server-rail/BrowseServersModal.tsx
+harmony-frontend/src/app/providers.tsx
+harmony-frontend/src/app/channels/page.tsx
+harmony-frontend/src/app/channels/layout.tsx
+harmony-frontend/src/app/channels/actions.ts
+harmony-frontend/src/app/layout.tsx
+harmony-frontend/src/app/channels/[serverSlug]/page.tsx
+harmony-frontend/src/app/channels/[serverSlug]/[channelSlug]/page.tsx
+harmony-frontend/src/app/channels/[serverSlug]/[channelSlug]/loading.tsx
+harmony-frontend/src/app/not-found.tsx
+harmony-frontend/src/app/global-error.tsx
+harmony-frontend/src/app/globals.css
+harmony-frontend/src/app/sitemap/[serverSlug]/route.ts
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/loading.tsx
+harmony-frontend/src/app/page.tsx
+harmony-frontend/src/app/sitemap/[serverSlug].xml/route.ts
+harmony-frontend/src/app/robots.txt/route.ts
+harmony-frontend/src/app/sitemap.xml/route.ts
+harmony-frontend/src/app/error.tsx
+harmony-frontend/src/middleware.ts
+harmony-frontend/src/app/auth/login/page.tsx
+harmony-frontend/src/app/favicon.ico
+harmony-frontend/src/contexts/VoiceContext.tsx
+harmony-frontend/src/app/settings/page.tsx
+harmony-frontend/src/app/settings/layout.tsx
+harmony-frontend/src/app/settings/actions.ts
+harmony-frontend/src/app/api/attachments/upload/route.ts
+harmony-frontend/src/app/settings/[serverSlug]/page.tsx
+harmony-frontend/src/app/settings/[serverSlug]/actions.ts
+harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts
+harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/page.tsx
+harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/actions.ts
+harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/updateVisibility.ts
+harmony-frontend/src/context/ToastContext.tsx
+harmony-frontend/src/context/AuthContext.tsx
+harmony-frontend/src/app/auth/signup/page.tsx
+harmony-frontend/src/types/message.ts
+harmony-frontend/src/types/user.ts
+harmony-frontend/src/types/server.ts
+harmony-frontend/src/types/index.ts
+harmony-frontend/src/types/channel.ts
+harmony-frontend/src/app/actions/session.ts
+harmony-frontend/src/app/actions/sendMessage.ts
+harmony-frontend/src/app/actions/createChannel.ts
+harmony-frontend/src/app/actions/getPinnedMessages.ts
+harmony-frontend/src/app/actions/pinMessage.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/events/eventTypes.ts
+```
+
+Output:
+
+```text
+/** Canonical visibility values — mirrors the Prisma ChannelVisibility enum. */
+export type ChannelVisibilityValue = 'PUBLIC_INDEXABLE' | 'PUBLIC_NO_INDEX' | 'PRIVATE';
+
+export const EventChannels = {
+  VISIBILITY_CHANGED: 'harmony:VISIBILITY_CHANGED',
+  MESSAGE_CREATED: 'harmony:MESSAGE_CREATED',
+  MESSAGE_EDITED: 'harmony:MESSAGE_EDITED',
+  MESSAGE_DELETED: 'harmony:MESSAGE_DELETED',
+  META_TAGS_UPDATED: 'harmony:META_TAGS_UPDATED',
+  MEMBER_JOINED: 'harmony:MEMBER_JOINED',
+  MEMBER_LEFT: 'harmony:MEMBER_LEFT',
+  USER_JOINED_VOICE: 'harmony:USER_JOINED_VOICE',
+  USER_LEFT_VOICE: 'harmony:USER_LEFT_VOICE',
+  VOICE_STATE_CHANGED: 'harmony:VOICE_STATE_CHANGED',
+  CHANNEL_CREATED: 'harmony:CHANNEL_CREATED',
+  CHANNEL_UPDATED: 'harmony:CHANNEL_UPDATED',
+  CHANNEL_DELETED: 'harmony:CHANNEL_DELETED',
+  SERVER_UPDATED: 'harmony:SERVER_UPDATED',
+  USER_STATUS_CHANGED: 'harmony:USER_STATUS_CHANGED',
+  REACTION_ADDED: 'harmony:REACTION_ADDED',
+  REACTION_REMOVED: 'harmony:REACTION_REMOVED',
+} as const;
+
+export type EventChannelName = (typeof EventChannels)[keyof typeof EventChannels];
+
+export interface VisibilityChangedPayload {
+  channelId: string;
+  serverId: string;
+  oldVisibility: ChannelVisibilityValue;
+  newVisibility: ChannelVisibilityValue;
+  actorId: string;
+  timestamp: string; // ISO 8601
+}
+
+export interface MessageCreatedPayload {
+  messageId: string;
+  channelId: string;
+  authorId: string;
+  /** Present only when the message is a thread reply; absent for top-level channel messages. */
+  parentMessageId?: string;
+  timestamp: string;
+}
+
+export interface MessageEditedPayload {
+  messageId: string;
+  channelId: string;
+  timestamp: string;
+}
+
+export interface MessageDeletedPayload {
+  messageId: string;
+  channelId: string;
+  timestamp: string;
+}
+
+export interface MetaTagsUpdatedPayload {
+  channelId: string;
+  version: number;
+  timestamp: string;
+}
+
+export type RoleTypeValue = 'OWNER' | 'ADMIN' | 'MODERATOR' | 'MEMBER' | 'GUEST';
+
+export interface MemberJoinedPayload {
+  userId: string;
+  serverId: string;
+  role: RoleTypeValue;
+  timestamp: string;
+}
+
+export interface MemberLeftPayload {
+  userId: string;
+  serverId: string;
+  reason: 'LEFT' | 'KICKED';
+  timestamp: string;
+}
+
+export interface UserJoinedVoicePayload {
+  userId: string;
+  channelId: string;
+  timestamp: string;
+}
+
+export interface UserLeftVoicePayload {
+  userId: string;
+  channelId: string;
+  timestamp: string;
+}
+
+export interface VoiceStateChangedPayload {
+  userId: string;
+  channelId: string;
+  muted: boolean;
+  deafened: boolean;
+  timestamp: string;
+}
+
+export interface ChannelCreatedPayload {
+  channelId: string;
+  serverId: string;
+  timestamp: string;
+}
+
+export interface ChannelUpdatedPayload {
+  channelId: string;
+  serverId: string;
+  timestamp: string;
+}
+
+export interface ChannelDeletedPayload {
+  channelId: string;
+  serverId: string;
+  timestamp: string;
+}
+
+export interface ServerUpdatedPayload {
+  serverId: string;
+  name?: string;
+  iconUrl?: string | null;
+  description?: string | null;
+  timestamp: string;
+}
+
+export interface UserStatusChangedPayload {
+  userId: string;
+  serverId: string;
+  /** Prisma UserStatus enum value; normalized to lowercase before emitting over SSE. */
+  status: 'ONLINE' | 'IDLE' | 'DND' | 'OFFLINE';
+}
+
+export interface ReactionAddedPayload {
+  messageId: string;
+  channelId: string;
+  userId: string;
+  emoji: string;
+  timestamp: string;
+}
+
+export interface ReactionRemovedPayload {
+  messageId: string;
+  channelId: string;
+  userId: string;
+  emoji: string;
+  timestamp: string;
+}
+
+export interface EventPayloadMap {
+  [EventChannels.VISIBILITY_CHANGED]: VisibilityChangedPayload;
+  [EventChannels.MESSAGE_CREATED]: MessageCreatedPayload;
+  [EventChannels.MESSAGE_EDITED]: MessageEditedPayload;
+  [EventChannels.MESSAGE_DELETED]: MessageDeletedPayload;
+  [EventChannels.META_TAGS_UPDATED]: MetaTagsUpdatedPayload;
+  [EventChannels.MEMBER_JOINED]: MemberJoinedPayload;
+  [EventChannels.MEMBER_LEFT]: MemberLeftPayload;
+  [EventChannels.USER_JOINED_VOICE]: UserJoinedVoicePayload;
+  [EventChannels.USER_LEFT_VOICE]: UserLeftVoicePayload;
+  [EventChannels.VOICE_STATE_CHANGED]: VoiceStateChangedPayload;
+  [EventChannels.CHANNEL_CREATED]: ChannelCreatedPayload;
+  [EventChannels.CHANNEL_UPDATED]: ChannelUpdatedPayload;
+  [EventChannels.CHANNEL_DELETED]: ChannelDeletedPayload;
+  [EventChannels.SERVER_UPDATED]: ServerUpdatedPayload;
+  [EventChannels.USER_STATUS_CHANGED]: UserStatusChangedPayload;
+  [EventChannels.REACTION_ADDED]: ReactionAddedPayload;
+  [EventChannels.REACTION_REMOVED]: ReactionRemovedPayload;
+}
+
+export type EventHandler<C extends EventChannelName> = (payload: EventPayloadMap[C]) => void;
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/app.ts
+```
+
+Output:
+
+```text
+import express, { NextFunction, Request, Response } from 'express';
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
+import helmet from 'helmet';
+import rateLimit, { type Store } from 'express-rate-limit';
+import { RedisStore } from 'rate-limit-redis';
+import corsMiddleware, { CorsError } from './middleware/cors';
+import { appRouter } from './trpc/router';
+import { createContext } from './trpc/init';
+import { authRouter } from './routes/auth.router';
+import { createPublicRouter } from './routes/public.router';
+import { seoRouter } from './routes/seo.router';
+import { eventsRouter } from './routes/events.router';
+import { attachmentRouter } from './routes/attachment.router';
+import { adminMetaTagRouter } from './routes/admin.metaTag.router';
+import { instanceId } from './lib/instance-identity';
+import { createLogger } from './lib/logger';
+import { redis } from './db/redis';
+
+const logger = createLogger({ component: 'app', instanceId });
+
+/**
+ * Creates one Redis store per rate-limit route in production.
+ * Each store gets a unique prefix so login/register/refresh counters don't
+ * collide in Redis, while all replicas share the same keyspace.
+ *
+ * Returns undefined in dev/test so express-rate-limit falls back to
+ * MemoryStore — keeps tests hermetic with no Redis dependency.
+ *
+ * Uses ioredis `.call()` which runs the rate-limit-redis Lua script as a
+ * single atomic command, satisfying the "no non-atomic INCR + EXPIRE"
+ * constraint from the replica-readiness audit (§3.1).
+ *
+ * express-rate-limit v8 requires each limiter to have its own store instance
+ * (it validates against shared instances to prevent route counter mixing),
+ * so callers must invoke this once per limiter.
+ */
+function buildProductionStore(prefix: string): Store | undefined {
+  if (process.env.NODE_ENV !== 'production') return undefined;
+  return new RedisStore({
+    prefix,
+    sendCommand: (...args: string[]) =>
+      redis.call(args[0] as string, ...(args.slice(1) as [string, ...string[]])) as Promise<number>,
+  });
+}
+
+export interface CreateAppOptions {
+  /**
+   * Store factory called once per limiter so each gets a distinct instance.
+   * express-rate-limit v8 requires separate instances per limiter to avoid
+   * counter mixing and to suppress the "unsharedStore" validation error.
+   * In tests: return a new mock per call but share an incrementCalls array
+   * to observe all calls across limiters. In production this is left undefined
+   * and buildProductionStore(prefix) is used instead.
+   */
+  rateLimitStore?: () => Store;
+}
+
+export function createApp(options: CreateAppOptions = {}) {
+  const isE2E = process.env.NODE_ENV === 'e2e';
+  const makeStore = (prefix: string): Store | undefined =>
+    options.rateLimitStore ? options.rateLimitStore() : buildProductionStore(prefix);
+
+  const loginLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: isE2E ? 1000 : 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: makeStore('rl:login:'),
+    message: { error: 'Too many login attempts. Please try again later.' },
+  });
+
+  const registerLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: process.env.NODE_ENV === 'production' ? 5 : 1000,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: makeStore('rl:register:'),
+    message: { error: 'Too many registration attempts. Please try again later.' },
+  });
+
+  const refreshLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: isE2E ? 1000 : 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: makeStore('rl:refresh:'),
+    message: { error: 'Too many token refresh attempts. Please try again later.' },
+  });
+  const app = express();
+
+  const trustProxyHopsEnv = process.env.TRUST_PROXY_HOPS;
+  if (trustProxyHopsEnv !== undefined && trustProxyHopsEnv.trim() === '') {
+    throw new Error(
+      `Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected a non-negative integer.`,
+    );
+  }
+  const trustProxyHops = trustProxyHopsEnv === undefined ? 0 : Number(trustProxyHopsEnv);
+  if (!Number.isInteger(trustProxyHops) || trustProxyHops < 0) {
+    throw new Error(
+      `Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected a non-negative integer.`,
+    );
+  }
+  if (trustProxyHops > 0) {
+    app.set('trust proxy', trustProxyHops);
+  }
+
+  app.use(helmet());
+
+  app.use((_req, res, next) => {
+    res.setHeader('X-Instance-Id', instanceId);
+    next();
+  });
+
+  app.use(corsMiddleware);
+  app.use(express.json());
+
+  app.get('/health', (_req, res) => {
+    res.json({
+      status: 'ok',
+      service: 'backend-api',
+      instanceId,
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  app.use(seoRouter);
+
+  app.use('/api/auth/login', loginLimiter);
+  app.use('/api/auth/register', registerLimiter);
+  app.use('/api/auth/refresh', refreshLimiter);
+  app.use('/api/auth', authRouter);
+
+  app.use('/api/public', createPublicRouter(makeStore('rl:public:')));
+
+  app.use('/api/events', eventsRouter);
+
+  app.use('/api/attachments', attachmentRouter);
+
+  app.use('/api/admin', adminMetaTagRouter);
+
+  app.use(
+    '/trpc',
+    createExpressMiddleware({
+      router: appRouter,
+      createContext,
+      onError({ error, path }) {
+        if (error.code === 'INTERNAL_SERVER_ERROR') {
+          logger.error({ err: error, path }, 'Unhandled tRPC error');
+        }
+      },
+    }),
+  );
+
+  app.use((_req: Request, res: Response) => {
+    res.status(404).json({ error: 'Not found' });
+  });
+
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    const isCorsError = err instanceof CorsError;
+    const status = isCorsError ? 403 : 500;
+    const message = isCorsError ? err.message : 'Internal server error';
+    if (!isCorsError) {
+      logger.error({ err, status }, 'Unhandled Express error');
+    }
+    res.status(status).json({ error: message });
+  });
+
+  return app;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep "EventSource|use.*Events|sse|events" harmony-frontend/src
+```
+
+Output:
+
+```text
+🔍 288 in 25F:
+
+📄 harmony-frontend/.../__tests__/channelService.test.ts (1):
+   485: it('passes pagination options to the query', async () => {
+
+📄 harmony-frontend/src/__tests__/middleware.test.ts (1):
+    63: it('passes through unprotected routes', () => {
+
+📄 harmony-frontend/.../__tests__/private-channel-pane-lock.test.tsx (2):
+    22: jest.mock('@/hooks/useServerEvents', () => ({
+    23: useServerEvents: (options: unknown) => mockUseServerEvents(options),
+
+📄 harmony-frontend/.../__tests__/useChannelEvents.test.tsx (64):
+     2: * useChannelEvents.test.tsx — Issue #180
+     4: * Tests the useChannelEvents hook that subscribes to real-time SSE events
+     7: * EventSource is mocked to avoid actual network connections.
+    11: import { useChannelEvents } from '../hooks/useChannelEvents';
+    21: // ─── Mock EventSource ─────────────────────────────────────────────────────...
+    23: type EventSourceHandler = (event: MessageEvent) => void;
+    25: interface MockEventSourceInstance {
+    38: let mockEventSourceInstance: MockEventSourceInstance | null = null;
+    40: const MockEventSource = jest.fn().mockImplementation((url: string) => {
+    41: const handlers = new Map<string, EventSourceHandler[]>();
+  +54
+
+📄 harmony-frontend/.../__tests__/useServerEvents.test.tsx (101):
+     2: * useServerEvents.test.tsx — Issue #185 / #186 / #187 / #189 / #231
+     4: * Tests the useServerEvents hook that subscribes to real-time SSE events for
+     6: * changes, message events, and server:updated events.
+     8: * EventSource is mocked to avoid actual network connections.
+    12: import { useServerEvents } from '../hooks/useServerEvents';
+    24: // ─── Mock EventSource ─────────────────────────────────────────────────────...
+    26: type EventSourceHandler = (event: MessageEvent) => void;
+    28: interface MockEventSourceInstance {
+    40: let mockEventSourceInstance: MockEventSourceInstance | null = null;
+    42: const MockEventSource = jest.fn().mockImplementation((url: string) => {
+  +91
+
+📄 harmony-frontend/src/__tests__/utils.test.ts (1):
+    15: it('merges conditional and conflicting Tailwind classes', () => {
+
+📄 harmony-frontend/src/app/actions/createChannel.ts (1):
+    10: * server membership + role before the mutation is processed. Unauthenticated or
+
+📄 harmony-frontend/.../channel/CreateChannelModal.tsx (1):
+   288: aria-pressed={type === opt.value}
+
+📄 harmony-frontend/.../channel/GuestHeader.tsx (1):
+    25: {/* Server name — min-w-0 flex-1 prevents overflow when CTAs are present */}
+
+📄 harmony-frontend/.../channel/GuestPromoBanner.tsx (9):
+    15: const DISMISS_KEY = 'harmony_guest_banner_dismissed';
+    17: function isDismissedInStorage(): boolean {
+    33: // useSyncExternalStore with a server snapshot of `true` (hidden) prevents
+    37: const storageDismissed = useSyncExternalStore(
+    38: () => () => {},       // sessionStorage has no change events
+    39: isDismissedInStorage, // client snapshot
+    45: const [manuallyDismissed, setManuallyDismissed] = useState(false);
+    53: setManuallyDismissed(true);
+    56: if (storageDismissed || manuallyDismissed || isAuthenticated) return null;
+
+📄 harmony-frontend/.../channel/MessageList.tsx (1):
+    72: /** Server ID passed to MessageItem for pin/unpin actions. */
+
+📄 harmony-frontend/.../channel/PinnedMessagesPanel.tsx (1):
+    93: // isCurrent guard: prevents a slow in-flight fetch from a previous channel
+
+📄 harmony-frontend/src/components/channel/TopBar.tsx (5):
+   118: ariaPressed,
+   125: /** Set for toggle buttons so screen readers announce pressed state */
+   126: ariaPressed?: boolean;
+   136: aria-pressed={ariaPressed}
+   238: ariaPressed={isMembersOpen}
+
+📄 harmony-frontend/.../channel/VisibilityToggle.tsx (2):
+   226: // Re-entrancy lock — prevents concurrent saves from a fast double-click.
+   288: // This prevents accidental saves while keyboard-browsing the options.
+
+📄 harmony-frontend/.../layout/HarmonyShell.tsx (6):
+    24: import { useServerEvents } from '@/hooks/useServerEvents';
+   139: // passes a fresh array (server navigation or revalidatePath refresh) — same
+   146: // Local members state so join/leave/status events update the sidebar without...
+   326: // Note: useServerEvents is only enabled for authenticated users, so this
+
+... +238
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/routes/events.router.ts
+```
+
+Output:
+
+```text
+/**
+ * SSE Router — Issue #180
+ *
+ * GET /api/events/channel/:channelId?token=<accessToken>
+ *
+ * Streams real-time message events to authenticated, authorised clients using
+ * Server-Sent Events.
+ *
+ * Auth: the browser's native EventSource API cannot send custom headers, so the
+ * access token is accepted via a `?token=` query parameter instead of the
+ * Authorization header. The token is validated identically to requireAuth.
+ *
+ * Authorisation: verifies the authenticated user is a member of the server that
+ * owns the requested channel, preventing access to PRIVATE channels by non-members.
+ */
+
+import { Router, Request, Response } from 'express';
+import { prisma } from '../db/prisma';
+import { createLogger } from '../lib/logger';
+import { authService } from '../services/auth.service';
+import { eventBus, EventChannels } from '../events/eventBus';
+import type {
+  MessageCreatedPayload,
+  MessageEditedPayload,
+  MessageDeletedPayload,
+  ChannelCreatedPayload,
+  ChannelUpdatedPayload,
+  ChannelDeletedPayload,
+  ServerUpdatedPayload,
+  UserStatusChangedPayload,
+  MemberJoinedPayload,
+  MemberLeftPayload,
+  VisibilityChangedPayload,
+} from '../events/eventTypes';
+
+export const eventsRouter = Router();
+const logger = createLogger({ component: 'events-router' });
+
+/**
+ * Validate that a channelId looks like a UUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).
+ * Rejects empty strings, whitespace-only strings, and obviously invalid values
+ * to prevent subscription to meaningless Redis channels.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidUUID(id: string): boolean {
+  return UUID_RE.test(id.trim());
+}
+
+const MESSAGE_SSE_INCLUDE = {
+  author: {
+    select: { id: true, username: true, displayName: true, avatarUrl: true },
+  },
+  attachments: {
+    select: { id: true, filename: true, url: true, contentType: true },
+  },
+} as const;
+
+type EventSubscription = { unsubscribe: () => void; ready: Promise<void> };
+
+type BufferedSseState = {
+  closed: boolean;
+  ready: boolean;
+  pendingFrames: string[];
+  heartbeat: ReturnType<typeof setInterval> | null;
+};
+
+function formatEvent(eventType: string, data: unknown): string {
+  return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function createBufferedSseState(): BufferedSseState {
+  return {
+    closed: false,
+    ready: false,
+    pendingFrames: [],
+    heartbeat: null,
+  };
+}
+
+function cleanupSseConnection(state: BufferedSseState, subscriptions: EventSubscription[]): void {
+  if (state.closed) return;
+  state.closed = true;
+  if (state.heartbeat) {
+    clearInterval(state.heartbeat);
+    state.heartbeat = null;
+  }
+  state.pendingFrames.length = 0;
+  for (const subscription of subscriptions) {
+    subscription.unsubscribe();
+  }
+}
+
+function createBufferedEventWriter(
+  res: Response,
+  state: BufferedSseState,
+): (eventType: string, data: unknown) => void {
+  return (eventType: string, data: unknown) => {
+    if (state.closed) return;
+    const frame = formatEvent(eventType, data);
+    if (!state.ready) {
+      state.pendingFrames.push(frame);
+      return;
+    }
+    res.write(frame);
+  };
+}
+
+async function finalizeSseSetup(
+  req: Request,
+  res: Response,
+  state: BufferedSseState,
+  subscriptions: EventSubscription[],
+  logContext: Record<string, string>,
+): Promise<boolean> {
+  const cleanup = () => cleanupSseConnection(state, subscriptions);
+  req.on('close', cleanup);
+
+  try {
+    await Promise.all(subscriptions.map((subscription) => subscription.ready));
+  } catch (err) {
+    cleanup();
+    logger.error({ err, ...logContext }, 'Failed to establish SSE subscriptions');
+    if (!res.headersSent) {
+      res.status(503).json({ error: 'Failed to establish event stream' });
+    }
+    return false;
+  }
+
+  if (state.closed) {
+    return false;
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+
+  state.ready = true;
+  for (const frame of state.pendingFrames.splice(0)) {
+    res.write(frame);
+  }
+
+  state.heartbeat = setInterval(() => {
+    if (state.closed) return;
+    res.write(':\n\n');
+  }, 30_000);
+
+  return true;
+}
+
+eventsRouter.get('/channel/:channelId', async (req: Request, res: Response) => {
+  const { channelId } = req.params;
+
+  if (!isValidUUID(channelId)) {
+    res.status(400).json({ error: 'Invalid channelId: must be a UUID' });
+    return;
+  }
+
+  const token = typeof req.query.token === 'string' ? req.query.token : null;
+  if (!token) {
+    res.status(401).json({ error: 'Missing token query parameter' });
+    return;
+  }
+
+  let userId: string;
+  try {
+    const payload = authService.verifyAccessToken(token);
+    userId = payload.sub;
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired access token' });
+    return;
+  }
+
+  const channel = await prisma.channel.findUnique({
+    where: { id: channelId },
+    select: { serverId: true },
+  });
+  if (!channel) {
+    res.status(404).json({ error: 'Channel not found' });
+    return;
+  }
+
+  const membership = await prisma.serverMember.findFirst({
+    where: { userId, serverId: channel.serverId },
+    select: { userId: true },
+  });
+  if (!membership) {
+    res.status(403).json({ error: 'You are not a member of this server' });
+    return;
+  }
+
+  const sseState = createBufferedSseState();
+  const writeEvent = createBufferedEventWriter(res, sseState);
+
+  const createdSubscription = eventBus.subscribe(
+    EventChannels.MESSAGE_CREATED,
+    async (payload: MessageCreatedPayload) => {
+      if (payload.channelId !== channelId) return;
+
+      try {
+        const message = await prisma.message.findUnique({
+          where: { id: payload.messageId },
+          include: MESSAGE_SSE_INCLUDE,
+        });
+        if (!message || message.isDeleted) return;
+
+        writeEvent('message:created', {
+          id: message.id,
+          channelId: message.channelId,
+          authorId: message.authorId,
+          author: message.author,
+          content: message.content,
+          timestamp: message.createdAt.toISOString(),
+          attachments: message.attachments,
+          editedAt: message.editedAt ? message.editedAt.toISOString() : null,
+        });
+      } catch (err) {
+        logger.warn(
+          { err, channelId, messageId: payload.messageId },
+          'Failed to hydrate SSE message:created payload',
+        );
+      }
+    },
+  );
+
+  const editedSubscription = eventBus.subscribe(
+    EventChannels.MESSAGE_EDITED,
+    async (payload: MessageEditedPayload) => {
+      if (payload.channelId !== channelId) return;
+
+      try {
+        const message = await prisma.message.findUnique({
+          where: { id: payload.messageId },
+          include: MESSAGE_SSE_INCLUDE,
+        });
+        if (!message || message.isDeleted) return;
+
+        writeEvent('message:edited', {
+          id: message.id,
+          channelId: message.channelId,
+          authorId: message.authorId,
+          author: message.author,
+          content: message.content,
+          timestamp: message.createdAt.toISOString(),
+          attachments: message.attachments,
+          editedAt: message.editedAt ? message.editedAt.toISOString() : null,
+        });
+      } catch (err) {
+        logger.warn(
+          { err, channelId, messageId: payload.messageId },
+          'Failed to hydrate SSE message:edited payload',
+        );
+      }
+    },
+  );
+
+  const deletedSubscription = eventBus.subscribe(
+    EventChannels.MESSAGE_DELETED,
+    (payload: MessageDeletedPayload) => {
+      if (payload.channelId !== channelId) return;
+      writeEvent('message:deleted', {
+        messageId: payload.messageId,
+        channelId: payload.channelId,
+      });
+    },
+  );
+
+  const serverUpdatedSubscription = eventBus.subscribe(
+    EventChannels.SERVER_UPDATED,
+    (payload: ServerUpdatedPayload) => {
+      if (payload.serverId !== channel.serverId) return;
+      writeEvent('server:updated', {
+        id: payload.serverId,
+        name: payload.name,
+        icon: payload.iconUrl ?? undefined,
+        description: payload.description,
+        updatedAt: payload.timestamp,
+      });
+    },
+  );
+
+  const channelSubscriptions = [
+    createdSubscription,
+    editedSubscription,
+    deletedSubscription,
+    serverUpdatedSubscription,
+  ];
+
+  await finalizeSseSetup(req, res, sseState, channelSubscriptions, {
+    route: 'channel-events',
+    channelId,
+    serverId: channel.serverId,
+  });
+});
+
+const CHANNEL_SSE_SELECT = {
+  id: true,
+  serverId: true,
+  name: true,
+  slug: true,
+  type: true,
+  visibility: true,
+  topic: true,
+  position: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+/**
+ * GET /api/events/server/:serverId?token=<accessToken>
+ *
+ * Streams real-time server events to authenticated, authorised clients using
+ * Server-Sent Events. Scoped to a server so all members see the same sidebar,
+ * member, message, and server updates regardless of which channel they are viewing.
+ *
+ * Auth: same token-via-query-param pattern as /channel/:channelId (EventSource cannot
+ * send custom headers).
+ *
+ * Authorisation: user must be a member of the server.
+ */
+eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
+  const { serverId } = req.params;
+
+  if (!isValidUUID(serverId)) {
+    res.status(400).json({ error: 'Invalid serverId: must be a UUID' });
+    return;
+  }
+
+  const token = typeof req.query.token === 'string' ? req.query.token : null;
+  if (!token) {
+    res.status(401).json({ error: 'Missing token query parameter' });
+    return;
+  }
+
+  let userId: string;
+  try {
+    const payload = authService.verifyAccessToken(token);
+    userId = payload.sub;
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired access token' });
+    return;
+  }
+
+  const server = await prisma.server.findUnique({
+    where: { id: serverId },
+    select: { id: true },
+  });
+  if (!server) {
+    res.status(404).json({ error: 'Server not found' });
+    return;
+  }
+
+  const membership = await prisma.serverMember.findFirst({
+    where: { userId, serverId },
+    select: { userId: true },
+  });
+  if (!membership) {
+    res.status(403).json({ error: 'You are not a member of this server' });
+    return;
+  }
+
+  const sseState = createBufferedSseState();
+  const writeEvent = createBufferedEventWriter(res, sseState);
+  const serverChannelIds = new Set<string>();
+  const subscriptions: EventSubscription[] = [];
+  let cleanedUp = false;
+
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    cleanupSseConnection(sseState, subscriptions);
+  };
+  req.on('close', cleanup);
+
+  const channelCreatedSubscription = eventBus.subscribe(
+    EventChannels.CHANNEL_CREATED,
+    async (payload: ChannelCreatedPayload) => {
+      if (payload.serverId !== serverId) return;
+      serverChannelIds.add(payload.channelId);
+
+      try {
+        const channel = await prisma.channel.findUnique({
+          where: { id: payload.channelId },
+          select: CHANNEL_SSE_SELECT,
+        });
+        if (!channel) return;
+
+        writeEvent('channel:created', channel);
+      } catch (err) {
+        logger.warn(
+          { err, serverId, channelId: payload.channelId },
+          'Failed to hydrate SSE channel:created payload',
+        );
+      }
+    },
+  );
+  subscriptions.push(channelCreatedSubscription);
+
+  const channelDeletedSubscription = eventBus.subscribe(
+    EventChannels.CHANNEL_DELETED,
+    (payload: ChannelDeletedPayload) => {
+      if (payload.serverId !== serverId) return;
+      serverChannelIds.delete(payload.channelId);
+      writeEvent('channel:deleted', { channelId: payload.channelId });
+    },
+  );
+  subscriptions.push(channelDeletedSubscription);
+
+  let serverChannels: { id: string }[];
+  try {
+    serverChannels = await prisma.channel.findMany({
+      where: { serverId },
+      select: { id: true },
+    });
+  } catch (err) {
+    cleanup();
+    logger.error({ err, serverId }, 'Failed to preload channel IDs for server SSE');
+    if (!res.headersSent) res.status(500).json({ error: 'Internal server error' });
+    return;
+  }
+  for (const currentChannel of serverChannels) {
+    serverChannelIds.add(currentChannel.id);
+  }
+
+  if (cleanedUp) return;
+
+  const messageCreatedSubscription = eventBus.subscribe(
+    EventChannels.MESSAGE_CREATED,
+    async (payload: MessageCreatedPayload) => {
+      if (!serverChannelIds.has(payload.channelId)) return;
+
+      try {
+        const message = await prisma.message.findUnique({
+          where: { id: payload.messageId },
+          include: MESSAGE_SSE_INCLUDE,
+        });
+        if (!message || message.isDeleted) return;
+
+        writeEvent('message:created', {
+          id: message.id,
+          channelId: message.channelId,
+          authorId: message.authorId,
+          author: message.author,
+          content: message.content,
+          timestamp: message.createdAt.toISOString(),
+          attachments: message.attachments,
+          editedAt: message.editedAt ? message.editedAt.toISOString() : null,
+        });
+      } catch (err) {
+        logger.warn(
+          { err, serverId, messageId: payload.messageId },
+          'Failed to hydrate SSE message:created payload on server endpoint',
+        );
+      }
+    },
+  );
+  subscriptions.push(messageCreatedSubscription);
+
+  const messageEditedSubscription = eventBus.subscribe(
+    EventChannels.MESSAGE_EDITED,
+    async (payload: MessageEditedPayload) => {
+      if (!serverChannelIds.has(payload.channelId)) return;
+
+      try {
+        const message = await prisma.message.findUnique({
+          where: { id: payload.messageId },
+          include: MESSAGE_SSE_INCLUDE,
+        });
+        if (!message || message.isDeleted) return;
+
+        writeEvent('message:edited', {
+          id: message.id,
+          channelId: message.channelId,
+          authorId: message.authorId,
+          author: message.author,
+          content: message.content,
+          timestamp: message.createdAt.toISOString(),
+          attachments: message.attachments,
+          editedAt: message.editedAt ? message.editedAt.toISOString() : null,
+        });
+      } catch (err) {
+        logger.warn(
+          { err, serverId, messageId: payload.messageId },
+          'Failed to hydrate SSE message:edited payload on server endpoint',
+        );
+      }
+    },
+  );
+  subscriptions.push(messageEditedSubscription);
+
+  const messageDeletedSubscription = eventBus.subscribe(
+    EventChannels.MESSAGE_DELETED,
+    (payload: MessageDeletedPayload) => {
+      if (!serverChannelIds.has(payload.channelId)) return;
+      writeEvent('message:deleted', {
+        messageId: payload.messageId,
+        channelId: payload.channelId,
+      });
+    },
+  );
+  subscriptions.push(messageDeletedSubscription);
+
+  const serverUpdatedSubscription = eventBus.subscribe(
+    EventChannels.SERVER_UPDATED,
+    (payload: ServerUpdatedPayload) => {
+      if (payload.serverId !== serverId) return;
+      writeEvent('server:updated', {
+        id: payload.serverId,
+        name: payload.name,
+        icon: payload.iconUrl ?? undefined,
+        description: payload.description,
+        updatedAt: payload.timestamp,
+      });
+    },
+  );
+  subscriptions.push(serverUpdatedSubscription);
+
+  const channelUpdatedSubscription = eventBus.subscribe(
+    EventChannels.CHANNEL_UPDATED,
+    async (payload: ChannelUpdatedPayload) => {
+      if (payload.serverId !== serverId) return;
+
+      try {
+        const channel = await prisma.channel.findUnique({
+          where: { id: payload.channelId },
+          select: CHANNEL_SSE_SELECT,
+        });
+        if (!channel) return;
+
+        writeEvent('channel:updated', channel);
+      } catch (err) {
+        logger.warn(
+          { err, serverId, channelId: payload.channelId },
+          'Failed to hydrate SSE channel:updated payload',
+        );
+      }
+    },
+  );
+  subscriptions.push(channelUpdatedSubscription);
+
+  const statusChangedSubscription = eventBus.subscribe(
+    EventChannels.USER_STATUS_CHANGED,
+    (payload: UserStatusChangedPayload) => {
+      if (payload.serverId !== serverId) return;
+      writeEvent('member:statusChanged', {
+        id: payload.userId,
+        status: payload.status.toLowerCase(),
+      });
+    },
+  );
+  subscriptions.push(statusChangedSubscription);
+
+  const memberJoinedSubscription = eventBus.subscribe(
+    EventChannels.MEMBER_JOINED,
+    async (payload: MemberJoinedPayload) => {
+      if (payload.serverId !== serverId) return;
+
+      try {
+        const user = await prisma.user.findUnique({
+          where: { id: payload.userId },
+          select: {
+            id: true,
+            username: true,
+            displayName: true,
+            avatarUrl: true,
+            status: true,
+            publicProfile: true,
+          },
+        });
+        if (!user) return;
+
+        const isPublic = user.publicProfile;
+        writeEvent('member:joined', {
+          id: user.id,
+          username: isPublic ? user.username : 'Anonymous',
+          displayName: isPublic ? user.displayName : undefined,
+          avatar: isPublic ? (user.avatarUrl ?? undefined) : undefined,
+          role: payload.role.toLowerCase(),
+          status: user.status.toLowerCase(),
+        });
+      } catch (err) {
+        logger.warn(
+          { err, serverId, userId: payload.userId },
+          'Failed to hydrate SSE member:joined payload',
+        );
+      }
+    },
+  );
+  subscriptions.push(memberJoinedSubscription);
+
+  const memberLeftSubscription = eventBus.subscribe(
+    EventChannels.MEMBER_LEFT,
+    (payload: MemberLeftPayload) => {
+      if (payload.serverId !== serverId) return;
+      writeEvent('member:left', { userId: payload.userId });
+    },
+  );
+  subscriptions.push(memberLeftSubscription);
+
+  const visibilityChangedSubscription = eventBus.subscribe(
+    EventChannels.VISIBILITY_CHANGED,
+    async (payload: VisibilityChangedPayload) => {
+      if (payload.serverId !== serverId) return;
+
+      try {
+        const channel = await prisma.channel.findUnique({
+          where: { id: payload.channelId },
+          select: CHANNEL_SSE_SELECT,
+        });
+        if (!channel) return;
+
+        writeEvent('channel:visibility-changed', {
+          ...channel,
+          oldVisibility: payload.oldVisibility,
+        });
+      } catch (err) {
+        logger.warn(
+          { err, serverId, channelId: payload.channelId },
+          'Failed to hydrate SSE channel:visibility-changed payload',
+        );
+      }
+    },
+  );
+  subscriptions.push(visibilityChangedSubscription);
+
+  await finalizeSseSetup(req, res, sseState, subscriptions, {
+    route: 'server-events',
+    serverId,
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/events/eventBus.ts
+```
+
+Output:
+
+```text
+/**
+ * EventBus — Redis Pub/Sub transport for cross-service events.
+ *
+ * Design notes:
+ * - Redis Pub/Sub requires a dedicated subscriber connection that cannot
+ *   issue other commands. We create one lazy subscriber client here and
+ *   reuse the shared `redis` publisher client for publishing.
+ * - Payloads are serialized as JSON strings on the wire.
+ * - All channelId / serverId values in payloads are UUIDs emitted by the
+ *   application after DB lookup — they never contain raw user input.
+ */
+
+import Redis from 'ioredis';
+import { redis } from '../db/redis';
+import { createLogger } from '../lib/logger';
+import { EventChannelName, EventPayloadMap, EventHandler, EventChannels } from './eventTypes';
+
+export { EventChannels, EventChannelName, EventPayloadMap, EventHandler };
+export type {
+  VisibilityChangedPayload,
+  MessageCreatedPayload,
+  MessageEditedPayload,
+  MessageDeletedPayload,
+  MetaTagsUpdatedPayload,
+  ServerUpdatedPayload,
+  ReactionAddedPayload,
+  ReactionRemovedPayload,
+} from './eventTypes';
+
+let subscriberClient: Redis | null = null;
+const logger = createLogger({ component: 'event-bus' });
+
+const channelHandlers = new Map<string, Set<(payload: any) => void>>();
+
+const channelReadyPromises = new Map<string, Promise<void>>();
+
+function getSubscriberClient(): Redis {
+  if (!subscriberClient) {
+    subscriberClient = new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379', {
+      maxRetriesPerRequest: null, // subscriber clients must not timeout on blocked commands
+      lazyConnect: true,
+      enableReadyCheck: false,
+    });
+
+    subscriberClient.on('message', (ch: string, rawMessage: string) => {
+      const handlers = channelHandlers.get(ch);
+      if (!handlers) return;
+      let payload: unknown;
+      try {
+        payload = JSON.parse(rawMessage);
+      } catch (err) {
+        logger.error({ err, channel: ch }, 'Failed to parse event payload');
+        return;
+      }
+      for (const handler of handlers) {
+        try {
+          handler(payload);
+        } catch (err) {
+          logger.error({ err, channel: ch }, 'Event handler threw synchronously');
+        }
+      }
+    });
+  }
+  return subscriberClient;
+}
+
+export const eventBus = {
+  /**
+   * Publish a typed event. Fire-and-forget: errors are logged, not thrown,
+   * so a Redis hiccup never blocks the calling service transaction.
+   */
+  async publish<C extends EventChannelName>(
+    channel: C,
+    payload: EventPayloadMap[C],
+  ): Promise<void> {
+    try {
+      await redis.publish(channel, JSON.stringify(payload));
+    } catch (err) {
+      logger.warn({ err, channel }, 'Failed to publish event');
+    }
+  },
+
+  /**
+   * Subscribe to a typed event channel.
+   * Returns `{ unsubscribe, ready }`:
+   *   - `unsubscribe()` removes this handler (and unsubscribes at the Redis level
+   *     when the last handler for the channel is removed).
+   *   - `ready` is a Promise that resolves when the Redis subscribe handshake
+   *     completes, so callers can await it before publishing test messages.
+   * Safe to call multiple times — each call registers an additional handler.
+   */
+  subscribe<C extends EventChannelName>(
+    channel: C,
+    handler: EventHandler<C>,
+  ): { unsubscribe: () => void; ready: Promise<void> } {
+    const client = getSubscriberClient();
+
+    let handlers = channelHandlers.get(channel) as Set<(p: any) => void> | undefined;
+    const isFirstSubscriber = !handlers || handlers.size === 0;
+    if (!handlers) {
+      handlers = new Set<(p: any) => void>();
+      channelHandlers.set(channel, handlers);
+    }
+    handlers.add(handler);
+
+    let ready: Promise<void>;
+    if (isFirstSubscriber) {
+      const handshake = new Promise<void>((resolve, reject) => {
+        client.subscribe(channel, (err) => {
+          if (err) {
+            logger.error({ err, channel }, 'Failed to subscribe to event channel');
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+      ready = handshake;
+      channelReadyPromises.set(channel, handshake);
+    } else {
+      ready = channelReadyPromises.get(channel) ?? Promise.resolve();
+    }
+
+    return {
+      unsubscribe: () => {
+        const set = channelHandlers.get(channel);
+        if (set) {
+          set.delete(handler);
+          if (set.size === 0) {
+            channelHandlers.delete(channel);
+            channelReadyPromises.delete(channel);
+            client
+              .unsubscribe(channel)
+              .catch((err) =>
+                logger.warn({ err, channel }, 'Failed to unsubscribe from event channel'),
+              );
+          }
+        }
+      },
+      ready,
+    };
+  },
+
+  /** Gracefully disconnect the subscriber client (call on server shutdown). */
+  async disconnect(): Promise<void> {
+    if (subscriberClient) {
+      await subscriberClient
+        .quit()
+        .catch((err) => logger.warn({ err }, 'Failed to close event subscriber client cleanly'));
+      subscriberClient = null;
+      channelHandlers.clear();
+      channelReadyPromises.clear();
+    }
+  },
+};
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/hooks/useServerEvents.ts
+```
+
+Output:
+
+```text
+/**
+ * useServerEvents — Issue #185 / #186 / #187 / #189 / #231
+ *
+ * Subscribes to real-time SSE events for a server.
+ * Handles channel list updates (created/updated/deleted), member list
+ * updates (joined/left), member status changes, visibility changes, and
+ * message events (created/edited/deleted) over the single
+ * /api/events/server/:serverId endpoint.
+ *
+ * Message events are scoped to the whole server; callers that only want
+ * messages for the current channel should filter by channelId in their
+ * callback.
+ *
+ * Uses the native EventSource API (no library needed).
+ *
+ * Usage:
+ *   useServerEvents({
+ *     serverId,
+ *     onChannelCreated: (ch) => setChannels(prev => [...prev, ch]),
+ *     onChannelUpdated: (ch) => setChannels(prev => prev.map(c => c.id === ch.id ? ch : c)),
+ *     onChannelDeleted: (id) => setChannels(prev => prev.filter(c => c.id !== id)),
+ *     onMemberJoined: (user) => setMembers(prev => [...prev, user]),
+ *     onMemberLeft: (userId) => setMembers(prev => prev.filter(m => m.id !== userId)),
+ *     onMemberStatusChanged: ({ id, status }) => setMembers(prev =>
+ *       prev.map(m => m.id === id ? { ...m, status } : m)
+ *     ),
+ *     onChannelVisibilityChanged: (ch, oldVis) => { ... },
+ *     onMessageCreated: (msg) => { if (msg.channelId === activeChannelId) append(msg); },
+ *     onMessageEdited: (msg) => { if (msg.channelId === activeChannelId) update(msg); },
+ *     onMessageDeleted: (messageId, channelId) => { if (channelId === activeChannelId) remove(messageId); },
+ *     onServerUpdated: (server) => updateServer(server),
+ *   });
+ */
+
+'use client';
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { Channel, ChannelVisibility } from '@/types/channel';
+import type { Message } from '@/types/message';
+import type { User, UserStatus } from '@/types/user';
+import type { Server } from '@/types/server';
+import { getAccessToken, refreshAccessToken } from '@/lib/api-client';
+import { createFrontendLogger } from '@/lib/frontend-logger';
+import { getApiBaseUrl } from '@/lib/runtime-config';
+
+const logger = createFrontendLogger({ component: 'use-server-events' });
+
+const MAX_RECONNECT_ATTEMPTS = 3;
+const RECONNECT_DELAY_MS = 2_000;
+
+export interface UseServerEventsOptions {
+  serverId: string;
+  onChannelCreated: (channel: Channel) => void;
+  onChannelUpdated: (channel: Channel) => void;
+  onChannelDeleted: (channelId: string) => void;
+  /** Called when a member joins the server. Optional. */
+  onMemberJoined?: (user: User) => void;
+  /** Called with the userId when a member leaves or is kicked. Optional. */
+  onMemberLeft?: (userId: string) => void;
+  /** Called when a member's presence status changes (online/idle/offline). Optional. */
+  onMemberStatusChanged?: (data: { id: string; status: UserStatus }) => void;
+  /**
+   * Called when a channel's visibility changes. The updated channel object is
+   * provided along with the previous visibility so callers can detect access
+   * revocation (e.g. a PUBLIC channel became PRIVATE). Optional.
+   */
+  onChannelVisibilityChanged?: (channel: Channel, oldVisibility: ChannelVisibility) => void;
+  /** Called when a new message is created in any channel of the server. Filter by msg.channelId as needed. Optional. */
+  onMessageCreated?: (msg: Message) => void;
+  /** Called when a message is edited in any channel of the server. Filter by msg.channelId as needed. Optional. */
+  onMessageEdited?: (msg: Message) => void;
+  /** Called when a message is deleted in any channel of the server. Provides messageId and channelId. Optional. */
+  onMessageDeleted?: (messageId: string, channelId: string) => void;
+  /** Called when server metadata (name, icon, description) changes. Optional. */
+  onServerUpdated?: (server: Server) => void;
+  /** Set to false to disable the connection (e.g. for unauthenticated guests). Defaults to true. */
+  enabled?: boolean;
+}
+
+export function useServerEvents({
+  serverId,
+  onChannelCreated,
+  onChannelUpdated,
+  onChannelDeleted,
+  onMemberJoined,
+  onMemberLeft,
+  onMemberStatusChanged,
+  onChannelVisibilityChanged,
+  onMessageCreated,
+  onMessageEdited,
+  onMessageDeleted,
+  onServerUpdated,
+  enabled = true,
+}: UseServerEventsOptions): void {
+  const [reconnectKey, setReconnectKey] = useState(0);
+  const reconnectCountRef = useRef(0);
+
+  const onCreatedRef = useRef(onChannelCreated);
+  const onUpdatedRef = useRef(onChannelUpdated);
+  const onDeletedRef = useRef(onChannelDeleted);
+  const onMemberJoinedRef = useRef(onMemberJoined);
+  const onMemberLeftRef = useRef(onMemberLeft);
+  const onMemberStatusChangedRef = useRef(onMemberStatusChanged);
+  const onVisibilityChangedRef = useRef(onChannelVisibilityChanged);
+  const onMessageCreatedRef = useRef(onMessageCreated);
+  const onMessageEditedRef = useRef(onMessageEdited);
+  const onMessageDeletedRef = useRef(onMessageDeleted);
+  const onServerUpdatedRef = useRef(onServerUpdated);
+
+  useLayoutEffect(() => {
+    onCreatedRef.current = onChannelCreated;
+    onUpdatedRef.current = onChannelUpdated;
+    onDeletedRef.current = onChannelDeleted;
+    onMemberJoinedRef.current = onMemberJoined;
+    onMemberLeftRef.current = onMemberLeft;
+    onMemberStatusChangedRef.current = onMemberStatusChanged;
+    onVisibilityChangedRef.current = onChannelVisibilityChanged;
+    onMessageCreatedRef.current = onMessageCreated;
+    onMessageEditedRef.current = onMessageEdited;
+    onMessageDeletedRef.current = onMessageDeleted;
+    onServerUpdatedRef.current = onServerUpdated;
+  });
+
+  useEffect(() => {
+    if (!enabled || !serverId) return;
+
+    const apiUrl = getApiBaseUrl();
+    const token = getAccessToken();
+    if (!token) return;
+
+    const url = `${apiUrl}/api/events/server/${serverId}?token=${encodeURIComponent(token)}`;
+    const es = new EventSource(url);
+
+    const handleCreated = (event: MessageEvent<string>) => {
+      try {
+        const channel = JSON.parse(event.data) as Channel;
+        onCreatedRef.current(channel);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'channel:created',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    const handleUpdated = (event: MessageEvent<string>) => {
+      try {
+        const channel = JSON.parse(event.data) as Channel;
+        onUpdatedRef.current(channel);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'channel:updated',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    const handleDeleted = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as { channelId: string };
+        onDeletedRef.current(payload.channelId);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'channel:deleted',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    const handleMemberJoined = (event: MessageEvent<string>) => {
+      try {
+        const user = JSON.parse(event.data) as User;
+        onMemberJoinedRef.current?.(user);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'member:joined',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    const handleMemberLeft = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as { userId: string };
+        onMemberLeftRef.current?.(payload.userId);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'member:left',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    const handleMemberStatusChanged = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as { id: string; status: UserStatus };
+        onMemberStatusChangedRef.current?.(payload);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'member:statusChanged',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    const handleVisibilityChanged = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as Channel & { oldVisibility: ChannelVisibility };
+        const { oldVisibility, ...channel } = payload;
+        onVisibilityChangedRef.current?.(channel, oldVisibility);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'channel:visibility-changed',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    const handleMessageCreated = (event: MessageEvent<string>) => {
+      try {
+        const msg = JSON.parse(event.data) as Message;
+        onMessageCreatedRef.current?.(msg);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'message:created',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    const handleMessageEdited = (event: MessageEvent<string>) => {
+      try {
+        const msg = JSON.parse(event.data) as Message;
+        onMessageEditedRef.current?.(msg);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'message:edited',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    const handleMessageDeleted = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as { messageId: string; channelId: string };
+        onMessageDeletedRef.current?.(payload.messageId, payload.channelId);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'message:deleted',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    const handleServerUpdated = (event: MessageEvent<string>) => {
+      try {
+        const server = JSON.parse(event.data) as Server;
+        onServerUpdatedRef.current?.(server);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'server:updated',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
+    es.addEventListener('channel:created', handleCreated);
+    es.addEventListener('channel:updated', handleUpdated);
+    es.addEventListener('channel:deleted', handleDeleted);
+    es.addEventListener('member:joined', handleMemberJoined);
+    es.addEventListener('member:left', handleMemberLeft);
+    es.addEventListener('member:statusChanged', handleMemberStatusChanged);
+    es.addEventListener('channel:visibility-changed', handleVisibilityChanged);
+    es.addEventListener('message:created', handleMessageCreated);
+    es.addEventListener('message:edited', handleMessageEdited);
+    es.addEventListener('message:deleted', handleMessageDeleted);
+    es.addEventListener('server:updated', handleServerUpdated);
+
+    let everOpened = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    es.onopen = () => {
+      everOpened = true;
+      reconnectCountRef.current = 0; // reset budget on successful connection
+    };
+    es.onerror = () => {
+      logger.warn('Server SSE connection failed', {
+        feature: 'server-events',
+        event: everOpened ? 'stream_disconnected' : 'stream_failed',
+        source: 'sse',
+        target: '/api/events/server/[serverId]',
+      });
+      if (!everOpened && reconnectCountRef.current === 0) {
+        es.close();
+        return;
+      }
+
+      es.close();
+      const attempt = reconnectCountRef.current;
+      if (attempt >= MAX_RECONNECT_ATTEMPTS) return;
+
+      reconnectCountRef.current += 1;
+      const delay = RECONNECT_DELAY_MS * reconnectCountRef.current;
+      reconnectTimer = setTimeout(() => {
+        refreshAccessToken().finally(() => {
+          setReconnectKey(k => k + 1);
+        });
+      }, delay);
+    };
+
+    return () => {
+      if (reconnectTimer !== null) clearTimeout(reconnectTimer);
+      es.removeEventListener('channel:created', handleCreated);
+      es.removeEventListener('channel:updated', handleUpdated);
+      es.removeEventListener('channel:deleted', handleDeleted);
+      es.removeEventListener('member:joined', handleMemberJoined);
+      es.removeEventListener('member:left', handleMemberLeft);
+      es.removeEventListener('member:statusChanged', handleMemberStatusChanged);
+      es.removeEventListener('channel:visibility-changed', handleVisibilityChanged);
+      es.removeEventListener('message:created', handleMessageCreated);
+      es.removeEventListener('message:edited', handleMessageEdited);
+      es.removeEventListener('message:deleted', handleMessageDeleted);
+      es.removeEventListener('server:updated', handleServerUpdated);
+      es.close();
+    };
+  }, [serverId, enabled, reconnectKey]);
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/components/layout/HarmonyShell.tsx
+```
+
+Output:
+
+```text
+/**
+ * Layout: HarmonyShell
+ * Full Discord-like 3-column layout shell.
+ * Wires together ServerRail, ChannelSidebar, TopBar, MessageList, MembersSidebar, SearchModal.
+ */
+
+'use client';
+
+import { useState, useEffect, useCallback, useMemo, useSyncExternalStore } from 'react';
+import { cn } from '@/lib/utils';
+import { TopBar } from '@/components/channel/TopBar';
+import { MembersSidebar } from '@/components/channel/MembersSidebar';
+import { SearchModal } from '@/components/channel/SearchModal';
+import { PinnedMessagesPanel } from '@/components/channel/PinnedMessagesPanel';
+import { ChannelSidebar } from '@/components/channel/ChannelSidebar';
+import { MessageInput } from '@/components/channel/MessageInput';
+import { MessageList } from '@/components/channel/MessageList';
+import { ServerRail } from '@/components/server-rail/ServerRail';
+import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+import { CreateChannelModal } from '@/components/channel/CreateChannelModal';
+import { useAuth } from '@/hooks/useAuth';
+import { VoiceProvider } from '@/contexts/VoiceContext';
+import { BrowseServersModal } from '@/components/server-rail/BrowseServersModal';
+import { useServerEvents } from '@/hooks/useServerEvents';
+import { useServerListSync } from '@/hooks/useServerListSync';
+import { ChannelType, ChannelVisibility, UserStatus } from '@/types';
+import { useRouter } from 'next/navigation';
+import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
+import type { Server, Channel, Message, User } from '@/types';
+
+const BG = {
+  tertiary: 'bg-[#202225]',
+  primary: 'bg-[#36393f]',
+};
+
+const subscribeToViewport = (cb: () => void) => {
+  const mql = window.matchMedia('(min-width: 640px)');
+  mql.addEventListener('change', cb);
+  return () => mql.removeEventListener('change', cb);
+};
+const getViewportSnapshot = () => window.matchMedia('(min-width: 640px)').matches;
+const getServerViewportSnapshot = () => false;
+
+export interface HarmonyShellProps {
+  servers: Server[];
+  currentServer: Server;
+  /** Channels belonging to the current server — used by ChannelSidebar */
+  channels: Channel[];
+  /**
+   * All channels across every server — used by ServerRail to derive the
+   * correct default channel slug when navigating to another server.
+   * #c32: passing only serverChannels here caused other server icons to link
+   * to a non-existent route because their channels weren't in the list.
+   */
+  allChannels: Channel[];
+  currentChannel: Channel;
+  messages: Message[];
+  members: User[];
+  /** Base path for navigation links. Use "/c" for public guest routes, "/channels" for authenticated routes. */
+  basePath?: string;
+  /** Optional replacement for the center chat pane while keeping the shell visible. */
+  lockedMessagePane?: React.ReactNode;
+}
+
+export function HarmonyShell({
+  servers,
+  currentServer,
+  channels,
+  allChannels,
+  currentChannel,
+  messages,
+  members,
+  basePath = '/c',
+  lockedMessagePane,
+}: HarmonyShellProps) {
+  const isChannelLocked = lockedMessagePane !== undefined;
+  const [membersOverride, setMembersOverride] = useState<boolean | null>(null);
+
+  const isDesktopViewport = useSyncExternalStore(
+    subscribeToViewport,
+    getViewportSnapshot,
+    getServerViewportSnapshot,
+  );
+
+  const isMembersOpen = membersOverride !== null ? membersOverride : isDesktopViewport;
+  const setIsMembersOpen = useCallback((val: boolean) => setMembersOverride(val), []);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [isPinsOpen, setIsPinsOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [localMessages, setLocalMessages] = useState<Message[]>(messages);
+  const [prevChannelId, setPrevChannelId] = useState(currentChannel.id);
+  if (prevChannelId !== currentChannel.id) {
+    setPrevChannelId(currentChannel.id);
+    setLocalMessages(messages);
+    setIsMenuOpen(false);
+    setIsPinsOpen(false);
+    if (typeof window !== 'undefined' && !window.matchMedia('(min-width: 640px)').matches) {
+      setIsMembersOpen(false);
+    }
+  }
+  const [localChannels, setLocalChannels] = useState<Channel[]>(channels);
+  const defaultChannelByServerId = useMemo(() => {
+    const map = new Map<string, string>();
+    const textOrAnnouncement = allChannels
+      .filter(c => c.type === ChannelType.TEXT || c.type === ChannelType.ANNOUNCEMENT)
+      .sort((a, b) => a.position - b.position);
+    for (const channel of textOrAnnouncement) {
+      if (!map.has(channel.serverId)) map.set(channel.serverId, channel.slug);
+    }
+    return map;
+  }, [allChannels]);
+
+  const voiceChannelIds = useMemo(
+    () => localChannels.filter(c => c.type === ChannelType.VOICE).map(c => c.id),
+    [localChannels],
+  );
+  const [prevChannelsProp, setPrevChannelsProp] = useState(channels);
+  if (prevChannelsProp !== channels) {
+    setPrevChannelsProp(channels);
+    setLocalChannels(channels);
+  }
+  const [localMembers, setLocalMembers] = useState<User[]>(members);
+  const [prevMembersProp, setPrevMembersProp] = useState(members);
+  if (prevMembersProp !== members) {
+    setPrevMembersProp(members);
+    setLocalMembers(members);
+  }
+  const [isCreateChannelOpen, setIsCreateChannelOpen] = useState(false);
+  const [createChannelDefaultType, setCreateChannelDefaultType] = useState<ChannelType>(
+    ChannelType.TEXT,
+  );
+
+  const {
+    user: authUser,
+    isAuthenticated,
+    isLoading: isAuthLoading,
+    isAdmin: checkIsAdmin,
+  } = useAuth();
+
+  const currentUser: User = authUser ?? {
+    id: 'guest',
+    username: 'Guest',
+    displayName: 'Guest',
+    status: 'online',
+    role: 'guest',
+  };
+
+  const router = useRouter();
+  const [isCreateServerOpen, setIsCreateServerOpen] = useState(false);
+  const [isBrowseServersOpen, setIsBrowseServersOpen] = useState(false);
+  const [localServers, setLocalServers] = useState<Server[]>(servers);
+  const [prevServers, setPrevServers] = useState<Server[]>(servers);
+  if (prevServers !== servers) {
+    setPrevServers(servers);
+    setLocalServers(servers);
+  }
+
+  const { notifyServerCreated, notifyServerJoined } = useServerListSync();
+
+  const currentMemberRecord = useMemo(
+    () => localMembers.find(m => m.id === authUser?.id),
+    [localMembers, authUser?.id],
+  );
+  const canPin = useMemo(
+    () =>
+      isAuthenticated &&
+      !isChannelLocked &&
+      (authUser?.isSystemAdmin ||
+        currentMemberRecord?.role === 'owner' ||
+        currentMemberRecord?.role === 'admin' ||
+        currentMemberRecord?.role === 'moderator'),
+    [isAuthenticated, isChannelLocked, authUser?.isSystemAdmin, currentMemberRecord?.role],
+  );
+
+  const handleServerCreated = useCallback(
+    (server: Server, defaultChannel: Channel) => {
+      setLocalServers(prev => [...prev, server]);
+      notifyServerCreated(server.id);
+      router.push(`${basePath}/${server.slug}/${defaultChannel.slug}`);
+    },
+    [basePath, notifyServerCreated, router],
+  );
+
+  const handleMessageSent = useCallback((msg: Message) => {
+    setLocalMessages(prev => (prev.some(m => m.id === msg.id) ? prev : [...prev, msg]));
+  }, []);
+
+  const handleRealTimeCreated = useCallback(
+    (msg: Message) => {
+      if (msg.channelId !== currentChannel.id) return;
+      setLocalMessages(prev => (prev.some(m => m.id === msg.id) ? prev : [...prev, msg]));
+    },
+    [currentChannel.id],
+  );
+
+  const handleRealTimeEdited = useCallback(
+    (msg: Message) => {
+      if (msg.channelId !== currentChannel.id) return;
+      setLocalMessages(prev => prev.map(m => (m.id === msg.id ? msg : m)));
+    },
+    [currentChannel.id],
+  );
+
+  const handleRealTimeDeleted = useCallback(
+    (messageId: string, channelId: string) => {
+      if (channelId !== currentChannel.id) return;
+      setLocalMessages(prev => prev.filter(m => m.id !== messageId));
+    },
+    [currentChannel.id],
+  );
+
+  const handleServerUpdated = useCallback((updatedServer: Server) => {
+    setLocalServers(prev =>
+      prev.map(s => (s.id === updatedServer.id ? { ...s, ...updatedServer } : s)),
+    );
+  }, []);
+
+  const handleChannelCreated = useCallback((channel: Channel) => {
+    setLocalChannels(prev => {
+      if (prev.some(c => c.id === channel.id)) return prev;
+      const insertIdx =
+        channel.type === ChannelType.VOICE
+          ? prev.length
+          : prev.findIndex(c => c.type === ChannelType.VOICE);
+      const at = insertIdx === -1 ? prev.length : insertIdx;
+      return [...prev.slice(0, at), channel, ...prev.slice(at)];
+    });
+  }, []);
+
+  const handleChannelUpdated = useCallback((channel: Channel) => {
+    setLocalChannels(prev => prev.map(c => (c.id === channel.id ? channel : c)));
+  }, []);
+
+  const handleChannelDeleted = useCallback(
+    (channelId: string) => {
+      setLocalChannels(prev => prev.filter(c => c.id !== channelId));
+      if (channelId === currentChannel.id) {
+        router.push(`${basePath}/${currentServer.slug}`);
+      }
+    },
+    [currentChannel.id, currentServer.slug, basePath, router],
+  );
+
+  const handleMemberJoined = useCallback((user: User) => {
+    setLocalMembers(prev => {
+      if (prev.some(m => m.id === user.id)) return prev;
+      return [...prev, user];
+    });
+  }, []);
+
+  const handleMemberLeft = useCallback((userId: string) => {
+    setLocalMembers(prev => prev.filter(m => m.id !== userId));
+  }, []);
+
+  const handleMemberStatusChanged = useCallback(
+    ({ id, status }: { id: string; status: UserStatus }) => {
+      setLocalMembers(prev => prev.map(m => (m.id === id ? { ...m, status } : m)));
+    },
+    [],
+  );
+
+  const handleChannelVisibilityChanged = useCallback(
+    (channel: Channel, oldVisibility: ChannelVisibility) => {
+      setLocalChannels(prev => prev.map(c => (c.id === channel.id ? channel : c)));
+
+      const memberRecord = localMembers.find(m => m.id === authUser?.id);
+      const userIsAdminOrOwner =
+        checkIsAdmin(currentServer.ownerId) ||
+        memberRecord?.role === 'owner' ||
+        memberRecord?.role === 'admin';
+      if (
+        channel.id === currentChannel.id &&
+        oldVisibility !== ChannelVisibility.PRIVATE &&
+        channel.visibility === ChannelVisibility.PRIVATE &&
+        !userIsAdminOrOwner
+      ) {
+        router.push(`${basePath}/${currentServer.slug}`);
+      }
+    },
+    [
+      currentChannel.id,
+      checkIsAdmin,
+      currentServer.ownerId,
+      basePath,
+      currentServer.slug,
+      router,
+      localMembers,
+      authUser?.id,
+    ],
+  );
+
+  useServerEvents({
+    serverId: currentServer.id,
+    onChannelCreated: handleChannelCreated,
+    onChannelUpdated: handleChannelUpdated,
+    onChannelDeleted: handleChannelDeleted,
+    onMemberJoined: handleMemberJoined,
+    onMemberLeft: handleMemberLeft,
+    onMemberStatusChanged: handleMemberStatusChanged,
+    onChannelVisibilityChanged: handleChannelVisibilityChanged,
+    onMessageCreated: isChannelLocked ? undefined : handleRealTimeCreated,
+    onMessageEdited: isChannelLocked ? undefined : handleRealTimeEdited,
+    onMessageDeleted: isChannelLocked ? undefined : handleRealTimeDeleted,
+    onServerUpdated: handleServerUpdated,
+    enabled: isAuthenticated,
+  });
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (isChannelLocked) return;
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault();
+        setIsSearchOpen(v => !v);
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isChannelLocked]);
+
+  return (
+    <VoiceProvider serverId={currentServer.id} voiceChannelIds={voiceChannelIds}>
+      <div className='flex h-screen overflow-hidden bg-[#202225] font-sans'>
+        <a
+          href='#main-content'
+          className='sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:z-50 focus-visible:m-2 focus-visible:rounded focus-visible:bg-[#5865f2] focus-visible:px-4 focus-visible:py-2 focus-visible:text-sm focus-visible:font-semibold focus-visible:text-white focus-visible:outline-none'
+        >
+          Skip to content
+        </a>
+
+        <ServerRail
+          servers={localServers}
+          allChannels={allChannels}
+          currentServerId={currentServer.id}
+          basePath={basePath}
+          isMobileVisible={isMenuOpen}
+          onBrowseServers={() => setIsBrowseServersOpen(true)}
+          onAddServer={
+            isAuthLoading
+              ? undefined
+              : () => {
+                  if (!isAuthenticated) {
+                    router.push('/auth/login');
+                    return;
+                  }
+                  setIsCreateServerOpen(true);
+                }
+          }
+        />
+
+        <ChannelSidebar
+          server={currentServer}
+          channels={localChannels}
+          currentChannelId={currentChannel.id}
+          currentUser={currentUser}
+          isOpen={isMenuOpen}
+          onClose={() => setIsMenuOpen(false)}
+          basePath={basePath}
+          isAuthenticated={isAuthenticated}
+          serverId={currentServer.id}
+          members={members}
+          onCreateChannel={defaultType => {
+            setCreateChannelDefaultType(defaultType);
+            setIsCreateChannelOpen(true);
+          }}
+        />
+
+        <main
+          id='main-content'
+          className='flex flex-1 flex-col overflow-hidden'
+          aria-label={`${currentChannel.name} channel`}
+          tabIndex={-1}
+        >
+          <TopBar
+            channel={currentChannel}
+            serverSlug={currentServer.slug}
+            isAdmin={checkIsAdmin(currentServer.ownerId)}
+            isMembersOpen={isMembersOpen}
+            onMembersToggle={() => setIsMembersOpen(!isMembersOpen)}
+            onSearchOpen={isChannelLocked ? undefined : () => setIsSearchOpen(true)}
+            onPinsOpen={isChannelLocked ? undefined : () => setIsPinsOpen(true)}
+            disableMessageActions={isChannelLocked}
+            isMenuOpen={isMenuOpen}
+            onMenuToggle={() => setIsMenuOpen(v => !v)}
+          />
+
+          <div className='flex flex-1 overflow-hidden'>
+            <div className={cn('flex flex-1 flex-col overflow-hidden', BG.primary)}>
+              {lockedMessagePane ? (
+                lockedMessagePane
+              ) : (
+                <>
+                  <MessageList
+                    key={currentChannel.id}
+                    channel={currentChannel}
+                    messages={localMessages}
+                    serverId={currentServer.id}
+                    canPin={canPin}
+                  />
+                  <MessageInput
+                    channelId={currentChannel.id}
+                    channelName={currentChannel.name}
+                    serverId={currentServer.id}
+                    isReadOnly={currentUser.role === 'guest'}
+                    onMessageSent={handleMessageSent}
+                  />
+                  {!isAuthLoading && !isAuthenticated && (
+                    <GuestPromoBanner
+                      serverName={currentServer.name}
+                      memberCount={currentServer.memberCount ?? members.length}
+                    />
+                  )}
+                </>
+              )}
+            </div>
+            {!isChannelLocked && (
+              <PinnedMessagesPanel
+                channelId={currentChannel.id}
+                serverId={currentServer.id}
+                channelName={currentChannel.name}
+                isOpen={isPinsOpen}
+                onClose={() => setIsPinsOpen(false)}
+              />
+            )}
+            <MembersSidebar
+              members={members}
+              isOpen={isMembersOpen}
+              onClose={() => setIsMembersOpen(false)}
+            />
+          </div>
+        </main>
+
+        <CreateServerModal
+          isOpen={isCreateServerOpen}
+          onClose={() => setIsCreateServerOpen(false)}
+          onCreated={handleServerCreated}
+        />
+
+        <BrowseServersModal
+          isOpen={isBrowseServersOpen}
+          onClose={() => setIsBrowseServersOpen(false)}
+          joinedServerIds={new Set(localServers.map(s => s.id))}
+          defaultChannelByServerId={defaultChannelByServerId}
+          basePath={basePath}
+          onJoined={notifyServerJoined}
+        />
+
+        {!isChannelLocked && (
+          <SearchModal
+            messages={localMessages}
+            channelName={currentChannel.name}
+            isOpen={isSearchOpen}
+            onClose={() => setIsSearchOpen(false)}
+          />
+        )}
+
+        {isCreateChannelOpen && (
+          <CreateChannelModal
+            serverId={currentServer.id}
+            serverSlug={currentServer.slug}
+            existingChannels={localChannels}
+            defaultType={createChannelDefaultType}
+            onCreated={newChannel =>
+              setLocalChannels(prev => {
+                const insertIdx =
+                  newChannel.type === ChannelType.VOICE
+                    ? prev.length
+                    : prev.findIndex(c => c.type === ChannelType.VOICE);
+                const at = insertIdx === -1 ? prev.length : insertIdx;
+                return [...prev.slice(0, at), newChannel, ...prev.slice(at)];
+              })
+            }
+            onClose={() => setIsCreateChannelOpen(false)}
+          />
+        )}
+      </div>
+    </VoiceProvider>
+  );
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/prisma/schema.prisma
+```
+
+Output:
+
+```text
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum ChannelVisibility {
+  PUBLIC_INDEXABLE
+  PUBLIC_NO_INDEX
+  PRIVATE
+
+  @@map("channel_visibility")
+}
+
+enum UserStatus {
+  ONLINE
+  IDLE
+  DND
+  OFFLINE
+
+  @@map("user_status")
+}
+
+enum ChannelType {
+  TEXT
+  VOICE
+  ANNOUNCEMENT
+
+  @@map("channel_type")
+}
+
+enum RoleType {
+  OWNER
+  ADMIN
+  MODERATOR
+  MEMBER
+  GUEST
+
+  @@map("role_type")
+}
+
+model User {
+  id            String     @id @default(uuid()) @db.Uuid
+  email         String     @unique @db.VarChar(254)
+  username      String     @unique @db.VarChar(32)
+  passwordHash  String     @map("password_hash") @db.VarChar(255)
+  displayName   String     @map("display_name") @db.VarChar(100)
+  avatarUrl     String?    @map("avatar_url") @db.VarChar(500)
+  publicProfile Boolean    @default(true) @map("public_profile")
+  status        UserStatus @default(OFFLINE)
+  createdAt     DateTime   @default(now()) @map("created_at") @db.Timestamptz
+
+  messages           Message[]
+  reactions          MessageReaction[]
+  visibilityAuditLog VisibilityAuditLog[] @relation("AuditActor")
+  refreshTokens      RefreshToken[]
+  ownedServers       Server[]             @relation("ServerOwner")
+  serverMemberships  ServerMember[]
+
+  @@map("users")
+}
+
+model RefreshToken {
+  id         String    @id @default(uuid()) @db.Uuid
+  tokenHash  String    @unique @map("token_hash") @db.VarChar(64)
+  userId     String    @map("user_id") @db.Uuid
+  expiresAt  DateTime  @map("expires_at") @db.Timestamptz
+  revokedAt  DateTime? @map("revoked_at") @db.Timestamptz
+  createdAt  DateTime  @default(now()) @map("created_at") @db.Timestamptz
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId], map: "idx_refresh_tokens_user")
+  @@map("refresh_tokens")
+}
+
+model Server {
+  id          String   @id @default(uuid()) @db.Uuid
+  name        String   @db.VarChar(100)
+  slug        String   @unique(map: "idx_servers_slug") @db.VarChar(100)
+  description String?  @db.Text
+  iconUrl     String?  @map("icon_url") @db.VarChar(500)
+  isPublic    Boolean  @default(false) @map("is_public")
+  memberCount Int      @default(0) @map("member_count")
+  ownerId     String   @map("owner_id") @db.Uuid
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  owner    User      @relation("ServerOwner", fields: [ownerId], references: [id])
+  channels Channel[]
+  members  ServerMember[]
+
+  @@map("servers")
+}
+
+model ServerMember {
+  userId    String   @map("user_id") @db.Uuid
+  serverId  String   @map("server_id") @db.Uuid
+  role      RoleType @default(MEMBER)
+  joinedAt  DateTime @default(now()) @map("joined_at") @db.Timestamptz
+
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  server Server @relation(fields: [serverId], references: [id], onDelete: Cascade)
+
+  @@id([userId, serverId])
+  @@index([serverId], map: "idx_server_members_server")
+  @@map("server_members")
+}
+
+model Channel {
+  id         String            @id @default(uuid()) @db.Uuid
+  serverId   String            @map("server_id") @db.Uuid
+  name       String            @db.VarChar(100)
+  slug       String            @db.VarChar(100)
+  type       ChannelType       @default(TEXT) @map("channel_type")
+  visibility ChannelVisibility @default(PRIVATE)
+  topic      String?           @db.Text
+  position   Int               @default(0)
+  indexedAt  DateTime?         @map("indexed_at") @db.Timestamptz
+  createdAt  DateTime          @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt  DateTime          @updatedAt @map("updated_at") @db.Timestamptz
+
+  server            Server              @relation(fields: [serverId], references: [id], onDelete: Cascade)
+  messages          Message[]
+  auditLog          VisibilityAuditLog[]
+  generatedMetaTags GeneratedMetaTags?
+
+  @@unique([serverId, slug], map: "idx_channels_server_slug")
+  @@index([serverId, visibility], map: "idx_channels_server_visibility")
+  @@map("channels")
+}
+
+model Message {
+  id              String    @id @default(uuid()) @db.Uuid
+  channelId       String    @map("channel_id") @db.Uuid
+  authorId        String    @map("author_id") @db.Uuid
+  content         String    @db.Text
+  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  editedAt        DateTime? @map("edited_at") @db.Timestamptz
+  isDeleted       Boolean   @default(false) @map("is_deleted")
+  pinned          Boolean   @default(false) @map("pinned")
+  pinnedAt        DateTime? @map("pinned_at") @db.Timestamptz
+  parentMessageId String?   @map("parent_message_id") @db.Uuid
+  replyCount      Int       @default(0) @map("reply_count")
+
+  channel     Channel          @relation(fields: [channelId], references: [id], onDelete: Cascade)
+  author      User             @relation(fields: [authorId], references: [id])
+  attachments Attachment[]
+  reactions   MessageReaction[]
+  parent      Message?         @relation("MessageReplies", fields: [parentMessageId], references: [id], onDelete: SetNull)
+  replies     Message[]        @relation("MessageReplies")
+
+  @@map("messages")
+}
+
+model MessageReaction {
+  id        String   @id @default(uuid()) @db.Uuid
+  messageId String   @map("message_id") @db.Uuid
+  userId    String   @map("user_id") @db.Uuid
+  emoji     String   @db.VarChar(100)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  message Message @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([messageId, userId, emoji], map: "idx_message_reactions_unique")
+  @@index([messageId], map: "idx_message_reactions_message")
+  @@map("message_reactions")
+}
+
+model Attachment {
+  id          String @id @default(uuid()) @db.Uuid
+  messageId   String @map("message_id") @db.Uuid
+  filename    String @db.VarChar(255)
+  url         String @db.VarChar(500)
+  contentType String @map("content_type") @db.VarChar(100)
+  sizeBytes   BigInt @map("size_bytes")
+
+  message Message @relation(fields: [messageId], references: [id], onDelete: Cascade)
+
+  @@map("attachments")
+}
+
+model VisibilityAuditLog {
+  id        String   @id @default(uuid()) @db.Uuid
+  channelId String   @map("channel_id") @db.Uuid
+  actorId   String   @map("actor_id") @db.Uuid
+  action    String   @db.VarChar(50)
+  oldValue  Json     @map("old_value")
+  newValue  Json     @map("new_value")
+  timestamp DateTime @default(now()) @db.Timestamptz
+  ipAddress String   @map("ip_address") @db.Inet
+  userAgent String   @map("user_agent") @db.VarChar(500)
+
+  channel Channel @relation(fields: [channelId], references: [id], onDelete: Cascade)
+  actor   User    @relation("AuditActor", fields: [actorId], references: [id])
+
+  @@map("visibility_audit_log")
+}
+
+model GeneratedMetaTags {
+  id                  String   @id @default(uuid()) @db.Uuid
+  channelId           String   @unique(map: "idx_meta_tags_channel") @map("channel_id") @db.Uuid
+  title               String   @db.VarChar(120)
+  description         String   @db.VarChar(320)
+  ogTitle             String   @map("og_title") @db.VarChar(120)
+  ogDescription       String   @map("og_description") @db.VarChar(320)
+  ogImage             String?  @map("og_image") @db.VarChar(500)
+  twitterCard         String   @map("twitter_card") @db.VarChar(20)
+  keywords            String   @db.Text
+  structuredData      Json     @map("structured_data")
+  contentHash         String   @map("content_hash") @db.VarChar(64)
+  needsRegeneration   Boolean  @default(false) @map("needs_regeneration")
+  generatedAt         DateTime @default(now()) @map("generated_at") @db.Timestamptz
+  schemaVersion       Int      @default(1) @map("schema_version")
+  customTitle         String?  @map("custom_title") @db.VarChar(70)
+  customDescription   String?  @map("custom_description") @db.VarChar(200)
+  customOgImage       String?  @map("custom_og_image") @db.VarChar(500)
+  createdAt           DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt           DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  channel Channel @relation(fields: [channelId], references: [id], onDelete: Cascade)
+
+  @@map("generated_meta_tags")
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/services/user.service.ts
+```
+
+Output:
+
+```text
+import { TRPCError } from '@trpc/server';
+import { Prisma, UserStatus } from '@prisma/client';
+import { isSystemAdmin } from '../lib/admin.utils';
+import { eventBus, EventChannels } from '../events/eventBus';
+import { userRepository } from '../repositories/user.repository';
+import { serverMemberRepository } from '../repositories/serverMember.repository';
+
+export interface UpdateUserInput {
+  displayName?: string;
+  avatarUrl?: string | null;
+  publicProfile?: boolean;
+  status?: UserStatus;
+}
+
+export const userService = {
+  /**
+   * Returns a user's profile by ID, respecting the publicProfile privacy flag.
+   * Users with publicProfile=false are returned anonymised — per architecture §4.1:
+   * "Users with public_profile = false are displayed as 'Anonymous' with no avatar."
+   * The publicProfile flag itself is also masked (returned as true) so callers
+   * cannot infer whether a user has a private profile.
+   * Credential fields (passwordHash, email) are never returned.
+   */
+  async getUser(userId: string) {
+    const user = await userRepository.findById(userId);
+    if (!user) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+    }
+    if (!user.publicProfile) {
+      return {
+        ...user,
+        username: 'anonymous',
+        displayName: 'Anonymous',
+        avatarUrl: null,
+        publicProfile: true, // mask the flag — callers cannot infer private status
+        status: UserStatus.OFFLINE,
+      };
+    }
+    return user;
+  },
+
+  /**
+   * Returns the full safe profile for the currently authenticated user.
+   * Bypasses the publicProfile privacy filter — a user always sees their own data.
+   * Never returns passwordHash.
+   */
+  async getCurrentUser(userId: string) {
+    const user = await userRepository.findSelf(userId);
+    if (!user) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+    }
+    return {
+      ...user,
+      isSystemAdmin: await isSystemAdmin(userId),
+    };
+  },
+
+  async updateUser(userId: string, patch: UpdateUserInput) {
+    try {
+      const updated = await userRepository.update(userId, {
+        ...(patch.displayName !== undefined && { displayName: patch.displayName }),
+        ...(patch.avatarUrl !== undefined && { avatarUrl: patch.avatarUrl }),
+        ...(patch.publicProfile !== undefined && { publicProfile: patch.publicProfile }),
+        ...(patch.status !== undefined && { status: patch.status }),
+      });
+
+      if (patch.status !== undefined) {
+        const memberships = await serverMemberRepository.findByUserIdSelect(userId);
+        for (const { serverId } of memberships) {
+          void eventBus.publish(EventChannels.USER_STATUS_CHANGED, {
+            userId,
+            serverId,
+            status: patch.status,
+          });
+        }
+      }
+
+      return updated;
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+      }
+      throw e;
+    }
+  },
+};
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/trpc/routers/user.router.ts
+```
+
+Output:
+
+```text
+import { z } from 'zod';
+import { UserStatus } from '@prisma/client';
+import { router, authedProcedure } from '../init';
+import { userService } from '../../services/user.service';
+
+const UserStatusSchema = z.nativeEnum(UserStatus);
+
+export const userRouter = router({
+  getCurrentUser: authedProcedure.query(({ ctx }) =>
+    userService.getCurrentUser(ctx.userId),
+  ),
+
+  getUser: authedProcedure
+    .input(z.object({ userId: z.string().uuid() }))
+    .query(({ input }) => userService.getUser(input.userId)),
+
+  updateUser: authedProcedure
+    .input(
+      z.object({
+        displayName: z.string().trim().min(1).max(100).optional(),
+        avatarUrl: z.string().url().regex(/^https?:\/\//).max(500).nullable().optional(),
+        publicProfile: z.boolean().optional(),
+        status: UserStatusSchema.optional(),
+      }),
+    )
+    .mutation(({ ctx, input }) => userService.updateUser(ctx.userId, input)),
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/repositories/user.repository.ts
+```
+
+Output:
+
+```text
+import { Prisma } from '@prisma/client';
+import { prisma } from '../db/prisma';
+
+type Client = Prisma.TransactionClient | typeof prisma;
+
+export const PUBLIC_PROFILE_SELECT = {
+  id: true,
+  username: true,
+  displayName: true,
+  avatarUrl: true,
+  publicProfile: true,
+  status: true,
+  createdAt: true,
+} as const;
+
+export const SELF_PROFILE_SELECT = {
+  id: true,
+  email: true,
+  username: true,
+  displayName: true,
+  avatarUrl: true,
+  publicProfile: true,
+  status: true,
+  createdAt: true,
+} as const;
+
+export const userRepository = {
+  findById(id: string, client: Client = prisma) {
+    return client.user.findUnique({ where: { id }, select: PUBLIC_PROFILE_SELECT });
+  },
+
+  findSelf(id: string, client: Client = prisma) {
+    return client.user.findUnique({ where: { id }, select: SELF_PROFILE_SELECT });
+  },
+
+  findByEmail(email: string, client: Client = prisma) {
+    return client.user.findUnique({ where: { email } });
+  },
+
+  findByEmailSelect(email: string, client: Client = prisma) {
+    return client.user.findUnique({ where: { email }, select: { passwordHash: true } });
+  },
+
+  findByUsername(username: string, client: Client = prisma) {
+    return client.user.findUnique({ where: { username } });
+  },
+
+  create(data: Prisma.UserCreateInput, client: Client = prisma) {
+    return client.user.create({ data });
+  },
+
+  upsert(
+    where: Prisma.UserWhereUniqueInput,
+    update: Prisma.UserUpdateInput,
+    create: Prisma.UserCreateInput,
+    client: Client = prisma,
+  ) {
+    return client.user.upsert({ where, update, create });
+  },
+
+  update(id: string, data: Prisma.UserUpdateInput, client: Client = prisma) {
+    return client.user.update({ where: { id }, select: SELF_PROFILE_SELECT, data });
+  },
+};
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/types/user.ts
+```
+
+Output:
+
+```text
+/**
+ * Type Definitions: User
+ * Based on dev spec data schemas (CL-D10, CL-E*)
+ */
+
+export type UserStatus = 'online' | 'idle' | 'dnd' | 'offline';
+
+export type UserRole = 'owner' | 'admin' | 'moderator' | 'member' | 'guest';
+
+export interface User {
+  id: string;
+  username: string;
+  displayName?: string;
+  avatar?: string;
+  status: UserStatus;
+  role: UserRole;
+  /** True when logged in as the dev system admin (admin@harmony.dev). */
+  isSystemAdmin?: boolean;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/lib/trpc-client.ts
+```
+
+Output:
+
+```text
+/**
+ * Server-side tRPC/API client for calling the Harmony backend.
+ *
+ * Uses plain HTTP (fetch) to call:
+
+import { API_CONFIG } from './constants';
+import { cookies } from 'next/headers';
+import { createFrontendLogger } from './frontend-logger';
+import { TrpcHttpError } from './trpc-errors';
+
+export { TrpcHttpError } from './trpc-errors';
+
+const logger = createFrontendLogger({ component: 'trpc-client' });
+
+/**
+ * Reads the auth token from the cookie store (Next.js server-side).
+ * Returns undefined if no token is available.
+ */
+async function getAuthToken(): Promise<string | undefined> {
+  try {
+    const cookieStore = await cookies();
+    return cookieStore.get('auth_token')?.value;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * GET from the public REST API. Returns null on 404, throws on other non-2xx responses.
+ * Return type is `T | null` to make 404 handling explicit at call sites.
+ */
+export async function publicGet<T>(path: string): Promise<T | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+  let res: Response;
+  try {
+    res = await fetch(`${API_CONFIG.BASE_URL}/api/public${path}`, {
+      next: { revalidate: 60 }, // ISR: revalidate every 60s
+      signal: controller.signal,
+    });
+  } catch (error) {
+    logger.error('Public API request threw before completion', {
+      feature: 'public-api',
+      event: 'request_exception',
+      method: 'GET',
+      route: path,
+      error,
+    });
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!res.ok) {
+    if (res.status === 404) return null;
+    logger.warn('Public API request failed', {
+      feature: 'public-api',
+      event: 'http_failure',
+      method: 'GET',
+      route: path,
+      statusCode: res.status,
+    });
+    throw new Error(`Public API error: ${res.status}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+/**
+ * Calls a tRPC query procedure via HTTP GET.
+ * Input is JSON-serialized as a query parameter.
+ */
+export async function trpcQuery<T>(procedure: string, input?: unknown): Promise<T> {
+  const url = new URL(`${API_CONFIG.BASE_URL}/trpc/${procedure}`);
+  if (input !== undefined) {
+    url.searchParams.set('input', JSON.stringify(input));
+  }
+
+  const token = await getAuthToken();
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+  let res: Response;
+  try {
+    res = await fetch(url.toString(), {
+      headers,
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+  } catch (error) {
+    logger.error('tRPC query request threw before completion', {
+      feature: 'trpc',
+      event: 'request_exception',
+      method: 'GET',
+      procedure,
+      route: `/trpc/${procedure}`,
+      error,
+    });
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    if (res.status !== 401 && res.status !== 403) {
+      logger.warn('tRPC query failed', {
+        feature: 'trpc',
+        event: 'http_failure',
+        method: 'GET',
+        procedure,
+        route: `/trpc/${procedure}`,
+        statusCode: res.status,
+      });
+    }
+    throw new TrpcHttpError(procedure, res.status, body);
+  }
+
+  const json = await res.json();
+  const data = json.result?.data;
+  if (data === undefined) {
+    logger.error('tRPC query response missing result.data', {
+      feature: 'trpc',
+      event: 'invalid_response',
+      method: 'GET',
+      procedure,
+      route: `/trpc/${procedure}`,
+    });
+    throw new Error(`tRPC query [${procedure}]: response missing result.data`);
+  }
+  return data as T;
+}
+
+interface BackendSessionUser {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  status: 'ONLINE' | 'IDLE' | 'DND' | 'OFFLINE';
+  isSystemAdmin?: boolean;
+}
+
+/**
+ * Returns the currently authenticated user using the server-side cookie,
+ * or null if no valid session exists.
+ *
+ * Safe to call from Server Components and Server Actions — uses the httpOnly
+ * `auth_token` cookie forwarded to the backend as a Bearer token.
+ */
+export async function getSessionUser(): Promise<{
+  id: string;
+  username: string;
+  displayName: string;
+  isSystemAdmin: boolean;
+} | null> {
+  const token = await getAuthToken();
+  if (!token) return null;
+  try {
+    const user = await trpcQuery<BackendSessionUser>('user.getCurrentUser');
+    return {
+      id: user.id,
+      username: user.username,
+      displayName: user.displayName ?? user.username,
+      isSystemAdmin: user.isSystemAdmin ?? false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Calls a tRPC mutation procedure via HTTP POST.
+ */
+export async function trpcMutate<T>(procedure: string, input?: unknown): Promise<T> {
+  const token = await getAuthToken();
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+  let res: Response;
+  try {
+    res = await fetch(`${API_CONFIG.BASE_URL}/trpc/${procedure}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(input ?? {}),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    logger.error('tRPC mutation request threw before completion', {
+      feature: 'trpc',
+      event: 'request_exception',
+      method: 'POST',
+      procedure,
+      route: `/trpc/${procedure}`,
+      error,
+    });
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    logger.warn('tRPC mutation failed', {
+      feature: 'trpc',
+      event: 'http_failure',
+      method: 'POST',
+      procedure,
+      route: `/trpc/${procedure}`,
+      statusCode: res.status,
+    });
+    throw new TrpcHttpError(procedure, res.status, body);
+  }
+
+  const json = await res.json();
+  const data = json.result?.data;
+  if (data === undefined) {
+    logger.error('tRPC mutation response missing result.data', {
+      feature: 'trpc',
+      event: 'invalid_response',
+      method: 'POST',
+      procedure,
+      route: `/trpc/${procedure}`,
+    });
+    throw new Error(`tRPC mutation [${procedure}]: response missing result.data`);
+  }
+  return data as T;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/lib/api-client.ts
+```
+
+Output:
+
+```text
+import axios, {
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  type InternalAxiosRequestConfig,
+} from 'axios';
+import { API_CONFIG } from './constants';
+import { createFrontendLogger } from './frontend-logger';
+import { setSessionCookie } from '@/app/actions/session';
+
+const REFRESH_TOKEN_KEY = 'harmony_refresh_token';
+const logger = createFrontendLogger({ component: 'api-client' });
+
+let _accessToken: string | null = null;
+let _isRefreshing = false;
+let _refreshQueue: Array<(token: string | null) => void> = [];
+
+function notifyRefreshQueue(token: string | null) {
+  _refreshQueue.forEach(resolve => resolve(token));
+  _refreshQueue = [];
+}
+
+export function setTokens(accessToken: string, refreshToken: string): void {
+  _accessToken = accessToken;
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+  }
+}
+
+export function clearTokens(): void {
+  _accessToken = null;
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+  }
+}
+
+export function getAccessToken(): string | null {
+  return _accessToken;
+}
+
+export function getRefreshToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+export interface TrpcResponse<T> {
+  result: { data: T };
+}
+
+/**
+ * API Client for Harmony backend.
+ * Handles JWT bearer auth, automatic token refresh on 401, and tRPC calls.
+ */
+class ApiClient {
+  private client: AxiosInstance;
+
+  constructor() {
+    this.client = axios.create({
+      baseURL: API_CONFIG.BASE_URL,
+      timeout: API_CONFIG.TIMEOUT,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    this.setupInterceptors();
+  }
+
+  private setupInterceptors() {
+    this.client.interceptors.request.use(
+      (config: InternalAxiosRequestConfig) => {
+        const token = getAccessToken();
+        if (token) {
+          config.headers = config.headers ?? {};
+          config.headers.Authorization = `Bearer ${token}`;
+        }
+        return config;
+      },
+      error => Promise.reject(error),
+    );
+
+    this.client.interceptors.response.use(
+      response => response,
+      async error => {
+        const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+        const statusCode =
+          typeof error.response?.status === 'number' ? error.response.status : undefined;
+        const method =
+          typeof originalRequest?.method === 'string'
+            ? originalRequest.method.toUpperCase()
+            : undefined;
+        const route = typeof originalRequest?.url === 'string' ? originalRequest.url : undefined;
+
+        if (statusCode === 401 && !originalRequest._retry) {
+          const refreshToken = getRefreshToken();
+          if (!refreshToken) {
+            logger.warn('Auth session refresh skipped because no refresh token is stored', {
+              feature: 'auth',
+              event: 'refresh_skipped',
+              method,
+              route,
+              statusCode,
+              reason: 'missing_refresh_token',
+            });
+            clearTokens();
+            return Promise.reject(error);
+          }
+
+          if (_isRefreshing) {
+            return new Promise(resolve => {
+              _refreshQueue.push((newToken: string | null) => {
+                if (newToken) {
+                  originalRequest.headers = originalRequest.headers ?? {};
+                  originalRequest.headers.Authorization = `Bearer ${newToken}`;
+                  resolve(this.client(originalRequest));
+                } else {
+                  resolve(Promise.reject(error));
+                }
+              });
+            });
+          }
+
+          originalRequest._retry = true;
+          _isRefreshing = true;
+
+          try {
+            const res = await axios.post<{ accessToken: string; refreshToken: string }>(
+              `${API_CONFIG.BASE_URL}/api/auth/refresh`,
+              { refreshToken },
+            );
+            const { accessToken: newAt, refreshToken: newRt } = res.data;
+            setTokens(newAt, newRt);
+            try {
+              await setSessionCookie(newAt);
+            } catch (sessionError) {
+              logger.warn('Server session cookie sync failed after token refresh', {
+                feature: 'auth',
+                event: 'cookie_sync_failed',
+                method: 'POST',
+                route: '/api/auth/refresh',
+                retryCount: 1,
+                error: sessionError,
+              });
+            }
+            notifyRefreshQueue(newAt);
+
+            originalRequest.headers = originalRequest.headers ?? {};
+            originalRequest.headers.Authorization = `Bearer ${newAt}`;
+            return this.client(originalRequest);
+          } catch (refreshError) {
+            logger.error('Auth session refresh failed', {
+              feature: 'auth',
+              event: 'refresh_failed',
+              method: 'POST',
+              route: '/api/auth/refresh',
+              retryCount: 1,
+              error: refreshError,
+            });
+            clearTokens();
+            notifyRefreshQueue(null);
+            if (typeof window !== 'undefined') {
+              window.location.href = '/auth/login';
+            }
+            return Promise.reject(error);
+          } finally {
+            _isRefreshing = false;
+          }
+        }
+
+        if (statusCode === undefined || statusCode >= 500) {
+          logger.error('Browser API request failed', {
+            feature: 'browser-api',
+            event: 'request_failed',
+            method,
+            route,
+            statusCode,
+            error,
+          });
+        }
+
+        return Promise.reject(error);
+      },
+    );
+  }
+
+  async get<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
+    const response = await this.client.get<T>(url, config);
+    return response.data;
+  }
+
+  async post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
+    const response = await this.client.post<T>(url, data, config);
+    return response.data;
+  }
+
+  async put<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
+    const response = await this.client.put<T>(url, data, config);
+    return response.data;
+  }
+
+  async delete<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
+    const response = await this.client.delete<T>(url, config);
+    return response.data;
+  }
+
+  /** Call a tRPC query procedure (GET). Returns the unwrapped data. */
+  async trpcQuery<T>(procedure: string, input?: unknown): Promise<T> {
+    const url =
+      input !== undefined
+        ? `/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
+        : `/trpc/${procedure}`;
+    const res = await this.client.get<TrpcResponse<T>>(url);
+    return res.data.result.data;
+  }
+
+  /** Call a tRPC mutation procedure (POST). Returns the unwrapped data. */
+  async trpcMutation<T>(procedure: string, input?: unknown): Promise<T> {
+    const res = await this.client.post<TrpcResponse<T>>(`/trpc/${procedure}`, input ?? null);
+    return res.data.result.data;
+  }
+}
+
+export const apiClient = new ApiClient();
+
+/**
+ * Proactively refreshes the access token using the stored refresh token.
+ * Safe to call from SSE hooks before reconnecting after a dropped connection.
+ *
+ * Reuses the module-level _isRefreshing/_refreshQueue so concurrent calls
+ * (e.g. an interceptor refresh already in flight) are coalesced rather than
+ * issuing a second /refresh request.
+ *
+ * On failure the function returns silently — it does NOT redirect or clear
+ * tokens. The caller (SSE reconnect logic) should proceed with whatever token
+ * is currently in memory; if that token is also expired the EventSource will
+ * fail cleanly on its next connection attempt.
+ */
+export async function refreshAccessToken(): Promise<void> {
+  if (typeof window === 'undefined') return;
+
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return;
+
+  if (_isRefreshing) {
+    await new Promise<void>(resolve => {
+      _refreshQueue.push(() => resolve());
+    });
+    return;
+  }
+
+  _isRefreshing = true;
+  try {
+    const res = await axios.post<{ accessToken: string; refreshToken: string }>(
+      `${API_CONFIG.BASE_URL}/api/auth/refresh`,
+      { refreshToken },
+    );
+    const { accessToken: newAt, refreshToken: newRt } = res.data;
+    setTokens(newAt, newRt);
+    try {
+      await setSessionCookie(newAt);
+    } catch {
+    }
+    notifyRefreshQueue(newAt);
+  } catch {
+    notifyRefreshQueue(null);
+  } finally {
+    _isRefreshing = false;
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/__tests__/useServerEvents.test.tsx
+```
+
+Output:
+
+```text
+/**
+ * useServerEvents.test.tsx — Issue #185 / #186 / #187 / #189 / #231
+ *
+ * Tests the useServerEvents hook that subscribes to real-time SSE events for
+ * channel list updates, member list updates, member status changes, visibility
+ * changes, message events, and server:updated events.
+ *
+ * EventSource is mocked to avoid actual network connections.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useServerEvents } from '../hooks/useServerEvents';
+import { ChannelType, ChannelVisibility } from '../types/channel';
+import type { Channel } from '../types/channel';
+import type { Message } from '../types/message';
+import type { User } from '../types/user';
+
+jest.mock('../lib/api-client', () => ({
+  getAccessToken: jest.fn(() => 'mock-token'),
+}));
+
+type EventSourceHandler = (event: MessageEvent) => void;
+
+interface MockEventSourceInstance {
+  url: string;
+  addEventListener: jest.Mock;
+  removeEventListener: jest.Mock;
+  close: jest.Mock;
+  onerror: ((event: Event) => void) | null;
+  onopen: ((event: Event) => void) | null;
+  simulateEvent: (type: string, data: unknown) => void;
+  simulateOpen: () => void;
+  simulateError: () => void;
+}
+
+let mockEventSourceInstance: MockEventSourceInstance | null = null;
+
+const MockEventSource = jest.fn().mockImplementation((url: string) => {
+  const handlers = new Map<string, EventSourceHandler[]>();
+
+  const instance: MockEventSourceInstance = {
+    url,
+    addEventListener: jest.fn((type: string, handler: EventSourceHandler) => {
+      if (!handlers.has(type)) handlers.set(type, []);
+      handlers.get(type)!.push(handler);
+    }),
+    removeEventListener: jest.fn((type: string, handler: EventSourceHandler) => {
+      const list = handlers.get(type) ?? [];
+      handlers.set(
+        type,
+        list.filter(h => h !== handler),
+      );
+    }),
+    close: jest.fn(),
+    onerror: null,
+    onopen: null,
+
+    simulateEvent(type: string, data: unknown) {
+      const event = new MessageEvent(type, { data: JSON.stringify(data) });
+      (handlers.get(type) ?? []).forEach(h => h(event));
+    },
+
+    simulateOpen() {
+      if (this.onopen) this.onopen(new Event('open'));
+    },
+
+    simulateError() {
+      if (this.onerror) this.onerror(new Event('error'));
+    },
+  };
+
+  mockEventSourceInstance = instance;
+  return instance;
+});
+
+(MockEventSource as unknown as { CONNECTING: number; OPEN: number; CLOSED: number }).CONNECTING = 0;
+(MockEventSource as unknown as { CONNECTING: number; OPEN: number; CLOSED: number }).OPEN = 1;
+(MockEventSource as unknown as { CONNECTING: number; OPEN: number; CLOSED: number }).CLOSED = 2;
+
+Object.defineProperty(global, 'EventSource', {
+  writable: true,
+  value: MockEventSource,
+});
+
+const SERVER_ID = '550e8400-e29b-41d4-a716-446655440010';
+const API_URL = 'http://localhost:4000';
+
+const MOCK_CHANNEL: Channel = {
+  id: 'ch-001',
+  serverId: SERVER_ID,
+  name: 'general',
+  slug: 'general',
+  type: ChannelType.TEXT,
+  visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+  position: 0,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+const MOCK_USER: User = {
+  id: 'user-new',
+  username: 'newmember',
+  displayName: 'New Member',
+  status: 'online',
+  role: 'member',
+};
+
+const MOCK_MESSAGE: Message = {
+  id: 'msg-001',
+  channelId: 'ch-001',
+  authorId: 'user-001',
+  author: { id: 'user-001', username: 'alice', displayName: 'Alice' },
+  content: 'Hello world',
+  timestamp: '2024-01-01T00:00:00.000Z',
+  attachments: [],
+};
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockEventSourceInstance = null;
+  process.env = { ...originalEnv, NEXT_PUBLIC_API_URL: API_URL };
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  process.env = originalEnv;
+});
+
+describe('useServerEvents — connection', () => {
+  it('creates an EventSource with the correct server URL', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    expect(MockEventSource).toHaveBeenCalledWith(
+      `${API_URL}/api/events/server/${SERVER_ID}?token=mock-token`,
+    );
+  });
+
+  it('does NOT create EventSource when enabled=false', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        enabled: false,
+      }),
+    );
+
+    expect(MockEventSource).not.toHaveBeenCalled();
+  });
+
+  it('closes the EventSource on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    unmount();
+
+    expect(mockEventSourceInstance?.close).toHaveBeenCalled();
+  });
+
+  it('registers listeners for all eleven event types', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberJoined: jest.fn(),
+        onMemberLeft: jest.fn(),
+        onMemberStatusChanged: jest.fn(),
+        onChannelVisibilityChanged: jest.fn(),
+        onMessageCreated: jest.fn(),
+        onMessageEdited: jest.fn(),
+        onMessageDeleted: jest.fn(),
+        onServerUpdated: jest.fn(),
+      }),
+    );
+
+    const addedTypes = (
+      mockEventSourceInstance!.addEventListener.mock.calls as [string, unknown][]
+    ).map(([type]) => type);
+
+    expect(addedTypes).toContain('channel:created');
+    expect(addedTypes).toContain('channel:updated');
+    expect(addedTypes).toContain('channel:deleted');
+    expect(addedTypes).toContain('member:joined');
+    expect(addedTypes).toContain('member:left');
+    expect(addedTypes).toContain('member:statusChanged');
+    expect(addedTypes).toContain('channel:visibility-changed');
+    expect(addedTypes).toContain('message:created');
+    expect(addedTypes).toContain('message:edited');
+    expect(addedTypes).toContain('message:deleted');
+    expect(addedTypes).toContain('server:updated');
+  });
+});
+
+describe('useServerEvents — channel events', () => {
+  it('calls onChannelCreated with parsed channel on channel:created event', () => {
+    const onChannelCreated = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated,
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('channel:created', MOCK_CHANNEL);
+    });
+
+    expect(onChannelCreated).toHaveBeenCalledTimes(1);
+    expect(onChannelCreated).toHaveBeenCalledWith(MOCK_CHANNEL);
+  });
+
+  it('calls onChannelUpdated with parsed channel on channel:updated event', () => {
+    const onChannelUpdated = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated,
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('channel:updated', {
+        ...MOCK_CHANNEL,
+        name: 'renamed',
+      });
+    });
+
+    expect(onChannelUpdated).toHaveBeenCalledTimes(1);
+    expect(onChannelUpdated).toHaveBeenCalledWith({ ...MOCK_CHANNEL, name: 'renamed' });
+  });
+
+  it('calls onChannelDeleted with channelId on channel:deleted event', () => {
+    const onChannelDeleted = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('channel:deleted', { channelId: 'ch-001' });
+    });
+
+    expect(onChannelDeleted).toHaveBeenCalledTimes(1);
+    expect(onChannelDeleted).toHaveBeenCalledWith('ch-001');
+  });
+});
+
+describe('useServerEvents — member events', () => {
+  it('calls onMemberJoined with parsed User on member:joined event', () => {
+    const onMemberJoined = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberJoined,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('member:joined', MOCK_USER);
+    });
+
+    expect(onMemberJoined).toHaveBeenCalledTimes(1);
+    expect(onMemberJoined).toHaveBeenCalledWith(MOCK_USER);
+  });
+
+  it('calls onMemberLeft with userId on member:left event', () => {
+    const onMemberLeft = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberLeft,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('member:left', { userId: 'user-new' });
+    });
+
+    expect(onMemberLeft).toHaveBeenCalledTimes(1);
+    expect(onMemberLeft).toHaveBeenCalledWith('user-new');
+  });
+
+  it('does not throw when onMemberJoined is not provided', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        mockEventSourceInstance!.simulateEvent('member:joined', MOCK_USER);
+      });
+    }).not.toThrow();
+  });
+
+  it('does not throw when onMemberLeft is not provided', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        mockEventSourceInstance!.simulateEvent('member:left', { userId: 'user-new' });
+      });
+    }).not.toThrow();
+  });
+
+  it('removes member:joined and member:left listeners on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberJoined: jest.fn(),
+        onMemberLeft: jest.fn(),
+      }),
+    );
+
+    unmount();
+
+    const removedTypes = (
+      mockEventSourceInstance!.removeEventListener.mock.calls as [string, unknown][]
+    ).map(([type]) => type);
+
+    expect(removedTypes).toContain('member:joined');
+    expect(removedTypes).toContain('member:left');
+  });
+
+  it('does not call onMemberJoined on malformed JSON', () => {
+    const onMemberJoined = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberJoined,
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        const badEvent = new MessageEvent('member:joined', { data: 'not-json{{{' });
+        (mockEventSourceInstance!.addEventListener.mock.calls as [string, EventSourceHandler][])
+          .filter(([type]) => type === 'member:joined')
+          .forEach(([, handler]) => handler(badEvent));
+      });
+    }).not.toThrow();
+
+    expect(onMemberJoined).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      '[frontend]',
+      expect.objectContaining({
+        message: 'Dropped malformed server SSE payload',
+        fields: expect.objectContaining({
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          operation: 'member:joined',
+        }),
+      }),
+    );
+  });
+});
+
+describe('useServerEvents — member status change events', () => {
+  it('calls onMemberStatusChanged with id and status on member:statusChanged event', () => {
+    const onMemberStatusChanged = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberStatusChanged,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('member:statusChanged', {
+        id: 'user-new',
+        status: 'idle',
+      });
+    });
+
+    expect(onMemberStatusChanged).toHaveBeenCalledTimes(1);
+    expect(onMemberStatusChanged).toHaveBeenCalledWith({ id: 'user-new', status: 'idle' });
+  });
+
+  it('does not throw when onMemberStatusChanged is not provided', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        mockEventSourceInstance!.simulateEvent('member:statusChanged', {
+          id: 'user-new',
+          status: 'offline',
+        });
+      });
+    }).not.toThrow();
+  });
+
+  it('removes member:statusChanged listener on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberStatusChanged: jest.fn(),
+      }),
+    );
+
+    unmount();
+
+    const removedTypes = (
+      mockEventSourceInstance!.removeEventListener.mock.calls as [string, unknown][]
+    ).map(([type]) => type);
+
+    expect(removedTypes).toContain('member:statusChanged');
+  });
+
+  it('does not call onMemberStatusChanged on malformed JSON', () => {
+    const onMemberStatusChanged = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMemberStatusChanged,
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        const badEvent = new MessageEvent('member:statusChanged', { data: 'not-json{{{' });
+        (mockEventSourceInstance!.addEventListener.mock.calls as [string, EventSourceHandler][])
+          .filter(([type]) => type === 'member:statusChanged')
+          .forEach(([, handler]) => handler(badEvent));
+      });
+    }).not.toThrow();
+
+    expect(onMemberStatusChanged).not.toHaveBeenCalled();
+  });
+});
+
+describe('useServerEvents — channel:visibility-changed events', () => {
+  it('registers a listener for channel:visibility-changed', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onChannelVisibilityChanged: jest.fn(),
+      }),
+    );
+
+    const addedTypes = (
+      mockEventSourceInstance!.addEventListener.mock.calls as [string, unknown][]
+    ).map(([type]) => type);
+
+    expect(addedTypes).toContain('channel:visibility-changed');
+  });
+
+  it('calls onChannelVisibilityChanged with channel and oldVisibility on event', () => {
+    const onChannelVisibilityChanged = jest.fn();
+    const updatedChannel: Channel = { ...MOCK_CHANNEL, visibility: ChannelVisibility.PRIVATE };
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onChannelVisibilityChanged,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('channel:visibility-changed', {
+        ...updatedChannel,
+        oldVisibility: ChannelVisibility.PUBLIC_INDEXABLE,
+      });
+    });
+
+    expect(onChannelVisibilityChanged).toHaveBeenCalledTimes(1);
+    expect(onChannelVisibilityChanged).toHaveBeenCalledWith(
+      updatedChannel,
+      ChannelVisibility.PUBLIC_INDEXABLE,
+    );
+  });
+
+  it('does not throw when onChannelVisibilityChanged is not provided', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        mockEventSourceInstance!.simulateEvent('channel:visibility-changed', {
+          ...MOCK_CHANNEL,
+          visibility: ChannelVisibility.PRIVATE,
+          oldVisibility: ChannelVisibility.PUBLIC_INDEXABLE,
+        });
+      });
+    }).not.toThrow();
+  });
+
+  it('removes channel:visibility-changed listener on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onChannelVisibilityChanged: jest.fn(),
+      }),
+    );
+
+    unmount();
+
+    const removedTypes = (
+      mockEventSourceInstance!.removeEventListener.mock.calls as [string, unknown][]
+    ).map(([type]) => type);
+
+    expect(removedTypes).toContain('channel:visibility-changed');
+  });
+
+  it('does not call onChannelVisibilityChanged on malformed JSON', () => {
+    const onChannelVisibilityChanged = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onChannelVisibilityChanged,
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        const badEvent = new MessageEvent('channel:visibility-changed', { data: 'not-json{{{' });
+        (mockEventSourceInstance!.addEventListener.mock.calls as [string, EventSourceHandler][])
+          .filter(([type]) => type === 'channel:visibility-changed')
+          .forEach(([, handler]) => handler(badEvent));
+      });
+    }).not.toThrow();
+
+    expect(onChannelVisibilityChanged).not.toHaveBeenCalled();
+  });
+
+  it('logs when the EventSource connection fails before opening', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateError();
+    });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[frontend]',
+      expect.objectContaining({
+        message: 'Server SSE connection failed',
+        fields: expect.objectContaining({
+          feature: 'server-events',
+          event: 'stream_failed',
+        }),
+      }),
+    );
+  });
+});
+
+describe('useServerEvents — message events', () => {
+  it('calls onMessageCreated with parsed message on message:created event', () => {
+    const onMessageCreated = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMessageCreated,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('message:created', MOCK_MESSAGE);
+    });
+
+    expect(onMessageCreated).toHaveBeenCalledTimes(1);
+    expect(onMessageCreated).toHaveBeenCalledWith(MOCK_MESSAGE);
+  });
+
+  it('calls onMessageEdited with parsed message on message:edited event', () => {
+    const onMessageEdited = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMessageEdited,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('message:edited', {
+        ...MOCK_MESSAGE,
+        content: 'edited content',
+      });
+    });
+
+    expect(onMessageEdited).toHaveBeenCalledTimes(1);
+    expect(onMessageEdited).toHaveBeenCalledWith({ ...MOCK_MESSAGE, content: 'edited content' });
+  });
+
+  it('calls onMessageDeleted with messageId and channelId on message:deleted event', () => {
+    const onMessageDeleted = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMessageDeleted,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('message:deleted', {
+        messageId: 'msg-001',
+        channelId: 'ch-001',
+      });
+    });
+
+    expect(onMessageDeleted).toHaveBeenCalledTimes(1);
+    expect(onMessageDeleted).toHaveBeenCalledWith('msg-001', 'ch-001');
+  });
+
+  it('does not throw when message callbacks are not provided', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        mockEventSourceInstance!.simulateEvent('message:created', MOCK_MESSAGE);
+        mockEventSourceInstance!.simulateEvent('message:edited', MOCK_MESSAGE);
+        mockEventSourceInstance!.simulateEvent('message:deleted', {
+          messageId: 'msg-001',
+          channelId: 'ch-001',
+        });
+      });
+    }).not.toThrow();
+  });
+
+  it('removes message listeners on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMessageCreated: jest.fn(),
+        onMessageEdited: jest.fn(),
+        onMessageDeleted: jest.fn(),
+      }),
+    );
+
+    unmount();
+
+    const removedTypes = (
+      mockEventSourceInstance!.removeEventListener.mock.calls as [string, unknown][]
+    ).map(([type]) => type);
+
+    expect(removedTypes).toContain('message:created');
+    expect(removedTypes).toContain('message:edited');
+    expect(removedTypes).toContain('message:deleted');
+  });
+
+  it('does not call onMessageCreated on malformed JSON', () => {
+    const onMessageCreated = jest.fn();
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onMessageCreated,
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        const badEvent = new MessageEvent('message:created', { data: 'not-json{{{' });
+        (mockEventSourceInstance!.addEventListener.mock.calls as [string, EventSourceHandler][])
+          .filter(([type]) => type === 'message:created')
+          .forEach(([, handler]) => handler(badEvent));
+      });
+    }).not.toThrow();
+
+    expect(onMessageCreated).not.toHaveBeenCalled();
+  });
+});
+
+describe('useServerEvents — server:updated events', () => {
+  it('calls onServerUpdated with parsed server on server:updated event', () => {
+    const onServerUpdated = jest.fn();
+    const MOCK_SERVER = { id: SERVER_ID, name: 'Test Server', iconUrl: null, description: null };
+
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onServerUpdated,
+      }),
+    );
+
+    act(() => {
+      mockEventSourceInstance!.simulateEvent('server:updated', MOCK_SERVER);
+    });
+
+    expect(onServerUpdated).toHaveBeenCalledTimes(1);
+    expect(onServerUpdated).toHaveBeenCalledWith(MOCK_SERVER);
+  });
+
+  it('does not throw when onServerUpdated is not provided', () => {
+    renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        mockEventSourceInstance!.simulateEvent('server:updated', {
+          id: SERVER_ID,
+          name: 'Updated Server',
+        });
+      });
+    }).not.toThrow();
+  });
+
+  it('removes server:updated listener on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useServerEvents({
+        serverId: SERVER_ID,
+        onChannelCreated: jest.fn(),
+        onChannelUpdated: jest.fn(),
+        onChannelDeleted: jest.fn(),
+        onServerUpdated: jest.fn(),
+      }),
+    );
+
+    unmount();
+
+    const removedTypes = (
+      mockEventSourceInstance!.removeEventListener.mock.calls as [string, unknown][]
+    ).map(([type]) => type);
+
+    expect(removedTypes).toContain('server:updated');
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rg --files harmony-backend/src harmony-backend/tests | grep test | sed -n '1,200p'
+```
+
+Output:
+
+```text
+harmony-backend/tests/__snapshots__/contentFilter.test.ts.snap
+harmony-backend/tests/attachment.service.test.ts
+harmony-backend/tests/logger.test.ts
+harmony-backend/tests/indexing.service.test.ts
+harmony-backend/tests/public.router.test.ts
+harmony-backend/tests/message.replies.test.ts
+harmony-backend/tests/helpers/async.ts
+harmony-backend/tests/events.router.member.test.ts
+harmony-backend/tests/visibility.service.test.ts
+harmony-backend/tests/server.test.ts
+harmony-backend/tests/server.flow.integration.test.ts
+harmony-backend/tests/trpc.error-formatter.test.ts
+harmony-backend/tests/serverMember.test.ts
+harmony-backend/tests/permission.service.test.ts
+harmony-backend/tests/channel.getAuditLog.test.ts
+harmony-backend/tests/cache.middleware.test.ts
+harmony-backend/tests/metaTagService.test.ts
+harmony-backend/tests/events.router.test.ts
+harmony-backend/tests/tsconfig.json
+harmony-backend/tests/metaTagUpdate.runtime.test.ts
+harmony-backend/tests/demo-seed.test.ts
+harmony-backend/tests/cache.service.test.ts
+harmony-backend/tests/metaTagUpdate.integration.test.ts
+harmony-backend/tests/user.service.test.ts
+harmony-backend/tests/rate-limit.redis.test.ts
+harmony-backend/tests/admin.utils.test.ts
+harmony-backend/tests/trpc.permission.middleware.test.ts
+harmony-backend/tests/message.service.events.test.ts
+harmony-backend/tests/admin.metaTag.router.test.ts
+harmony-backend/tests/contentFilter.test.ts
+harmony-backend/tests/contentAnalysis.test.ts
+harmony-backend/tests/reaction.test.ts
+harmony-backend/tests/events.router.status.test.ts
+harmony-backend/tests/events.router.sse-server-updated.test.ts
+harmony-backend/tests/auth.service.test.ts
+harmony-backend/tests/channel.service.events.test.ts
+harmony-backend/tests/message.service.test.ts
+harmony-backend/tests/channel.service.test.ts
+harmony-backend/tests/metaTagUpdate.pipeline.test.ts
+harmony-backend/tests/auth.flow.integration.test.ts
+harmony-backend/tests/eventBus.test.ts
+harmony-backend/tests/auditLog.service.test.ts
+harmony-backend/tests/app.rate-limit.test.ts
+harmony-backend/tests/seo.router.test.ts
+harmony-backend/tests/voice.service.test.ts
+harmony-backend/tests/mock-seed.test.ts
+harmony-backend/tests/rate-limit.middleware.test.ts
+harmony-backend/tests/events.router.server.test.ts
+harmony-backend/tests/events.router.visibility.test.ts
+harmony-backend/tests/auth.test.ts
+harmony-backend/tests/metaTagUpdate.queue.test.ts
+harmony-backend/tests/schema.test.ts
+harmony-backend/tests/metaTagUpdate.worker.test.ts
+harmony-backend/tests/auth.service.init.test.ts
+harmony-backend/tests/server.service.test.ts
+harmony-backend/tests/attachment.router.test.ts
+harmony-backend/tests/app.test.ts
+harmony-backend/tests/metaTag.repository.test.ts
+harmony-backend/tests/metaTagService.integration.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/trpc/init.ts
+```
+
+Output:
+
+```text
+import { initTRPC, TRPCError } from '@trpc/server';
+import type { Request } from 'express';
+import { authService } from '../services/auth.service';
+import { permissionService, type Action } from '../services/permission.service';
+
+export interface TRPCContext {
+  userId: string | null;
+  ip: string;
+  userAgent: string;
+}
+
+export function createContext({ req }: { req: Request }): TRPCContext {
+  let userId: string | null = null;
+
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith('Bearer ')) {
+    try {
+      const payload = authService.verifyAccessToken(authHeader.slice(7));
+      userId = payload.sub;
+    } catch {
+    }
+  }
+
+  return { userId, ip: req.ip ?? '', userAgent: req.get('user-agent') ?? '' };
+}
+
+const t = initTRPC.context<TRPCContext>().create({
+  errorFormatter({ shape }) {
+    return {
+      ...shape,
+      data: {
+        ...shape.data,
+        stack: process.env.NODE_ENV === 'development' ? shape.data.stack : undefined,
+      },
+    };
+  },
+});
+
+export const router = t.router;
+export const createCallerFactory = t.createCallerFactory;
+
+/** Use for unauthenticated procedures (health, public REST). */
+export const publicProcedure = t.procedure;
+
+/** Use for all admin/authenticated tRPC procedures.
+ *  Throws UNAUTHORIZED if no userId is present in context. */
+export const authedProcedure = t.procedure.use(({ ctx, next }) => {
+  if (!ctx.userId) {
+    throw new TRPCError({ code: 'UNAUTHORIZED' });
+  }
+  return next({ ctx: { ...ctx, userId: ctx.userId } });
+});
+
+/**
+ * Returns a procedure that requires the caller to hold the given `action`
+ * permission inside the server identified by `input.serverId`.
+ *
+ * Usage:
+ *   withPermission('channel:create')
+ *     .input(z.object({ serverId: z.string().uuid(), ... }))
+ *     .mutation(...)
+ *
+ * The input schema MUST include `serverId: string` (UUID).
+ *
+ * Throws:
+ *   - BAD_REQUEST  — `serverId` is absent from the input
+ *   - FORBIDDEN    — caller is not a member, lacks the action, or the server
+ *                    does not exist (NOT_FOUND is collapsed to FORBIDDEN to
+ *                    prevent callers from probing arbitrary server UUIDs)
+ */
+export function withPermission(action: Action) {
+  return authedProcedure.use(async ({ ctx, getRawInput, next }) => {
+    const raw = await getRawInput();
+    const input = raw as { serverId?: unknown };
+    const serverId = input?.serverId;
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (typeof serverId !== 'string' || !UUID_RE.test(serverId)) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'serverId must be a valid UUID' });
+    }
+    try {
+      await permissionService.requirePermission(ctx.userId, serverId, action);
+    } catch (err) {
+      if (err instanceof TRPCError && err.code === 'NOT_FOUND') {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' });
+      }
+      throw err;
+    }
+    return next();
+  });
+}
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:37:17.736Z
+
+There is already a `USER_STATUS_CHANGED` event and the server SSE endpoint forwards it as `member:statusChanged`; the missing pieces are automatic client activity reporting, a unload-safe offline path, and a small display-state wiring fix so the members sidebar uses the live member list. I’m adding those with focused backend route coverage and frontend hook tests.
+
+#### Tool: exec_command
+
+```sh
+rtk gh issue comment 490 --repo CS485-Harmony/Harmony --body "**[AI Agent — Starting]**
+
+Implementing automatic presence tracking for issue #490. I found the existing USER_STATUS_CHANGED event and server SSE member:statusChanged forwarding, so the plan is to reuse that path, add authenticated presence endpoints for browser-safe activity/offline reporting, add a frontend activity tracker, and verify with targeted backend/frontend tests."
+```
+
+Output:
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/490#issuecomment-4338099091
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/tests/user.service.test.ts
+```
+
+Output:
+
+```text
+/**
+ * User service tests — Issue #98
+ *
+ * Covers happy-path CRUD operations for user profile management.
+ * Requires DATABASE_URL pointing at a running Postgres instance.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { TRPCError } from '@trpc/server';
+import { userService } from '../src/services/user.service';
+
+const prisma = new PrismaClient();
+
+let userId: string;
+let privateUserId: string;
+
+beforeAll(async () => {
+  const user = await prisma.user.create({
+    data: {
+      email: `testuser-${Date.now()}@test.com`,
+      username: `testuser-${Date.now()}`,
+      passwordHash: 'testhash',
+      displayName: 'Test User',
+      publicProfile: true,
+    },
+  });
+  userId = user.id;
+
+  const privateUser = await prisma.user.create({
+    data: {
+      email: `private-${Date.now()}@test.com`,
+      username: `private-${Date.now()}`,
+      passwordHash: 'testhash',
+      displayName: 'Private User',
+      publicProfile: false,
+    },
+  });
+  privateUserId = privateUser.id;
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({
+    where: { id: { in: [userId, privateUserId].filter(Boolean) } },
+  }).catch((e) => console.error('afterAll cleanup failed:', e));
+  await prisma.$disconnect();
+});
+
+describe('userService.getUser', () => {
+  it('returns a public user by id', async () => {
+    const user = await userService.getUser(userId);
+    expect(user.id).toBe(userId);
+    expect(user.displayName).toBe('Test User');
+    expect(user.status).toBe('OFFLINE');
+  });
+
+  it('never exposes passwordHash or email for a public user', async () => {
+    const user = await userService.getUser(userId);
+    expect(user).not.toHaveProperty('passwordHash');
+    expect(user).not.toHaveProperty('email');
+  });
+
+  it('anonymises a user with publicProfile=false', async () => {
+    const user = await userService.getUser(privateUserId);
+    expect(user.id).toBe(privateUserId);
+    expect(user.displayName).toBe('Anonymous');
+    expect(user.username).toBe('anonymous');
+    expect(user.avatarUrl).toBeNull();
+    expect(user.status).toBe('OFFLINE');
+    expect(user.publicProfile).toBe(true); // flag itself is masked
+  });
+
+  it('never exposes passwordHash or email for a private user', async () => {
+    const user = await userService.getUser(privateUserId);
+    expect(user).not.toHaveProperty('passwordHash');
+    expect(user).not.toHaveProperty('email');
+  });
+
+  it('throws NOT_FOUND for unknown userId', async () => {
+    await expect(
+      userService.getUser('00000000-0000-0000-0000-000000000000'),
+    ).rejects.toThrow(TRPCError);
+  });
+});
+
+describe('userService.getCurrentUser', () => {
+  it('returns the authenticated user by id', async () => {
+    const user = await userService.getCurrentUser(userId);
+    expect(user.id).toBe(userId);
+  });
+
+  it('bypasses publicProfile filter — returns own full profile even when private', async () => {
+    const user = await userService.getCurrentUser(privateUserId);
+    expect(user.id).toBe(privateUserId);
+    expect(user.displayName).toBe('Private User');
+    expect(user.username).not.toBe('anonymous');
+  });
+
+  it('includes email for self but never exposes passwordHash', async () => {
+    const user = await userService.getCurrentUser(userId);
+    expect(user).toHaveProperty('email');
+    expect(user).not.toHaveProperty('passwordHash');
+  });
+
+  it('throws NOT_FOUND for unknown userId', async () => {
+    await expect(
+      userService.getCurrentUser('00000000-0000-0000-0000-000000000000'),
+    ).rejects.toThrow(TRPCError);
+  });
+});
+
+describe('userService.updateUser', () => {
+  it('empty patch is a no-op — returns unchanged user', async () => {
+    const before = await userService.getCurrentUser(userId);
+    const after = await userService.updateUser(userId, {});
+    expect(after.displayName).toBe(before.displayName);
+    expect(after.publicProfile).toBe(before.publicProfile);
+    expect(after.status).toBe(before.status);
+  });
+
+  it('never exposes passwordHash in update response', async () => {
+    const updated = await userService.updateUser(userId, { displayName: 'Safe Name' });
+    expect(updated).not.toHaveProperty('passwordHash');
+  });
+
+  it('updates displayName', async () => {
+    const updated = await userService.updateUser(userId, { displayName: 'Updated Name' });
+    expect(updated.displayName).toBe('Updated Name');
+  });
+
+  it('updates publicProfile to false', async () => {
+    const updated = await userService.updateUser(userId, { publicProfile: false });
+    expect(updated.publicProfile).toBe(false);
+  });
+
+  it('updates status to ONLINE', async () => {
+    const updated = await userService.updateUser(userId, { status: 'ONLINE' });
+    expect(updated.status).toBe('ONLINE');
+  });
+
+  it('updates status to IDLE', async () => {
+    const updated = await userService.updateUser(userId, { status: 'IDLE' });
+    expect(updated.status).toBe('IDLE');
+  });
+
+  it('updates status to DND', async () => {
+    const updated = await userService.updateUser(userId, { status: 'DND' });
+    expect(updated.status).toBe('DND');
+  });
+
+  it('updates status to OFFLINE', async () => {
+    const updated = await userService.updateUser(userId, { status: 'OFFLINE' });
+    expect(updated.status).toBe('OFFLINE');
+  });
+
+  it('updates avatarUrl', async () => {
+    const updated = await userService.updateUser(userId, {
+      avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=test',
+    });
+    expect(updated.avatarUrl).toContain('dicebear');
+  });
+
+  it('clears avatarUrl when set to null', async () => {
+    const updated = await userService.updateUser(userId, { avatarUrl: null });
+    expect(updated.avatarUrl).toBeNull();
+  });
+
+  it('throws NOT_FOUND for unknown userId', async () => {
+    await expect(
+      userService.updateUser('00000000-0000-0000-0000-000000000000', { displayName: 'Ghost' }),
+    ).rejects.toThrow(TRPCError);
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/tests/events.router.status.test.ts
+```
+
+Output:
+
+```text
+/**
+ * events.router.status.test.ts — Issue #231
+ *
+ * Integration tests for member:statusChanged SSE events on
+ * GET /api/events/server/:serverId.
+ *
+ * eventBus, prisma, and authService are mocked — no running Redis/DB needed.
+ */
+
+import http from 'http';
+import { createApp } from '../src/app';
+import { eventBus } from '../src/events/eventBus';
+import { prisma } from '../src/db/prisma';
+import type { Express } from 'express';
+
+const VALID_TOKEN = 'valid-token';
+const VALID_SERVER_ID = '550e8400-e29b-41d4-a716-446655440002';
+const CHANGING_USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-ffffffffffff';
+
+jest.mock('../src/events/eventBus', () => ({
+  eventBus: {
+    subscribe: jest.fn(),
+    publish: jest.fn().mockResolvedValue(undefined),
+  },
+  EventChannels: {
+    MESSAGE_CREATED: 'harmony:MESSAGE_CREATED',
+    MESSAGE_EDITED: 'harmony:MESSAGE_EDITED',
+    MESSAGE_DELETED: 'harmony:MESSAGE_DELETED',
+    CHANNEL_CREATED: 'harmony:CHANNEL_CREATED',
+    CHANNEL_UPDATED: 'harmony:CHANNEL_UPDATED',
+    CHANNEL_DELETED: 'harmony:CHANNEL_DELETED',
+    MEMBER_JOINED: 'harmony:MEMBER_JOINED',
+    MEMBER_LEFT: 'harmony:MEMBER_LEFT',
+    USER_STATUS_CHANGED: 'harmony:USER_STATUS_CHANGED',
+  },
+}));
+
+jest.mock('../src/services/auth.service', () => ({
+  authService: {
+    verifyAccessToken: jest.fn(() => ({ sub: 'test-user-id' })),
+  },
+}));
+
+jest.mock('../src/db/prisma', () => ({
+  prisma: {
+    message: { findUnique: jest.fn(), create: jest.fn(), update: jest.fn() },
+    channel: { findUnique: jest.fn(), findMany: jest.fn() },
+    server: { findUnique: jest.fn() },
+    serverMember: { findFirst: jest.fn() },
+    user: { findUnique: jest.fn() },
+  },
+}));
+
+jest.mock('../src/services/cache.service', () => ({
+  cacheService: {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    invalidate: jest.fn().mockResolvedValue(undefined),
+    invalidatePattern: jest.fn().mockResolvedValue(undefined),
+    getOrRevalidate: jest.fn(),
+  },
+  CacheTTL: { channelMessages: 60, channelVisibility: 60 },
+  CacheKeys: { channelMessages: jest.fn(), channelVisibility: jest.fn() },
+  sanitizeKeySegment: (s: string) => s,
+}));
+
+jest.mock('../src/middleware/rate-limit.middleware', () => ({
+  createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+function sseGet(
+  server: http.Server,
+  path: string,
+  timeoutMs = 400,
+): Promise<{ statusCode: number; headers: Record<string, string | string[] | undefined> }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
+    const port = addr.port;
+
+    const req = http.get({ hostname: 'localhost', port, path }, (res) => {
+      const headers = res.headers as Record<string, string | string[] | undefined>;
+      const statusCode = res.statusCode ?? 0;
+      res.on('data', () => {});
+      const timer = setTimeout(() => {
+        res.destroy();
+        resolve({ statusCode, headers });
+      }, timeoutMs);
+      res.on('close', () => {
+        clearTimeout(timer);
+        resolve({ statusCode, headers });
+      });
+    });
+
+    req.on('error', reject);
+    req.setTimeout(timeoutMs + 500, () => {
+      req.destroy();
+      reject(new Error('Request timed out'));
+    });
+  });
+}
+
+const mockSubscribe = eventBus.subscribe as jest.Mock;
+
+let app: Express;
+let httpServer: http.Server;
+
+beforeAll((done) => {
+  mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
+  app = createApp();
+  httpServer = app.listen(0, done);
+});
+
+afterAll((done) => {
+  httpServer.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
+  (prisma.server.findUnique as jest.Mock).mockResolvedValue({ id: VALID_SERVER_ID });
+  (prisma.serverMember.findFirst as jest.Mock).mockResolvedValue({ userId: 'test-user-id' });
+  (prisma.channel.findMany as jest.Mock).mockResolvedValue([]);
+});
+
+describe('GET /api/events/server/:serverId — status event subscription', () => {
+  const sseUrl = (id: string) => `/api/events/server/${id}?token=${VALID_TOKEN}`;
+
+  it('subscribes to USER_STATUS_CHANGED event channel', async () => {
+    await sseGet(httpServer, sseUrl(VALID_SERVER_ID));
+
+    const subscribedChannels = (mockSubscribe.mock.calls as unknown[][]).map((c) => c[0]);
+    expect(subscribedChannels).toContain('harmony:USER_STATUS_CHANGED');
+  });
+
+  it('subscribes to channel events alongside the status event', async () => {
+    await sseGet(httpServer, sseUrl(VALID_SERVER_ID));
+
+    const subscribedChannels = (mockSubscribe.mock.calls as unknown[][]).map((c) => c[0]);
+    expect(subscribedChannels).toContain('harmony:CHANNEL_CREATED');
+    expect(subscribedChannels).toContain('harmony:CHANNEL_UPDATED');
+    expect(subscribedChannels).toContain('harmony:CHANNEL_DELETED');
+  });
+});
+
+describe('GET /api/events/server/:serverId — member:statusChanged event', () => {
+  it('fires the USER_STATUS_CHANGED handler and emits member:statusChanged', async () => {
+    let statusChangedHandler: ((payload: unknown) => void) | null = null;
+
+    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => void) => {
+      if (channel === 'harmony:USER_STATUS_CHANGED') {
+        statusChangedHandler = handler;
+      }
+      return { unsubscribe: jest.fn(), ready: Promise.resolve() };
+    });
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad address');
+    const port = (addr as { port: number }).port;
+
+    const chunks: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get(
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        (res) => {
+          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+
+          setTimeout(() => {
+            if (statusChangedHandler) {
+              statusChangedHandler({
+                userId: CHANGING_USER_ID,
+                serverId: VALID_SERVER_ID,
+                status: 'IDLE',
+              });
+            }
+
+            setTimeout(() => {
+              res.destroy();
+              resolve();
+            }, 50);
+          }, 50);
+
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+    });
+
+    const body = chunks.join('');
+    expect(body).toContain('event: member:statusChanged');
+    expect(body).toContain(CHANGING_USER_ID);
+    expect(body).toContain('"status":"idle"');
+  });
+
+  it('does not emit member:statusChanged for a different server', async () => {
+    let statusChangedHandler: ((payload: unknown) => void) | null = null;
+
+    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => void) => {
+      if (channel === 'harmony:USER_STATUS_CHANGED') {
+        statusChangedHandler = handler;
+      }
+      return { unsubscribe: jest.fn(), ready: Promise.resolve() };
+    });
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad address');
+    const port = (addr as { port: number }).port;
+
+    const chunks: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get(
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        (res) => {
+          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+
+          setTimeout(() => {
+            if (statusChangedHandler) {
+              statusChangedHandler({
+                userId: CHANGING_USER_ID,
+                serverId: 'different-server-id',
+                status: 'OFFLINE',
+              });
+            }
+
+            setTimeout(() => {
+              res.destroy();
+              resolve();
+            }, 50);
+          }, 50);
+
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+    });
+
+    const body = chunks.join('');
+    expect(body).not.toContain('event: member:statusChanged');
+  });
+
+  it('emits member:statusChanged regardless of publicProfile (status reflects presence not identity)', async () => {
+    let statusChangedHandler: ((payload: unknown) => void) | null = null;
+
+    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => void) => {
+      if (channel === 'harmony:USER_STATUS_CHANGED') {
+        statusChangedHandler = handler;
+      }
+      return { unsubscribe: jest.fn(), ready: Promise.resolve() };
+    });
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad address');
+    const port = (addr as { port: number }).port;
+
+    const chunks: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get(
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        (res) => {
+          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+
+          setTimeout(() => {
+            if (statusChangedHandler) {
+              statusChangedHandler({
+                userId: CHANGING_USER_ID,
+                serverId: VALID_SERVER_ID,
+                status: 'ONLINE',
+              });
+            }
+
+            setTimeout(() => {
+              res.destroy();
+              resolve();
+            }, 50);
+          }, 50);
+
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+    });
+
+    const body = chunks.join('');
+    expect(body).toContain('event: member:statusChanged');
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/tests/auth.test.ts
+```
+
+Output:
+
+```text
+/**
+ * Auth route tests — Issue #97 / #313
+ *
+ * Covers the challenge-based verifier flow so raw passwords never reach the
+ * auth REST endpoints that mint tokens.
+ */
+
+import crypto from 'crypto';
+import request from 'supertest';
+import { createApp } from '../src/app';
+import type { Express } from 'express';
+import bcrypt from 'bcryptjs';
+
+const PASSWORD_SALT = '00112233445566778899aabbccddeeff';
+
+function derivePasswordVerifier(password: string, passwordSalt = PASSWORD_SALT): string {
+  return crypto
+    .pbkdf2Sync(password, Buffer.from(passwordSalt, 'hex'), 310000, 32, 'sha256')
+    .toString('base64');
+}
+
+const mockUser = {
+  id: '00000000-0000-0000-0000-000000000001',
+  email: 'alice@example.com',
+  username: 'alice',
+  passwordHash: '',
+  displayName: 'alice',
+  avatarUrl: null,
+  publicProfile: true,
+  createdAt: new Date(),
+};
+
+const mockRefreshToken = {
+  id: '00000000-0000-0000-0000-000000000002',
+  tokenHash: '',
+  userId: mockUser.id,
+  expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  revokedAt: null,
+  createdAt: new Date(),
+};
+
+jest.mock('../src/db/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      upsert: jest.fn(),
+    },
+    refreshToken: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    server: {
+      findFirst: jest.fn().mockResolvedValue(null),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    serverMember: {
+      create: jest.fn(),
+      upsert: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../src/services/serverMember.service', () => ({
+  serverMemberService: { joinServer: jest.fn().mockResolvedValue(undefined) },
+}));
+
+import { prisma } from '../src/db/prisma';
+
+const mockPrisma = prisma as unknown as {
+  user: {
+    findUnique: jest.Mock;
+    create: jest.Mock;
+    upsert: jest.Mock;
+  };
+  refreshToken: {
+    create: jest.Mock;
+    findUnique: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+  };
+  server: {
+    findFirst: jest.Mock;
+    findMany: jest.Mock;
+  };
+  serverMember: {
+    create: jest.Mock;
+    upsert: jest.Mock;
+  };
+};
+
+let app: Express;
+
+beforeAll(async () => {
+  const verifierHash = await bcrypt.hash(derivePasswordVerifier('password123'), 4);
+  mockUser.passwordHash = `v1$${PASSWORD_SALT}$${verifierHash}`;
+  app = createApp();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /api/auth/register/challenge', () => {
+  it('returns a 32-char hexadecimal password salt', async () => {
+    const res = await request(app)
+      .post('/api/auth/register/challenge')
+      .set('Origin', 'http://localhost:3000')
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.passwordSalt).toMatch(/^[0-9a-f]{32}$/i);
+  });
+});
+
+describe('POST /api/auth/register', () => {
+  it('creates a new user and returns access + refresh tokens', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+    mockPrisma.user.create.mockResolvedValue(mockUser);
+    mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'alice@example.com',
+        username: 'alice',
+        passwordSalt: PASSWORD_SALT,
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(201);
+    expect(typeof res.body.accessToken).toBe('string');
+    expect(typeof res.body.refreshToken).toBe('string');
+  });
+
+  it('returns 400 when the verifier payload is missing', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({ email: 'bad-email', username: 'a' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Validation failed');
+  });
+
+  it('returns 409 when email is already in use', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'alice@example.com',
+        username: 'alice2',
+        passwordSalt: PASSWORD_SALT,
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/email/i);
+  });
+});
+
+describe('POST /api/auth/register — reserved identities (issue #466)', () => {
+  it('rejects registration with the reserved admin email', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'admin@harmony.dev',
+        username: 'notadmin',
+        passwordSalt: PASSWORD_SALT,
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/reserved/i);
+  });
+
+  it('rejects registration with the reserved admin email regardless of case', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'Admin@Harmony.Dev',
+        username: 'notadmin',
+        passwordSalt: PASSWORD_SALT,
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/reserved/i);
+  });
+
+  it('rejects registration with the reserved username "admin"', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'someone@example.com',
+        username: 'admin',
+        passwordSalt: PASSWORD_SALT,
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/reserved/i);
+  });
+});
+
+describe('POST /api/auth/login/challenge', () => {
+  it('returns the stored password salt for existing users', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+
+    const res = await request(app)
+      .post('/api/auth/login/challenge')
+      .set('Origin', 'http://localhost:3000')
+      .send({ email: 'alice@example.com' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.passwordSalt).toBe(PASSWORD_SALT);
+  });
+
+  it('returns a deterministic dummy salt for unknown users', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    const first = await request(app)
+      .post('/api/auth/login/challenge')
+      .set('Origin', 'http://localhost:3000')
+      .send({ email: 'nobody@example.com' });
+    const second = await request(app)
+      .post('/api/auth/login/challenge')
+      .set('Origin', 'http://localhost:3000')
+      .send({ email: 'nobody@example.com' });
+
+    expect(first.status).toBe(200);
+    expect(first.body.passwordSalt).toMatch(/^[0-9a-f]{32}$/i);
+    expect(second.body.passwordSalt).toBe(first.body.passwordSalt);
+  });
+});
+
+describe('POST /api/auth/login', () => {
+  it('returns access + refresh tokens on a valid verifier payload', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+    mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'alice@example.com',
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.accessToken).toBe('string');
+    expect(typeof res.body.refreshToken).toBe('string');
+  });
+
+  it('returns 401 for the wrong verifier', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'alice@example.com',
+        passwordVerifier: derivePasswordVerifier('wrongpassword'),
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/invalid credentials/i);
+  });
+
+  it('returns 401 for an unknown email', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'nobody@example.com',
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for malformed request payloads', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .set('Origin', 'http://localhost:3000')
+      .send({ email: 'not-an-email' });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/auth/logout', () => {
+  it('revokes the refresh token and returns 204', async () => {
+    mockPrisma.refreshToken.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+    mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
+
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'alice@example.com',
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    const { refreshToken } = loginRes.body as { refreshToken: string };
+
+    const logoutRes = await request(app)
+      .post('/api/auth/logout')
+      .set('Origin', 'http://localhost:3000')
+      .send({ refreshToken });
+
+    expect(logoutRes.status).toBe(204);
+    expect(mockPrisma.refreshToken.updateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 when refreshToken is missing', async () => {
+    const res = await request(app)
+      .post('/api/auth/logout')
+      .set('Origin', 'http://localhost:3000')
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/auth/refresh', () => {
+  it('issues new tokens when given a valid refresh token', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+    mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
+
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'alice@example.com',
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    const { refreshToken } = loginRes.body as { refreshToken: string };
+
+    mockPrisma.refreshToken.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
+
+    const refreshRes = await request(app)
+      .post('/api/auth/refresh')
+      .set('Origin', 'http://localhost:3000')
+      .send({ refreshToken });
+
+    expect(refreshRes.status).toBe(200);
+    expect(typeof refreshRes.body.accessToken).toBe('string');
+    expect(typeof refreshRes.body.refreshToken).toBe('string');
+  });
+});
+
+describe('tRPC health check with Bearer token', () => {
+  it('returns 200 for /trpc/health with a valid Bearer token', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+    mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
+
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: 'alice@example.com',
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    const { accessToken } = loginRes.body as { accessToken: string };
+
+    const res = await request(app)
+      .get('/trpc/health')
+      .set('Origin', 'http://localhost:3000')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/context/AuthContext.tsx
+```
+
+Output:
+
+```text
+'use client';
+
+import { createContext, useState, useEffect, useCallback } from 'react';
+import type { ReactNode } from 'react';
+import type { User } from '@/types';
+import * as authService from '@/services/authService';
+import { getAccessToken } from '@/lib/api-client';
+import { setSessionCookie, clearSessionCookie } from '@/app/actions/session';
+
+export interface AuthContextValue {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (
+    email: string,
+    username: string,
+    displayName: string,
+    password: string,
+  ) => Promise<void>;
+  logout: () => Promise<void>;
+  updateUser: (patch: Partial<Pick<User, 'displayName' | 'status'>>) => Promise<void>;
+  /**
+   * Returns true if the current user has admin-level access.
+   * Pass `serverOwnerId` to check ownership of a specific server — this is the
+   * reliable path since User.role is not populated from the backend.
+   * Without `serverOwnerId`, falls back to checking User.role (always 'member'
+   * until a global-role endpoint is added).
+   */
+  isAdmin: (serverOwnerId?: string) => boolean;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    authService
+      .getCurrentUser()
+      .then(async restored => {
+        if (restored) {
+          setUser(restored);
+          const token = getAccessToken();
+          if (token) await setSessionCookie(token);
+        }
+      })
+      .catch(() => {
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const login = useCallback(async (email: string, password: string) => {
+    const loggedInUser = await authService.login(email, password);
+    setUser(loggedInUser);
+    const token = getAccessToken();
+    if (token) await setSessionCookie(token);
+  }, []);
+
+  const register = useCallback(
+    async (email: string, username: string, displayName: string, password: string) => {
+      const newUser = await authService.register(email, username, displayName, password);
+      setUser(newUser);
+      const token = getAccessToken();
+      if (token) await setSessionCookie(token);
+    },
+    [],
+  );
+
+  const logout = useCallback(async () => {
+    await authService.logout();
+    setUser(null);
+    await clearSessionCookie();
+  }, []);
+
+  const updateUser = useCallback(async (patch: Partial<Pick<User, 'displayName' | 'status'>>) => {
+    const updated = await authService.updateCurrentUser(patch);
+    setUser(updated);
+  }, []);
+
+  const isAdmin = useCallback(
+    (serverOwnerId?: string) => {
+      if (!user) return false;
+      if (user.isSystemAdmin) return true;
+      if (serverOwnerId) return user.id === serverOwnerId;
+      return user.role === 'owner' || user.role === 'admin';
+    },
+    [user],
+  );
+
+  const value: AuthContextValue = {
+    user,
+    isAuthenticated: user !== null,
+    isLoading,
+    login,
+    register,
+    logout,
+    updateUser,
+    isAdmin,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/hooks/useAuth.ts
+```
+
+Output:
+
+```text
+import { useContext } from 'react';
+import { AuthContext } from '@/context/AuthContext';
+import type { AuthContextValue } from '@/context/AuthContext';
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+nl -ba harmony-backend/src/app.ts | sed -n '1,180p'
+```
+
+Output:
+
+```text
+     1	import express, { NextFunction, Request, Response } from 'express';
+     2	import { createExpressMiddleware } from '@trpc/server/adapters/express';
+     3	import helmet from 'helmet';
+     4	import rateLimit, { type Store } from 'express-rate-limit';
+     5	import { RedisStore } from 'rate-limit-redis';
+     6	import corsMiddleware, { CorsError } from './middleware/cors';
+     7	import { appRouter } from './trpc/router';
+     8	import { createContext } from './trpc/init';
+     9	import { authRouter } from './routes/auth.router';
+    10	import { createPublicRouter } from './routes/public.router';
+    11	import { seoRouter } from './routes/seo.router';
+    12	import { eventsRouter } from './routes/events.router';
+    13	import { attachmentRouter } from './routes/attachment.router';
+    14	import { adminMetaTagRouter } from './routes/admin.metaTag.router';
+    15	import { instanceId } from './lib/instance-identity';
+    16	import { createLogger } from './lib/logger';
+    17	import { redis } from './db/redis';
+    18	
+    19	const logger = createLogger({ component: 'app', instanceId });
+    20	
+    21	/**
+    22	 * Creates one Redis store per rate-limit route in production.
+    23	 * Each store gets a unique prefix so login/register/refresh counters don't
+    24	 * collide in Redis, while all replicas share the same keyspace.
+    25	 *
+    26	 * Returns undefined in dev/test so express-rate-limit falls back to
+    27	 * MemoryStore — keeps tests hermetic with no Redis dependency.
+    28	 *
+    29	 * Uses ioredis `.call()` which runs the rate-limit-redis Lua script as a
+    30	 * single atomic command, satisfying the "no non-atomic INCR + EXPIRE"
+    31	 * constraint from the replica-readiness audit (§3.1).
+    32	 *
+    33	 * express-rate-limit v8 requires each limiter to have its own store instance
+    34	 * (it validates against shared instances to prevent route counter mixing),
+    35	 * so callers must invoke this once per limiter.
+    36	 */
+    37	function buildProductionStore(prefix: string): Store | undefined {
+    38	  if (process.env.NODE_ENV !== 'production') return undefined;
+    39	  return new RedisStore({
+    40	    prefix,
+    41	    sendCommand: (...args: string[]) =>
+    42	      redis.call(args[0] as string, ...(args.slice(1) as [string, ...string[]])) as Promise<number>,
+    43	  });
+    44	}
+    45	
+    46	export interface CreateAppOptions {
+    47	  /**
+    48	   * Store factory called once per limiter so each gets a distinct instance.
+    49	   * express-rate-limit v8 requires separate instances per limiter to avoid
+    50	   * counter mixing and to suppress the "unsharedStore" validation error.
+    51	   * In tests: return a new mock per call but share an incrementCalls array
+    52	   * to observe all calls across limiters. In production this is left undefined
+    53	   * and buildProductionStore(prefix) is used instead.
+    54	   */
+    55	  rateLimitStore?: () => Store;
+    56	}
+    57	
+    58	export function createApp(options: CreateAppOptions = {}) {
+    59	  const isE2E = process.env.NODE_ENV === 'e2e';
+    60	  // Each limiter calls makeStore() independently so it gets its own instance.
+    61	  const makeStore = (prefix: string): Store | undefined =>
+    62	    options.rateLimitStore ? options.rateLimitStore() : buildProductionStore(prefix);
+    63	
+    64	  // ─── Auth rate limiters ─────────────────────────────────────────────────────
+    65	  // Each limiter gets its own store instance (express-rate-limit v8 requirement).
+    66	  // In production: separate RedisStore per route with a unique prefix so
+    67	  // login/register/refresh counters are independent in Redis.
+    68	
+    69	  const loginLimiter = rateLimit({
+    70	    windowMs: 15 * 60 * 1000, // 15 minutes
+    71	    max: isE2E ? 1000 : 10,
+    72	    standardHeaders: true,
+    73	    legacyHeaders: false,
+    74	    store: makeStore('rl:login:'),
+    75	    message: { error: 'Too many login attempts. Please try again later.' },
+    76	  });
+    77	
+    78	  const registerLimiter = rateLimit({
+    79	    windowMs: 60 * 60 * 1000, // 1 hour
+    80	    max: process.env.NODE_ENV === 'production' ? 5 : 1000,
+    81	    standardHeaders: true,
+    82	    legacyHeaders: false,
+    83	    store: makeStore('rl:register:'),
+    84	    message: { error: 'Too many registration attempts. Please try again later.' },
+    85	  });
+    86	
+    87	  const refreshLimiter = rateLimit({
+    88	    windowMs: 15 * 60 * 1000, // 15 minutes
+    89	    max: isE2E ? 1000 : 30,
+    90	    standardHeaders: true,
+    91	    legacyHeaders: false,
+    92	    store: makeStore('rl:refresh:'),
+    93	    message: { error: 'Too many token refresh attempts. Please try again later.' },
+    94	  });
+    95	  const app = express();
+    96	
+    97	  // Trust N proxy hops so req.ip and express-rate-limit can read
+    98	  // X-Forwarded-For safely. Gated on TRUST_PROXY_HOPS so running the backend
+    99	  // without a proxy in front (local dev, direct port exposure) doesn't let
+   100	  // clients spoof XFF and poison rate-limit buckets. Set to `1` on Railway.
+   101	  const trustProxyHopsEnv = process.env.TRUST_PROXY_HOPS;
+   102	  if (trustProxyHopsEnv !== undefined && trustProxyHopsEnv.trim() === '') {
+   103	    throw new Error(
+   104	      `Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected a non-negative integer.`,
+   105	    );
+   106	  }
+   107	  const trustProxyHops = trustProxyHopsEnv === undefined ? 0 : Number(trustProxyHopsEnv);
+   108	  if (!Number.isInteger(trustProxyHops) || trustProxyHops < 0) {
+   109	    throw new Error(
+   110	      `Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected a non-negative integer.`,
+   111	    );
+   112	  }
+   113	  if (trustProxyHops > 0) {
+   114	    app.set('trust proxy', trustProxyHops);
+   115	  }
+   116	
+   117	  app.use(helmet());
+   118	
+   119	  // Replica identity header — stamped on every response (including CORS errors)
+   120	  // so load-balancer distribution across 2+ backend-api replicas is externally
+   121	  // observable (curl -I /health across repeated requests should cycle through ids).
+   122	  app.use((_req, res, next) => {
+   123	    res.setHeader('X-Instance-Id', instanceId);
+   124	    next();
+   125	  });
+   126	
+   127	  // CORS must come before body parsers so error responses include CORS headers
+   128	  app.use(corsMiddleware);
+   129	  app.use(express.json());
+   130	
+   131	  // Health check (plain HTTP — no tRPC client required)
+   132	  app.get('/health', (_req, res) => {
+   133	    res.json({
+   134	      status: 'ok',
+   135	      service: 'backend-api',
+   136	      instanceId,
+   137	      timestamp: new Date().toISOString(),
+   138	    });
+   139	  });
+   140	
+   141	  // SEO endpoints (robots.txt, sitemaps) — before auth so they're publicly accessible
+   142	  // Backend SEO routes remain available as transitional XML sources; the
+   143	  // frontend apex domain owns the canonical crawler-facing entrypoints.
+   144	  app.use(seoRouter);
+   145	
+   146	  // Auth endpoints
+   147	  app.use('/api/auth/login', loginLimiter);
+   148	  app.use('/api/auth/register', registerLimiter);
+   149	  app.use('/api/auth/refresh', refreshLimiter);
+   150	  app.use('/api/auth', authRouter);
+   151	
+   152	  // Public API endpoints (cached, no auth required)
+   153	  app.use('/api/public', createPublicRouter(makeStore('rl:public:')));
+   154	
+   155	  // Real-time SSE endpoints
+   156	  app.use('/api/events', eventsRouter);
+   157	
+   158	  // Attachment upload + file serving
+   159	  app.use('/api/attachments', attachmentRouter);
+   160	
+   161	  // Admin meta-tag management endpoints (server admin only)
+   162	  app.use('/api/admin', adminMetaTagRouter);
+   163	
+   164	  // tRPC endpoint
+   165	  app.use(
+   166	    '/trpc',
+   167	    createExpressMiddleware({
+   168	      router: appRouter,
+   169	      createContext,
+   170	      onError({ error, path }) {
+   171	        // Only log unexpected server errors; auth/validation errors (4xx) are routine
+   172	        if (error.code === 'INTERNAL_SERVER_ERROR') {
+   173	          logger.error({ err: error, path }, 'Unhandled tRPC error');
+   174	        }
+   175	      },
+   176	    }),
+   177	  );
+   178	
+   179	  // 404 — unknown routes
+   180	  app.use((_req: Request, res: Response) => {
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:38:56.387Z
+
+The backend route and frontend tracker are in place. I’m adding regression tests now: backend validation/auth/status update behavior, and frontend timing/unload behavior so idle and offline transitions don’t rely on manual testing.
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts
+```
+
+Output:
+
+```text
+> jest presence.router.test.ts
+sh: jest: command not found
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+> jest --forceExit usePresenceTracker.test.tsx
+sh: jest: command not found
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat
+```
+
+Output:
+
+```text
+harmony-backend/src/app.ts                              | 4 ++++
+ harmony-frontend/src/components/layout/HarmonyShell.tsx | 5 ++++-
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:39:44.446Z
+
+The targeted tests are written, but this worktree currently has no local Jest binary available (`jest: command not found`). I’m checking dependency state and then I’ll install or use the repo’s available tooling path if it exists.
+
+#### Tool: exec_command
+
+```sh
+rtk ls harmony-backend/node_modules/.bin
+```
+
+Output:
+
+```text
+ls: harmony-backend/node_modules/.bin: No such file or directory
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls harmony-frontend/node_modules/.bin
+```
+
+Output:
+
+```text
+ls: harmony-frontend/node_modules/.bin: No such file or directory
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ M harmony-backend/src/app.ts
+ M harmony-frontend/src/components/layout/HarmonyShell.tsx
+?? harmony-backend/src/routes/presence.router.ts
+?? harmony-backend/tests/presence.router.test.ts
+?? harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+?? harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat --cached
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rg --files | grep 'package-lock.json\|pnpm-lock.yaml\|yarn.lock'
+```
+
+Output:
+
+```text
+tests/integration/package-lock.json
+harmony-backend/package-lock.json
+harmony-frontend/package-lock.json
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls harmony-backend | head
+```
+
+Output:
+
+```text
+prisma/
+src/
+tests/
+.env  887B
+.env.example  2.8K
+.gitignore  203B
+.nvmrc  3B
+.prettierrc.cjs  165B
+README.md  15.4K
+docker-compose.e2e.yml  642B
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls harmony-frontend | head
+```
+
+Output:
+
+```text
+public/
+src/
+tests/
+.env.example  233B
+.gitignore  540B
+.prettierignore  47B
+.prettierrc.cjs  342B
+README.md  5.7K
+bun.lock  174.6K
+eslint.config.mjs  786B
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend ci
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend ci
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 56911,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 8000
+}
+```
+
+Output:
+
+```text
+Chunk ID: ac8894
+Wall time: 0.0000 seconds
+Process exited with code 1
+Original token count: 75
+Output:
+npm error Missing script: "ci"
+npm error
+npm error To see a list of scripts, run:
+npm error   npm run
+npm error Log files were not written due to an error writing to the directory: /Users/allen/.npm/_logs
+npm error You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 80808,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 8000
+}
+```
+
+Output:
+
+```text
+Chunk ID: d106e3
+Wall time: 0.0004 seconds
+Process exited with code 1
+Original token count: 75
+Output:
+npm error Missing script: "ci"
+npm error
+npm error To see a list of scripts, run:
+npm error   npm run
+npm error Log files were not written due to an error writing to the directory: /Users/allen/.npm/_logs
+npm error You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:40:06.152Z
+
+`rtk npm` treated `ci` as a script name in this wrapper, so I’m switching to plain `npm ci` for dependency installation in the two package directories.
+
+#### Tool: exec_command
+
+```sh
+npm ci
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+npm ci
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 63801,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 8000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 3996d7
+Wall time: 5.0015 seconds
+Process running with session ID 63801
+Original token count: 173
+Output:
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated scmp@2.1.0: Just use Node.js's crypto.timingSafeEqual()
+
+added 695 packages in 14s
+
+110 packages are looking for funding
+  run `npm fund` for details
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 61081,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 8000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 31db87
+Wall time: 5.0014 seconds
+Process running with session ID 61081
+Original token count: 161
+Output:
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated whatwg-encoding@3.1.1: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 63801,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Chunk ID: cdcddd
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 61081,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 8000
+}
+```
+
+Output:
+
+```text
+Chunk ID: ca395f
+Wall time: 5.0032 seconds
+Process running with session ID 61081
+Original token count: 70
+Output:
+npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 61081,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 8000
+}
+```
+
+Output:
+
+```text
+Chunk ID: aeab5b
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 24
+Output:
+
+added 704 packages in 29s
+
+187 packages are looking for funding
+  run `npm fund` for details
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:40:42.139Z
+
+Dependencies are installed in both packages. I’m running the targeted suites first, then I’ll run typecheck/lint/format checks around the touched areas.
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts
+```
+
+Output:
+
+```text
+[rtk] /!\ Hook outdated — run `rtk init -g` to update
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+[rtk] /!\ Hook outdated — run `rtk init -g` to update
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 56233,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: fddd4e
+Wall time: 0.0000 seconds
+Process exited with code 1
+Original token count: 128
+Output:
+> jest presence.router.test.ts
+FAIL tests/presence.router.test.ts
+  ● Test suite failed to run
+    [96msrc/services/permission.service.ts[0m:[93m1[0m:[93m10[0m - [91merror[0m[90m TS2305: [0mModule '"@prisma/client"' has no exported member 'RoleType'.
+    [7m1[0m import { RoleType } from '@prisma/client';
+    [7m [0m [91m         ~~~~~~~~[0m
+Test Suites: 1 failed, 1 total
+Tests:       0 total
+Snapshots:   0 total
+Time:        2.424 s
+Ran all test suites matching /presence.router.test.ts/i.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 71973,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 249148
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 87
+Output:
+> jest --forceExit usePresenceTracker.test.tsx
+Test Suites: 1 passed, 1 total
+Tests:       5 passed, 5 total
+Snapshots:   0 total
+Time:        0.65 s
+Ran all test suites matching usePresenceTracker.test.tsx.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:40:48.976Z
+
+The frontend presence tests pass. The backend test is blocked by a stale Prisma client (`RoleType` missing from generated client), so I’m regenerating Prisma with the repo’s approved command and rerunning it.
+
+#### Tool: exec_command
+
+```sh
+npx prisma generate
+```
+
+Output:
+
+```text
+Environment variables loaded from .env
+Prisma schema loaded from prisma/schema.prisma
+
+✔ Generated Prisma Client (v5.22.0) to ./node_modules/@prisma/client in 55ms
+
+Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
+
+Tip: Want real-time updates to your database without manual polling? Discover how with Pulse: https://pris.ly/tip-0-pulse
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 20537,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 6c1b58
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts
+```
+
+Output:
+
+```text
+[rtk] /!\ Hook outdated — run `rtk init -g` to update
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 85645,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: e756b6
+Wall time: 0.0000 seconds
+Process exited with code 1
+Original token count: 650
+Output:
+> jest presence.router.test.ts
+node:events:487
+      throw er; // Unhandled 'error' event
+      ^
+Error: listen EPERM: operation not permitted 0.0.0.0
+    at Server.setupListenHandle [as _listen2] (node:net:1986:21)
+    at listenInCluster (node:net:2065:12)
+    at Server.listen (node:net:2170:7)
+    at Test.serverAddress (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/supertest/lib/test.js:63:35)
+    at new Test (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/supertest/lib/test.js:49:14)
+    at Object.obj.<computed> [as post] (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/supertest/index.js:40:18)
+    at Object.<anonymous> (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/tests/presence.router.test.ts:34:14)
+    at Promise.then.completed (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-circus/build/utils.js:298:28)
+    at new Promise (<anonymous>)
+    at callAsyncCircusFn (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-circus/build/utils.js:231:10)
+    at _callCircusTest (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-circus/build/run.js:316:40)
+    at _runTest (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-circus/build/run.js:252:3)
+    at _runTestsForDescribeBlock (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-circus/build/run.js:126:9)
+    at _runTestsForDescribeBlock (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-circus/build/run.js:121:9)
+    at run (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-circus/build/run.js:71:3)
+    at runAndTransformResultsToJestFormat (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
+    at jestAdapter (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
+    at runTestInternal (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-runner/build/runTest.js:367:16)
+    at runTest (/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/node_modules/jest-runner/build/runTest.js:444:34)
+Emitted 'error' event on Server instance at:
+    at emitErrorNT (node:net:2044:8)
+    at processTicksAndRejections (node:internal/process/task_queues:90:21) {
+  code: 'EPERM',
+  errno: -1,
+  syscall: 'listen',
+  address: '0.0.0.0'
+}
+Node.js v25.9.0
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts
+```
+
+Output:
+
+```text
+[rtk] /!\ Hook outdated — run `rtk init -g` to update
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 3680,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: bd260e
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 160
+Output:
+> jest presence.router.test.ts
+PASS tests/presence.router.test.ts
+  POST /api/presence/status
+    ✓ updates authenticated users to ONLINE (16 ms)
+    ✓ updates authenticated users to IDLE (1 ms)
+    ✓ rejects DND because automatic presence only owns online, idle, and offline (3 ms)
+    ✓ rejects missing bearer token (2 ms)
+  POST /api/presence/beacon
+    ✓ accepts token in the body for unload-safe beacon requests (1 ms)
+    ✓ rejects expired beacon tokens (2 ms)
+Test Suites: 1 passed, 1 total
+Tests:       6 passed, 6 total
+Snapshots:   0 total
+Time:        1.628 s
+Ran all test suites matching /presence.router.test.ts/i.
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:41:27.848Z
+
+I tightened the presence route error path so service failures go through the app’s normal Express error middleware instead of depending on async route behavior. Now I’m formatting and running the package checks.
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write src/routes/presence.router.ts tests/presence.router.test.ts
+```
+
+Output:
+
+```text
+src/routes/presence.router.ts 43ms (unchanged)
+tests/presence.router.test.ts 11ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write src/hooks/usePresenceTracker.ts src/__tests__/usePresenceTracker.test.tsx src/components/layout/HarmonyShell.tsx
+```
+
+Output:
+
+```text
+[warn] jsxBracketSameLine is deprecated.
+src/hooks/usePresenceTracker.ts 48ms
+src/__tests__/usePresenceTracker.test.tsx 7ms
+src/components/layout/HarmonyShell.tsx 34ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend run build
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend run build
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 2610,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 32c57a
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 160
+Output:
+> jest presence.router.test.ts
+PASS tests/presence.router.test.ts
+  POST /api/presence/status
+    ✓ updates authenticated users to ONLINE (15 ms)
+    ✓ updates authenticated users to IDLE (2 ms)
+    ✓ rejects DND because automatic presence only owns online, idle, and offline (2 ms)
+    ✓ rejects missing bearer token (1 ms)
+  POST /api/presence/beacon
+    ✓ accepts token in the body for unload-safe beacon requests (1 ms)
+    ✓ rejects expired beacon tokens (1 ms)
+Test Suites: 1 passed, 1 total
+Tests:       6 passed, 6 total
+Snapshots:   0 total
+Time:        2.911 s
+Ran all test suites matching /presence.router.test.ts/i.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 76012,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 60380b
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 91
+Output:
+> jest --forceExit usePresenceTracker.test.tsx
+Test Suites: 1 passed, 1 total
+Tests:       5 passed, 5 total
+Snapshots:   0 total
+Time:        0.656 s, estimated 1 s
+Ran all test suites matching usePresenceTracker.test.tsx.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 53417,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 5c17b3
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 2
+Output:
+> tsc
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 85413,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 1cb404
+Wall time: 5.0015 seconds
+Process running with session ID 85413
+Original token count: 0
+Output:
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 85413,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 20000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 781b1f
+Wall time: 4.9874 seconds
+Process exited with code 1
+Original token count: 177
+Output:
+> next build
+▲ Next.js 16.1.6 (Turbopack)
+  Creating an optimized production build ...
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+Turbopack build encountered 1 warnings:
+[next]/internal/font/google/inter_fe8b9d92.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap
+> Build error occurred
+Error: Turbopack build failed with 1 errors:
+[next]/internal/font/google/inter_fe8b9d92.module.css
+next/font: error:
+Failed to fetch `Inter` from Google Fonts.
+    at ignore-listed frames
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:42:02.476Z
+
+Targeted tests and backend typecheck pass. The frontend production build is blocked by Next trying to fetch the Inter font from Google Fonts in the network-restricted sandbox; I’m running lint next to catch local code issues.
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend run lint
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend run lint
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend run format:check
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 48692,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 207db3
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 74
+Output:
+> eslint src tests
+/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/tests/events.router.sse-server-updated.test.ts
+  83:10  warning  'sseGetWithEvent' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+✖ 1 problem (0 errors, 1 warning)
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 17363,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: ccf01c
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 3
+Output:
+> eslint
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 29313,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 36f1af
+Wall time: 0.0000 seconds
+Process exited with code 1
+Original token count: 351
+Output:
+> prettier --check .
+Checking formatting...
+[warn] jsxBracketSameLine is deprecated.
+[warn] src/__tests__/metaTagAdminService.test.ts
+[warn] src/__tests__/serverService.test.ts
+[warn] src/__tests__/VisibilityToggle.test.tsx
+[warn] src/app/actions/getPinnedMessages.ts
+[warn] src/app/channels/[serverSlug]/page.tsx
+[warn] src/app/channels/actions.ts
+[warn] src/app/providers.tsx
+[warn] src/components/channel/ChannelPageContent.tsx
+[warn] src/components/channel/ChannelSidebar.tsx
+[warn] src/components/channel/CreateChannelModal.tsx
+[warn] src/components/channel/GuestHeader.tsx
+[warn] src/components/channel/GuestPromoBanner.tsx
+[warn] src/components/channel/MessageInput.tsx
+[warn] src/components/channel/MessageList.tsx
+[warn] src/components/channel/PinnedMessagesPanel.tsx
+[warn] src/components/channel/UserStatusBar.tsx
+[warn] src/components/channel/VisibilityToggle.tsx
+[warn] src/components/layout/EmptyShell.tsx
+[warn] src/components/message/MessageItem.tsx
+[warn] src/components/server-rail/CreateServerModal.tsx
+[warn] src/components/server-rail/ServerRail.tsx
+[warn] src/components/settings/UserSettingsPage.tsx
+[warn] src/components/ui/Toast.tsx
+[warn] src/context/ToastContext.tsx
+[warn] src/hooks/useToast.ts
+[warn] src/middleware.ts
+[warn] tests/e2e/auth.spec.ts
+[warn] tests/e2e/support/start-backend-e2e.mjs
+[warn] Code style issues found in 28 files. Run Prettier with --write to fix.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat
+```
+
+Output:
+
+```text
+harmony-backend/src/app.ts                              | 4 ++++
+ harmony-frontend/src/components/layout/HarmonyShell.tsx | 5 ++++-
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff -- harmony-backend/src/routes/presence.router.ts harmony-frontend/src/hooks/usePresenceTracker.ts harmony-frontend/src/components/layout/HarmonyShell.tsx
+```
+
+Output:
+
+```text
+harmony-frontend/src/components/layout/HarmonyShell.tsx | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- Changes ---
+
+harmony-frontend/src/components/layout/HarmonyShell.tsx
+  @@ -23,6 +23,7 @@ import { VoiceProvider } from '@/contexts/VoiceContext';
+  +import { usePresenceTracker } from '@/hooks/usePresenceTracker';
+   import { ChannelType, ChannelVisibility, UserStatus } from '@/types';
+   import { useRouter } from 'next/navigation';
+   import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
+  @@ -375,6 +376,8 @@ export function HarmonyShell({
+  +  usePresenceTracker(isAuthenticated);
+  +
+     // #c10/#c23: single global Ctrl+K / Cmd+K handler — SearchModal no longer needs its own
+     useEffect(() => {
+       function handleKeyDown(e: KeyboardEvent) {
+  @@ -497,7 +500,7 @@ export function HarmonyShell({
+  -              members={members}
+  +              members={localMembers}
+                 isOpen={isMembersOpen}
+                 onClose={() => setIsMembersOpen(false)}
+               />
+  +4 -1
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 68876,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: fc6000
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 7
+Output:
+TypeScript: No errors found
+```
+
+#### Tool: exec_command
+
+```sh
+nl -ba harmony-frontend/src/components/layout/HarmonyShell.tsx | sed -n '110,210p'
+```
+
+Output:
+
+```text
+   110	    setPrevChannelId(currentChannel.id);
+   111	    setLocalMessages(messages);
+   112	    setIsMenuOpen(false);
+   113	    setIsPinsOpen(false);
+   114	    // Only auto-close the members sidebar on mobile so desktop keeps it open by default.
+   115	    if (typeof window !== 'undefined' && !window.matchMedia('(min-width: 640px)').matches) {
+   116	      setIsMembersOpen(false);
+   117	    }
+   118	  }
+   119	  // Local channels state so newly created channels appear immediately in the sidebar.
+   120	  const [localChannels, setLocalChannels] = useState<Channel[]>(channels);
+   121	  // Map of serverId → default channel slug — used by BrowseServersModal for "Open" navigation.
+   122	  // Mirrors the same derivation in ServerRail so both always agree on the default channel.
+   123	  const defaultChannelByServerId = useMemo(() => {
+   124	    const map = new Map<string, string>();
+   125	    const textOrAnnouncement = allChannels
+   126	      .filter(c => c.type === ChannelType.TEXT || c.type === ChannelType.ANNOUNCEMENT)
+   127	      .sort((a, b) => a.position - b.position);
+   128	    for (const channel of textOrAnnouncement) {
+   129	      if (!map.has(channel.serverId)) map.set(channel.serverId, channel.slug);
+   130	    }
+   131	    return map;
+   132	  }, [allChannels]);
+   133	
+   134	  // Stable list of voice channel IDs for VoiceProvider — recomputed only when channels change.
+   135	  const voiceChannelIds = useMemo(
+   136	    () => localChannels.filter(c => c.type === ChannelType.VOICE).map(c => c.id),
+   137	    [localChannels],
+   138	  );
+   139	  // Track the channels prop reference so localChannels resets whenever the server
+   140	  // passes a fresh array (server navigation or revalidatePath refresh) — same
+   141	  // render-time derivation pattern used above for localMessages/prevChannelId.
+   142	  const [prevChannelsProp, setPrevChannelsProp] = useState(channels);
+   143	  if (prevChannelsProp !== channels) {
+   144	    setPrevChannelsProp(channels);
+   145	    setLocalChannels(channels);
+   146	  }
+   147	  // Local members state so join/leave/status events update the sidebar without reload.
+   148	  const [localMembers, setLocalMembers] = useState<User[]>(members);
+   149	  // Reset when the members prop changes (server navigation or SSR revalidation).
+   150	  const [prevMembersProp, setPrevMembersProp] = useState(members);
+   151	  if (prevMembersProp !== members) {
+   152	    setPrevMembersProp(members);
+   153	    setLocalMembers(members);
+   154	  }
+   155	  // Channel creation modal state.
+   156	  const [isCreateChannelOpen, setIsCreateChannelOpen] = useState(false);
+   157	  const [createChannelDefaultType, setCreateChannelDefaultType] = useState<ChannelType>(
+   158	    ChannelType.TEXT,
+   159	  );
+   160	
+   161	  const {
+   162	    user: authUser,
+   163	    isAuthenticated,
+   164	    isLoading: isAuthLoading,
+   165	    isAdmin: checkIsAdmin,
+   166	  } = useAuth();
+   167	
+   168	  // Fallback for guest/unauthenticated view
+   169	  const currentUser: User = authUser ?? {
+   170	    id: 'guest',
+   171	    username: 'Guest',
+   172	    displayName: 'Guest',
+   173	    status: 'online',
+   174	    role: 'guest',
+   175	  };
+   176	
+   177	  const router = useRouter();
+   178	  const [isCreateServerOpen, setIsCreateServerOpen] = useState(false);
+   179	  const [isBrowseServersOpen, setIsBrowseServersOpen] = useState(false);
+   180	  const [localServers, setLocalServers] = useState<Server[]>(servers);
+   181	  const [prevServers, setPrevServers] = useState<Server[]>(servers);
+   182	  if (prevServers !== servers) {
+   183	    setPrevServers(servers);
+   184	    setLocalServers(servers);
+   185	  }
+   186	
+   187	  const { notifyServerCreated, notifyServerJoined } = useServerListSync();
+   188	
+   189	  // Show the pin UI only to users with MODERATOR+ server-scoped role, and never
+   190	  // while the channel is locked (pinning would be meaningless/unauthorized anyway).
+   191	  // localMembers is populated by toFrontendMember() in serverService.ts, which maps
+   192	  // the backend ServerMember.role field (server-scoped) to User.role.
+   193	  // System admins bypass membership checks — they are authorized server-side regardless.
+   194	  const currentMemberRecord = useMemo(
+   195	    () => localMembers.find(m => m.id === authUser?.id),
+   196	    [localMembers, authUser?.id],
+   197	  );
+   198	  const canPin = useMemo(
+   199	    () =>
+   200	      isAuthenticated &&
+   201	      !isChannelLocked &&
+   202	      (authUser?.isSystemAdmin ||
+   203	        currentMemberRecord?.role === 'owner' ||
+   204	        currentMemberRecord?.role === 'admin' ||
+   205	        currentMemberRecord?.role === 'moderator'),
+   206	    [isAuthenticated, isChannelLocked, authUser?.isSystemAdmin, currentMemberRecord?.role],
+   207	  );
+   208	
+   209	  const handleServerCreated = useCallback(
+   210	    (server: Server, defaultChannel: Channel) => {
+```
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write src/components/layout/HarmonyShell.tsx
+```
+
+Output:
+
+```text
+[warn] jsxBracketSameLine is deprecated.
+src/components/layout/HarmonyShell.tsx 123ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 24509,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 21353f
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 7
+Output:
+TypeScript: No errors found
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 64676,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 81c413
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 91
+Output:
+> jest --forceExit usePresenceTracker.test.tsx
+Test Suites: 1 passed, 1 total
+Tests:       5 passed, 5 total
+Snapshots:   0 total
+Time:        0.567 s, estimated 1 s
+Ran all test suites matching usePresenceTracker.test.tsx.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend run lint
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend run lint
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 10029,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: ab8b11
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 164
+Output:
+> jest presence.router.test.ts
+PASS tests/presence.router.test.ts
+  POST /api/presence/status
+    ✓ updates authenticated users to ONLINE (20 ms)
+    ✓ updates authenticated users to IDLE (2 ms)
+    ✓ rejects DND because automatic presence only owns online, idle, and offline (1 ms)
+    ✓ rejects missing bearer token (1 ms)
+  POST /api/presence/beacon
+    ✓ accepts token in the body for unload-safe beacon requests (1 ms)
+    ✓ rejects expired beacon tokens (1 ms)
+Test Suites: 1 passed, 1 total
+Tests:       6 passed, 6 total
+Snapshots:   0 total
+Time:        1.939 s, estimated 3 s
+Ran all test suites matching /presence.router.test.ts/i.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 46208,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 2db630
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 3
+Output:
+> eslint
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 48426,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 8cd16f
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 74
+Output:
+> eslint src tests
+/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/tests/events.router.sse-server-updated.test.ts
+  83:10  warning  'sseGetWithEvent' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+✖ 1 problem (0 errors, 1 warning)
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:43:13.037Z
+
+The final targeted reruns still pass, frontend lint passes, and backend lint has only an existing warning in an unrelated test file. I’m doing one broader frontend Jest pass now; for backend, the targeted route suite plus typecheck/lint is the meaningful local verification here because many backend suites require local Postgres/Redis.
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- --runInBand
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ M harmony-backend/src/app.ts
+ M harmony-frontend/src/components/layout/HarmonyShell.tsx
+?? harmony-backend/src/routes/presence.router.ts
+?? harmony-backend/tests/presence.router.test.ts
+?? harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+?? harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat
+```
+
+Output:
+
+```text
+harmony-backend/src/app.ts                         |  4 +++
+ .../src/components/layout/HarmonyShell.tsx         | 38 ++++++++++++++--------
+ 2 files changed, 28 insertions(+), 14 deletions(-)
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 36408,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 20000
+}
+```
+
+Output:
+
+```text
+Chunk ID: ee1898
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 76
+Output:
+> jest --forceExit --runInBand
+Test Suites: 24 passed, 24 total
+Tests:       334 passed, 334 total
+Snapshots:   0 total
+Time:        2.009 s
+Ran all test suites.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+Output:
+
+```text
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { getAccessToken } from '@/lib/api-client';
+import { createFrontendLogger } from '@/lib/frontend-logger';
+import { getApiBaseUrl } from '@/lib/runtime-config';
+
+type PresenceStatus = 'ONLINE' | 'IDLE' | 'OFFLINE';
+
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const ACTIVE_THROTTLE_MS = 30_000;
+const ACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll', 'focus'];
+
+const logger = createFrontendLogger({ component: 'presence-tracker' });
+
+function postPresence(status: PresenceStatus): void {
+  const token = getAccessToken();
+  if (!token) return;
+
+  fetch(`${getApiBaseUrl()}/api/presence/status`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ status }),
+    keepalive: status === 'OFFLINE',
+  }).catch(error => {
+    logger.warn('Presence update failed', {
+      feature: 'presence',
+      event: 'status_update_failed',
+      method: 'POST',
+      route: '/api/presence/status',
+      error,
+    });
+  });
+}
+
+function beaconPresence(status: PresenceStatus): void {
+  const token = getAccessToken();
+  if (!token) return;
+
+  const payload = JSON.stringify({ token, status });
+  if (navigator.sendBeacon) {
+    const body = new Blob([payload], { type: 'application/json' });
+    navigator.sendBeacon(`${getApiBaseUrl()}/api/presence/beacon`, body);
+    return;
+  }
+
+  postPresence(status);
+}
+
+export function usePresenceTracker(enabled: boolean): void {
+  const statusRef = useRef<PresenceStatus>('OFFLINE');
+  const lastActivePostRef = useRef(0);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return;
+
+    const clearIdleTimer = () => {
+      if (idleTimerRef.current) {
+        clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+    };
+
+    const setPresence = (status: PresenceStatus, force = false) => {
+      const now = Date.now();
+      if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) {
+        return;
+      }
+      if (!force && statusRef.current === status) return;
+
+      statusRef.current = status;
+      if (status === 'ONLINE') lastActivePostRef.current = now;
+      postPresence(status);
+    };
+
+    const armIdleTimer = () => {
+      clearIdleTimer();
+      idleTimerRef.current = setTimeout(() => {
+        setPresence('IDLE', true);
+      }, IDLE_TIMEOUT_MS);
+    };
+
+    const markActive = () => {
+      setPresence('ONLINE');
+      armIdleTimer();
+    };
+
+    const markOffline = () => {
+      statusRef.current = 'OFFLINE';
+      beaconPresence('OFFLINE');
+    };
+
+    setPresence('ONLINE', true);
+    armIdleTimer();
+    for (const event of ACTIVITY_EVENTS) {
+      window.addEventListener(event, markActive, { passive: true });
+    }
+    window.addEventListener('pagehide', markOffline);
+
+    return () => {
+      clearIdleTimer();
+      for (const event of ACTIVITY_EVENTS) {
+        window.removeEventListener(event, markActive);
+      }
+      window.removeEventListener('pagehide', markOffline);
+    };
+  }, [enabled]);
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/routes/presence.router.ts
+```
+
+Output:
+
+```text
+import { NextFunction, Router, Request, Response } from 'express';
+import { UserStatus } from '@prisma/client';
+import { z } from 'zod';
+import { authService } from '../services/auth.service';
+import { userService } from '../services/user.service';
+
+export const presenceRouter = Router();
+
+const PresenceStatusSchema = z.enum([UserStatus.ONLINE, UserStatus.IDLE, UserStatus.OFFLINE]);
+const PresenceBodySchema = z.object({ status: PresenceStatusSchema });
+const BeaconPresenceBodySchema = PresenceBodySchema.extend({ token: z.string().min(1) });
+
+function getBearerToken(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+}
+
+function verifyToken(token: string): string | null {
+  try {
+    return authService.verifyAccessToken(token).sub;
+  } catch {
+    return null;
+  }
+}
+
+async function updatePresence(userId: string, status: UserStatus, res: Response): Promise<void> {
+  await userService.updateUser(userId, { status });
+  res.status(204).send();
+}
+
+presenceRouter.post('/status', async (req: Request, res: Response, next: NextFunction) => {
+  const token = getBearerToken(req);
+  if (!token) {
+    res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    return;
+  }
+
+  const userId = verifyToken(token);
+  if (!userId) {
+    res.status(401).json({ error: 'Invalid or expired access token' });
+    return;
+  }
+
+  const parsed = PresenceBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+    return;
+  }
+
+  try {
+    await updatePresence(userId, parsed.data.status, res);
+  } catch (err) {
+    next(err);
+  }
+});
+
+presenceRouter.post('/beacon', async (req: Request, res: Response, next: NextFunction) => {
+  const parsed = BeaconPresenceBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+    return;
+  }
+
+  const userId = verifyToken(parsed.data.token);
+  if (!userId) {
+    res.status(401).json({ error: 'Invalid or expired access token' });
+    return;
+  }
+
+  try {
+    await updatePresence(userId, parsed.data.status, res);
+  } catch (err) {
+    next(err);
+  }
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff -- harmony-frontend/src/components/layout/HarmonyShell.tsx harmony-backend/src/app.ts
+```
+
+Output:
+
+```text
+harmony-backend/src/app.ts                         |  4 +++
+ .../src/components/layout/HarmonyShell.tsx         | 38 ++++++++++++++--------
+ 2 files changed, 28 insertions(+), 14 deletions(-)
+
+--- Changes ---
+
+harmony-backend/src/app.ts
+  @@ -10,6 +10,7 @@ import { authRouter } from './routes/auth.router';
+  +import { presenceRouter } from './routes/presence.router';
+   import { attachmentRouter } from './routes/attachment.router';
+   import { adminMetaTagRouter } from './routes/admin.metaTag.router';
+   import { instanceId } from './lib/instance-identity';
+  @@ -155,6 +156,9 @@ export function createApp(options: CreateAppOptions = {}) {
+  +  // Presence updates from authenticated browser clients
+  +  app.use('/api/presence', presenceRouter);
+  +
+     // Attachment upload + file serving
+     app.use('/api/attachments', attachmentRouter);
+   
+  +4 -0
+
+harmony-frontend/src/components/layout/HarmonyShell.tsx
+  @@ -23,6 +23,7 @@ import { VoiceProvider } from '@/contexts/VoiceContext';
+  +import { usePresenceTracker } from '@/hooks/usePresenceTracker';
+   import { ChannelType, ChannelVisibility, UserStatus } from '@/types';
+   import { useRouter } from 'next/navigation';
+   import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
+  @@ -164,15 +165,6 @@ export function HarmonyShell({
+  -  // Fallback for guest/unauthenticated view
+  -  const currentUser: User = authUser ?? {
+  -    id: 'guest',
+  -    username: 'Guest',
+  -    displayName: 'Guest',
+  -    status: 'online',
+  -    role: 'guest',
+  -  };
+  -
+     const router = useRouter();
+     const [isCreateServerOpen, setIsCreateServerOpen] = useState(false);
+     const [isBrowseServersOpen, setIsBrowseServersOpen] = useState(false);
+  @@ -185,15 +177,31 @@ export function HarmonyShell({
+  +  const currentMemberRecord = useMemo(
+  +    () => localMembers.find(m => m.id === authUser?.id),
+  +    [localMembers, authUser?.id],
+  +  );
+  +
+  +  // Fallback for guest/unauthenticated view.
+  +  const currentUser: User = authUser
+  +    ? {
+  +        ...authUser,
+  +        status: currentMemberRecord?.status ?? authUser.status,
+  +        role: currentMemberRecord?.role ?? authUser.role,
+  +      }
+  +    : {
+  +        id: 'guest',
+  +        username: 'Guest',
+  +        displayName: 'Guest',
+  +        status: 'online',
+  +        role: 'guest',
+  +      };
+  +
+     // Show the pin UI only to users with MODERATOR+ server-scoped role, and never
+     // while the channel is locked (pinning would be meaningless/unauthorized anyway).
+     // localMembers is populated by toFrontendMember() in serverService.ts, which maps
+     // the backend ServerMember.role field (server-scoped) to User.role.
+     // System admins bypass membership checks — they are authorized server-side regardless.
+  -  const currentMemberRecord = useMemo(
+  -    () => localMembers.find(m => m.id === authUser?.id),
+  -    [localMembers, authUser?.id],
+  -  );
+     const canPin = useMemo(
+       () =>
+         isAuthenticated &&
+  @@ -375,6 +383,8 @@ export function HarmonyShell({
+  +  usePresenceTracker(isAuthenticated);
+  +
+     // #c10/#c23: single global Ctrl+K / Cmd+K handler — SearchModal no longer needs its own
+     useEffect(() => {
+       function handleKeyDown(e: KeyboardEvent) {
+  @@ -497,7 +507,7 @@ export function HarmonyShell({
+  -              members={members}
+  +              members={localMembers}
+                 isOpen={isMembersOpen}
+                 onClose={() => setIsMembersOpen(false)}
+               />
+  +24 -14
+```
+
+#### Tool: exec_command
+
+```sh
+rtk gh issue comment 490 --repo CS485-Harmony/Harmony --body "**[AI Agent — Complete]**
+
+Implemented automatic presence tracking for issue #490.
+
+Changes:
+- Added authenticated presence REST endpoints: /api/presence/status for normal activity updates and /api/presence/beacon for unload-safe browser close/pagehide updates.
+- Reused the existing userService.updateUser status path, so USER_STATUS_CHANGED is still broadcast through the existing server SSE member:statusChanged event.
+- Added a frontend presence tracker that marks users ONLINE on activity, IDLE after 5 minutes of inactivity, and OFFLINE on pagehide with sendBeacon.
+- Updated HarmonyShell so member/status SSE updates feed the members sidebar and current user display state.
+- Added backend and frontend regression tests for the new behavior.
+
+Verification:
+- PASS: npm --prefix harmony-backend test -- presence.router.test.ts
+- PASS: npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+- PASS: npm --prefix harmony-frontend test -- --runInBand
+- PASS: npm --prefix harmony-backend run build
+- PASS: npx tsc --noEmit in harmony-frontend
+- PASS: npm --prefix harmony-frontend run lint
+- PASS with existing unrelated warning: npm --prefix harmony-backend run lint
+- BLOCKED by sandbox network: npm --prefix harmony-frontend run build, because Next/font could not fetch Inter from https://fonts.googleapis.com."
+```
+
+Output:
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/490#issuecomment-4338135308
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ M harmony-backend/src/app.ts
+ M harmony-frontend/src/components/layout/HarmonyShell.tsx
+?? harmony-backend/src/routes/presence.router.ts
+?? harmony-backend/tests/presence.router.test.ts
+?? harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+?? harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --stat HEAD -- harmony-backend/src/app.ts harmony-backend/src/routes/presence.router.ts harmony-backend/tests/presence.router.test.ts harmony-frontend/src/components/layout/HarmonyShell.tsx harmony-frontend/src/hooks/usePresenceTracker.ts harmony-frontend/src/__tests__/usePresenceTracker.test.tsx tasks/todo.md
+```
+
+Output:
+
+```text
+ harmony-backend/src/app.ts                         |  4 +++
+ .../src/components/layout/HarmonyShell.tsx         | 38 ++++++++++++++--------
+ 2 files changed, 28 insertions(+), 14 deletions(-)
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:44:07.823Z
+
+Implemented issue #490.
+
+What changed:
+- Added backend presence endpoints:
+  - `POST /api/presence/status`
+  - `POST /api/presence/beacon`
+- Added `usePresenceTracker` to mark users `ONLINE`, `IDLE` after 5 minutes, and `OFFLINE` on `pagehide`.
+- Reused existing `userService.updateUser` broadcasting, so status changes flow through existing SSE `member:statusChanged`.
+- Fixed `HarmonyShell` to render `localMembers`, so real-time status updates actually appear in the members sidebar.
+- Added backend and frontend regression tests.
+- Posted start and completion comments on GitHub issue #490.
+
+Verification:
+- PASS `npm --prefix harmony-backend test -- presence.router.test.ts`
+- PASS `npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx`
+- PASS `npm --prefix harmony-frontend test -- --runInBand`
+- PASS `npm --prefix harmony-backend run build`
+- PASS frontend `npx tsc --noEmit`
+- PASS frontend lint
+- PASS backend lint with one pre-existing unrelated warning
+- BLOCKED frontend production build: sandbox could not fetch Google Fonts `Inter`.
+
+Files changed are still local and unstaged.
+
+<oai-mem-citation>
+<citation_entries>
+MEMORY.md:478-480|note=[confirmed Harmony PR and workflow memory group relevance]
+</citation_entries>
+<rollout_ids>
+</rollout_ids>
+</oai-mem-citation>
+
+### Turn 2: wdym offline on pagehide? like if they minimize the page they go
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T18:44:53.849Z
+
+```text
+wdym offline on pagehide? like if they minimize the page they go offline?
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:44:59.467Z
+
+`pagehide` fires when the page is being unloaded or put away by the browser, not just when the tab loses focus.
+
+So with the current implementation:
+- Switching tabs: should not mark offline.
+- Minimizing the browser window: should not mark offline.
+- Closing the tab/window: marks offline.
+- Navigating away / reload: marks offline.
+- Some mobile/browser lifecycle cases where the page is frozen or put into back-forward cache may also fire `pagehide`, so it can mark offline there too.
+
+If you want stricter semantics, we should avoid treating every `pagehide` as offline and instead add a heartbeat/lease on the backend: clients keep renewing presence while connected/active, and the server marks them offline only after the lease expires. That is more accurate for crashes, network drops, and mobile backgrounding.
+
+### Turn 3: yeah do
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T18:46:22.416Z
+
+```text
+yeah do that
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:46:35.320Z
+
+I’ll replace the unload-only offline behavior with a backend lease: the browser renews presence periodically, and the server marks the user offline only when renewals stop. That handles tab closes, crashes, and most network drops without treating normal tab switches/minimizing as offline.
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/db/redis.ts
+```
+
+Output:
+
+```text
+import Redis from 'ioredis';
+
+const globalForRedis = globalThis as unknown as { redis?: Redis };
+
+export const redis =
+  globalForRedis.redis ??
+  new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379', {
+    maxRetriesPerRequest: 3,
+    lazyConnect: true,
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForRedis.redis = redis;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/services/cacheInvalidator.service.ts
+```
+
+Output:
+
+```text
+/**
+ * CacheInvalidator — subscribes to domain events and invalidates the
+ * corresponding Redis cache keys per the §4.4 cache schema.
+ *
+ * Invalidation rules:
+ *   VISIBILITY_CHANGED  → channel:{id}:visibility
+ *                       → server:{id}:public_channels
+ *                       → meta:channel:{id}
+ *   MESSAGE_CREATED     → channel:msgs:{id}:* (all pages)
+ *                       → analysis:channel:{id}
+ *                       → meta:channel:{id}
+ *   MESSAGE_EDITED      → channel:msgs:{id}:* (all pages)
+ *                       → analysis:channel:{id}
+ *                       → meta:channel:{id}
+ *   MESSAGE_DELETED     → channel:msgs:{id}:* (all pages)
+ *                       → analysis:channel:{id}
+ *                       → meta:channel:{id}
+ */
+
+import { eventBus, EventChannels } from '../events/eventBus';
+import { createLogger } from '../lib/logger';
+import { cacheService, CacheKeys, sanitizeKeySegment } from './cache.service';
+import { indexingService } from './indexing.service';
+
+type UnsubscribeFn = () => void;
+
+let unsubscribers: UnsubscribeFn[] = [];
+const logger = createLogger({ component: 'cache-invalidator' });
+// Shared startup promise — concurrent callers all await the same initialization
+// so no caller returns before subscriptions are confirmed ready.
+let startPromise: Promise<void> | null = null;
+
+export const cacheInvalidator = {
+  /**
+   * Start all event subscriptions.
+   * Returns a Promise that resolves once all Redis subscribe handshakes
+   * are confirmed — await this in tests to avoid timing-dependent failures.
+   * Idempotent: concurrent or repeated calls share the same startup promise.
+   */
+  start(): Promise<void> {
+    if (startPromise !== null) return startPromise;
+
+    startPromise = (async () => {
+      const sub1 = eventBus.subscribe(EventChannels.VISIBILITY_CHANGED, (payload) => {
+        cacheService
+          .invalidate(CacheKeys.channelVisibility(payload.channelId))
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Visibility cache invalidation failed',
+            ),
+          );
+
+        cacheService
+          .invalidate(`server:${sanitizeKeySegment(payload.serverId)}:public_channels`)
+          .catch((err) =>
+            logger.warn(
+              { err, serverId: payload.serverId },
+              'Public channel cache invalidation failed',
+            ),
+          );
+
+        cacheService
+          .invalidate(CacheKeys.metaChannel(payload.channelId))
+          .catch((err) =>
+            logger.warn({ err, channelId: payload.channelId }, 'Meta cache invalidation failed'),
+          );
+
+        // Update sitemap on visibility changes
+        indexingService
+          .onVisibilityChanged(payload)
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Sitemap update on visibility change failed',
+            ),
+          );
+      });
+
+      const sub2 = eventBus.subscribe(EventChannels.MESSAGE_CREATED, (payload) => {
+        cacheService
+          .invalidatePattern(`channel:msgs:${sanitizeKeySegment(payload.channelId)}:*`)
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Message cache invalidation failed after create',
+            ),
+          );
+
+        cacheService
+          .invalidate(CacheKeys.analysisChannel(payload.channelId))
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Analysis cache invalidation failed after create',
+            ),
+          );
+
+        cacheService
+          .invalidate(CacheKeys.metaChannel(payload.channelId))
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Meta cache invalidation failed after create',
+            ),
+          );
+      });
+
+      const sub3 = eventBus.subscribe(EventChannels.MESSAGE_EDITED, (payload) => {
+        cacheService
+          .invalidatePattern(`channel:msgs:${sanitizeKeySegment(payload.channelId)}:*`)
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Message cache invalidation failed after edit',
+            ),
+          );
+
+        cacheService
+          .invalidate(CacheKeys.analysisChannel(payload.channelId))
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Analysis cache invalidation failed after edit',
+            ),
+          );
+
+        cacheService
+          .invalidate(CacheKeys.metaChannel(payload.channelId))
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Meta cache invalidation failed after edit',
+            ),
+          );
+      });
+
+      const sub4 = eventBus.subscribe(EventChannels.MESSAGE_DELETED, (payload) => {
+        cacheService
+          .invalidatePattern(`channel:msgs:${sanitizeKeySegment(payload.channelId)}:*`)
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Message cache invalidation failed after delete',
+            ),
+          );
+
+        cacheService
+          .invalidate(CacheKeys.analysisChannel(payload.channelId))
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Analysis cache invalidation failed after delete',
+            ),
+          );
+
+        cacheService
+          .invalidate(CacheKeys.metaChannel(payload.channelId))
+          .catch((err) =>
+            logger.warn(
+              { err, channelId: payload.channelId },
+              'Meta cache invalidation failed after delete',
+            ),
+          );
+      });
+
+      unsubscribers = [sub1.unsubscribe, sub2.unsubscribe, sub3.unsubscribe, sub4.unsubscribe];
+
+      // Wait for all Redis subscribe handshakes to complete
+      await Promise.all([sub1.ready, sub2.ready, sub3.ready, sub4.ready]);
+    })();
+
+    return startPromise;
+  },
+
+  /** Stop all subscriptions and disconnect the subscriber client. */
+  async stop(): Promise<void> {
+    startPromise = null; // allow restart after stop
+    for (const unsub of unsubscribers) unsub();
+    unsubscribers = [];
+    await eventBus.disconnect();
+  },
+};
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/index.ts
+```
+
+Output:
+
+```text
+import 'dotenv/config';
+import { createApp } from './app';
+import { instanceId } from './lib/instance-identity';
+import { createLogger } from './lib/logger';
+import { parsePortEnv } from './lib/parsePortEnv';
+
+const PORT = parsePortEnv(4000);
+const HOST = '0.0.0.0';
+const DISPLAY_HOST = process.env.NODE_ENV === 'development' ? 'localhost' : HOST;
+const logger = createLogger({ component: 'api-bootstrap', instanceId, pid: process.pid });
+
+const app = createApp();
+
+const server = app.listen(PORT, HOST, () => {
+  logger.info({ host: DISPLAY_HOST, port: PORT }, 'Harmony backend-api listening');
+});
+
+// NOTE: cacheInvalidator (Redis Pub/Sub subscribers) runs on backend-worker,
+// NOT here. Running it on every API replica would duplicate subscriber
+// connections and background side effects. See
+// docs/deployment/replica-readiness-audit.md §4.1 and
+// docs/deployment/deployment-architecture.md §2.2.
+
+let shuttingDown = false;
+const shutdown = async () => {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  logger.info('Shutdown signal received');
+  const timer = setTimeout(() => process.exit(1), 10_000);
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  clearTimeout(timer);
+  process.exit(0);
+};
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/tests/cache.service.test.ts
+```
+
+Output:
+
+```text
+/**
+ * Cache service tests — Issue #109
+ *
+ * Tests cache hit, miss, invalidation, stale-while-revalidate,
+ * and key pattern invalidation.
+ * Requires REDIS_URL pointing at a running Redis instance.
+ */
+
+import { cacheService, CacheKeys, CacheTTL, CacheEntry, sanitizeKeySegment } from '../src/services/cache.service';
+import { redis } from '../src/db/redis';
+
+beforeAll(async () => {
+  await redis.connect().catch(() => {});
+});
+
+afterAll(async () => {
+  await redis.quit();
+});
+
+afterEach(async () => {
+  // Clean up test keys
+  const keys = await redis.keys('test:*');
+  if (keys.length > 0) await redis.del(...keys);
+});
+
+// ─── Cache key patterns ──────────────────────────────────────────────────────
+
+describe('CacheKeys', () => {
+  it('generates correct channel visibility key', () => {
+    expect(CacheKeys.channelVisibility('abc-123')).toBe('channel:abc-123:visibility');
+  });
+
+  it('generates correct channel messages key', () => {
+    expect(CacheKeys.channelMessages('abc-123', 2)).toBe('channel:msgs:abc-123:page:2');
+  });
+
+  it('generates correct server info key', () => {
+    expect(CacheKeys.serverInfo('srv-1')).toBe('server:srv-1:info');
+  });
+});
+
+// ─── Key sanitization ───────────────────────────────────────────────────────
+
+describe('sanitizeKeySegment', () => {
+  it('strips glob-special characters from keys', () => {
+    expect(sanitizeKeySegment('abc*def')).toBe('abcdef');
+    expect(sanitizeKeySegment('abc?def')).toBe('abcdef');
+    expect(sanitizeKeySegment('abc[0]def')).toBe('abc0def');
+  });
+
+  it('leaves valid UUIDs unchanged', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(sanitizeKeySegment(uuid)).toBe(uuid);
+  });
+
+  it('produces safe cache keys via CacheKeys helpers', () => {
+    expect(CacheKeys.channelVisibility('*')).toBe('channel::visibility');
+    expect(CacheKeys.channelMessages('a]b[c', 1)).toBe('channel:msgs:abc:page:1');
+  });
+});
+
+// ─── TTL values ──────────────────────────────────────────────────────────────
+
+describe('CacheTTL', () => {
+  it('has correct TTL values from spec', () => {
+    expect(CacheTTL.channelVisibility).toBe(3600);
+    expect(CacheTTL.channelMessages).toBe(60);
+    expect(CacheTTL.serverInfo).toBe(300);
+  });
+});
+
+// ─── set / get (cache miss → cache hit) ──────────────────────────────────────
+
+describe('cacheService.set / get', () => {
+  it('returns null on cache miss', async () => {
+    const result = await cacheService.get('test:nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('returns cached entry on cache hit', async () => {
+    const data = { visibility: 'PUBLIC_INDEXABLE' };
+    await cacheService.set('test:hit', data, { ttl: 60 });
+
+    const entry = await cacheService.get<typeof data>('test:hit');
+    expect(entry).not.toBeNull();
+    expect(entry!.data).toEqual(data);
+    expect(entry!.createdAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('stores entry with correct TTL in Redis', async () => {
+    await cacheService.set('test:ttl', 'value', { ttl: 120 });
+
+    const ttl = await redis.ttl('test:ttl');
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(120);
+  });
+
+  it('adds staleTtl to total Redis TTL', async () => {
+    await cacheService.set('test:stale-ttl', 'value', { ttl: 60, staleTtl: 30 });
+
+    const ttl = await redis.ttl('test:stale-ttl');
+    expect(ttl).toBeGreaterThan(60);
+    expect(ttl).toBeLessThanOrEqual(90);
+  });
+});
+
+// ─── invalidate ──────────────────────────────────────────────────────────────
+
+describe('cacheService.invalidate', () => {
+  it('removes a single cached key', async () => {
+    await cacheService.set('test:del', 'to-delete', { ttl: 60 });
+    expect(await cacheService.get('test:del')).not.toBeNull();
+
+    await cacheService.invalidate('test:del');
+    expect(await cacheService.get('test:del')).toBeNull();
+  });
+});
+
+// ─── invalidatePattern ───────────────────────────────────────────────────────
+
+describe('cacheService.invalidatePattern', () => {
+  it('removes all keys matching a glob pattern', async () => {
+    await Promise.all([
+      cacheService.set('test:msgs:ch1:page:1', 'p1', { ttl: 60 }),
+      cacheService.set('test:msgs:ch1:page:2', 'p2', { ttl: 60 }),
+      cacheService.set('test:msgs:ch2:page:1', 'other', { ttl: 60 }),
+    ]);
+
+    await cacheService.invalidatePattern('test:msgs:ch1:*');
+
+    expect(await cacheService.get('test:msgs:ch1:page:1')).toBeNull();
+    expect(await cacheService.get('test:msgs:ch1:page:2')).toBeNull();
+    // ch2 should be untouched
+    expect(await cacheService.get('test:msgs:ch2:page:1')).not.toBeNull();
+  });
+});
+
+// ─── isStale ─────────────────────────────────────────────────────────────────
+
+describe('cacheService.isStale', () => {
+  it('returns false for fresh entries', () => {
+    const entry: CacheEntry = { data: 'fresh', createdAt: Date.now() };
+    expect(cacheService.isStale(entry, 60)).toBe(false);
+  });
+
+  it('returns true for entries older than TTL', () => {
+    const entry: CacheEntry = { data: 'old', createdAt: Date.now() - 120_000 };
+    expect(cacheService.isStale(entry, 60)).toBe(true);
+  });
+});
+
+// ─── getOrRevalidate (stale-while-revalidate) ────────────────────────────────
+
+describe('cacheService.getOrRevalidate', () => {
+  it('calls fetcher on cache miss and caches result', async () => {
+    const fetcher = jest.fn().mockResolvedValue({ id: 1, name: 'test' });
+
+    const result = await cacheService.getOrRevalidate('test:swr-miss', fetcher, { ttl: 60 });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ id: 1, name: 'test' });
+
+    // Verify it was cached
+    const entry = await cacheService.get('test:swr-miss');
+    expect(entry).not.toBeNull();
+    expect(entry!.data).toEqual({ id: 1, name: 'test' });
+  });
+
+  it('returns cached data without calling fetcher on fresh hit', async () => {
+    await cacheService.set('test:swr-hit', { cached: true }, { ttl: 60 });
+    const fetcher = jest.fn().mockResolvedValue({ cached: false });
+
+    const result = await cacheService.getOrRevalidate('test:swr-hit', fetcher, { ttl: 60 });
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(result).toEqual({ cached: true });
+  });
+
+  it('returns stale data immediately and triggers background revalidation', async () => {
+    // Set entry with createdAt in the past (stale)
+    const staleEntry: CacheEntry = { data: { version: 'old' }, createdAt: Date.now() - 120_000 };
+    await redis.set('test:swr-stale', JSON.stringify(staleEntry), 'EX', 300);
+
+    let resolveRevalidation: (v: unknown) => void;
+    const revalidationDone = new Promise((r) => { resolveRevalidation = r; });
+
+    const fetcher = jest.fn().mockImplementation(() => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({ version: 'new' });
+          resolveRevalidation(undefined);
+        }, 50);
+      });
+    });
+
+    // Should return stale data immediately
+    const result = await cacheService.getOrRevalidate('test:swr-stale', fetcher, {
+      ttl: 60,
+      staleTtl: 300,
+    });
+    expect(result).toEqual({ version: 'old' });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    // Wait for background revalidation to complete
+    await revalidationDone;
+    // Small delay for the set to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Cache should now have fresh data
+    const updated = await cacheService.get('test:swr-stale');
+    expect(updated!.data).toEqual({ version: 'new' });
+  });
+});
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:46:50.300Z
+
+I’m going to change the design slightly from “send offline on pagehide” to “renew a Redis-backed lease.” Each heartbeat writes an expiry timestamp, and a sweeper marks the user offline only after the shared lease expires, which avoids false offline states from minimize/tab switch and works better across replicas.
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/tests/presence.router.test.ts && rtk read harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+import request from 'supertest';
+import { createApp } from '../src/app';
+import { authService } from '../src/services/auth.service';
+import { userService } from '../src/services/user.service';
+
+jest.mock('../src/services/auth.service', () => ({
+  authService: {
+    verifyAccessToken: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/user.service', () => ({
+  userService: {
+    updateUser: jest.fn().mockResolvedValue({ id: 'user-1', status: 'ONLINE' }),
+  },
+}));
+
+jest.mock('../src/middleware/rate-limit.middleware', () => ({
+  createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const app = createApp();
+const mockVerifyAccessToken = authService.verifyAccessToken as jest.Mock;
+const mockUpdateUser = userService.updateUser as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerifyAccessToken.mockReturnValue({ sub: 'user-1' });
+  mockUpdateUser.mockResolvedValue({ id: 'user-1', status: 'ONLINE' });
+});
+
+describe('POST /api/presence/status', () => {
+  it('updates authenticated users to ONLINE', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'ONLINE' });
+
+    expect(res.status).toBe(204);
+    expect(mockVerifyAccessToken).toHaveBeenCalledWith('valid-token');
+    expect(mockUpdateUser).toHaveBeenCalledWith('user-1', { status: 'ONLINE' });
+  });
+
+  it('updates authenticated users to IDLE', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'IDLE' });
+
+    expect(res.status).toBe(204);
+    expect(mockUpdateUser).toHaveBeenCalledWith('user-1', { status: 'IDLE' });
+  });
+
+  it('rejects DND because automatic presence only owns online, idle, and offline', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'DND' });
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing bearer token', async () => {
+    const res = await request(app).post('/api/presence/status').send({ status: 'ONLINE' });
+
+    expect(res.status).toBe(401);
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/presence/beacon', () => {
+  it('accepts token in the body for unload-safe beacon requests', async () => {
+    const res = await request(app)
+      .post('/api/presence/beacon')
+      .send({ token: 'valid-token', status: 'OFFLINE' });
+
+    expect(res.status).toBe(204);
+    expect(mockVerifyAccessToken).toHaveBeenCalledWith('valid-token');
+    expect(mockUpdateUser).toHaveBeenCalledWith('user-1', { status: 'OFFLINE' });
+  });
+
+  it('rejects expired beacon tokens', async () => {
+    mockVerifyAccessToken.mockImplementation(() => {
+      throw new Error('expired');
+    });
+
+    const res = await request(app)
+      .post('/api/presence/beacon')
+      .send({ token: 'expired-token', status: 'OFFLINE' });
+
+    expect(res.status).toBe(401);
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+});
+import { renderHook, act } from '@testing-library/react';
+import { usePresenceTracker } from '../hooks/usePresenceTracker';
+
+jest.mock('../lib/api-client', () => ({
+  getAccessToken: jest.fn(() => 'mock-token'),
+}));
+
+const API_URL = 'http://localhost:4000';
+const mockFetch = jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock;
+const mockSendBeacon = jest.fn(() => true);
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_API_URL = API_URL;
+  Object.defineProperty(global, 'fetch', { writable: true, value: mockFetch });
+  Object.defineProperty(navigator, 'sendBeacon', { writable: true, value: mockSendBeacon });
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe('usePresenceTracker', () => {
+  it('posts ONLINE when enabled', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer mock-token' }),
+        body: JSON.stringify({ status: 'ONLINE' }),
+      }),
+    );
+  });
+
+  it('does not post when disabled', () => {
+    renderHook(() => usePresenceTracker(false));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('posts IDLE after five minutes of inactivity', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000);
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        body: JSON.stringify({ status: 'IDLE' }),
+      }),
+    );
+  });
+
+  it('returns to ONLINE after activity while idle', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        body: JSON.stringify({ status: 'ONLINE' }),
+      }),
+    );
+  });
+
+  it('uses sendBeacon to mark OFFLINE on pagehide', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      window.dispatchEvent(new PageTransitionEvent('pagehide'));
+    });
+
+    expect(mockSendBeacon).toHaveBeenCalledTimes(1);
+    expect(mockSendBeacon).toHaveBeenCalledWith(`${API_URL}/api/presence/beacon`, expect.any(Blob));
+  });
+});
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:48:10.511Z
+
+One important cleanup: with periodic heartbeats, renewing `ONLINE` every 30 seconds should not rebroadcast status if the user is already online. I’m adding a status-change guard in the presence service and a small unit test for lease expiry.
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write src/services/presence.service.ts src/routes/presence.router.ts tests/presence.router.test.ts tests/presence.service.test.ts
+```
+
+Output:
+
+```text
+src/services/presence.service.ts 30ms
+src/routes/presence.router.ts 7ms (unchanged)
+tests/presence.router.test.ts 8ms (unchanged)
+tests/presence.service.test.ts 5ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write src/hooks/usePresenceTracker.ts src/__tests__/usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+[warn] jsxBracketSameLine is deprecated.
+src/hooks/usePresenceTracker.ts 35ms (unchanged)
+src/__tests__/usePresenceTracker.test.tsx 9ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts presence.service.test.ts
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend run build
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 3324,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 5db7df
+Wall time: 0.0000 seconds
+Process exited with code 1
+Original token count: 428
+Output:
+> jest presence.router.test.ts presence.service.test.ts
+FAIL tests/presence.service.test.ts
+  ● Test suite failed to run
+    [96msrc/services/presence.service.ts[0m:[93m22[0m:[93m44[0m - [91merror[0m[90m TS2702: [0m'UserStatus' only refers to a type, but is being used as a namespace here.
+    [7m22[0m   async renewLease(userId: string, status: UserStatus.ONLINE | UserStatus.IDLE): Promise<void> {
+    [7m  [0m [91m                                           ~~~~~~~~~~[0m
+    [96msrc/services/presence.service.ts[0m:[93m22[0m:[93m64[0m - [91merror[0m[90m TS2702: [0m'UserStatus' only refers to a type, but is being used as a namespace here.
+    [7m22[0m   async renewLease(userId: string, status: UserStatus.ONLINE | UserStatus.IDLE): Promise<void> {
+    [7m  [0m [91m                                                               ~~~~~~~~~~[0m
+FAIL tests/presence.router.test.ts
+  ● Test suite failed to run
+    [96msrc/routes/presence.router.ts[0m:[93m27[0m:[93m11[0m - [91merror[0m[90m TS2702: [0m'UserStatus' only refers to a type, but is being used as a namespace here.
+    [7m27[0m   status: UserStatus.ONLINE | UserStatus.IDLE,
+    [7m  [0m [91m          ~~~~~~~~~~[0m
+    [96msrc/routes/presence.router.ts[0m:[93m27[0m:[93m31[0m - [91merror[0m[90m TS2702: [0m'UserStatus' only refers to a type, but is being used as a namespace here.
+    [7m27[0m   status: UserStatus.ONLINE | UserStatus.IDLE,
+    [7m  [0m [91m                              ~~~~~~~~~~[0m
+Test Suites: 2 failed, 2 total
+Tests:       0 total
+Snapshots:   0 total
+Time:        3.122 s
+Ran all test suites matching /presence.router.test.ts|presence.service.test.ts/i.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 57434,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 45e5af
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 91
+Output:
+> jest --forceExit usePresenceTracker.test.tsx
+Test Suites: 1 passed, 1 total
+Tests:       6 passed, 6 total
+Snapshots:   0 total
+Time:        0.691 s, estimated 1 s
+Ran all test suites matching usePresenceTracker.test.tsx.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 56370,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 60bdd7
+Wall time: 0.0000 seconds
+Process exited with code 2
+Original token count: 130
+Output:
+> tsc
+src/routes/presence.router.ts(27,11): error TS2702: 'UserStatus' only refers to a type, but is being used as a namespace here.
+src/routes/presence.router.ts(27,31): error TS2702: 'UserStatus' only refers to a type, but is being used as a namespace here.
+src/services/presence.service.ts(22,44): error TS2702: 'UserStatus' only refers to a type, but is being used as a namespace here.
+src/services/presence.service.ts(22,64): error TS2702: 'UserStatus' only refers to a type, but is being used as a namespace here.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 87534,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 9b90b9
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 7
+Output:
+TypeScript: No errors found
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts presence.service.test.ts
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend run build
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 17643,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 2c9def
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 79
+Output:
+> jest presence.router.test.ts presence.service.test.ts
+PASS tests/presence.service.test.ts
+PASS tests/presence.router.test.ts
+Test Suites: 2 passed, 2 total
+Tests:       9 passed, 9 total
+Snapshots:   0 total
+Time:        3.593 s
+Ran all test suites matching /presence.router.test.ts|presence.service.test.ts/i.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 11564,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 00a8d4
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 2
+Output:
+> tsc
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:49:31.162Z
+
+The lease-based version is now passing targeted backend and frontend tests, and backend typecheck is clean. I’m running lint plus the frontend suite again before I wrap this change up.
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend run lint
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend run lint
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- --runInBand
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 96615,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 66e335
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 74
+Output:
+> eslint src tests
+/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/tests/events.router.sse-server-updated.test.ts
+  83:10  warning  'sseGetWithEvent' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+✖ 1 problem (0 errors, 1 warning)
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 17625,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: fb0d5f
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 3
+Output:
+> eslint
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 32479,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 0e3c3e
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 76
+Output:
+> jest --forceExit --runInBand
+Test Suites: 24 passed, 24 total
+Tests:       335 passed, 335 total
+Snapshots:   0 total
+Time:        2.061 s
+Ran all test suites.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 48261,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 82dea3
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 7
+Output:
+TypeScript: No errors found
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ M harmony-backend/src/app.ts
+ M harmony-frontend/src/components/layout/HarmonyShell.tsx
+?? harmony-backend/src/routes/presence.router.ts
+?? harmony-backend/src/services/presence.service.ts
+?? harmony-backend/tests/presence.router.test.ts
+?? harmony-backend/tests/presence.service.test.ts
+?? harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+?? harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --stat HEAD -- harmony-backend/src/app.ts harmony-backend/src/routes/presence.router.ts harmony-backend/src/services/presence.service.ts harmony-backend/tests/presence.router.test.ts harmony-backend/tests/presence.service.test.ts harmony-frontend/src/components/layout/HarmonyShell.tsx harmony-frontend/src/hooks/usePresenceTracker.ts harmony-frontend/src/__tests__/usePresenceTracker.test.tsx tasks/todo.md
+```
+
+Output:
+
+```text
+ harmony-backend/src/app.ts                         |  7 ++++
+ .../src/components/layout/HarmonyShell.tsx         | 38 ++++++++++++++--------
+ 2 files changed, 31 insertions(+), 14 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read tasks/todo.md
+```
+
+Output:
+
+```text
+# Issue #490 - Real-time presence status
+
+- [x] Read workflow and inspect existing SSE/status plumbing.
+- [x] Add backend presence update endpoints that reuse existing status broadcasts.
+- [x] Add frontend activity tracker for online, idle, and unload offline transitions.
+- [x] Wire live member state into the members sidebar.
+- [x] Add targeted regression tests.
+- [x] Run formatter/typecheck/tests and summarize results.
+
+## Review
+
+- Added `/api/presence/status` for authenticated activity updates and `/api/presence/beacon` for unload-safe offline updates.
+- Added `usePresenceTracker` to set `ONLINE` on activity, `IDLE` after 5 minutes, and `OFFLINE` on `pagehide`.
+- Reused existing `userService.updateUser` status broadcasts, so server SSE clients receive `member:statusChanged`.
+- Updated `HarmonyShell` to render the live `localMembers` list and keep the current user's status/role aligned with real-time member updates.
+- Verification: targeted backend and frontend presence tests pass; frontend Jest suite passes; backend/frontend lint pass aside from one pre-existing backend warning; backend and frontend typechecks pass. Frontend production build is blocked by network-restricted Google Fonts fetch.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk gh issue comment 490 --repo CS485-Harmony/Harmony --body "**[AI Agent — In Progress]**
+
+Adjusted the presence implementation to use a backend lease instead of marking users offline on pagehide.
+
+Updated behavior:
+- Browser sends ONLINE/IDLE heartbeats through /api/presence/status.
+- Backend stores a Redis-backed presence lease with a 75s expiry.
+- Backend sweeper marks the user OFFLINE only after the lease expires, so minimizing, switching tabs, and normal page lifecycle events do not immediately mark offline.
+- Heartbeat renewals avoid rebroadcasting when the status has not changed.
+
+Verification after the adjustment:
+- PASS: npm --prefix harmony-backend test -- presence.router.test.ts presence.service.test.ts
+- PASS: npm --prefix harmony-backend run build
+- PASS: npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+- PASS: npm --prefix harmony-frontend test -- --runInBand
+- PASS: frontend npx tsc --noEmit
+- PASS: frontend lint
+- PASS with existing unrelated warning: backend lint"
+```
+
+Output:
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/490#issuecomment-4338172136
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:50:14.751Z
+
+Changed it to the lease-based approach.
+
+Now the browser does not mark offline on `pagehide`. Instead:
+- Frontend sends `ONLINE`/`IDLE` heartbeats every 30s.
+- Backend stores a Redis lease with a 75s expiry.
+- A backend sweeper marks the user `OFFLINE` only after heartbeats stop.
+- Switching tabs/minimizing should not immediately make them offline.
+- Closing the tab, crashing, or losing network eventually makes them offline when the lease expires.
+
+Verification passed:
+- Backend presence route/service tests: `9 passed`
+- Backend build/typecheck: passed
+- Frontend presence test: passed
+- Full frontend Jest suite: `335 passed`
+- Frontend typecheck/lint: passed
+- Backend lint: passed with the existing unrelated warning in `events.router.sse-server-updated.test.ts`
+
+I also posted the updated implementation note on issue #490.
+
+### Turn 4: make a
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T18:51:12.008Z
+
+```text
+make a PR
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:51:20.509Z
+
+I’ll package the current issue #490 work into a branch, commit it with the required Harmony co-author trailer, push it, and open a draft PR. First I’m checking the publish workflow and current diff so I only include the intended files.
+
+#### Tool: exec_command
+
+```sh
+rtk read /Users/allen/.codex/plugins/cache/openai-curated/github/6807e4de/skills/yeet/SKILL.md
+```
+
+Output:
+
+```text
+---
+name: "yeet"
+description: "Publish local changes to GitHub by confirming scope, committing intentionally, pushing the branch, and opening a draft PR through the GitHub app from this plugin, with `gh` used only as a fallback where connector coverage is insufficient."
+---
+
+# GitHub Publish Changes
+
+## Overview
+
+Use this skill only when the user explicitly wants the full publish flow from the local checkout: branch setup if needed, staging, commit, push, and opening a pull request.
+
+This workflow is hybrid:
+
+- Use local `git` for branch creation, staging, commit, and push.
+- Prefer the GitHub app from this plugin for pull request creation after the branch is on the remote.
+- Use `gh` as a fallback for current-branch PR discovery, auth checks, or PR creation when the connector path cannot infer the repository or head branch cleanly.
+
+## Prerequisites
+
+- Require GitHub CLI `gh`. Check `gh --version`. If missing, ask the user to install `gh` and stop.
+- Require authenticated `gh` session. Run `gh auth status`. If not authenticated, ask the user to run `gh auth login` (and re-run `gh auth status`) before continuing.
+- Require a local git repository with a clean understanding of which changes belong in the PR.
+
+## Naming conventions
+
+- Branch: `codex/{description}` when starting from main/master/default.
+- Commit: `{description}` (terse).
+- PR title: `[codex] {description}` summarizing the full diff.
+
+## Workflow
+
+1. Confirm intended scope.
+   - Run `git status -sb` and inspect the diff before staging.
+   - If the working tree contains unrelated changes, do not default to `git add -A`. Ask the user which files belong in the PR.
+2. Determine the branch strategy.
+   - If on `main`, `master`, or another default branch, create `codex/{description}`.
+   - Otherwise stay on the current branch.
+3. Stage only the intended changes.
+   - Prefer explicit file paths when the worktree is mixed.
+   - Use `git add -A` only when the user has confirmed the whole worktree belongs in scope.
+4. Commit tersely with the confirmed description.
+5. Run the most relevant checks available if they have not already been run.
+   - If checks fail due to missing dependencies or tools, install what is needed and rerun once.
+6. Push with tracking: `git push -u origin $(git branch --show-current)`.
+7. Open a draft PR.
+   - Prefer the GitHub app from this plugin for PR creation after the push succeeds.
+   - Derive `repository_full_name` from the remote, for example by normalizing `git remote get-url origin` or by using `gh repo view --json nameWithOwner`.
+   - Derive `head_branch` from `git branch --show-current`.
+   - Derive `base_branch` from the user request when specified; otherwise use the remote default branch, for example via `gh repo view --json defaultBranchRef`.
+   - If the branch is being pushed from a fork or the PR target differs from the remote that was just pushed, prefer `gh pr create` fallback because the connector PR creation flow expects one repository target and may not encode cross-repo head semantics cleanly.
+   - If connector-based PR creation cannot infer the repository or branch cleanly, fall back to `gh pr create --draft --fill --head $(git branch --show-current)`.
+   - Write the PR body to a temp file with real newlines when using CLI fallback so the markdown renders cleanly.
+8. Summarize the result with branch name, commit, PR target, validation, and anything the user still needs to confirm.
+
+## Write Safety
+
+- Never stage unrelated user changes silently.
+- Never push without confirming scope when the worktree is mixed.
+- Default to a draft PR unless the user explicitly asks for a ready-for-review PR.
+- If the repository does not appear to be connected to an accessible GitHub remote, stop and explain the blocker before making assumptions.
+
+## PR Body Expectations
+
+The PR description should use real Markdown prose and cover:
+
+- what changed
+- why it changed
+- the user or developer impact
+- the root cause when the PR is a fix
+- the checks used to validate it
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ M harmony-backend/src/app.ts
+ M harmony-frontend/src/components/layout/HarmonyShell.tsx
+?? harmony-backend/src/routes/presence.router.ts
+?? harmony-backend/src/services/presence.service.ts
+?? harmony-backend/tests/presence.router.test.ts
+?? harmony-backend/tests/presence.service.test.ts
+?? harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+?? harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat
+```
+
+Output:
+
+```text
+harmony-backend/src/app.ts                         |  7 ++++
+ .../src/components/layout/HarmonyShell.tsx         | 38 ++++++++++++++--------
+ 2 files changed, 31 insertions(+), 14 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git branch --show-current
+```
+
+Output:
+
+```text
+
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:51:29.008Z
+
+The only visible worktree changes are the presence feature files. The current checkout is detached/no branch name, so I’m going to create a `codex/issue-490-presence-leases` branch before staging.
+
+#### Tool: exec_command
+
+```sh
+rtk git status -sb
+```
+
+Output:
+
+```text
+## HEAD (no branch)
+ M harmony-backend/src/app.ts
+ M harmony-frontend/src/components/layout/HarmonyShell.tsx
+?? harmony-backend/src/routes/presence.router.ts
+?? harmony-backend/src/services/presence.service.ts
+?? harmony-backend/tests/presence.router.test.ts
+?? harmony-backend/tests/presence.service.test.ts
+?? harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+?? harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git remote -v
+```
+
+Output:
+
+```text
+origin	git@github.com:CS485-Harmony/Harmony.git (fetch)
+origin	git@github.com:CS485-Harmony/Harmony.git (push)
+```
+
+#### Tool: exec_command
+
+```sh
+gh --version
+```
+
+Output:
+
+```text
+gh version 2.92.0 (2026-04-28)
+https://github.com/cli/cli/releases/tag/v2.92.0
+```
+
+#### Tool: exec_command
+
+```sh
+gh auth status
+```
+
+Output:
+
+```text
+github.com
+  ✓ Logged in to github.com account acabrera04 (keyring)
+  - Active account: true
+  - Git operations protocol: ssh
+  - Token: gho_************************************
+  - Token scopes: 'admin:public_key', 'gist', 'project', 'read:org', 'repo', 'workflow'
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff -- harmony-backend/src/app.ts harmony-frontend/src/components/layout/HarmonyShell.tsx
+```
+
+Output:
+
+```text
+harmony-backend/src/app.ts                         |  7 ++++
+ .../src/components/layout/HarmonyShell.tsx         | 38 ++++++++++++++--------
+ 2 files changed, 31 insertions(+), 14 deletions(-)
+
+--- Changes ---
+
+harmony-backend/src/app.ts
+  @@ -10,11 +10,13 @@ import { authRouter } from './routes/auth.router';
+  +import { presenceRouter } from './routes/presence.router';
+   import { attachmentRouter } from './routes/attachment.router';
+   import { adminMetaTagRouter } from './routes/admin.metaTag.router';
+   import { instanceId } from './lib/instance-identity';
+   import { createLogger } from './lib/logger';
+   import { redis } from './db/redis';
+  +import { presenceService } from './services/presence.service';
+   
+   const logger = createLogger({ component: 'app', instanceId });
+   
+  @@ -56,6 +58,8 @@ export interface CreateAppOptions {
+  +  presenceService.startSweeper();
+  +
+     const isE2E = process.env.NODE_ENV === 'e2e';
+     // Each limiter calls makeStore() independently so it gets its own instance.
+     const makeStore = (prefix: string): Store | undefined =>
+  @@ -155,6 +159,9 @@ export function createApp(options: CreateAppOptions = {}) {
+  +  // Presence updates from authenticated browser clients
+  +  app.use('/api/presence', presenceRouter);
+  +
+     // Attachment upload + file serving
+     app.use('/api/attachments', attachmentRouter);
+   
+  +7 -0
+
+harmony-frontend/src/components/layout/HarmonyShell.tsx
+  @@ -23,6 +23,7 @@ import { VoiceProvider } from '@/contexts/VoiceContext';
+  +import { usePresenceTracker } from '@/hooks/usePresenceTracker';
+   import { ChannelType, ChannelVisibility, UserStatus } from '@/types';
+   import { useRouter } from 'next/navigation';
+   import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
+  @@ -164,15 +165,6 @@ export function HarmonyShell({
+  -  // Fallback for guest/unauthenticated view
+  -  const currentUser: User = authUser ?? {
+  -    id: 'guest',
+  -    username: 'Guest',
+  -    displayName: 'Guest',
+  -    status: 'online',
+  -    role: 'guest',
+  -  };
+  -
+     const router = useRouter();
+     const [isCreateServerOpen, setIsCreateServerOpen] = useState(false);
+     const [isBrowseServersOpen, setIsBrowseServersOpen] = useState(false);
+  @@ -185,15 +177,31 @@ export function HarmonyShell({
+  +  const currentMemberRecord = useMemo(
+  +    () => localMembers.find(m => m.id === authUser?.id),
+  +    [localMembers, authUser?.id],
+  +  );
+  +
+  +  // Fallback for guest/unauthenticated view.
+  +  const currentUser: User = authUser
+  +    ? {
+  +        ...authUser,
+  +        status: currentMemberRecord?.status ?? authUser.status,
+  +        role: currentMemberRecord?.role ?? authUser.role,
+  +      }
+  +    : {
+  +        id: 'guest',
+  +        username: 'Guest',
+  +        displayName: 'Guest',
+  +        status: 'online',
+  +        role: 'guest',
+  +      };
+  +
+     // Show the pin UI only to users with MODERATOR+ server-scoped role, and never
+     // while the channel is locked (pinning would be meaningless/unauthorized anyway).
+     // localMembers is populated by toFrontendMember() in serverService.ts, which maps
+     // the backend ServerMember.role field (server-scoped) to User.role.
+     // System admins bypass membership checks — they are authorized server-side regardless.
+  -  const currentMemberRecord = useMemo(
+  -    () => localMembers.find(m => m.id === authUser?.id),
+  -    [localMembers, authUser?.id],
+  -  );
+     const canPin = useMemo(
+       () =>
+         isAuthenticated &&
+  @@ -375,6 +383,8 @@ export function HarmonyShell({
+  +  usePresenceTracker(isAuthenticated);
+  +
+     // #c10/#c23: single global Ctrl+K / Cmd+K handler — SearchModal no longer needs its own
+     useEffect(() => {
+       function handleKeyDown(e: KeyboardEvent) {
+  @@ -497,7 +507,7 @@ export function HarmonyShell({
+  -              members={members}
+  +              members={localMembers}
+                 isOpen={isMembersOpen}
+                 onClose={() => setIsMembersOpen(false)}
+               />
+  +24 -14
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/routes/presence.router.ts
+```
+
+Output:
+
+```text
+import { NextFunction, Router, Request, Response } from 'express';
+import { UserStatus } from '@prisma/client';
+import { z } from 'zod';
+import { authService } from '../services/auth.service';
+import { presenceService } from '../services/presence.service';
+
+export const presenceRouter = Router();
+
+const PresenceStatusSchema = z.enum([UserStatus.ONLINE, UserStatus.IDLE]);
+const PresenceBodySchema = z.object({ status: PresenceStatusSchema });
+type ActivePresenceStatus = z.infer<typeof PresenceStatusSchema>;
+
+function getBearerToken(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+}
+
+function verifyToken(token: string): string | null {
+  try {
+    return authService.verifyAccessToken(token).sub;
+  } catch {
+    return null;
+  }
+}
+
+async function updatePresence(
+  userId: string,
+  status: ActivePresenceStatus,
+  res: Response,
+): Promise<void> {
+  await presenceService.renewLease(userId, status);
+  res.status(204).send();
+}
+
+presenceRouter.post('/status', async (req: Request, res: Response, next: NextFunction) => {
+  const token = getBearerToken(req);
+  if (!token) {
+    res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    return;
+  }
+
+  const userId = verifyToken(token);
+  if (!userId) {
+    res.status(401).json({ error: 'Invalid or expired access token' });
+    return;
+  }
+
+  const parsed = PresenceBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+    return;
+  }
+
+  try {
+    await updatePresence(userId, parsed.data.status, res);
+  } catch (err) {
+    next(err);
+  }
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/services/presence.service.ts
+```
+
+Output:
+
+```text
+import { UserStatus } from '@prisma/client';
+import { redis } from '../db/redis';
+import { createLogger } from '../lib/logger';
+import { userRepository } from '../repositories/user.repository';
+import { userService } from './user.service';
+
+const PRESENCE_LEASE_SET = 'presence:leases';
+export const PRESENCE_LEASE_TTL_MS = 75_000;
+const PRESENCE_SWEEP_INTERVAL_MS = 15_000;
+
+const logger = createLogger({ component: 'presence-service' });
+let sweeper: ReturnType<typeof setInterval> | null = null;
+type ActivePresenceStatus = Extract<UserStatus, 'ONLINE' | 'IDLE'>;
+
+async function updateUserStatusIfChanged(userId: string, status: UserStatus): Promise<void> {
+  const user = await userRepository.findSelf(userId);
+  if (!user || user.status !== status) {
+    await userService.updateUser(userId, { status });
+  }
+}
+
+export const presenceService = {
+  async renewLease(userId: string, status: ActivePresenceStatus): Promise<void> {
+    const expiresAt = Date.now() + PRESENCE_LEASE_TTL_MS;
+    await redis.zadd(PRESENCE_LEASE_SET, expiresAt, userId);
+    await updateUserStatusIfChanged(userId, status);
+  },
+
+  async expireStaleLeases(now = Date.now()): Promise<number> {
+    const expiredUserIds = await redis.zrangebyscore(PRESENCE_LEASE_SET, 0, now);
+    let expiredCount = 0;
+
+    for (const userId of expiredUserIds) {
+      const removed = await redis.eval(
+        `
+          local score = redis.call("ZSCORE", KEYS[1], ARGV[1])
+          if score and tonumber(score) <= tonumber(ARGV[2]) then
+            return redis.call("ZREM", KEYS[1], ARGV[1])
+          end
+          return 0
+        `,
+        1,
+        PRESENCE_LEASE_SET,
+        userId,
+        String(now),
+      );
+      if (removed !== 1) continue;
+
+      try {
+        await updateUserStatusIfChanged(userId, UserStatus.OFFLINE);
+        expiredCount += 1;
+      } catch (err) {
+        logger.warn({ err, userId }, 'Failed to expire stale presence lease');
+      }
+    }
+
+    return expiredCount;
+  },
+
+  startSweeper(): void {
+    if (sweeper !== null || process.env.NODE_ENV === 'test') return;
+
+    sweeper = setInterval(() => {
+      presenceService
+        .expireStaleLeases()
+        .catch((err) => logger.warn({ err }, 'Presence lease sweep failed'));
+    }, PRESENCE_SWEEP_INTERVAL_MS);
+    sweeper.unref?.();
+  },
+
+  stopSweeper(): void {
+    if (sweeper === null) return;
+    clearInterval(sweeper);
+    sweeper = null;
+  },
+};
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+Output:
+
+```text
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { getAccessToken } from '@/lib/api-client';
+import { createFrontendLogger } from '@/lib/frontend-logger';
+import { getApiBaseUrl } from '@/lib/runtime-config';
+
+type PresenceStatus = 'ONLINE' | 'IDLE';
+
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const ACTIVE_THROTTLE_MS = 30_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const ACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll', 'focus'];
+
+const logger = createFrontendLogger({ component: 'presence-tracker' });
+
+function postPresence(status: PresenceStatus): void {
+  const token = getAccessToken();
+  if (!token) return;
+
+  fetch(`${getApiBaseUrl()}/api/presence/status`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ status }),
+  }).catch(error => {
+    logger.warn('Presence update failed', {
+      feature: 'presence',
+      event: 'status_update_failed',
+      method: 'POST',
+      route: '/api/presence/status',
+      error,
+    });
+  });
+}
+
+export function usePresenceTracker(enabled: boolean): void {
+  const statusRef = useRef<PresenceStatus>('ONLINE');
+  const lastActivePostRef = useRef(0);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return;
+
+    const clearIdleTimer = () => {
+      if (idleTimerRef.current) {
+        clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+    };
+    const clearHeartbeatTimer = () => {
+      if (heartbeatTimerRef.current) {
+        clearInterval(heartbeatTimerRef.current);
+        heartbeatTimerRef.current = null;
+      }
+    };
+
+    const setPresence = (status: PresenceStatus, force = false) => {
+      const now = Date.now();
+      if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) {
+        return;
+      }
+      if (!force && statusRef.current === status) return;
+
+      statusRef.current = status;
+      if (status === 'ONLINE') lastActivePostRef.current = now;
+      postPresence(status);
+    };
+
+    const armIdleTimer = () => {
+      clearIdleTimer();
+      idleTimerRef.current = setTimeout(() => {
+        setPresence('IDLE', true);
+      }, IDLE_TIMEOUT_MS);
+    };
+
+    const markActive = () => {
+      setPresence('ONLINE');
+      armIdleTimer();
+    };
+
+    setPresence('ONLINE', true);
+    armIdleTimer();
+    heartbeatTimerRef.current = setInterval(() => {
+      postPresence(statusRef.current);
+    }, HEARTBEAT_INTERVAL_MS);
+    for (const event of ACTIVITY_EVENTS) {
+      window.addEventListener(event, markActive, { passive: true });
+    }
+
+    return () => {
+      clearIdleTimer();
+      clearHeartbeatTimer();
+      for (const event of ACTIVITY_EVENTS) {
+        window.removeEventListener(event, markActive);
+      }
+    };
+  }, [enabled]);
+}
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:51:46.330Z
+
+The scope still matches issue #490 only. I’ve also checked the key files after the lease change: no `pagehide` offline write remains. Next I’m creating the branch and staging only these feature files.
+
+#### Tool: exec_command
+
+```sh
+rtk git switch -c codex/issue-490-presence-leases
+```
+
+Output:
+
+```text
+fatal: cannot lock ref 'refs/heads/codex/issue-490-presence-leases': Unable to create '/Users/allen/repos/Harmony/.git/refs/heads/codex/issue-490-presence-leases.lock': Operation not permitted
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:51:50.374Z
+
+Branch creation is blocked by the sandbox because this worktree’s git metadata lives under `/Users/allen/repos/Harmony/.git`, outside the writable worktree. I’m rerunning the same non-destructive branch creation with escalation.
+
+#### Tool: exec_command
+
+```sh
+rtk git switch -c codex/issue-490-presence-leases
+```
+
+Output:
+
+```text
+Switched to a new branch 'codex/issue-490-presence-leases'
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git add harmony-backend/src/app.ts harmony-backend/src/routes/presence.router.ts harmony-backend/src/services/presence.service.ts harmony-backend/tests/presence.router.test.ts harmony-backend/tests/presence.service.test.ts harmony-frontend/src/components/layout/HarmonyShell.tsx harmony-frontend/src/hooks/usePresenceTracker.ts harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+ok 8 files changed, 537 insertions(+), 14 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+M  harmony-backend/src/app.ts
+A  harmony-backend/src/routes/presence.router.ts
+A  harmony-backend/src/services/presence.service.ts
+A  harmony-backend/tests/presence.router.test.ts
+A  harmony-backend/tests/presence.service.test.ts
+A  harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+M  harmony-frontend/src/components/layout/HarmonyShell.tsx
+A  harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --cached --stat
+```
+
+Output:
+
+```text
+harmony-backend/src/app.ts                         |   7 ++
+ harmony-backend/src/routes/presence.router.ts      |  59 ++++++++++++
+ harmony-backend/src/services/presence.service.ts   |  76 +++++++++++++++
+ harmony-backend/tests/presence.router.test.ts      |  81 ++++++++++++++++
+ harmony-backend/tests/presence.service.test.ts     |  89 ++++++++++++++++++
+ .../src/__tests__/usePresenceTracker.test.tsx      |  99 ++++++++++++++++++++
+ .../src/components/layout/HarmonyShell.tsx         |  38 +++++---
+ harmony-frontend/src/hooks/usePresenceTracker.ts   | 102 +++++++++++++++++++++
+ 8 files changed, 537 insertions(+), 14 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat
+```
+
+Output:
+
+```text
+
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:52:16.878Z
+
+Staging contains exactly the eight issue #490 files and no unstaged diff remains. I’m committing with the Harmony co-author trailer now.
+
+#### Tool: exec_command
+
+```sh
+rtk git commit -m "Implement lease-based presence tracking" -m "Co-authored-by: GPT-5 <noreply@openai.com>"
+```
+
+Output:
+
+```text
+ok codex/i
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status -sb
+```
+
+Output:
+
+```text
+## codex/issue-490-presence-leases
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git log -1 --pretty=fuller
+```
+
+Output:
+
+```text
+commit b7699a2feed3c2e50a1f904a460bbceed2514a54
+Author:     acabrera04 <acabrera04164@gmail.com>
+AuthorDate: Tue Apr 28 14:52:22 2026 -0400
+Commit:     acabrera04 <acabrera04164@gmail.com>
+CommitDate: Tue Apr 28 14:52:22 2026 -0400
+
+    Implement lease-based presence tracking
+    
+    Co-authored-by: GPT-5 <noreply@openai.com>
+```
+
+#### Tool: exec_command
+
+```sh
+gh repo view --json defaultBranchRef,nameWithOwner
+```
+
+Output:
+
+```text
+{"defaultBranchRef":{"name":"main"},"nameWithOwner":"CS485-Harmony/Harmony"}
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:52:43.709Z
+
+The commit is clean on `codex/issue-490-presence-leases` with the required co-author trailer. I’m doing the pre-push diff/check summary now, then I’ll push and open the draft PR.
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat main...HEAD
+```
+
+Output:
+
+```text
+.github/workflows/run-integration-tests.yml        |    20 +-
+ README.md                                          |   114 +
+ docs/deployment/deployment-architecture.md         |    24 +
+ docs/deployment/vercel-setup.md                    |    34 +
+ docs/submission/seo-evidence/README.md             |    34 +
+ harmony-backend/src/app.ts                         |     7 +
+ harmony-backend/src/routes/presence.router.ts      |    59 +
+ harmony-backend/src/services/presence.service.ts   |    76 +
+ harmony-backend/tests/presence.router.test.ts      |    81 +
+ harmony-backend/tests/presence.service.test.ts     |    89 +
+ .../src/__tests__/metaTagAdminService.test.ts      |    88 +
+ .../src/__tests__/usePresenceTracker.test.tsx      |    99 +
+ .../src/components/layout/HarmonyShell.tsx         |    38 +-
+ harmony-frontend/src/hooks/usePresenceTracker.ts   |   102 +
+ .../src/services/metaTagAdminService.ts            |     2 +-
+ llm-logs/2026-04-26-142314-session-d7954b96.md     |   762 ++
+ llm-logs/2026-04-27-112629-session-fe57cdd1.md     |   693 ++
+ llm-logs/2026-04-27-113438-session-c16cc337.md     |   347 +
+ llm-logs/2026-04-27-165929-session-25b7e9be.md     |   786 ++
+ .../2026-04-26-complete-issue-363-019dc7b7.md      | 11871 +++++++++++++++++++
+ .../final/2026-04-27-review-pr-477-019dd0a2.md     |  6731 +++++++++++
+ tests/integration/env.test.ts                      |    36 +
+ tests/integration/env.ts                           |    23 +-
+ tests/integration/seo-meta-tags.test.ts            |   560 +
+ 24 files changed, 22653 insertions(+), 23 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts presence.service.test.ts
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+> jest --forceExit usePresenceTracker.test.tsx
+Test Suites: 1 passed, 1 total
+Tests:       6 passed, 6 total
+Snapshots:   0 total
+Time:        0.493 s, estimated 1 s
+Ran all test suites matching usePresenceTracker.test.tsx.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend run build
+```
+
+Output:
+
+```text
+
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:52:57.169Z
+
+The targeted checks are running, but I found an important branch-base issue: this detached worktree was not based directly on `main`, so `main...HEAD` includes older unrelated committed files. I’m going to preserve the commit, reset the PR branch onto `origin/main`, cherry-pick only this presence commit, rerun the diff check, then push.
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 3529,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: c014f2
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 82
+Output:
+> jest presence.router.test.ts presence.service.test.ts
+PASS tests/presence.service.test.ts
+PASS tests/presence.router.test.ts
+Test Suites: 2 passed, 2 total
+Tests:       9 passed, 9 total
+Snapshots:   0 total
+Time:        1.857 s, estimated 4 s
+Ran all test suites matching /presence.router.test.ts|presence.service.test.ts/i.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 54146,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: a2ffd1
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 2
+Output:
+> tsc
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git log --oneline main..HEAD | head -20
+```
+
+Output:
+
+```text
+b7699a2 Implement lease-based presence tracking
+184369c chore: add llm logs
+cbdc7ee chore: add llm logs
+b729e44 fix: update env.test.ts expectations for publicChannels in CloudFixture
+f78d854 fix: address PR #477 review findings — 3-channel cloud crawler-UA and...
+9663cad chore: export Codex conversation log
+a39d110 chore: add llm logs
+e82c0f5 chore: add llm logs
+65ca418 fix: address PR review findings in seo-meta-tags integration tests
+97176ba docs: fix README SEO section ordering
+7b9a781 chore: add llm logs
+5ede537 feat(#360): add SEO meta tag integration tests covering AC-1 through ...
+9230944 docs: add Search Console registration steps
+767b968 docs: explain Google indexing flow
+36aa68d docs: finalize SEO README and deployer guide
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git log --oneline --decorate -5
+```
+
+Output:
+
+```text
+b7699a2 (HEAD -> codex/issue-490-presence-leases) Implement lease-based presence tracking
+184369c chore: add llm logs
+cbdc7ee (origin/feat/360-seo-integration-tests, feat/360-seo-integration-tests) chore: add llm logs
+b729e44 fix: update env.test.ts expectations for publicChannels in CloudFixture
+f78d854 fix: address PR #477 review findings — 3-channel cloud crawler-UA and beforeAll status checks
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ok
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git rev-parse --verify origin/main
+```
+
+Output:
+
+```text
+7fc7f7b64078151f43d6358f53cdf5268ab3804a
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git branch --list 'codex/issue-490-presence' 'codex/issue-490-presence-leases-pr'
+```
+
+Output:
+
+```text
+*
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:53:11.772Z
+
+The presence commit is good, but it sits on top of another feature branch’s history. I’m creating a clean PR branch from `origin/main` and cherry-picking only `b7699a2` so the PR contains just issue #490.
+
+#### Tool: exec_command
+
+```sh
+rtk git switch -c codex/issue-490-presence origin/main
+```
+
+Output:
+
+```text
+Switched to a new branch 'codex/issue-490-presence'
+branch 'codex/issue-490-presence' set up to track 'origin/main'.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git cherry-pick b7699a2feed3c2e50a1f904a460bbceed2514a54
+```
+
+Output:
+
+```text
+[codex/issue-490-presence b6fec37] Implement lease-based presence tracking
+ Date: Tue Apr 28 14:52:22 2026 -0400
+ 8 files changed, 537 insertions(+), 14 deletions(-)
+ create mode 100644 harmony-backend/src/routes/presence.router.ts
+ create mode 100644 harmony-backend/src/services/presence.service.ts
+ create mode 100644 harmony-backend/tests/presence.router.test.ts
+ create mode 100644 harmony-backend/tests/presence.service.test.ts
+ create mode 100644 harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+ create mode 100644 harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat origin/main...HEAD
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status -sb
+```
+
+Output:
+
+```text
+## codex/issue-490-presence...origin/main [ahead 1]
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git log -1 --pretty=fuller
+```
+
+Output:
+
+```text
+commit b6fec375fa2561886da724fcbe900de07c520dd2
+Author:     acabrera04 <acabrera04164@gmail.com>
+AuthorDate: Tue Apr 28 14:52:22 2026 -0400
+Commit:     acabrera04 <acabrera04164@gmail.com>
+CommitDate: Tue Apr 28 14:53:32 2026 -0400
+
+    Implement lease-based presence tracking
+    
+    Co-authored-by: GPT-5 <noreply@openai.com>
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --stat origin/main..HEAD
+```
+
+Output:
+
+```text
+ harmony-backend/src/app.ts                         |   7 ++
+ harmony-backend/src/routes/presence.router.ts      |  59 ++++++++++++
+ harmony-backend/src/services/presence.service.ts   |  76 +++++++++++++++
+ harmony-backend/tests/presence.router.test.ts      |  81 ++++++++++++++++
+ harmony-backend/tests/presence.service.test.ts     |  89 ++++++++++++++++++
+ .../src/__tests__/usePresenceTracker.test.tsx      |  99 ++++++++++++++++++++
+ .../src/components/layout/HarmonyShell.tsx         |  38 +++++---
+ harmony-frontend/src/hooks/usePresenceTracker.ts   | 102 +++++++++++++++++++++
+ 8 files changed, 537 insertions(+), 14 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --name-status origin/main..HEAD
+```
+
+Output:
+
+```text
+M	harmony-backend/src/app.ts
+A	harmony-backend/src/routes/presence.router.ts
+A	harmony-backend/src/services/presence.service.ts
+A	harmony-backend/tests/presence.router.test.ts
+A	harmony-backend/tests/presence.service.test.ts
+A	harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+M	harmony-frontend/src/components/layout/HarmonyShell.tsx
+A	harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### Tool: exec_command
+
+```sh
+git show --stat --oneline --name-status HEAD
+```
+
+Output:
+
+```text
+b6fec37 Implement lease-based presence tracking
+M	harmony-backend/src/app.ts
+A	harmony-backend/src/routes/presence.router.ts
+A	harmony-backend/src/services/presence.service.ts
+A	harmony-backend/tests/presence.router.test.ts
+A	harmony-backend/tests/presence.service.test.ts
+A	harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+M	harmony-frontend/src/components/layout/HarmonyShell.tsx
+A	harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:54:02.083Z
+
+The clean branch now contains only the eight presence files against `origin/main`. I’m rerunning the targeted checks on this clean branch before pushing.
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts presence.service.test.ts
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend run build
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 48376,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 8a32b9
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 79
+Output:
+> jest presence.router.test.ts presence.service.test.ts
+PASS tests/presence.service.test.ts
+PASS tests/presence.router.test.ts
+Test Suites: 2 passed, 2 total
+Tests:       9 passed, 9 total
+Snapshots:   0 total
+Time:        3.096 s
+Ran all test suites matching /presence.router.test.ts|presence.service.test.ts/i.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 74048,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 56054b
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 91
+Output:
+> jest --forceExit usePresenceTracker.test.tsx
+Test Suites: 1 passed, 1 total
+Tests:       6 passed, 6 total
+Snapshots:   0 total
+Time:        0.592 s, estimated 1 s
+Ran all test suites matching usePresenceTracker.test.tsx.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 92440,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 5d54be
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 2
+Output:
+> tsc
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 42029,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 2c02a0
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 7
+Output:
+TypeScript: No errors found
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:54:15.407Z
+
+Final checks on the clean branch passed. I’m pushing `codex/issue-490-presence` and then opening a draft PR against `main`.
+
+#### Tool: exec_command
+
+```sh
+rtk git push -u origin codex/issue-490-presence
+```
+
+Output:
+
+```text
+ok codex/issue-490-presence
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr create --draft --base main --head codex/issue-490-presence --title "[codex] Implement lease-based presence tracking" --body "## Summary
+- add authenticated presence heartbeat endpoint and Redis-backed lease expiry
+- track browser activity with online/idle heartbeats instead of pagehide offline writes
+- wire real-time member status updates into the visible members sidebar
+
+## Why
+Issue #490 asks for automatic online, idle, and offline presence broadcast over existing SSE. Offline is handled by server-side lease expiry so minimizing or switching tabs does not immediately mark a user offline.
+
+## Verification
+- npm --prefix harmony-backend test -- presence.router.test.ts presence.service.test.ts
+- npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+- npm --prefix harmony-backend run build
+- npx tsc --noEmit in harmony-frontend
+
+Notes: frontend production build was previously blocked locally by sandbox network access to Google Fonts, not by this change."
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 55728,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 40e3c2
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/CS485-Harmony/Harmony/pull/510
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status -sb
+```
+
+Output:
+
+```text
+## codex/issue-490-presence...origin/codex/issue-490-presence
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr view 510 --json title,isDraft,baseRefName,headRefName,url
+```
+
+Output:
+
+```text
+{"baseRefName":"main","headRefName":"codex/issue-490-presence","isDraft":true,"title":"[codex] Implement lease-based presence tracking","url":"https://github.com/CS485-Harmony/Harmony/pull/510"}
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T18:54:59.070Z
+
+Created draft PR #510: [Implement lease-based presence tracking](https://github.com/CS485-Harmony/Harmony/pull/510)
+
+Branch: `codex/issue-490-presence`  
+Commit: `b6fec37`  
+Base: `main`
+
+Verified on the clean PR branch:
+- `npm --prefix harmony-backend test -- presence.router.test.ts presence.service.test.ts`
+- `npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx`
+- `npm --prefix harmony-backend run build`
+- `npx tsc --noEmit` in `harmony-frontend`
+
+Worktree is clean.
+
+<oai-mem-citation>
+<citation_entries>
+MEMORY.md:478-480|note=[used Harmony PR workflow memory group]
+</citation_entries>
+<rollout_ids>
+</rollout_ids>
+</oai-mem-citation>
+
+### Turn 5: [$resolve-reviews](/Users/allen/.agents/skills/resolve-reviews/SKILL.md)
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T19:15:23.488Z
+
+```text
+[$resolve-reviews](/Users/allen/.agents/skills/resolve-reviews/SKILL.md)
+```
+
+_No assistant or tool activity recorded after this prompt._
+
+### Turn 6: <skill> <name>resolve-reviews</name>
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T19:15:23.488Z
+
+````text
+<skill>
+<name>resolve-reviews</name>
+<path>/Users/allen/.agents/skills/resolve-reviews/SKILL.md</path>
+---
+name: resolve-reviews
+description: Resolve all PR review comments (human and bot) on current PR. Fetches unanswered comments, evaluates each one, fixes real issues, dismisses false positives, and replies to every comment with the outcome.
+license: MIT
+compatibility: Requires git, gh (GitHub CLI), and Node.js installed.
+allowed-tools: Bash(npx agent-reviews *) Bash(pnpm dlx agent-reviews *) Bash(yarn dlx agent-reviews *) Bash(bunx agent-reviews *) Bash(git config *) Bash(git add *) Bash(git commit *) Bash(git push *)
+metadata:
+  author: pbakaus
+  version: "1.0.1"
+  homepage: https://github.com/pbakaus/agent-reviews
+---
+
+Automatically resolve all review comments (both human and bot) on the current PR. Uses a two-phase workflow: fix all existing issues, then poll for new ones until quiet.
+
+## Prerequisites
+
+All commands below use `npx agent-reviews`. If the project uses a different package manager, substitute the appropriate runner (e.g., `pnpm dlx agent-reviews` for pnpm, `yarn dlx agent-reviews` for Yarn, `bunx agent-reviews` for Bun). Honor the user's package manager preference throughout.
+
+**Cloud environments only** (e.g., Codespaces, remote agents): verify git author identity so CI checks can map commits to the user. Run `git config --global --get user.email` and if empty or a placeholder, set it manually. Skip this check in local environments.
+
+## Phase 1: FETCH & FIX (synchronous)
+
+### Step 1: Fetch All Comments (Expanded)
+
+Run `npx agent-reviews --unanswered --expanded`
+
+The CLI auto-detects the current branch, finds the associated PR, and authenticates via `gh` CLI or environment variables. If anything fails (no token, no PR, CLI not installed), it exits with a clear error message.
+
+This shows all unanswered comments (both human and bot) with full detail: complete comment body (no truncation), diff hunk (code context), and all replies. Each comment shows its ID in brackets (e.g., `[12345678]`).
+
+If zero comments are returned, print "No unanswered comments found" and skip to Phase 2.
+
+### Step 3: Process Each Unanswered Comment
+
+For each comment from the expanded output, apply the appropriate evaluation based on whether the author is a bot or a human.
+
+#### For Bot Comments
+
+Read the referenced code and determine:
+
+1. **TRUE POSITIVE** - A real bug that needs fixing
+2. **FALSE POSITIVE** - Not actually a bug (intentional behavior, bot misunderstanding)
+3. **UNCERTAIN** - Not sure; ask the user
+
+**Likely TRUE POSITIVE:**
+- Code obviously violates stated behavior
+- Missing null checks on potentially undefined values
+- Type mismatches or incorrect function signatures
+- Logic errors in conditionals
+- Missing error handling for documented failure cases
+
+**Likely FALSE POSITIVE:**
+- Bot doesn't understand the framework/library patterns
+- Code is intentionally structured that way (with comments explaining why)
+- Bot is flagging style preferences, not bugs
+- The "bug" is actually a feature or intentional behavior
+- Bot misread the code flow
+
+#### For Human Comments
+
+Read the referenced code and the reviewer's comment. Human reviewers are generally more accurate and context-aware than bots. Determine:
+
+1. **ACTIONABLE** - The reviewer identified a real issue or requested a concrete change
+2. **DISCUSSION** - The comment raises a valid point but the right approach is unclear
+3. **ALREADY ADDRESSED** - The concern has already been fixed or is no longer relevant
+
+**Likely ACTIONABLE:**
+- Reviewer points out a bug or logic error
+- Reviewer requests a specific code change
+- Reviewer identifies missing edge cases or error handling
+
+**Likely DISCUSSION -- ask the user:**
+- Reviewer suggests an architectural change you're unsure about
+- Comment involves a tradeoff (performance vs readability, etc.)
+- The feedback is subjective without team consensus
+
+#### When UNCERTAIN -- ask the user
+
+For both bot and human comments:
+- The fix would require architectural changes
+- You're genuinely unsure if the behavior is intentional
+- Multiple valid interpretations exist
+- The fix could have unintended side effects
+
+#### Act on Evaluation
+
+**If TRUE POSITIVE / ACTIONABLE:** Fix the code. Track the comment ID and a brief description of the fix.
+
+**If FALSE POSITIVE:** Do NOT change the code. Track the comment ID and the reason it's not a real bug.
+
+**If DISCUSSION:** Ask the user to consult the PR author. Apply their decision and track it.
+
+**If ALREADY ADDRESSED:** Track the comment ID and note why.
+
+**If UNCERTAIN:** Ask the user. If they say skip, track it as skipped.
+
+Do NOT reply to comments yet. Replies happen after the commit (Step 5).
+
+### Step 4: Commit and Push
+
+After evaluating and fixing ALL unanswered comments:
+
+1. Run your project's lint and type-check
+2. Stage, commit, and push:
+   ```bash
+   git add -A
+   git commit -m "fix: address PR review findings
+
+   {List of changes made, grouped by reviewer/bot}"
+   git push
+   ```
+3. Capture the commit hash from the output.
+
+### Step 5: Reply to All Comments
+
+Now that the commit hash exists, reply to every processed comment. The `--resolve` flag marks the review thread as resolved on GitHub.
+
+**For each TRUE POSITIVE / ACTIONABLE:**
+
+Run `npx agent-reviews --reply <comment_id> "Fixed in {hash}. {Brief description of the fix}" --resolve`
+
+**For each FALSE POSITIVE:**
+
+Run `npx agent-reviews --reply <comment_id> "Won't fix: {reason}. {Explanation of why this is intentional or not applicable}" --resolve`
+
+**For each DISCUSSION (after user decision):**
+
+Run `npx agent-reviews --reply <comment_id> "{Outcome}. {Explanation of the decision and any changes made}" --resolve`
+
+**For each ALREADY ADDRESSED:**
+
+Run `npx agent-reviews --reply <comment_id> "Already addressed. {Explanation of when/how this was fixed}" --resolve`
+
+**For each SKIPPED:**
+
+Run `npx agent-reviews --reply <comment_id> "Skipped per user request" --resolve`
+
+**DO NOT start Phase 2 until all replies are posted.**
+
+---
+
+## Phase 2: POLL FOR NEW COMMENTS (loop until quiet)
+
+The watcher exits immediately when new comments are found (after a 5s grace period to catch batch posts). This means you run it in a loop: start watcher, process any comments it returns, restart watcher, repeat until the watcher times out with no new comments.
+
+### Step 6: Start Watcher Loop
+
+Repeat the following until the watcher exits with no new comments:
+
+**6a.** Launch the watcher in the background:
+
+Run `npx agent-reviews --watch` as a background task.
+
+**6b.** Wait for the background command to complete (default 10 minutes; override with `--timeout`).
+
+**6c.** Check the output:
+
+- **If new comments were found** (output contains `EXITING WITH NEW COMMENTS`):
+  1. Use `--detail <id>` to read each new comment's full detail
+  2. Process them exactly as in Phase 1, Steps 3-5 (evaluate, fix, commit, push, reply)
+  3. **Go back to Step 6a** to restart the watcher
+
+- **If no new comments** (output contains `WATCH COMPLETE`):
+  Stop looping and move to the Summary Report.
+
+---
+
+## Summary Report
+
+After both phases complete, provide a summary:
+
+```text
+## PR Review Resolution Summary
+
+### Results
+- Fixed: X issues
+- Already addressed: X
+- Won't fix (false positives): X
+- Discussion resolved: X
+- Skipped per user: X
+
+### By Reviewer/Bot
+#### cursor[bot]
+- {description} - Fixed in {commit}
+- {description} - Won't fix: {reason}
+
+#### @reviewer-name
+- {description} - Fixed in {commit}
+
+### Status
+All findings addressed. Watch completed.
+```
+
+## Important Notes
+
+### Response Policy
+- **Every comment gets a response** - No silent ignores
+- For bots: responses help train them and prevent re-raised false positives
+- For humans: replies keep reviewers informed and unblock approvals
+
+### User Interaction
+- Ask the user when uncertain about a finding
+- Don't guess on architectural or business logic questions
+- It's better to ask than to make a wrong fix or wrong dismissal
+- Human reviewers often have context you don't - defer to the author when unsure
+
+### Best Practices
+- Verify findings before fixing - bots have false positives, humans rarely do
+- Keep fixes minimal and focused - don't refactor unrelated code
+- Ensure type-check and lint pass before committing
+- Group related fixes into a single commit
+- Copilot `suggestion` blocks often contain ready-to-use fixes
+- If a human reviewer suggests a specific code change, prefer their version unless it introduces issues
+
+</skill>
+````
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:15:34.034Z
+
+I’ll run the resolve-reviews workflow on the current PR: fetch unanswered review comments, evaluate each one, make focused fixes if needed, reply/resolve each thread, then watch for any new comments until quiet.
+
+#### Tool: exec_command
+
+```sh
+rtk read /Users/allen/.agents/skills/resolve-reviews/SKILL.md
+```
+
+Output:
+
+````text
+---
+name: resolve-reviews
+description: Resolve all PR review comments (human and bot) on current PR. Fetches unanswered comments, evaluates each one, fixes real issues, dismisses false positives, and replies to every comment with the outcome.
+license: MIT
+compatibility: Requires git, gh (GitHub CLI), and Node.js installed.
+allowed-tools: Bash(npx agent-reviews *) Bash(pnpm dlx agent-reviews *) Bash(yarn dlx agent-reviews *) Bash(bunx agent-reviews *) Bash(git config *) Bash(git add *) Bash(git commit *) Bash(git push *)
+metadata:
+  author: pbakaus
+  version: "1.0.1"
+  homepage: https://github.com/pbakaus/agent-reviews
+---
+
+Automatically resolve all review comments (both human and bot) on the current PR. Uses a two-phase workflow: fix all existing issues, then poll for new ones until quiet.
+
+## Prerequisites
+
+All commands below use `npx agent-reviews`. If the project uses a different package manager, substitute the appropriate runner (e.g., `pnpm dlx agent-reviews` for pnpm, `yarn dlx agent-reviews` for Yarn, `bunx agent-reviews` for Bun). Honor the user's package manager preference throughout.
+
+**Cloud environments only** (e.g., Codespaces, remote agents): verify git author identity so CI checks can map commits to the user. Run `git config --global --get user.email` and if empty or a placeholder, set it manually. Skip this check in local environments.
+
+## Phase 1: FETCH & FIX (synchronous)
+
+### Step 1: Fetch All Comments (Expanded)
+
+Run `npx agent-reviews --unanswered --expanded`
+
+The CLI auto-detects the current branch, finds the associated PR, and authenticates via `gh` CLI or environment variables. If anything fails (no token, no PR, CLI not installed), it exits with a clear error message.
+
+This shows all unanswered comments (both human and bot) with full detail: complete comment body (no truncation), diff hunk (code context), and all replies. Each comment shows its ID in brackets (e.g., `[12345678]`).
+
+If zero comments are returned, print "No unanswered comments found" and skip to Phase 2.
+
+### Step 3: Process Each Unanswered Comment
+
+For each comment from the expanded output, apply the appropriate evaluation based on whether the author is a bot or a human.
+
+#### For Bot Comments
+
+Read the referenced code and determine:
+
+1. **TRUE POSITIVE** - A real bug that needs fixing
+2. **FALSE POSITIVE** - Not actually a bug (intentional behavior, bot misunderstanding)
+3. **UNCERTAIN** - Not sure; ask the user
+
+**Likely TRUE POSITIVE:**
+- Code obviously violates stated behavior
+- Missing null checks on potentially undefined values
+- Type mismatches or incorrect function signatures
+- Logic errors in conditionals
+- Missing error handling for documented failure cases
+
+**Likely FALSE POSITIVE:**
+- Bot doesn't understand the framework/library patterns
+- Code is intentionally structured that way (with comments explaining why)
+- Bot is flagging style preferences, not bugs
+- The "bug" is actually a feature or intentional behavior
+- Bot misread the code flow
+
+#### For Human Comments
+
+Read the referenced code and the reviewer's comment. Human reviewers are generally more accurate and context-aware than bots. Determine:
+
+1. **ACTIONABLE** - The reviewer identified a real issue or requested a concrete change
+2. **DISCUSSION** - The comment raises a valid point but the right approach is unclear
+3. **ALREADY ADDRESSED** - The concern has already been fixed or is no longer relevant
+
+**Likely ACTIONABLE:**
+- Reviewer points out a bug or logic error
+- Reviewer requests a specific code change
+- Reviewer identifies missing edge cases or error handling
+
+**Likely DISCUSSION -- ask the user:**
+- Reviewer suggests an architectural change you're unsure about
+- Comment involves a tradeoff (performance vs readability, etc.)
+- The feedback is subjective without team consensus
+
+#### When UNCERTAIN -- ask the user
+
+For both bot and human comments:
+- The fix would require architectural changes
+- You're genuinely unsure if the behavior is intentional
+- Multiple valid interpretations exist
+- The fix could have unintended side effects
+
+#### Act on Evaluation
+
+**If TRUE POSITIVE / ACTIONABLE:** Fix the code. Track the comment ID and a brief description of the fix.
+
+**If FALSE POSITIVE:** Do NOT change the code. Track the comment ID and the reason it's not a real bug.
+
+**If DISCUSSION:** Ask the user to consult the PR author. Apply their decision and track it.
+
+**If ALREADY ADDRESSED:** Track the comment ID and note why.
+
+**If UNCERTAIN:** Ask the user. If they say skip, track it as skipped.
+
+Do NOT reply to comments yet. Replies happen after the commit (Step 5).
+
+### Step 4: Commit and Push
+
+After evaluating and fixing ALL unanswered comments:
+
+1. Run your project's lint and type-check
+2. Stage, commit, and push:
+   ```bash
+   git add -A
+   git commit -m "fix: address PR review findings
+
+   {List of changes made, grouped by reviewer/bot}"
+   git push
+   ```
+3. Capture the commit hash from the output.
+
+### Step 5: Reply to All Comments
+
+Now that the commit hash exists, reply to every processed comment. The `--resolve` flag marks the review thread as resolved on GitHub.
+
+**For each TRUE POSITIVE / ACTIONABLE:**
+
+Run `npx agent-reviews --reply <comment_id> "Fixed in {hash}. {Brief description of the fix}" --resolve`
+
+**For each FALSE POSITIVE:**
+
+Run `npx agent-reviews --reply <comment_id> "Won't fix: {reason}. {Explanation of why this is intentional or not applicable}" --resolve`
+
+**For each DISCUSSION (after user decision):**
+
+Run `npx agent-reviews --reply <comment_id> "{Outcome}. {Explanation of the decision and any changes made}" --resolve`
+
+**For each ALREADY ADDRESSED:**
+
+Run `npx agent-reviews --reply <comment_id> "Already addressed. {Explanation of when/how this was fixed}" --resolve`
+
+**For each SKIPPED:**
+
+Run `npx agent-reviews --reply <comment_id> "Skipped per user request" --resolve`
+
+**DO NOT start Phase 2 until all replies are posted.**
+
+---
+
+## Phase 2: POLL FOR NEW COMMENTS (loop until quiet)
+
+The watcher exits immediately when new comments are found (after a 5s grace period to catch batch posts). This means you run it in a loop: start watcher, process any comments it returns, restart watcher, repeat until the watcher times out with no new comments.
+
+### Step 6: Start Watcher Loop
+
+Repeat the following until the watcher exits with no new comments:
+
+**6a.** Launch the watcher in the background:
+
+Run `npx agent-reviews --watch` as a background task.
+
+**6b.** Wait for the background command to complete (default 10 minutes; override with `--timeout`).
+
+**6c.** Check the output:
+
+- **If new comments were found** (output contains `EXITING WITH NEW COMMENTS`):
+  1. Use `--detail <id>` to read each new comment's full detail
+  2. Process them exactly as in Phase 1, Steps 3-5 (evaluate, fix, commit, push, reply)
+  3. **Go back to Step 6a** to restart the watcher
+
+- **If no new comments** (output contains `WATCH COMPLETE`):
+  Stop looping and move to the Summary Report.
+
+---
+
+## Summary Report
+
+After both phases complete, provide a summary:
+
+```text
+## PR Review Resolution Summary
+
+### Results
+- Fixed: X issues
+- Already addressed: X
+- Won't fix (false positives): X
+- Discussion resolved: X
+- Skipped per user: X
+
+### By Reviewer/Bot
+#### cursor[bot]
+- {description} - Fixed in {commit}
+- {description} - Won't fix: {reason}
+
+#### @reviewer-name
+- {description} - Fixed in {commit}
+
+### Status
+All findings addressed. Watch completed.
+```
+
+## Important Notes
+
+### Response Policy
+- **Every comment gets a response** - No silent ignores
+- For bots: responses help train them and prevent re-raised false positives
+- For humans: replies keep reviewers informed and unblock approvals
+
+### User Interaction
+- Ask the user when uncertain about a finding
+- Don't guess on architectural or business logic questions
+- It's better to ask than to make a wrong fix or wrong dismissal
+- Human reviewers often have context you don't - defer to the author when unsure
+
+### Best Practices
+- Verify findings before fixing - bots have false positives, humans rarely do
+- Keep fixes minimal and focused - don't refactor unrelated code
+- Ensure type-check and lint pass before committing
+- Group related fixes into a single commit
+- Copilot `suggestion` blocks often contain ready-to-use fixes
+- If a human reviewer suggests a specific code change, prefer their version unless it introduces issues
+````
+
+#### Tool: exec_command
+
+```sh
+rg -n "resolve-reviews|Harmony PR review|PR review and review-resolution" /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+115:- resolve-reviews, PR #449, npx agent-reviews --pr 449 --unanswered --expanded, npx agent-reviews --watch --timeout 60, harmony-backend/src/lib/storage/s3.provider.ts, full trailing slash stripping, mockSeed SHA-256, tests/events.router.sse-server-updated.test.ts, sseGetWithEvent, npm run lint, listen EPERM 0.0.0.0, c14b754, 07f148b
+121:- when the user invoked `resolve-reviews` on PR #449 and later said "the backend lint tests are failing" -> fetch the actual review/lint state, fix the concrete regression or warning, and push the follow-up commits to the same PR branch rather than treating the failures as noise [Task 2]
+478:# Task Group: Harmony PR review and review-resolution workflow
+480:applies_to: cwd=/Users/allen/.codex/worktrees/*/Harmony; reuse_rule=safe for Harmony PR review tasks that follow the repo's `WORKFLOW.md` and `.github/PR_REVIEW.md`; verify current remote/worktree before assuming repo names or branch refs.
+513:- Harmony PR review, .github/PR_REVIEW.md, WORKFLOW.md, bundled review, single bundled review, checklist of 8 guidelines, gh pr view, gh pr diff, gh pr review, gh api, file_comments expected objects not strings, acabrera04/Harmony, EmptyShell, VoiceProvider, system admin bypass, useChannelEvents, useServerEvents, SSE reconnect
+529:- rollout_summaries/2026-04-17T20-52-45-5MRj-harmony_pr_397_review_resolution.md (cwd=/Users/allen/.codex/worktrees/5935/Harmony, rollout_path=/Users/allen/.codex/sessions/2026/04/17/rollout-2026-04-17T16-52-45-019d9d37-b0c1-7c92-a450-7cb87456f4c1.jsonl, updated_at=2026-04-18T02:03:25+00:00, thread_id=019d9d37-b0c1-7c92-a450-7cb87456f4c1, resolve-reviews workflow with follow-up commit and watch mode)
+533:- PR #397, resolve-reviews, npx agent-reviews --pr 397 --unanswered --expanded, sitemap host rewrite, unanswered review, follow-up commit, watch mode, no new comments, seo-routes.test.ts, reply 4132592219
+575:- when the user invokes `resolve-reviews` in Harmony, the expected default is to fetch the open review, fix any real issues, reply on GitHub, and then watch for new comments instead of only summarizing the review [Task 5]
+585:- In Harmony PR reviews, load `WORKFLOW.md` and `.github/PR_REVIEW.md` first. The durable pattern is checklist first, then one bundled review with line-specific findings or a clear approval if the updated head is good [Task 1][Task 2][Task 3][Task 4][Task 6]
+642:- when the user invoked `resolve-reviews` -> fetch unanswered comments, make the minimal necessary fixes, and reply to every comment instead of only summarizing the review [Task 1]
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status -sb
+```
+
+Output:
+
+```text
+## codex/issue-490-presence...origin/codex/issue-490-presence
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr view --json number,url,headRefName,baseRefName,isDraft,title
+```
+
+Output:
+
+```text
+{"baseRefName":"main","headRefName":"codex/issue-490-presence","isDraft":false,"number":510,"title":"[codex] Implement lease-based presence tracking","url":"https://github.com/CS485-Harmony/Harmony/pull/510"}
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:15:44.928Z
+
+I’m on PR #510 and the worktree is clean. The PR is no longer draft. Next I’m fetching all unanswered review comments with the required `agent-reviews` expanded output.
+
+#### Tool: exec_command
+
+```sh
+npx agent-reviews --unanswered --expanded
+```
+
+Output:
+
+````text
+[1mFound 1 comment[0m
+
+=== Comment [4191693937] ===
+Type: REVIEW | By: AvanishKulkarni | Status: ○ no reply
+URL: https://github.com/CS485-Harmony/Harmony/pull/510#pullrequestreview-4191693937
+
+## Code Review: PR #510 — Lease-Based Presence Tracking
+
+### Overview
+
+The overall design is sound — a Redis sorted-set lease model is a good fit here. It avoids false offline signals from tab-switching, handles multi-replica deployment via a Lua atomic-remove race, and the `MembersSidebar` is correctly wired to `localMembers` (SSE-updated) rather than the stale prop. Three issues warrant attention before merge.
+
+---
+
+### Issues
+
+#### 1. Duplicates `requireAuth` middleware (significant)
+
+`presence.router.ts` re-implements `getBearerToken` + `verifyToken` inline, but an identical `requireAuth` middleware already exists in `auth.middleware.ts`. This duplicates ~20 lines and diverges from every other authenticated route.
+
+The router should use `requireAuth` directly:
+
+```ts
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth.middleware';
+
+presenceRouter.post('/status', requireAuth, async (req, res, next) => {
+  const userId = (req as AuthenticatedRequest).userId;
+  // ...
+});
+```
+
+#### 2. `setPresence` throttle can suppress IDLE→ONLINE transition (bug)
+
+In `usePresenceTracker.ts`, the ONLINE throttle check fires before the status-change check:
+
+```ts
+if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) return; // ← runs first
+if (!force && statusRef.current === status) return;
+```
+
+Scenario: user is active (ONLINE posted at t=0), goes idle at t=4m59s (via the idle timer), immediately moves mouse at t=5m+5s. `now - lastActivePost = 5m+5s > 30s` — fine. But if the gap is shorter (e.g., ONLINE posted at t=28s ago, then IDLE fires at t=29s, user moves mouse at t=30s), the throttle fires first and swallows the IDLE→ONLINE transition. `statusRef` stays `IDLE` for up to another 30s.
+
+Fix: dedup same-status first, *then* throttle:
+
+```ts
+if (!force && statusRef.current === status) return;
+if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) return;
+```
+
+#### 3. `updateUserStatusIfChanged` updates even when user is not found
+
+```ts
+const user = await userRepository.findSelf(userId);
+if (!user || user.status !== status) {   // ← calls updateUser even when user is null
+  await userService.updateUser(userId, { status });
+}
+```
+
+If `findSelf` returns `null` (deleted/deactivated user), `updateUser` is still called with a non-existent ID. Should be:
+
+```ts
+if (!user) return;
+if (user.status !== status) {
+  await userService.updateUser(userId, { status });
+}
+```
+
+---
+
+### Minor
+
+- **`updatePresence` helper in router**: The wrapper that calls `renewLease` then `res.status(204).send()` adds indirection for trivial logic — can be inlined.
+- **Missing router test for invalid token**: Tests cover a missing Authorization header but not a present-but-invalid token (where `verifyAccessToken` throws). The 401 branch in `verifyToken` is untested.
+- **`ACTIVE_THROTTLE_MS === HEARTBEAT_INTERVAL_MS`**: Both are `30_000`. A single named constant (e.g. `PRESENCE_INTERVAL_MS`) would make the intentional coupling explicit.
+
+---
+
+### Positives
+
+- Lua atomic-remove correctly handles the multi-replica race in `expireStaleLeases`.
+- `sweeper.unref?.()` prevents the interval from blocking process exit.
+- `currentUser` now derives `status`/`role` from `currentMemberRecord` — fixes the stale auth snapshot in the shell.
+- Test coverage is solid for happy paths and key edge cases (race condition, DND rejection, pagehide no-op, heartbeat).
+````
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 71232,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 1f66bf
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:16:09.569Z
+
+There is one human review with three actionable issues and three minor cleanups. I’m applying them all: reuse `requireAuth`, fix the IDLE-to-ONLINE throttle ordering, avoid updating deleted users, inline the small route helper, add invalid-token coverage, and consolidate the interval constant.
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/middleware/auth.middleware.ts
+```
+
+Output:
+
+```text
+import { Request, Response, NextFunction } from 'express';
+import { authService } from '../services/auth.service';
+
+export interface AuthenticatedRequest extends Request {
+  userId: string;
+}
+
+/**
+ * Express middleware that validates a Bearer JWT access token.
+ * Attaches `req.userId` on success; responds 401 on failure.
+ */
+export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    return;
+  }
+
+  const token = authHeader.slice(7);
+  try {
+    const payload = authService.verifyAccessToken(token);
+    (req as AuthenticatedRequest).userId = payload.sub;
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired access token' });
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/routes/presence.router.ts
+```
+
+Output:
+
+```text
+import { NextFunction, Router, Request, Response } from 'express';
+import { UserStatus } from '@prisma/client';
+import { z } from 'zod';
+import { authService } from '../services/auth.service';
+import { presenceService } from '../services/presence.service';
+
+export const presenceRouter = Router();
+
+const PresenceStatusSchema = z.enum([UserStatus.ONLINE, UserStatus.IDLE]);
+const PresenceBodySchema = z.object({ status: PresenceStatusSchema });
+type ActivePresenceStatus = z.infer<typeof PresenceStatusSchema>;
+
+function getBearerToken(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+}
+
+function verifyToken(token: string): string | null {
+  try {
+    return authService.verifyAccessToken(token).sub;
+  } catch {
+    return null;
+  }
+}
+
+async function updatePresence(
+  userId: string,
+  status: ActivePresenceStatus,
+  res: Response,
+): Promise<void> {
+  await presenceService.renewLease(userId, status);
+  res.status(204).send();
+}
+
+presenceRouter.post('/status', async (req: Request, res: Response, next: NextFunction) => {
+  const token = getBearerToken(req);
+  if (!token) {
+    res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    return;
+  }
+
+  const userId = verifyToken(token);
+  if (!userId) {
+    res.status(401).json({ error: 'Invalid or expired access token' });
+    return;
+  }
+
+  const parsed = PresenceBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+    return;
+  }
+
+  try {
+    await updatePresence(userId, parsed.data.status, res);
+  } catch (err) {
+    next(err);
+  }
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/tests/presence.router.test.ts
+```
+
+Output:
+
+```text
+import request from 'supertest';
+import { createApp } from '../src/app';
+import { authService } from '../src/services/auth.service';
+import { presenceService } from '../src/services/presence.service';
+
+jest.mock('../src/services/auth.service', () => ({
+  authService: {
+    verifyAccessToken: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/presence.service', () => ({
+  presenceService: {
+    renewLease: jest.fn().mockResolvedValue(undefined),
+    startSweeper: jest.fn(),
+  },
+}));
+
+jest.mock('../src/middleware/rate-limit.middleware', () => ({
+  createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const app = createApp();
+const mockVerifyAccessToken = authService.verifyAccessToken as jest.Mock;
+const mockRenewLease = presenceService.renewLease as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerifyAccessToken.mockReturnValue({ sub: 'user-1' });
+  mockRenewLease.mockResolvedValue(undefined);
+});
+
+describe('POST /api/presence/status', () => {
+  it('updates authenticated users to ONLINE', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'ONLINE' });
+
+    expect(res.status).toBe(204);
+    expect(mockVerifyAccessToken).toHaveBeenCalledWith('valid-token');
+    expect(mockRenewLease).toHaveBeenCalledWith('user-1', 'ONLINE');
+  });
+
+  it('updates authenticated users to IDLE', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'IDLE' });
+
+    expect(res.status).toBe(204);
+    expect(mockRenewLease).toHaveBeenCalledWith('user-1', 'IDLE');
+  });
+
+  it('rejects DND because automatic presence only owns online and idle leases', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'DND' });
+
+    expect(res.status).toBe(400);
+    expect(mockRenewLease).not.toHaveBeenCalled();
+  });
+
+  it('rejects explicit OFFLINE updates because stale leases expire server-side', async () => {
+    const res = await request(app)
+      .post('/api/presence/status')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ status: 'OFFLINE' });
+
+    expect(res.status).toBe(400);
+    expect(mockRenewLease).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing bearer token', async () => {
+    const res = await request(app).post('/api/presence/status').send({ status: 'ONLINE' });
+
+    expect(res.status).toBe(401);
+    expect(mockRenewLease).not.toHaveBeenCalled();
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/tests/presence.service.test.ts
+```
+
+Output:
+
+```text
+import { UserStatus } from '@prisma/client';
+import { presenceService, PRESENCE_LEASE_TTL_MS } from '../src/services/presence.service';
+import { redis } from '../src/db/redis';
+import { userRepository } from '../src/repositories/user.repository';
+import { userService } from '../src/services/user.service';
+
+jest.mock('../src/db/redis', () => ({
+  redis: {
+    zadd: jest.fn(),
+    zrangebyscore: jest.fn(),
+    eval: jest.fn(),
+  },
+}));
+
+jest.mock('../src/repositories/user.repository', () => ({
+  userRepository: {
+    findSelf: jest.fn(),
+  },
+}));
+
+jest.mock('../src/services/user.service', () => ({
+  userService: {
+    updateUser: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+const mockRedis = redis as unknown as {
+  zadd: jest.Mock;
+  zrangebyscore: jest.Mock;
+  eval: jest.Mock;
+};
+const mockFindSelf = userRepository.findSelf as jest.Mock;
+const mockUpdateUser = userService.updateUser as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(Date, 'now').mockReturnValue(1_000);
+  mockFindSelf.mockResolvedValue({ id: 'user-1', status: UserStatus.OFFLINE });
+  mockUpdateUser.mockResolvedValue({});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('presenceService.renewLease', () => {
+  it('stores a shared Redis lease and updates status when it changed', async () => {
+    await presenceService.renewLease('user-1', UserStatus.ONLINE);
+
+    expect(mockRedis.zadd).toHaveBeenCalledWith(
+      'presence:leases',
+      1_000 + PRESENCE_LEASE_TTL_MS,
+      'user-1',
+    );
+    expect(mockUpdateUser).toHaveBeenCalledWith('user-1', { status: UserStatus.ONLINE });
+  });
+
+  it('does not rebroadcast when renewing the same status', async () => {
+    mockFindSelf.mockResolvedValue({ id: 'user-1', status: UserStatus.ONLINE });
+
+    await presenceService.renewLease('user-1', UserStatus.ONLINE);
+
+    expect(mockRedis.zadd).toHaveBeenCalled();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('presenceService.expireStaleLeases', () => {
+  it('marks users offline after winning conditional lease removal', async () => {
+    mockRedis.zrangebyscore.mockResolvedValue(['user-1']);
+    mockRedis.eval.mockResolvedValue(1);
+    mockFindSelf.mockResolvedValue({ id: 'user-1', status: UserStatus.ONLINE });
+
+    const expiredCount = await presenceService.expireStaleLeases(2_000);
+
+    expect(expiredCount).toBe(1);
+    expect(mockUpdateUser).toHaveBeenCalledWith('user-1', { status: UserStatus.OFFLINE });
+  });
+
+  it('does not mark offline when another replica renewed the lease first', async () => {
+    mockRedis.zrangebyscore.mockResolvedValue(['user-1']);
+    mockRedis.eval.mockResolvedValue(0);
+
+    const expiredCount = await presenceService.expireStaleLeases(2_000);
+
+    expect(expiredCount).toBe(0);
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+import { renderHook, act } from '@testing-library/react';
+import { usePresenceTracker } from '../hooks/usePresenceTracker';
+
+jest.mock('../lib/api-client', () => ({
+  getAccessToken: jest.fn(() => 'mock-token'),
+}));
+
+const API_URL = 'http://localhost:4000';
+const mockFetch = jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_API_URL = API_URL;
+  Object.defineProperty(global, 'fetch', { writable: true, value: mockFetch });
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe('usePresenceTracker', () => {
+  it('posts ONLINE when enabled', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer mock-token' }),
+        body: JSON.stringify({ status: 'ONLINE' }),
+      }),
+    );
+  });
+
+  it('does not post when disabled', () => {
+    renderHook(() => usePresenceTracker(false));
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('posts IDLE after five minutes of inactivity', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000);
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        body: JSON.stringify({ status: 'IDLE' }),
+      }),
+    );
+  });
+
+  it('returns to ONLINE after activity while idle', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        body: JSON.stringify({ status: 'ONLINE' }),
+      }),
+    );
+  });
+
+  it('renews the current presence status on a heartbeat interval', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      jest.advanceTimersByTime(30 * 1000);
+    });
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${API_URL}/api/presence/status`,
+      expect.objectContaining({
+        body: JSON.stringify({ status: 'ONLINE' }),
+      }),
+    );
+  });
+
+  it('does not mark OFFLINE on pagehide because the backend lease handles disconnects', () => {
+    renderHook(() => usePresenceTracker(true));
+
+    act(() => {
+      window.dispatchEvent(new PageTransitionEvent('pagehide'));
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:16:42.964Z
+
+The review fixes are applied. I’m formatting the touched files and then running the focused backend/frontend tests plus typechecks before committing.
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write src/routes/presence.router.ts src/services/presence.service.ts tests/presence.router.test.ts tests/presence.service.test.ts
+```
+
+Output:
+
+```text
+src/routes/presence.router.ts 27ms
+src/services/presence.service.ts 8ms (unchanged)
+tests/presence.router.test.ts 9ms (unchanged)
+tests/presence.service.test.ts 5ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write src/hooks/usePresenceTracker.ts src/__tests__/usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+[warn] jsxBracketSameLine is deprecated.
+src/hooks/usePresenceTracker.ts 33ms (unchanged)
+src/__tests__/usePresenceTracker.test.tsx 9ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- presence.router.test.ts presence.service.test.ts
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend run build
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npx tsc --noEmit
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 43732,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 1da114
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 79
+Output:
+> jest presence.router.test.ts presence.service.test.ts
+PASS tests/presence.service.test.ts
+PASS tests/presence.router.test.ts
+Test Suites: 2 passed, 2 total
+Tests:       11 passed, 11 total
+Snapshots:   0 total
+Time:        3.029 s
+Ran all test suites matching /presence.router.test.ts|presence.service.test.ts/i.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 4922,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 8f39e4
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 91
+Output:
+> jest --forceExit usePresenceTracker.test.tsx
+Test Suites: 1 passed, 1 total
+Tests:       7 passed, 7 total
+Snapshots:   0 total
+Time:        0.686 s, estimated 1 s
+Ran all test suites matching usePresenceTracker.test.tsx.
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 3670,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 742382
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 2
+Output:
+> tsc
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 45115,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 626eda
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 7
+Output:
+TypeScript: No errors found
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend run lint
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend run lint
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat
+```
+
+Output:
+
+```text
+harmony-backend/src/routes/presence.router.ts      | 68 ++++++----------------
+ harmony-backend/src/services/presence.service.ts   |  4 +-
+ harmony-backend/tests/presence.router.test.ts      | 14 +++++
+ harmony-backend/tests/presence.service.test.ts     |  9 +++
+ .../src/__tests__/usePresenceTracker.test.tsx      | 18 ++++++
+ harmony-frontend/src/hooks/usePresenceTracker.ts   |  9 ++-
+ 6 files changed, 67 insertions(+), 55 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff -- harmony-backend/src/routes/presence.router.ts harmony-backend/src/services/presence.service.ts harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+Output:
+
+```text
+harmony-backend/src/routes/presence.router.ts    | 68 +++++++-----------------
+ harmony-backend/src/services/presence.service.ts |  4 +-
+ harmony-frontend/src/hooks/usePresenceTracker.ts |  9 ++--
+ 3 files changed, 26 insertions(+), 55 deletions(-)
+
+--- Changes ---
+
+harmony-backend/src/routes/presence.router.ts
+  @@ -1,59 +1,29 @@
+  -import { authService } from '../services/auth.service';
+  +import { AuthenticatedRequest, requireAuth } from '../middleware/auth.middleware';
+   import { presenceService } from '../services/presence.service';
+   
+   export const presenceRouter = Router();
+   
+   const PresenceStatusSchema = z.enum([UserStatus.ONLINE, UserStatus.IDLE]);
+   const PresenceBodySchema = z.object({ status: PresenceStatusSchema });
+  -type ActivePresenceStatus = z.infer<typeof PresenceStatusSchema>;
+   
+  -function getBearerToken(req: Request): string | null {
+  -  const authHeader = req.headers.authorization;
+  -  return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  -}
+  -
+  -function verifyToken(token: string): string | null {
+  -  try {
+  -    return authService.verifyAccessToken(token).sub;
+  -  } catch {
+  -    return null;
+  -  }
+  -}
+  -
+  -async function updatePresence(
+  -  userId: string,
+  -  status: ActivePresenceStatus,
+  -  res: Response,
+  -): Promise<void> {
+  -  await presenceService.renewLease(userId, status);
+  -  res.status(204).send();
+  -}
+  -
+  -presenceRouter.post('/status', async (req: Request, res: Response, next: NextFunction) => {
+  -  const token = getBearerToken(req);
+  -  if (!token) {
+  -    res.status(401).json({ error: 'Missing or invalid Authorization header' });
+  -    return;
+  -  }
+  -
+  -  const userId = verifyToken(token);
+  -  if (!userId) {
+  -    res.status(401).json({ error: 'Invalid or expired access token' });
+  -    return;
+  -  }
+  -
+  -  const parsed = PresenceBodySchema.safeParse(req.body);
+  -  if (!parsed.success) {
+  -    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+  -    return;
+  -  }
+  -
+  -  try {
+  -    await updatePresence(userId, parsed.data.status, res);
+  -  } catch (err) {
+  -    next(err);
+  -  }
+  -});
+  +presenceRouter.post(
+  +  '/status',
+  +  requireAuth,
+  +  async (req: Request, res: Response, next: NextFunction) => {
+  +    const parsed = PresenceBodySchema.safeParse(req.body);
+  +    if (!parsed.success) {
+  +      res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+  +      return;
+  +    }
+  +
+  +    try {
+  +      await presenceService.renewLease((req as AuthenticatedRequest).userId, parsed.data.status);
+  +      res.status(204).send();
+  +    } catch (err) {
+  +      next(err);
+  +    }
+  +  },
+  +);
+  +19 -49
+
+harmony-backend/src/services/presence.service.ts
+  @@ -14,7 +14,9 @@ type ActivePresenceStatus = Extract<UserStatus, 'ONLINE' | 'IDLE'>;
+  -  if (!user || user.status !== status) {
+  +  if (!user) return;
+  +
+  +  if (user.status !== status) {
+       await userService.updateUser(userId, { status });
+     }
+   }
+  +3 -1
+
+harmony-frontend/src/hooks/usePresenceTracker.ts
+  @@ -8,8 +8,7 @@ import { getApiBaseUrl } from '@/lib/runtime-config';
+  -const ACTIVE_THROTTLE_MS = 30_000;
+  -const HEARTBEAT_INTERVAL_MS = 30_000;
+  +const PRESENCE_INTERVAL_MS = 30_000;
+   const ACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll', 'focus'];
+   
+   const logger = createFrontendLogger({ component: 'presence-tracker' });
+  @@ -60,10 +59,10 @@ export function usePresenceTracker(enabled: boolean): void {
+  -      if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) {
+  +      if (!force && statusRef.current === status) return;
+  +      if (!force && status === 'ONLINE' && now - lastActivePostRef.current < PRESENCE_INTERVAL_MS) {
+           return;
+         }
+  -      if (!force && statusRef.current === status) return;
+   
+         statusRef.current = status;
+         if (status === 'ONLINE') lastActivePostRef.current = now;
+  @@ -86,7 +85,7 @@ export function usePresenceTracker(enabled: boolean): void {
+  -    }, HEARTBEAT_INTERVAL_MS);
+  +    }, PRESENCE_INTERVAL_MS);
+       for (const event of ACTIVITY_EVENTS) {
+         window.addEventListener(event, markActive, { passive: true });
+       }
+  +4 -5
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 71994,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 6191e6
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 74
+Output:
+> eslint src tests
+/Users/allen/.codex/worktrees/7aee/Harmony/harmony-backend/tests/events.router.sse-server-updated.test.ts
+  83:10  warning  'sseGetWithEvent' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+✖ 1 problem (0 errors, 1 warning)
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 41462,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 313fde
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 3
+Output:
+> eslint
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:17:22.719Z
+
+All requested fixes pass the focused tests and typechecks; backend lint is still clean except the existing unrelated warning. I’m committing and pushing the review-resolution changes, then I’ll reply to the review comment with the commit hash and resolve it.
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ M harmony-backend/src/routes/presence.router.ts
+ M harmony-backend/src/services/presence.service.ts
+ M harmony-backend/tests/presence.router.test.ts
+ M harmony-backend/tests/presence.service.test.ts
+ M harmony-frontend/src/__tests__/usePresenceTracker.test.tsx
+ M harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat
+```
+
+Output:
+
+```text
+harmony-backend/src/routes/presence.router.ts      | 68 ++++++----------------
+ harmony-backend/src/services/presence.service.ts   |  4 +-
+ harmony-backend/tests/presence.router.test.ts      | 14 +++++
+ harmony-backend/tests/presence.service.test.ts     |  9 +++
+ .../src/__tests__/usePresenceTracker.test.tsx      | 18 ++++++
+ harmony-frontend/src/hooks/usePresenceTracker.ts   |  9 ++-
+ 6 files changed, 67 insertions(+), 55 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git add harmony-backend/src/routes/presence.router.ts harmony-backend/src/services/presence.service.ts harmony-backend/tests/presence.router.test.ts harmony-backend/tests/presence.service.test.ts harmony-frontend/src/__tests__/usePresenceTracker.test.tsx harmony-frontend/src/hooks/usePresenceTracker.ts
+```
+
+Output:
+
+```text
+ok 6 files changed, 67 insertions(+), 55 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git commit -m "fix: address presence review findings" -m "Reuse requireAuth for presence updates, fix the idle-to-online throttle ordering, skip stale user status writes, and expand regression coverage.\n\nCo-authored-by: GPT-5 <noreply@openai.com>"
+```
+
+Output:
+
+```text
+ok codex/i
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git log -1 --pretty=fuller
+```
+
+Output:
+
+```text
+commit 589b278a822fef233b08d33850c20647b60cd1c3
+Author:     acabrera04 <acabrera04164@gmail.com>
+AuthorDate: Tue Apr 28 15:17:44 2026 -0400
+Commit:     acabrera04 <acabrera04164@gmail.com>
+CommitDate: Tue Apr 28 15:17:44 2026 -0400
+
+    fix: address presence review findings
+    
+    Reuse requireAuth for presence updates, fix the idle-to-online throttle ordering, skip stale user status writes, ...
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status -sb
+```
+
+Output:
+
+```text
+## codex/issue-490-presence...origin/codex/issue-490-presence [ahead 1]
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat origin/codex/issue-490-presence..HEAD
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+git log -1 --format=%B
+```
+
+Output:
+
+```text
+fix: address presence review findings
+
+Reuse requireAuth for presence updates, fix the idle-to-online throttle ordering, skip stale user status writes, and expand regression coverage.\n\nCo-authored-by: GPT-5 <noreply@openai.com>
+```
+
+#### Tool: exec_command
+
+```sh
+git diff --stat origin/codex/issue-490-presence..HEAD
+```
+
+Output:
+
+```text
+ harmony-backend/src/routes/presence.router.ts      | 68 ++++++----------------
+ harmony-backend/src/services/presence.service.ts   |  4 +-
+ harmony-backend/tests/presence.router.test.ts      | 14 +++++
+ harmony-backend/tests/presence.service.test.ts     |  9 +++
+ .../src/__tests__/usePresenceTracker.test.tsx      | 18 ++++++
+ harmony-frontend/src/hooks/usePresenceTracker.ts   |  9 ++-
+ 6 files changed, 67 insertions(+), 55 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+git show --stat --oneline HEAD
+```
+
+Output:
+
+```text
+589b278 fix: address presence review findings
+ harmony-backend/src/routes/presence.router.ts      | 68 ++++++----------------
+ harmony-backend/src/services/presence.service.ts   |  4 +-
+ harmony-backend/tests/presence.router.test.ts      | 14 +++++
+ harmony-backend/tests/presence.service.test.ts     |  9 +++
+ .../src/__tests__/usePresenceTracker.test.tsx      | 18 ++++++
+ harmony-frontend/src/hooks/usePresenceTracker.ts   |  9 ++-
+ 6 files changed, 67 insertions(+), 55 deletions(-)
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:18:02.072Z
+
+I caught that the commit body has literal `\\n\\n` before the co-author trailer. I’m amending it to a proper multiline trailer before pushing.
+
+#### Tool: exec_command
+
+```sh
+rtk git commit --amend -m "fix: address presence review findings" -m "Reuse requireAuth for presence updates, fix the idle-to-online throttle ordering, skip stale user status writes, and expand regression coverage." -m "Co-authored-by: GPT-5 <noreply@openai.com>"
+```
+
+Output:
+
+```text
+ok codex/i
+```
+
+#### Tool: exec_command
+
+```sh
+git log -1 --format=%H%n%B
+```
+
+Output:
+
+```text
+5a2c1b2c8501b161ae5b97bd39e09ccfd2af045e
+fix: address presence review findings
+
+Reuse requireAuth for presence updates, fix the idle-to-online throttle ordering, skip stale user status writes, and expand regression coverage.
+
+Co-authored-by: GPT-5 <noreply@openai.com>
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status -sb
+```
+
+Output:
+
+```text
+## codex/issue-490-presence...origin/codex/issue-490-presence [ahead 1]
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git push
+```
+
+Output:
+
+```text
+ok codex/issue-490-presence
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:18:30.129Z
+
+The review-resolution commit is pushed as `5a2c1b2`. I’m replying to the unanswered review comment with the fix summary and resolving the thread, then I’ll start watch mode for any new comments.
+
+#### Tool: exec_command
+
+```sh
+npx agent-reviews --reply 4191693937 "Fixed in 5a2c1b2. Reused requireAuth in the presence router, inlined the trivial route helper, fixed the IDLE-to-ONLINE throttle ordering, skipped status writes for missing users, consolidated the presence interval constant, and added invalid-token/deleted-user/throttle regression coverage." --resolve
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 45795,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 12000
+}
+```
+
+Output:
+
+```text
+Chunk ID: ce724c
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 47
+Output:
+[32m✓ Reply posted successfully[0m
+  [2mhttps://github.com/CS485-Harmony/Harmony/pull/510#issuecomment-4338356288[0m
+[2mThread resolution skipped (not a review comment thread)[0m
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:18:48.356Z
+
+The review comment was a top-level review, not an inline thread, so `agent-reviews` posted the reply and reported that thread resolution does not apply. I’m running watch mode now to catch any new review comments.
+
+#### Tool: exec_command
+
+```sh
+npx agent-reviews --watch --timeout 60
+```
+
+Output:
+
+```text
+
+[1m=== PR Comments Watch Mode ===[0m
+[2mPR #510: https://github.com/CS485-Harmony/Harmony/pull/510[0m
+[2mPolling every 30s, exit after 60s of inactivity[0m
+[2mFilters: all, all comments[0m
+[2mStarted at 2026-04-28 19:18:55[0m
+
+[2m[2026-04-28 19:18:55] Initial state: 1 existing comments tracked[0m
+
+[33m=== EXISTING COMMENTS ===[0m
+[1m[4191693937][0m [35mREVIEW[0m by [32mAvanishKulkarni[0m [31m○ no reply[0m
+  [2m## Code Review: PR #510 — Lease-Based Presence Tracking  ### Overview  The overall design is soun...[0m
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 24807,
+  "chars": "",
+  "yield_time_ms": 65000,
+  "max_output_tokens": 16000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 6ff806
+Wall time: 56.9715 seconds
+Process exited with code 0
+Original token count: 74
+Output:
+[2m[2026-04-28 19:19:26] Poll #1: No new comments (31s/60s idle)[0m
+[2m[2026-04-28 19:19:56] Poll #2: No new comments (61s/60s idle)[0m
+
+[32m=== WATCH COMPLETE ===[0m
+[2mNo new comments after 60s of inactivity.[0m
+[2mTotal comments tracked: 1[0m
+[2mExiting at 2026-04-28 19:19:56[0m
+```
+
+#### Tool: exec_command
+
+```sh
+npx agent-reviews --unanswered --expanded
+```
+
+Output:
+
+````text
+[1mFound 1 comment[0m
+
+=== Comment [4191693937] ===
+Type: REVIEW | By: AvanishKulkarni | Status: ○ no reply
+URL: https://github.com/CS485-Harmony/Harmony/pull/510#pullrequestreview-4191693937
+
+## Code Review: PR #510 — Lease-Based Presence Tracking
+
+### Overview
+
+The overall design is sound — a Redis sorted-set lease model is a good fit here. It avoids false offline signals from tab-switching, handles multi-replica deployment via a Lua atomic-remove race, and the `MembersSidebar` is correctly wired to `localMembers` (SSE-updated) rather than the stale prop. Three issues warrant attention before merge.
+
+---
+
+### Issues
+
+#### 1. Duplicates `requireAuth` middleware (significant)
+
+`presence.router.ts` re-implements `getBearerToken` + `verifyToken` inline, but an identical `requireAuth` middleware already exists in `auth.middleware.ts`. This duplicates ~20 lines and diverges from every other authenticated route.
+
+The router should use `requireAuth` directly:
+
+```ts
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth.middleware';
+
+presenceRouter.post('/status', requireAuth, async (req, res, next) => {
+  const userId = (req as AuthenticatedRequest).userId;
+  // ...
+});
+```
+
+#### 2. `setPresence` throttle can suppress IDLE→ONLINE transition (bug)
+
+In `usePresenceTracker.ts`, the ONLINE throttle check fires before the status-change check:
+
+```ts
+if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) return; // ← runs first
+if (!force && statusRef.current === status) return;
+```
+
+Scenario: user is active (ONLINE posted at t=0), goes idle at t=4m59s (via the idle timer), immediately moves mouse at t=5m+5s. `now - lastActivePost = 5m+5s > 30s` — fine. But if the gap is shorter (e.g., ONLINE posted at t=28s ago, then IDLE fires at t=29s, user moves mouse at t=30s), the throttle fires first and swallows the IDLE→ONLINE transition. `statusRef` stays `IDLE` for up to another 30s.
+
+Fix: dedup same-status first, *then* throttle:
+
+```ts
+if (!force && statusRef.current === status) return;
+if (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) return;
+```
+
+#### 3. `updateUserStatusIfChanged` updates even when user is not found
+
+```ts
+const user = await userRepository.findSelf(userId);
+if (!user || user.status !== status) {   // ← calls updateUser even when user is null
+  await userService.updateUser(userId, { status });
+}
+```
+
+If `findSelf` returns `null` (deleted/deactivated user), `updateUser` is still called with a non-existent ID. Should be:
+
+```ts
+if (!user) return;
+if (user.status !== status) {
+  await userService.updateUser(userId, { status });
+}
+```
+
+---
+
+### Minor
+
+- **`updatePresence` helper in router**: The wrapper that calls `renewLease` then `res.status(204).send()` adds indirection for trivial logic — can be inlined.
+- **Missing router test for invalid token**: Tests cover a missing Authorization header but not a present-but-invalid token (where `verifyAccessToken` throws). The 401 branch in `verifyToken` is untested.
+- **`ACTIVE_THROTTLE_MS === HEARTBEAT_INTERVAL_MS`**: Both are `30_000`. A single named constant (e.g. `PRESENCE_INTERVAL_MS`) would make the intentional coupling explicit.
+
+---
+
+### Positives
+
+- Lua atomic-remove correctly handles the multi-replica race in `expireStaleLeases`.
+- `sweeper.unref?.()` prevents the interval from blocking process exit.
+- `currentUser` now derives `status`/`role` from `currentMemberRecord` — fixes the stale auth snapshot in the shell.
+- Test coverage is solid for happy paths and key edge cases (race condition, DND rejection, pagehide no-op, heartbeat).
+````
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:20:17.937Z
+
+The final unanswered check still lists the original top-level review as “no reply” even though `agent-reviews --reply` posted a response; this appears to be because the item is a top-level PR review, not an inline review thread. I’m verifying the posted reply is visible on the PR before summarizing.
+
+#### Tool: exec_command
+
+```sh
+gh pr view 510 --comments --json comments,reviews
+```
+
+Output:
+
+````text
+{"comments":[{"id":"IC_kwDORIrGY88AAAABApOlhw","author":{"login":"vercel"},"authorAssociation":"NONE","body":"[vc]: #o0jK0BTLfgUuqllh8kPanHNBeSKpCAZ6Om8qs7SbIK0=:eyJpc01vbm9yZXBvIjp0cnVlLCJ0eXBlIjoiZ2l0aHViIiwicHJvamVjdHMiOlt7Im5hbWUiOiJoYXJtb255IiwicHJvamVjdElkIjoicHJqXzIyWEc4M2lJZVNqeVFkVmlWdDhNcXp4VW9kTFkiLCJpbnNwZWN0b3JVcmwiOiJodHRwczovL3ZlcmNlbC5jb20vZGVjbGFucy1wcm9qZWN0cy0xNDFhOGI0Yy9oYXJtb255L0RGYVU4ZFc1ZTRWMUhFRERxTnBKN2g5MzkzblgiLCJwcmV2aWV3VXJsIjoiaGFybW9ueS1naXQtY29kZXgtaXNzdWUtNDkwLXByZXNlbmNlLWRlY2xhbnMtcHJvamVjdHMtMTQxYThiNGMudmVyY2VsLmFwcCIsIm5leHRDb21taXRTdGF0dXMiOiJERVBMT1lFRCIsImxpdmVGZWVkYmFjayI6eyJyZXNvbHZlZCI6MCwidW5yZXNvbHZlZCI6MCwidG90YWwiOjAsImxpbmsiOiJoYXJtb255LWdpdC1jb2RleC1pc3N1ZS00OTAtcHJlc2VuY2UtZGVjbGFucy1wcm9qZWN0cy0xNDFhOGI0Yy52ZXJjZWwuYXBwIn0sInJvb3REaXJlY3RvcnkiOiJoYXJtb255LWZyb250ZW5kIn1dfQ==\nThe latest updates on your projects. Learn more about [Vercel for GitHub](https://vercel.link/github-learn-more).\n\n| Project | Deployment | Actions | Updated (UTC) |\n| :--- | :----- | :------ | :------ |\n| [harmony](https://vercel.com/declans-projects-141a8b4c/harmony) | ![Ready](https://vercel.com/static/status/ready.svg) [Ready](https://vercel.com/declans-projects-141a8b4c/harmony/DFaU8dW5e4V1HEDDqNpJ7h9393nX) | [Preview](https://harmony-git-codex-issue-490-presence-declans-projects-141a8b4c.vercel.app), [Comment](https://vercel.live/open-feedback/harmony-git-codex-issue-490-presence-declans-projects-141a8b4c.vercel.app?via=pr-comment-feedback-link) | Apr 28, 2026 7:19pm |\n\n","createdAt":"2026-04-28T18:54:39Z","includesCreatedEdit":true,"isMinimized":false,"minimizedReason":"","reactionGroups":[],"url":"https://github.com/CS485-Harmony/Harmony/pull/510#issuecomment-4338197895","viewerDidAuthor":false},{"id":"IC_kwDORIrGY88AAAABApYQQA","author":{"login":"acabrera04"},"authorAssociation":"MEMBER","body":"> Re: comment 4191693937\n\nFixed in 5a2c1b2. Reused requireAuth in the presence router, inlined the trivial route helper, fixed the IDLE-to-ONLINE throttle ordering, skipped status writes for missing users, consolidated the presence interval constant, and added invalid-token/deleted-user/throttle regression coverage.","createdAt":"2026-04-28T19:18:41Z","includesCreatedEdit":false,"isMinimized":false,"minimizedReason":"","reactionGroups":[],"url":"https://github.com/CS485-Harmony/Harmony/pull/510#issuecomment-4338356288","viewerDidAuthor":true}],"reviews":[{"id":"PRR_kwDORIrGY8752Cxx","author":{"login":"AvanishKulkarni"},"authorAssociation":"MEMBER","body":"## Code Review: PR #510 — Lease-Based Presence Tracking\n\n### Overview\n\nThe overall design is sound — a Redis sorted-set lease model is a good fit here. It avoids false offline signals from tab-switching, handles multi-replica deployment via a Lua atomic-remove race, and the `MembersSidebar` is correctly wired to `localMembers` (SSE-updated) rather than the stale prop. Three issues warrant attention before merge.\n\n---\n\n### Issues\n\n#### 1. Duplicates `requireAuth` middleware (significant)\n\n`presence.router.ts` re-implements `getBearerToken` + `verifyToken` inline, but an identical `requireAuth` middleware already exists in `auth.middleware.ts`. This duplicates ~20 lines and diverges from every other authenticated route.\n\nThe router should use `requireAuth` directly:\n\n```ts\nimport { requireAuth, AuthenticatedRequest } from '../middleware/auth.middleware';\n\npresenceRouter.post('/status', requireAuth, async (req, res, next) => {\n  const userId = (req as AuthenticatedRequest).userId;\n  // ...\n});\n```\n\n#### 2. `setPresence` throttle can suppress IDLE→ONLINE transition (bug)\n\nIn `usePresenceTracker.ts`, the ONLINE throttle check fires before the status-change check:\n\n```ts\nif (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) return; // ← runs first\nif (!force && statusRef.current === status) return;\n```\n\nScenario: user is active (ONLINE posted at t=0), goes idle at t=4m59s (via the idle timer), immediately moves mouse at t=5m+5s. `now - lastActivePost = 5m+5s > 30s` — fine. But if the gap is shorter (e.g., ONLINE posted at t=28s ago, then IDLE fires at t=29s, user moves mouse at t=30s), the throttle fires first and swallows the IDLE→ONLINE transition. `statusRef` stays `IDLE` for up to another 30s.\n\nFix: dedup same-status first, *then* throttle:\n\n```ts\nif (!force && statusRef.current === status) return;\nif (!force && status === 'ONLINE' && now - lastActivePostRef.current < ACTIVE_THROTTLE_MS) return;\n```\n\n#### 3. `updateUserStatusIfChanged` updates even when user is not found\n\n```ts\nconst user = await userRepository.findSelf(userId);\nif (!user || user.status !== status) {   // ← calls updateUser even when user is null\n  await userService.updateUser(userId, { status });\n}\n```\n\nIf `findSelf` returns `null` (deleted/deactivated user), `updateUser` is still called with a non-existent ID. Should be:\n\n```ts\nif (!user) return;\nif (user.status !== status) {\n  await userService.updateUser(userId, { status });\n}\n```\n\n---\n\n### Minor\n\n- **`updatePresence` helper in router**: The wrapper that calls `renewLease` then `res.status(204).send()` adds indirection for trivial logic — can be inlined.\n- **Missing router test for invalid token**: Tests cover a missing Authorization header but not a present-but-invalid token (where `verifyAccessToken` throws). The 401 branch in `verifyToken` is untested.\n- **`ACTIVE_THROTTLE_MS === HEARTBEAT_INTERVAL_MS`**: Both are `30_000`. A single named constant (e.g. `PRESENCE_INTERVAL_MS`) would make the intentional coupling explicit.\n\n---\n\n### Positives\n\n- Lua atomic-remove correctly handles the multi-replica race in `expireStaleLeases`.\n- `sweeper.unref?.()` prevents the interval from blocking process exit.\n- `currentUser` now derives `status`/`role` from `currentMemberRecord` — fixes the stale auth snapshot in the shell.\n- Test coverage is solid for happy paths and key edge cases (race condition, DND rejection, pagehide no-op, heartbeat).","submittedAt":"2026-04-28T19:12:11Z","includesCreatedEdit":false,"reactionGroups":[],"state":"COMMENTED","commit":{"oid":"b6fec375fa2561886da724fcbe900de07c520dd2"}}]}
+````
+
+#### Tool: exec_command
+
+```sh
+rtk git status -sb
+```
+
+Output:
+
+```text
+## codex/issue-490-presence...origin/codex/issue-490-presence
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git log --oneline -3
+```
+
+Output:
+
+```text
+5a2c1b2 fix: address presence review findings
+b6fec37 Implement lease-based presence tracking
+184369c chore: add llm logs
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:20:33.967Z
+
+Resolved PR #510 review feedback and pushed commit `5a2c1b2`.
+
+Fixed:
+- Reused existing `requireAuth` in `presence.router.ts`.
+- Fixed the `IDLE -> ONLINE` throttle ordering bug.
+- Avoided status updates when the user no longer exists.
+- Inlined the trivial route helper.
+- Added invalid-token, deleted-user, and throttle regression coverage.
+- Consolidated the heartbeat/throttle interval constant.
+
+Verification:
+- `npm --prefix harmony-backend test -- presence.router.test.ts presence.service.test.ts` passed, `11` tests.
+- `npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx` passed, `7` tests.
+- `npm --prefix harmony-backend run build` passed.
+- Frontend `npx tsc --noEmit` passed.
+- Frontend lint passed.
+- Backend lint passed with the existing unrelated warning.
+
+I replied on the PR review. `agent-reviews` could not resolve it as a thread because it is a top-level review, not an inline review thread. Watch mode completed with no new comments after 60s.
+
+<oai-mem-citation>
+<citation_entries>
+MEMORY.md:575-575|note=[used Harmony resolve-reviews expectation]
+MEMORY.md:478-480|note=[used Harmony review workflow context]
+</citation_entries>
+<rollout_ids>
+</rollout_ids>
+</oai-mem-citation>
+
+### Turn 7: [$codex-conversation-exporter](/Users/allen/repos/codex-logs-export/skil
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T19:30:16.538Z
+
+```text
+[$codex-conversation-exporter](/Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md) 019dd560-58ad-7053-a6cf-bf4a7384f242 to my final logs location
+```
+
+_No assistant or tool activity recorded after this prompt._
+
+### Turn 8: <skill> <name>codex-conversation-exporter</name>
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T19:30:16.539Z
+
+````text
+<skill>
+<name>codex-conversation-exporter</name>
+<path>/Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md</path>
+---
+name: codex-conversation-exporter
+description: Export Codex session logs to Markdown using the local codex-export CLI instead of reconstructing transcripts with model tokens.
+---
+
+# Codex Conversation Exporter
+
+Use this skill when the user asks to export Codex logs, save a Codex conversation, convert a session to Markdown, or archive a transcript locally.
+
+## Rules
+
+- Prefer the local `codex-export` CLI over reconstructing a transcript in-model.
+- If the user has not identified a session, run `codex-export list` first and show the relevant candidates.
+- Default to messages plus tool activity.
+- Include hidden system/developer prompts only when the user explicitly asks for them.
+- Write to a user-visible path unless the user asks for stdout or another destination.
+- Report the output path back to the user after a file export.
+
+## Command patterns
+
+List recent sessions:
+
+```bash
+codex-export list
+codex-export list --limit 10
+codex-export list --since 2026-03-30
+```
+
+Export by thread id:
+
+```bash
+codex-export export <thread-id>
+codex-export export <thread-id> --out ~/Desktop
+codex-export export <thread-id> --messages-only
+codex-export export <thread-id> --all
+codex-export export <thread-id> --include-hidden-prompts
+codex-export export <thread-id> --stdout
+```
+
+Export by rollout path:
+
+```bash
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl --out ~/Desktop
+```
+
+## Flag guide
+
+- `--out <file-or-dir>` writes to a specific file or directory.
+- `--stdout` prints the Markdown instead of writing a file.
+- `--messages-only` omits tool calls and tool outputs.
+- `--all` includes low-level tool metadata and raw wrappers that are hidden by default.
+- `--include-hidden-prompts` includes developer/system prompt layers.
+- `--since <date>` filters `list` results.
+- `--limit <n>` caps `list` results.
+
+## Agent behavior
+
+When the user says "export this conversation" without a thread id:
+
+1. Run `codex-export list`.
+2. Identify the most likely current session from title, cwd, and recency.
+3. Export it with the default mode unless the user requested a different output.
+4. Return the exact file path written.
+
+`codex-log-export` remains available as a compatibility alias.
+
+</skill>
+````
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:30:26.797Z
+
+I’ll use the local `codex-export` CLI for that thread id and resolve the established “final logs” destination from the repo context before exporting.
+
+#### Tool: exec_command
+
+```sh
+rtk read /Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md
+```
+
+Output:
+
+````text
+---
+name: codex-conversation-exporter
+description: Export Codex session logs to Markdown using the local codex-export CLI instead of reconstructing transcripts with model tokens.
+---
+
+# Codex Conversation Exporter
+
+Use this skill when the user asks to export Codex logs, save a Codex conversation, convert a session to Markdown, or archive a transcript locally.
+
+## Rules
+
+- Prefer the local `codex-export` CLI over reconstructing a transcript in-model.
+- If the user has not identified a session, run `codex-export list` first and show the relevant candidates.
+- Default to messages plus tool activity.
+- Include hidden system/developer prompts only when the user explicitly asks for them.
+- Write to a user-visible path unless the user asks for stdout or another destination.
+- Report the output path back to the user after a file export.
+
+## Command patterns
+
+List recent sessions:
+
+```bash
+codex-export list
+codex-export list --limit 10
+codex-export list --since 2026-03-30
+```
+
+Export by thread id:
+
+```bash
+codex-export export <thread-id>
+codex-export export <thread-id> --out ~/Desktop
+codex-export export <thread-id> --messages-only
+codex-export export <thread-id> --all
+codex-export export <thread-id> --include-hidden-prompts
+codex-export export <thread-id> --stdout
+```
+
+Export by rollout path:
+
+```bash
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl --out ~/Desktop
+```
+
+## Flag guide
+
+- `--out <file-or-dir>` writes to a specific file or directory.
+- `--stdout` prints the Markdown instead of writing a file.
+- `--messages-only` omits tool calls and tool outputs.
+- `--all` includes low-level tool metadata and raw wrappers that are hidden by default.
+- `--include-hidden-prompts` includes developer/system prompt layers.
+- `--since <date>` filters `list` results.
+- `--limit <n>` caps `list` results.
+
+## Agent behavior
+
+When the user says "export this conversation" without a thread id:
+
+1. Run `codex-export list`.
+2. Identify the most likely current session from title, cwd, and recency.
+3. Export it with the default mode unless the user requested a different output.
+4. Return the exact file path written.
+
+`codex-log-export` remains available as a compatibility alias.
+````
+
+#### Tool: exec_command
+
+```sh
+rg -n "final logs|llm-logs/acabrera04-logs/final|codex-export export|019dd560" /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+187:## Task 1: Export two Codex conversations to `llm-logs/acabrera04-logs/final` and push them on the active PR branch
+191:- rollout_summaries/2026-04-23T20-38-29-MgZp-codex_conversation_export_final_logs_push.md (cwd=/Users/allen/.codex/worktrees/3cb6/Harmony, rollout_path=/Users/allen/.codex/sessions/2026/04/23/rollout-2026-04-23T16-38-29-019dbc10-c896-7f60-920d-191e50d53b4f.jsonl, updated_at=2026-04-24T04:13:08+00:00, thread_id=019dbc10-c896-7f60-920d-191e50d53b4f, two explicit thread exports to final logs path, commit, rebase, and push on `codex/issue-359-seo-admin-ui`)
+195:- codex-export export, 019dbc10-8982-77b0-8757-8c926efb778c, 019dbc10-c896-7f60-920d-191e50d53b4f, llm-logs/acabrera04-logs/final, 2026-04-23-review-pr-460-019dbc10.md, 2026-04-23-complete-issue-359-019dbc10.md, codex/issue-359-seo-admin-ui, chore: export codex conversation logs, rejected (fetch first), git rebase origin/codex/issue-359-seo-admin-ui
+197:## Task 2: Export PR #443 conversation log to `llm-logs/acabrera04-logs/final` on the PR branch
+205:- codex-conversation-exporter, codex-export export, llm-logs/acabrera04-logs/final, 2026-04-20-review-harmony-pr-443-019dabb8.md, PR branch, feature/issue-350-meta-tag-service-skeleton, pr-443, detached HEAD, non-fast-forward push, git rebase origin/feature/issue-350-meta-tag-service-skeleton, 2819f80380f86c6ddf67b9997574ea4eb1f5d694
+215:- codex-export export, llm-logs/acabrera04-logs/acabrera04-deployment, logs/acabrera04-deployment, deployment logs, git diff --cached --stat, one markdown file per thread, keep this on a logs branch
+245:- Review Avanish's latest PR, PR #457, feature/issue-423-local-e2e-scripts, llm-logs/acabrera04-logs/final, 2026-04-23-review-avanish-pr-019dbafe.md, git worktree list, detached HEAD, codex/expand-sonarjs-ci, fce27df, push it to the PR branch
+247:## Task 7: Export the issue #363 conversation log to `llm-logs/acabrera04-logs/final` and push it on the PR branch after rebasing
+255:- codex-export export, 019dc7b7-88d5-73f0-a613-09b11df3e903, llm-logs/acabrera04-logs/final, 2026-04-26-complete-issue-363-019dc7b7.md, codex/issue-363-readme-deployer-pass, push, rejected (fetch first), git fetch origin codex/issue-363-readme-deployer-pass, git rebase origin/codex/issue-363-readme-deployer-pass
+259:- when the user says `<thread-id>, <thread-id> to llm-logs/acabrera04-logs/final and push` -> use the exporter directly on each provided id, preserve the exact destination path, and treat the export as a real branch artifact that must be committed and pushed [Task 1]
+261:- when the user explicitly asked for `[$codex-conversation-exporter](...) 019dabb8-56c4-7e63-bbdb-d18101c2c726 to the PR branch under llm-logs/acabrera04-logs/final` -> use the exporter skill, write into that exact `llm-logs/acabrera04-logs/final` location, and treat the export as a branch change that should be committed and pushed [Task 2]
+267:- when the user says to put an export "to the PR branch and push it" after a review -> preserve the exact `llm-logs/acabrera04-logs/final` destination and move to the actual branch-owning worktree before committing if the review checkout is detached [Task 6]
+271:- `codex-export export <threadId> --out llm-logs/acabrera04-logs/final` can be run once per explicit thread id, and in this run it produced `2026-04-23-review-pr-460-019dbc10.md` plus `2026-04-23-complete-issue-359-019dbc10.md` under the requested final bucket [Task 1]
+274:- `codex-export export <threadId> --out <dir>` writes a single Markdown export and prints the exact path. In the PR #443 run the output file was `llm-logs/acabrera04-logs/final/2026-04-20-review-harmony-pr-443-019dabb8.md` [Task 2]
+278:- `codex-export export <thread_id> --out <folder>` creates one markdown export per thread. The filename is derived from thread content/title plus the thread id, so staging only the new markdown file is the right default [Task 3]
+283:- The exported PR-review log from thread `019dbafe-8c33-7970-a41b-6c984b61be26` landed at `llm-logs/acabrera04-logs/final/2026-04-23-review-avanish-pr-019dbafe.md` and was pushed as commit `fce27df` [Task 6]
+284:- The issue #363 export produced `llm-logs/acabrera04-logs/final/2026-04-26-complete-issue-363-019dc7b7.md` on branch `codex/issue-363-readme-deployer-pass`; when the first push was rejected, fetching and rebasing onto `origin/codex/issue-363-readme-deployer-pass` was the working recovery [Task 7]
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls llm-logs/acabrera04-logs/final
+```
+
+Output:
+
+```text
+2026-04-20-review-harmony-pr-443-019dabb8.md  961.9K
+2026-04-23-complete-issue-359-019dbc10.md  803.7K
+2026-04-23-complete-issue-419-019dbaff.md  115.9K
+2026-04-23-review-pr-460-019dbc10.md  633.9K
+2026-04-25-fix-issue-468-019dc607.md  236.4K
+2026-04-25-review-pr-462-019dc5e2.md  410.0K
+2026-04-26-add-google-verification-meta-tag-019dc7ce.md  58.8K
+2026-04-26-complete-issue-363-019dc7b7.md  454.6K
+2026-04-26-fix-476-019dcbbe.md  341.3K
+2026-04-27-review-pr-477-019dd0a2.md  418.4K
+```
+
+#### Tool: exec_command
+
+```sh
+codex-export --help
+```
+
+Output:
+
+```text
+Usage: codex-export [options] [command]
+
+Export Codex conversation logs to Markdown
+
+Options:
+  -h, --help                   display help for command
+
+Commands:
+  list [options]
+  export [options] [threadId]
+  help [command]               display help for command
+```
+
+#### 🤖 gpt-5.5 (low)
+
+- Time: 2026-04-28T19:30:31.797Z
+
+The established final bucket is `llm-logs/acabrera04-logs/final`. I’m exporting thread `019dd560-58ad-7053-a6cf-bf4a7384f242` there now with default messages plus tool activity.
+
+#### Tool: exec_command
+
+```sh
+codex-export export 019dd560-58ad-7053-a6cf-bf4a7384f242 --out llm-logs/acabrera04-logs/final
+```


### PR DESCRIPTION
## Summary
- add authenticated presence heartbeat endpoint and Redis-backed lease expiry
- track browser activity with online/idle heartbeats instead of pagehide offline writes
- wire real-time member status updates into the visible members sidebar

## Why
Issue #490 asks for automatic online, idle, and offline presence broadcast over existing SSE. Offline is handled by server-side lease expiry so minimizing or switching tabs does not immediately mark a user offline.

## Verification
- npm --prefix harmony-backend test -- presence.router.test.ts presence.service.test.ts
- npm --prefix harmony-frontend test -- usePresenceTracker.test.tsx
- npm --prefix harmony-backend run build
- npx tsc --noEmit in harmony-frontend

Notes: frontend production build was previously blocked locally by sandbox network access to Google Fonts, not by this change.