### PR TITLE
Make frontend builds sandbox safe

### DIFF
--- a/harmony-frontend/package.json
+++ b/harmony-frontend/package.json
@@ -4,9 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build --webpack",
+    "build": "next build",
+    "build:sandbox": "next build --webpack",
     "start": "next start",
-    "build:local-e2e": "NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next build --webpack",
+    "build:local-e2e": "NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next build",
+    "build:local-e2e:sandbox": "NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next build --webpack",
     "start:local-e2e": "PORT=3000 NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next start",
     "test": "jest --forceExit",
     "test:e2e": "playwright test",

--- a/harmony-frontend/package.json
+++ b/harmony-frontend/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
-    "build:local-e2e": "NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next build",
+    "build:local-e2e": "NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next build --webpack",
     "start:local-e2e": "PORT=3000 NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next start",
     "test": "jest --forceExit",
     "test:e2e": "playwright test",

--- a/harmony-frontend/src/__tests__/seo-routes.test.ts
+++ b/harmony-frontend/src/__tests__/seo-routes.test.ts
@@ -99,7 +99,7 @@ describe('frontend SEO route handlers', () => {
     );
 
     const response = await getServerSitemap(new Request('https://harmony.chat/sitemap/demo.xml'), {
-      params: Promise.resolve({}),
+      params: Promise.resolve({ serverSlug: 'demo' }),
     });
 
     expect(global.fetch).toHaveBeenCalledWith('https://api.harmony.chat/sitemap/demo.xml', {
@@ -119,7 +119,7 @@ describe('frontend SEO route handlers', () => {
     );
 
     const response = await getServerSitemap(new Request('http://localhost:3000/sitemap/demo.xml'), {
-      params: Promise.resolve({}),
+      params: Promise.resolve({ serverSlug: 'demo' }),
     });
 
     await expect(response.text()).resolves.toContain(

--- a/harmony-frontend/src/__tests__/seo-routes.test.ts
+++ b/harmony-frontend/src/__tests__/seo-routes.test.ts
@@ -99,7 +99,7 @@ describe('frontend SEO route handlers', () => {
     );
 
     const response = await getServerSitemap(new Request('https://harmony.chat/sitemap/demo.xml'), {
-      params: Promise.resolve({ serverSlug: 'demo' }),
+      params: Promise.resolve({}),
     });
 
     expect(global.fetch).toHaveBeenCalledWith('https://api.harmony.chat/sitemap/demo.xml', {
@@ -119,7 +119,7 @@ describe('frontend SEO route handlers', () => {
     );
 
     const response = await getServerSitemap(new Request('http://localhost:3000/sitemap/demo.xml'), {
-      params: Promise.resolve({ serverSlug: 'demo' }),
+      params: Promise.resolve({}),
     });
 
     await expect(response.text()).resolves.toContain(

--- a/harmony-frontend/src/app/globals.css
+++ b/harmony-frontend/src/app/globals.css
@@ -4,6 +4,7 @@
 :root {
   --background: #36393f;
   --foreground: #dcddde;
+  --font-inter: Inter, 'Open Sans', Arial, Helvetica, sans-serif;
 }
 
 @theme inline {
@@ -15,5 +16,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-inter), 'Open Sans', Arial, Helvetica, sans-serif;
+  font-family: var(--font-inter);
 }

--- a/harmony-frontend/src/app/layout.tsx
+++ b/harmony-frontend/src/app/layout.tsx
@@ -1,14 +1,8 @@
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import { Providers } from './providers';
 import { APP_DESCRIPTION, APP_NAME } from '@/lib/constants';
 import { getPublicMetadataBase } from '@/lib/runtime-config';
 import './globals.css';
-
-const inter = Inter({
-  variable: '--font-inter',
-  subsets: ['latin'],
-});
 
 export const metadata: Metadata = {
   metadataBase: getPublicMetadataBase(),
@@ -26,7 +20,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='en'>
-      <body className={`${inter.variable} antialiased`}>
+      <body className='antialiased'>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/harmony-frontend/src/app/sitemap/[serverSlug].xml/route.ts
+++ b/harmony-frontend/src/app/sitemap/[serverSlug].xml/route.ts
@@ -5,7 +5,7 @@ import { proxySitemapXml } from '@/lib/sitemap-response';
 export const revalidate = 300;
 
 interface RouteContext {
-  params: Promise<Record<string, never>>;
+  params: Promise<unknown>;
 }
 
 /**
@@ -14,11 +14,11 @@ interface RouteContext {
  * never need the API domain as the primary SEO surface.
  */
 export async function GET(request: Request, context: RouteContext) {
-  await context.params;
-  const pathname = new URL(request.url).pathname;
-  const slugSegment = pathname.split('/').at(-1) ?? '';
-  const serverSlug = slugSegment.endsWith('.xml') ? slugSegment.slice(0, -4) : slugSegment;
-  if (!serverSlug) {
+  const params = context?.params ? await context.params : undefined;
+  const { serverSlug } = (params ?? {}) as {
+    serverSlug?: string | string[];
+  };
+  if (typeof serverSlug !== 'string') {
     return new Response('Sitemap not found.', {
       status: 404,
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },

--- a/harmony-frontend/src/app/sitemap/[serverSlug].xml/route.ts
+++ b/harmony-frontend/src/app/sitemap/[serverSlug].xml/route.ts
@@ -5,7 +5,7 @@ import { proxySitemapXml } from '@/lib/sitemap-response';
 export const revalidate = 300;
 
 interface RouteContext {
-  params: Promise<Record<string, string | string[] | undefined>>;
+  params: Promise<Record<string, never>>;
 }
 
 /**
@@ -13,10 +13,12 @@ interface RouteContext {
  * proxy of the backend XML generator, revalidating periodically, so crawlers
  * never need the API domain as the primary SEO surface.
  */
-export async function GET(request: Request, context?: RouteContext) {
-  const params = await context?.params;
-  const serverSlug = params?.serverSlug;
-  if (typeof serverSlug !== 'string') {
+export async function GET(request: Request, context: RouteContext) {
+  await context.params;
+  const pathname = new URL(request.url).pathname;
+  const slugSegment = pathname.split('/').at(-1) ?? '';
+  const serverSlug = slugSegment.endsWith('.xml') ? slugSegment.slice(0, -4) : slugSegment;
+  if (!serverSlug) {
     return new Response('Sitemap not found.', {
       status: 404,
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },


### PR DESCRIPTION
## Summary

- remove `next/font/google` from the frontend root layout so production builds no longer fetch Google Fonts
- define the Inter font token through local CSS fallbacks
- use Next's webpack build mode for frontend build scripts so sandboxed builds avoid Turbopack's internal process/port restriction
- update the `.xml` sitemap route handler and tests for the stricter generated route type exposed by the webpack build

## Verification

- `rtk npx prettier --write package.json src/__tests__/seo-routes.test.ts src/app/sitemap/[serverSlug].xml/route.ts src/app/layout.tsx src/app/globals.css`
- `./node_modules/.bin/tsc --noEmit`
- `rtk npm run lint`
- `rtk npm test -- --runInBand`
- `rtk npm run build`

Note: the build still emits existing warnings for the deprecated `middleware` convention and the module type of `tailwind.config.ts`; it exits successfully.
