### PR TITLE
fix: sanitize public channel metadata titles

### DIFF
--- a/harmony-backend/src/services/metaTag/titleGenerator.ts
+++ b/harmony-backend/src/services/metaTag/titleGenerator.ts
@@ -43,7 +43,12 @@ export const TitleGenerator: IMetaTagGenerator & {
 
   sanitizeForTitle(text: string): string {
     return text
-      .replace(/<[^>]*>/g, '')
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/\\/g, '/')
+      .split('/')
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0 && segment !== '.' && segment !== '..')
+      .join(' / ')
       .replace(/\s+/g, ' ')
       .trim();
   },

--- a/harmony-backend/tests/metaTagService.test.ts
+++ b/harmony-backend/tests/metaTagService.test.ts
@@ -97,6 +97,11 @@ describe('TitleGenerator', () => {
     expect(result).toBe('foo bar baz');
   });
 
+  it('sanitizeForTitle removes dot-segment path prefixes', () => {
+    const result = TitleGenerator.sanitizeForTitle('../../../admin');
+    expect(result).toBe('admin');
+  });
+
   it('applyTemplate replaces template variables', () => {
     const result = TitleGenerator.applyTemplate('{channelName} on {serverName}', {
       channelName: 'general',

--- a/harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+++ b/harmony-frontend/src/__tests__/channel-page-metadata.test.ts
@@ -192,6 +192,31 @@ describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
       },
     });
   });
+
+  it('sanitizes path-like server names before building fallback metadata', async () => {
+    mockFetchPublicServer.mockResolvedValue(
+      makeServer({
+        name: '../../../admin',
+      }),
+    );
+
+    const meta = await generateMetadata(makeParams('admin', 'general'));
+    const page = await GuestChannelPage(makeParams('admin', 'general'));
+    const html = renderToStaticMarkup(page);
+    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+
+    expect(meta.title).toBe('general - admin | Harmony');
+    expect(meta.description).toBe('Welcome to general');
+    expect(ldMatch).not.toBeNull();
+    expect(JSON.parse(ldMatch![1])).toMatchObject({
+      author: {
+        '@type': 'Organization',
+        'name': 'admin',
+      },
+      name: 'general - admin | Harmony',
+      headline: 'general - admin | Harmony',
+    });
+  });
 });
 
 describe('generateMetadata — PUBLIC_NO_INDEX channel', () => {

--- a/harmony-frontend/src/__tests__/guest-server-name-sanitization.test.tsx
+++ b/harmony-frontend/src/__tests__/guest-server-name-sanitization.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { GuestHeader } from '@/components/channel/GuestHeader';
+import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+
+const mockUseAuth = jest.fn();
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/c/admin/general',
+}));
+
+describe('guest server name sanitization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      isAdmin: () => false,
+    });
+  });
+
+  it('sanitizes the guest header server label', () => {
+    render(
+      <GuestHeader
+        server={{
+          id: 'server-1',
+          name: '../../../admin',
+          slug: 'admin',
+          createdAt: '2026-04-28T00:00:00.000Z',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('admin')).toBeInTheDocument();
+    expect(screen.queryByText('../../../admin')).not.toBeInTheDocument();
+  });
+
+  it('sanitizes the guest promo banner label and avatar initial', () => {
+    render(<GuestPromoBanner serverName='../../../admin' memberCount={2} />);
+
+    expect(screen.getByText('admin')).toBeInTheDocument();
+    expect(screen.queryByText('../../../admin')).not.toBeInTheDocument();
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+});

--- a/harmony-frontend/src/__tests__/utils.test.ts
+++ b/harmony-frontend/src/__tests__/utils.test.ts
@@ -7,6 +7,7 @@ import {
   formatTimeOnly,
   getChannelUrl,
   getUserErrorMessage,
+  sanitizeDisplayLabel,
   truncate,
 } from '../lib/utils';
 
@@ -155,6 +156,20 @@ describe('utils', () => {
 
     it('adds an ellipsis when the text exceeds the limit', () => {
       expect(truncate('hello world', 5)).toBe('hello...');
+    });
+  });
+
+  describe('sanitizeDisplayLabel', () => {
+    it('removes dot-segment path prefixes', () => {
+      expect(sanitizeDisplayLabel('../../../admin')).toBe('admin');
+    });
+
+    it('normalizes slash-separated names without preserving traversal segments', () => {
+      expect(sanitizeDisplayLabel(' ../ community // general ')).toBe('community / general');
+    });
+
+    it('strips HTML and collapses whitespace', () => {
+      expect(sanitizeDisplayLabel('<b>Game</b>   Dev\nHub')).toBe('Game Dev Hub');
     });
   });
 

--- a/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+++ b/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
@@ -12,6 +12,18 @@ interface PageProps {
   params: Promise<{ serverSlug: string; channelSlug: string }>;
 }
 
+function sanitizeMetadataLabel(value: string): string {
+  return value
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\\/g, '/')
+    .split('/')
+    .map(segment => segment.trim())
+    .filter(segment => segment.length > 0 && segment !== '.' && segment !== '..')
+    .join(' / ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 function getSeoContent(
   serverSlug: string,
   channelSlug: string,
@@ -20,8 +32,10 @@ function getSeoContent(
   publicMetaTags: Awaited<ReturnType<typeof fetchPublicMetaTags>>,
 ) {
   const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
-  const channelName = channel?.name ?? channelSlug;
-  const serverName = server?.name ?? serverSlug;
+  const channelName =
+    sanitizeMetadataLabel(channel?.name ?? '') || sanitizeMetadataLabel(channelSlug) || 'channel';
+  const serverName =
+    sanitizeMetadataLabel(server?.name ?? '') || sanitizeMetadataLabel(serverSlug) || 'server';
   const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
   const description =
     publicMetaTags?.description ??

--- a/harmony-frontend/src/components/channel/GuestHeader.tsx
+++ b/harmony-frontend/src/components/channel/GuestHeader.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
+import { sanitizeDisplayLabel } from '@/lib/utils';
 import type { Server } from '@/types';
 
 type PublicServer = Omit<Server, 'ownerId'>;
@@ -11,6 +12,7 @@ export function GuestHeader({ server }: { server: PublicServer }) {
   const { isAuthenticated } = useAuth();
   const pathname = usePathname();
   const returnUrl = encodeURIComponent(pathname);
+  const safeServerName = sanitizeDisplayLabel(server.name) || 'Server';
 
   return (
     <header className='flex h-14 shrink-0 items-center gap-3 border-b border-black/20 bg-[#2f3136] px-4'>
@@ -23,7 +25,9 @@ export function GuestHeader({ server }: { server: PublicServer }) {
       </span>
 
       {/* Server name — min-w-0 flex-1 prevents overflow when CTAs are present */}
-      <span className='min-w-0 flex-1 truncate text-sm font-semibold text-white'>{server.name}</span>
+      <span className='min-w-0 flex-1 truncate text-sm font-semibold text-white'>
+        {safeServerName}
+      </span>
 
       {/* Auth CTAs — hidden for authenticated users (e.g. non-member 403 path) */}
       {!isAuthenticated && (

--- a/harmony-frontend/src/components/channel/GuestPromoBanner.tsx
+++ b/harmony-frontend/src/components/channel/GuestPromoBanner.tsx
@@ -11,6 +11,7 @@ import { useState, useCallback, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
+import { sanitizeDisplayLabel } from '@/lib/utils';
 
 const DISMISS_KEY = 'harmony_guest_banner_dismissed';
 
@@ -30,14 +31,15 @@ interface GuestPromoBannerProps {
 export function GuestPromoBanner({ serverName, memberCount }: GuestPromoBannerProps) {
   const { isAuthenticated } = useAuth();
   const pathname = usePathname();
+  const safeServerName = sanitizeDisplayLabel(serverName) || 'Server';
   // useSyncExternalStore with a server snapshot of `true` (hidden) prevents
   // hydration mismatch: SSR and initial client render both produce null, then
   // React reconciles with the real client snapshot after hydration — no
   // setState-in-effect needed.
   const storageDismissed = useSyncExternalStore(
-    () => () => {},       // sessionStorage has no change events
+    () => () => {}, // sessionStorage has no change events
     isDismissedInStorage, // client snapshot
-    () => true,           // server snapshot: always hidden
+    () => true, // server snapshot: always hidden
   );
 
   // Tracks in-memory dismiss for the current render cycle, covering the case
@@ -68,12 +70,12 @@ export function GuestPromoBanner({ serverName, memberCount }: GuestPromoBannerPr
           className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#5865f2] text-sm font-bold text-white'
           aria-hidden='true'
         >
-          {serverName[0].toUpperCase()}
+          {safeServerName[0].toUpperCase()}
         </div>
 
         {/* Server info */}
         <div className='min-w-0 flex-1'>
-          <p className='truncate text-sm font-semibold text-white'>{serverName}</p>
+          <p className='truncate text-sm font-semibold text-white'>{safeServerName}</p>
           <p className='text-xs text-gray-400'>{memberCount.toLocaleString()} members</p>
         </div>
 

--- a/harmony-frontend/src/lib/utils.ts
+++ b/harmony-frontend/src/lib/utils.ts
@@ -121,6 +121,18 @@ export function truncate(text: string, maxLength: number): string {
   return text.slice(0, maxLength) + '...';
 }
 
+export function sanitizeDisplayLabel(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\\/g, '/')
+    .split('/')
+    .map(segment => segment.trim())
+    .filter(segment => segment.length > 0 && segment !== '.' && segment !== '..')
+    .join(' / ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 /**
  * Generate a canonical URL for a public channel
  */

--- a/llm-logs/acabrera04-logs/final/2026-04-28-fix-issue-484-019dd579.md
+++ b/llm-logs/acabrera04-logs/final/2026-04-28-fix-issue-484-019dd579.md
@@ -1,0 +1,7213 @@
+# Codex Conversation Export
+
+## Metadata
+
+- Thread ID: 019dd579-c2d3-7350-a286-448f5cb9cae2
+- Timestamp: 2026-04-28T19:03:40.001Z
+- CWD: /Users/allen/.codex/worktrees/20cf/Harmony
+- Source: vscode
+- Model Provider: openai
+- Model: gpt-5.4
+- Reasoning Effort: medium
+- Rollout Path: /Users/allen/.codex/sessions/2026/04/28/rollout-2026-04-28T15-03-40-019dd579-c2d3-7350-a286-448f5cb9cae2.jsonl
+
+## Transcript
+
+### Turn 1: https://github.com/CS485-Harmony/Harmony/issues/484 verify and fix this
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T19:03:41.594Z
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/484 verify and fix this issue. make a PR if you made changes
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:03:48.777Z
+
+I’m pulling the issue details and the repo workflow first, then I’ll reproduce the reported behavior before changing code.
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "484|issue 484|#484" /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+0 matches for '484|issue 484|#484'
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read WORKFLOW.md
+```
+
+Output:
+
+````text
+## Workflow Orchestration
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean 
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop 
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests - then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+This project uses a **hybrid approach**: `tasks/todo.md` for AI context, GitHub Issues as the canonical tracker on the Harmony Project Board (course requirement).
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items (local scratch pad for AI context)
+2. **Identify the Issue**: If the task maps to an existing GitHub Issue, note the issue number at the top of `tasks/todo.md`
+3. **Announce Start**: Post an opening comment to the issue — `gh issue comment <number> --body "..."` — describing what will be done
+4. **Track Progress**: Mark items complete in `tasks/todo.md` as you go; post a comment to the issue at meaningful milestones (e.g., after a major step or when blocked)
+5. **Explain Changes**: High-level summary at each step
+6. **Document Results**: Add a review section to `tasks/todo.md` and post a final summary comment to the issue when complete
+7. **Capture Lessons**: Update `tasks/lessons.md` after corrections. Post the new lessons learned as a comment to the issue.
+
+### Issue Comment Format
+Use this structure for issue comments to keep the audit trail readable:
+
+```
+**[AI Agent — <Step>]**
+
+<What was done or decided>
+
+<Any blockers, decisions, or next steps>
+```
+
+Example steps: `Starting`, `In Progress`, `Blocked`, `Complete`
+
+## Core Principles
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
+- **Lean Context Files**: Keep AGENTS.md and similar files to only non-obvious, non-discoverable essentials. Research shows context file bloat decreases task success rates and increases inference cost by 20%+ with 2–4 extra steps per task (Gloaguen et al., 2026).
+
+
+#### Taken from https://x.com/mdancho84/status/2023738764841894352
+
+Gloaguen, T., Mündler, N., Müller, M., Raychev, V., & Vechev, M. (2026, February 12). Evaluating AGENTS.MD: Are Repository-Level context Files helpful for coding agents? arXiv.org. https://arxiv.org/abs/2602.11988
+````
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short --branch
+```
+
+Output:
+
+```text
+## HEAD (no branch)
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:03:52.544Z
+
+I have the repo workflow and the worktree is on detached `HEAD`. Next I’m pulling the issue, checking the current task scratchpad, and reproducing the report before I create a branch or edit anything.
+
+#### Tool: update_plan
+
+- Explanation: Working issue #484 end-to-end: capture workflow requirements, verify the bug, fix only if reproducible, then verify and publish.
+
+- Plan:
+  - [in_progress] Inspect issue #484 details and current repo/task context
+  - [pending] Reproduce and validate the reported bug locally
+  - [pending] Implement the minimal fix and add/update tests if needed
+  - [pending] Run formatter, typecheck, and relevant tests
+  - [pending] Create branch, commit with required co-author, push, and open draft PR if changes are made
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue view 484 --json number,title,body,state,author,labels,url
+```
+
+Output:
+
+```text
+error connecting to api.github.com
+check your internet connection or https://githubstatus.com
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls tasks
+```
+
+Output:
+
+```text
+lessons.md  9.5K
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read AGENTS.md
+```
+
+Output:
+
+```text
+# Agent Instructions for Harmony
+
+This file provides context and guidelines for AI coding agents (GitHub Copilot, Cursor, etc.) working on the Harmony project.
+
+## Harmony is a **search engine indexable chat application** @README.md .
+
+## Agent Workflow Guidelines
+Always write design rationale comments if intentions are not immediately obvious and ensure these comments are up to date.
+Before starting any development task, read and follow the rules in @WORKFLOW.md 
+It defines workflow orchestration, task management, and core principles all agents must follow.
+
+Always check for lint or build errors before committing code.
+
+### Specs/Docs
+- No build/test commands for specifications
+- Jest/Playwright/Lighthouse referenced in specs are design intent for future implementation
+- Specs and architecture documents are located in @docs/
+
+## Key repository conventions
+- Dev specs use a strict numbered structure (`1`–`13`; SEO spec also has `14. Acceptance Criteria`).
+- Preserve spec labeling prefixes exactly: `M#` (modules), `CL-C#`/`CL-D#`/`CL-E#`/`CL-I#` (classes/DTOs/entities/interfaces), `D#`/`T#`/`F#`/`S#`/`B#` (schemas/tech/flows/states).
+- Keep **Section 3 (Class Diagram)** and **Section 4 (List of Classes)** synchronized whenever classes are added/renamed.
+- Preserve canonical visibility enum values exactly: `PUBLIC_INDEXABLE`, `PUBLIC_NO_INDEX`, `PRIVATE`.
+
+- Always verify tests are running successfully in both the backend and the frontend before pushing changes
+
+### Role-Specific Behaviors
+
+#### PR Reviews
+IF your current task involves conducting a code review or reviewing a Pull Request, THEN you MUST read and strictly adhere to the guidelines defined in `@.github/PR_REVIEW.md`. Do not begin the review until you have parsed this file.
+
+#### Addressing Open PRs
+IF your current task involves addressing review comments or requested changes on an open PR (e.g. "babysit PRs", "get PR into approvable state"), THEN use the `resolve-reviews` skill if it is available.
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:04:02.399Z
+
+The GitHub lookup failed on network access, so I’m re-running it with approval. I also confirmed there’s no existing `tasks/todo.md`, so I’ll create the scratchpad once I have the issue details.
+
+#### Tool: exec_command
+
+```sh
+gh issue view 484 --json number,title,body,state,author,labels,url
+```
+
+Output:
+
+```text
+{"author":{"id":"U_kgDOCKUwww","is_bot":false,"login":"acabrera04","name":"Allen Cabrera"},"body":"## Summary\nA channel route renders a path-like server slug in the browser title.\n\n## Actual behavior\nAt `https://harmony-dun-omega.vercel.app/c/admin/general`, the page title is:\n- `general - ../../../admin | Harmony`\n\n## Expected behavior\nTitle should use a safe, sanitized server display value (no path-like segments such as `../`).\n\n## Repro steps (production)\n1. Open `https://harmony-dun-omega.vercel.app/c/admin/general`.\n2. Check the browser tab title.\n3. Observe it renders `general - ../../../admin | Harmony`.\n\n## Impact\nUser-facing metadata looks broken/untrusted and may indicate missing slug sanitization in title generation.\n\n## Notes\nThis is dogfood ISSUE-005.\n","labels":[{"id":"LA_kwDORIrGY88AAAACgEHxdw","name":"security","description":"Security vulnerability or hardening","color":"e11d48"}],"number":484,"state":"OPEN","title":"Sanitize server slug in channel page title (renders '../../../admin')","url":"https://github.com/CS485-Harmony/Harmony/issues/484"}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "Harmony\|title\|generateMetadata\|document.title\|server slug\|slug" apps packages src
+```
+
+Output:
+
+```text
+rg: apps: No such file or directory (os error 2)
+rg: packages: No such file or directory (os error 2)
+rg: src: No such file or directory (os error 2)
+0 matches for 'Harmony\|title\|generateMetadata\|document.title\|server slug\|slug'
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read tasks/lessons.md
+```
+
+Output:
+
+```text
+# Lessons Learned
+
+Shared knowledge base for the Harmony team. Add an entry whenever a mistake is caught, a better approach is discovered, or an AI agent is corrected.
+
+---
+
+## Template
+
+**Date:** YYYY-MM-DD  
+**Caught by:** [Human: @username] or [AI Agent: Copilot/Cursor]  
+**Related Issue:** #<number> (optional)  
+**Mistake / Situation:** One sentence describing what went wrong or what was unclear.  
+**Rule / Fix:** The actionable rule derived — written so it prevents the same mistake next time.
+
+---
+
+## Log
+
+<!-- Most recent entries at the top -->
+
+**Date:** 2026-04-23  
+**Caught by:** [Human: user]  
+**Related Issue:** #354  
+**Mistake / Situation:** I changed the GitHub issue and PR scope to defer acceptance criteria instead of implementing the missing worker-consumer path that the issue explicitly required.  
+**Rule / Fix:** When a Harmony issue's acceptance criteria are still technically feasible on the active PR branch, do not narrow scope or create a follow-up issue without explicit user approval; implement the missing work on the branch first and treat scope changes as an escalation path, not a default solution.
+
+**Date:** 2026-04-11  
+**Caught by:** [Human: user]  
+**Related Issue:** #313  
+**Mistake / Situation:** I changed the password verifier flow but left backend-only PBKDF2 helpers and E2E bootstrap code deriving with the literal hex salt string instead of decoded salt bytes, so browser auth and E2E diverged from local service tests.  
+**Rule / Fix:** When introducing a client/server crypto contract, centralize or explicitly mirror the byte-level encoding rules across backend helpers, tests, seed data, and E2E bootstraps; verify at least one browser-facing path, not just service-level tests.
+
+**Date:** 2026-04-11  
+**Caught by:** [Human: user]  
+**Related Issue:** #313  
+**Mistake / Situation:** I updated auth-related tests for the new verifier contract but missed another backend suite that still called `authService.register` with the old 3-argument signature, which broke CI.  
+**Rule / Fix:** After changing any shared service contract, grep the full repo for old call sites and run at least the affected package typecheck before pushing so stale compile-time usages do not escape to CI.
+
+**Date:** 2026-04-11  
+**Caught by:** [Human: user]  
+**Related Issue:** #313  
+**Mistake / Situation:** I began patching the auth implementation in the same pass as test creation instead of first proving the security regression with a failing test run.  
+**Rule / Fix:** For every non-trivial Harmony code change, especially security work, do strict red-green-refactor: write or update the regression tests first, run them to capture the red state, and only then modify implementation.
+
+**Date:** 2026-04-04  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I assumed serial CI workers and relaxed auth throttles were enough, but the WebKit-only auth flake was still tied to running the Next frontend in dev mode inside GitHub Actions.  
+**Rule / Fix:** For browser E2E in CI, prefer production-style frontend serving (`build + start`) over `next dev`; dev-mode tooling can introduce non-product flakiness that hides the real signal of the suite.
+
+**Date:** 2026-04-04  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I kept a browser matrix in the PR-gating CI path even after reproducing that only WebKit was flaky under CI-mode E2E, which blocked the suite without proving a product defect.  
+**Rule / Fix:** Keep every-PR E2E checks focused on the stable smoke browser for this repo, and move additional browser coverage like WebKit to non-blocking or follow-up coverage until the browser-specific flake has a rooted product cause.
+
+**Date:** 2026-04-01  
+**Caught by:** [Human: @acabrera04]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The new E2E suite passed locally but still failed in CI because production-style auth rate limits and full worker parallelism interacted badly with concurrent browser runs.  
+**Rule / Fix:** When adding full-stack E2E to CI, review backend throttles and shared-state assumptions explicitly; either relax them for `NODE_ENV=e2e` or reduce CI concurrency so auth/setup traffic cannot invalidate the suite.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The E2E suite mixed selector expectations based on route slugs with UI labels rendered from channel display names, and one startup preflight used a one-shot auth check while the rest of setup retried.  
+**Rule / Fix:** E2E assertions must target the exact accessibility text the UI renders, not adjacent seed identifiers, and all backend readiness checks should share the same retry semantics so cold-start timing does not create false failures.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** E2E preflight initially verified seeded content but skipped critical auth assumptions, and the shared E2E helper encoded environment defaults too implicitly.  
+**Rule / Fix:** E2E preconditions must verify every special-case fixture the suite depends on, including auth overrides, and shared test helpers should avoid hidden runtime defaults like hardcoded `NODE_ENV`.
+
+**Date:** 2026-03-31  
+**Caught by:** [AI Agent: Claude]  
+**Related Issue:** N/A  
+**Mistake / Situation:** The first true-E2E pass duplicated stack constants across TS and Node launcher files and allowed local server reuse, which made reruns stateful and brittle.  
+**Rule / Fix:** For stateful E2E stacks, keep shared ports/URLs/test credentials in one cross-runtime JS module and force the backend launcher to restart/reset locally unless there is an explicit reason to preserve state.
+**Date:** 2026-03-31  
+**Caught by:** [Human: user]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I left brittle expectations inside integration-test helpers, used a vacuous exclusion assertion in a membership-scoping test, hardcoded a slug-collision suffix, and missed unauthenticated plus join/leave coverage in the server lifecycle suite.  
+**Rule / Fix:** In Harmony integration tests, keep helpers assertion-light with descriptive failures, avoid vacuous negatives by asserting the response shape/status first, never hardcode collision suffixes when uniqueness is data-dependent, and cover both unauthenticated access and core membership transitions for authenticated server flows.
+
+**Date:** 2026-03-31  
+**Caught by:** [Human: user]  
+**Related Issue:** N/A  
+**Mistake / Situation:** I initially called a mocked page-level test an integration test and also let a backend integration suite depend on state created in a prior `it` block.  
+**Rule / Fix:** In this repo, only call a test "integration" when it crosses real module boundaries without mocking application internals, and keep each integration test self-contained so it does not rely on execution order across `it` blocks.
+**Date:** 2026-04-03  
+**Caught by:** [Human: user]  
+**Mistake / Situation:** I renamed the branch and PR for a log export when the user meant to rename the exported log file itself.  
+**Rule / Fix:** When a user asks to "rename it" during log-export/PR work, confirm whether the target is the file, branch, PR, or commit before changing GitHub metadata; if context strongly points to the artifact path, rename the file first.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Related Issue:** #331  
+**Mistake / Situation:** I described the preferred custom-domain deployment contract too prominently in the root README when the user wanted the current live Vercel and Railway hostnames treated as the actual deployment URLs.  
+**Rule / Fix:** In Harmony deployment docs, present the currently serving hostnames as the source of truth unless the task is explicitly about future domain setup; mention custom domains only as preferred future state when they are not actually configured.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Related Issue:** #331  
+**Mistake / Situation:** I documented `npm run dev` and `npm run dev:worker` as if the worker would naturally stay on `4100`, but the backend `.env.example` sets `PORT=4000`, so both processes collide unless the worker port is overridden explicitly.  
+**Rule / Fix:** When documenting split-process local startup in Harmony, verify how `.env` values interact with entrypoint defaults; if a shared `PORT` variable exists, either force the worker dev script to `4100` or document an explicit `PORT=4100` override instead of relying on fallback defaults.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Related Issue:** #331  
+**Mistake / Situation:** I wrote a chained `cd` sequence in the README that ended with `cd ..` after entering `tests/integration`, which only returns to `tests/` rather than the repository root.  
+**Rule / Fix:** When documenting multi-step shell navigation in Harmony, trace the working directory after each `cd` and prefer exact return paths like `cd ../..` when the instructions are meant to end back at the repo root.
+
+**Date:** 2026-04-19  
+**Caught by:** [Human: user]  
+**Mistake / Situation:** I documented `npm run test:integration` from the repo root without verifying the actual root script invocation. The root script was forwarding an extra `--config jest.config.js` even though the integration package already sets its own config, which breaks Jest argument parsing.  
+**Rule / Fix:** For Harmony root wrapper scripts, always execute the command once from the repo root before documenting it. If the delegated package already owns its config flags, the root wrapper should forward cleanly instead of duplicating CLI options.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git branch --all --list "codex/*"
+```
+
+Output:
+
+```text
+* 
+  codex/automate-cloud-integration-tests
+  codex/backend-integration-tests
+  codex/disable-frontend-e2e-pr-trigger
+  codex/expand-sonarjs-ci
+  codex/export-log-019d3f88
+  codex/export-log-019d4b86
+  codex/export-thread-019d54bf
+  codex/fix-cloud-integration-fixtures
+  codex/fix-issue-468-structured-data-fields
+  codex/fix-issue-476-sitemap-reliability
+  codex/fix-server-settings-auth
+  codex/fix-sitemap-host-issue-371
+  codex/fix-sse-readiness-window
+  codex/frontend-safe-logging
+  codex/google-search-console-verification
+  codex/improve-mcdc-tests
+  codex/integration-e2e-readme
+  codex/issue-194-logging
+  codex/issue-260-frontend-server-service-spec
+  codex/issue-261-frontend-channel-service-spec
+  codex/issue-262-ci-workflows
+  codex/issue-268-server-member-test-spec
+  codex/issue-269-server-member-service-tests
+  codex/issue-289-public-api-service-spec
+  codex/issue-290-public-api-service-tests
+  codex/issue-313-password-verifier
+  codex/issue-316-deployment-architecture
+  codex/issue-321-frontend-production-config
+  codex/issue-330-deployment-evidence
+  codex/issue-331-readme
+  codex/issue-338-private-channel-lock
+  codex/issue-359-seo-admin-ui
+  codex/issue-363-readme-deployer-pass
+  codex/issue-376-signup-empty-data-regression
+  + codex/issue-483-guest-message-actions
+  + codex/issue-490-presence
+  codex/issue-490-presence-leases
+  codex/issue-502-wire-edit-message-trpc
+  codex/log-board-testing-submission-thread
+  codex/pr-277-review
+  codex/pr-277-review-2
+  codex/pr-302-review
+  + codex/pr-303-review
+  + codex/pr-314-review
+  codex/pr-506-review
+  codex/readme-test-instructions
+  codex/retry-cloud-fixture-discovery
+  codex/review-pr-280
+  codex/review-pr-280-v2
+  codex/root-jest-workflow
+  + codex/self-host-font-build
+  codex/silence-public-router-test-console-errors
+  codex/sprint-4-deployment-plan
+  codex/true-e2e-auth-coverage
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:04:27.485Z
+
+I have the issue now: the browser title is rendering `general - ../../../admin | Harmony`, which points to unsafe slug handling in metadata generation. I’m locating the route and title code path next so I can reproduce the exact source of the bad value.
+
+#### Tool: exec_command
+
+```sh
+rtk ls
+```
+
+Output:
+
+```text
+.claude/
+.github/
+docs/
+harmony-backend/
+harmony-frontend/
+llm-logs/
+mockups/
+planning/
+scripts/
+tasks/
+tests/
+.gitignore  66B
+AGENTS.md  1.9K
+CLAUDE.md  11B
+README.md  13.7K
+WORKFLOW.md  3.7K
+dev-spec-guidelines.pdf  507.5K
+dev.sh  2.1K
+package.json  422B
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "generateMetadata|title:|document.title|\\| Harmony|serverSlug|channelSlug|params\.slug|params\.server|slug" frontend backend
+```
+
+Output:
+
+```text
+rg: frontend: No such file or directory (os error 2)
+rg: backend: No such file or directory (os error 2)
+0 matches for 'generateMetadata|title:|document.title|\| Harmony|serverSlug|channelSlug|params\.slug|params\.server|slug'
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "generateMetadata|document.title|\\| Harmony|serverSlug|channelSlug|params\.slug|params\.server|slug" harmony-frontend harmony-backend
+```
+
+Output:
+
+```text
+80590 matches in 323F:
+
+[file] harmony-backend/.env.example (65):
+     1: # Environment — set to 'production' in prod, 'test' for the test suite.
+     2: # Missing JWT secrets cause a hard crash unless NODE_ENV=test.
+     3: NODE_ENV=development
+     4: 
+     5: # Server
+     6: PORT=4000
+     7: 
+     8: # Database (matches docker-compose.yml defaults)
+     9: DATABASE_URL=postgresql://harmony:harmony@localhost:5432/harmony_dev
+    10: 
+    11: # Redis (matches docker-compose.yml defaults)
+    12: REDIS_URL=redis://:devsecret@localhost:6379
+    13: 
+    14: # Frontend origins allowed by CORS — comma-separated list of allowed origins.
+    15: # In Railway, set to the deployed Vercel URL and optionally the production do...
+    16: # FRONTEND_URL=https://harmony-dun-omega.vercel.app,https://harmony.chat
+    17: FRONTEND_URL=http://localhost:3000
+    18: 
+    19: # Canonical public frontend origin used for generated public links and sitemaps
+    20: BASE_URL=http://localhost:3000
+    21: 
+    22: # Railway proxy hop count — set to 1 in Railway (behind one proxy layer) so
+    23: # express-rate-limit reads the real client IP from X-Forwarded-For.
+    24: # Leave unset in local dev (no proxy).
+    25: # TRUST_PROXY_HOPS=1
+  +40
+
+[file] harmony-backend/README.md (285):
+     1: # Harmony Backend
+     2: 
+     3: Express + tRPC server for the Harmony chat application.
+     4: 
+     5: ## Architecture
+     6: 
+     7: > **Before making changes to this backend, read the unified backend architect...
+     8: > [`docs/unified-backend-architecture.md`](../docs/unified-backend-architectu...
+     9: 
+    10: The architecture doc covers:
+    11: 
+    12: - **Module map** — what each module (M-B1–M-B7, M-D1–M-D3) owns and its bound...
+    13: - **Class diagrams** — all services, repositories, controllers, entities, and...
+    14: - **Data model** — ER diagram for all shared database tables
+    15: - **API surface** — tRPC procedures and public REST endpoints
+    16: - **Event bus** — Redis Pub/Sub event flow between modules
+    17: - **Cache strategy** — Redis key layout and TTLs
+    18: - **Security model** — rate limiting, visibility guards, content filtering
+    19: 
+    20: ---
+    21: 
+    22: ## Dependencies
+    23: 
+    24: ### Frameworks & Runtime
+    25: 
+  +260
+
+[file] harmony-backend/docker-compose.e2e.yml (27):
+     1: services:
+     2: postgres:
+     3: image: postgres:16
+     4: restart: unless-stopped
+     5: environment:
+     6: POSTGRES_USER: harmony
+     7: POSTGRES_PASSWORD: harmony
+     8: POSTGRES_DB: harmony_e2e
+     9: ports:
+    10: - '55432:5432'
+    11: healthcheck:
+    12: test: ['CMD-SHELL', 'pg_isready -U harmony -d harmony_e2e']
+    13: interval: 5s
+    14: timeout: 5s
+    15: retries: 20
+    16: 
+    17: redis:
+    18: image: redis:7-alpine
+    19: restart: unless-stopped
+    20: command: 'redis-server --requirepass e2esecret'
+    21: ports:
+    22: - '56379:6379'
+    23: healthcheck:
+    24: test: ['CMD-SHELL', 'redis-cli -a e2esecret ping | grep PONG']
+    25: interval: 5s
+  +2
+
+[file] harmony-backend/docker-compose.yml (25):
+     1: services:
+     2: postgres:
+     3: image: postgres:16
+     4: restart: unless-stopped
+     5: environment:
+     6: POSTGRES_USER: harmony
+     7: POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-harmony}
+     8: POSTGRES_DB: harmony_dev
+     9: ports:
+    10: - "5432:5432"
+    11: volumes:
+    12: - postgres_data:/var/lib/postgresql/data
+    13: 
+    14: redis:
+    15: image: redis:7-alpine
+    16: restart: unless-stopped
+    17: command: "redis-server --requirepass ${REDIS_PASSWORD:-devsecret}"
+    18: ports:
+    19: - "6379:6379"
+    20: volumes:
+    21: - redis_data:/data
+    22: 
+    23: volumes:
+    24: postgres_data:
+    25: redis_data:
+
+[file] harmony-backend/eslint.config.mjs (20):
+     1: import { defineConfig, globalIgnores } from 'eslint/config';
+     2: import tsPlugin from '@typescript-eslint/eslint-plugin';
+     3: import prettierConfig from 'eslint-config-prettier';
+     4: 
+     5: const eslintConfig = defineConfig([
+     6: ...tsPlugin.configs['flat/recommended'],
+     7: {
+     8: files: ['src/**/*.ts', 'tests/**/*.ts'],
+     9: rules: {
+    10: '@typescript-eslint/no-unused-vars': [
+    11: 'warn',
+    12: { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    13: ],
+    14: },
+    15: },
+    16: prettierConfig,
+    17: globalIgnores(['dist/**', 'node_modules/**']),
+    18: ]);
+    19: 
+    20: export default eslintConfig;
+
+[file] harmony-backend/jest.config.js (12):
+     1: /** @type {import('ts-jest').JestConfigWithTsJest} */
+     2: module.exports = {
+     3: preset: 'ts-jest',
+     4: testEnvironment: 'node',
+     5: setupFiles: ['dotenv/config'],
+     6: roots: ['<rootDir>/tests'],
+     7: testMatch: ['**/*.test.ts'],
+     8: moduleFileExtensions: ['ts', 'js', 'json'],
+     9: transform: {
+    10: '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
+    11: },
+    12: };
+
+[file] harmony-backend/package-lock.json (9771):
+     1: {
+     2: "name": "harmony-backend",
+     3: "version": "0.1.0",
+     4: "lockfileVersion": 3,
+     5: "requires": true,
+     6: "packages": {
+     7: "": {
+     8: "name": "harmony-backend",
+     9: "version": "0.1.0",
+    10: "dependencies": {
+    11: "@aws-sdk/client-s3": "^3.1030.0",
+    12: "@prisma/client": "^5.22.0",
+    13: "@trpc/server": "^11.0.0",
+    14: "bcryptjs": "^3.0.3",
+    15: "bullmq": "^5.75.2",
+    16: "cors": "^2.8.5",
+    17: "express": "^4.21.2",
+    18: "express-rate-limit": "^8.3.0",
+    19: "file-type": "^21.3.2",
+    20: "helmet": "^8.1.0",
+    21: "ioredis": "^5.10.0",
+    22: "jsonwebtoken": "^9.0.3",
+    23: "multer": "^2.1.1",
+    24: "pino": "^10.3.1",
+    25: "rate-limit-redis": "^4.3.1",
+  +9746
+
+[file] harmony-backend/package.json (69):
+     1: {
+     2: "name": "harmony-backend",
+     3: "version": "0.1.0",
+     4: "private": true,
+     5: "scripts": {
+     6: "dev": "tsx watch src/index.ts",
+     7: "dev:worker": "PORT=4100 tsx watch src/worker.ts",
+     8: "dev:e2e": "NODE_ENV=e2e PORT=4000 tsx src/index.ts",
+     9: "dev:e2e:worker": "NODE_ENV=e2e PORT=4100 tsx src/worker.ts",
+    10: "build": "tsc",
+    11: "start": "node dist/index.js",
+    12: "start:api": "node dist/index.js",
+    13: "start:worker": "node dist/worker.js",
+    14: "lint": "eslint src tests",
+    15: "test": "jest",
+    16: "db:seed:mock": "prisma db seed",
+    17: "db:seed:demo": "tsx src/dev/demoSeed.ts"
+    18: },
+    19: "prisma": {
+    20: "seed": "tsx prisma/seed.ts"
+    21: },
+    22: "dependencies": {
+    23: "@aws-sdk/client-s3": "^3.1030.0",
+    24: "@prisma/client": "^5.22.0",
+    25: "@trpc/server": "^11.0.0",
+  +44
+
+[file] harmony-backend/.../20260305161727_init/migration.sql (184):
+     1: -- CreateEnum
+     2: CREATE TYPE "channel_visibility" AS ENUM ('PUBLIC_INDEXABLE', 'PUBLIC_NO_INDE...
+     3: 
+     4: -- CreateEnum
+     5: CREATE TYPE "channel_type" AS ENUM ('TEXT', 'VOICE', 'ANNOUNCEMENT');
+     6: 
+     7: -- CreateTable
+     8: CREATE TABLE "users" (
+     9: "id" UUID NOT NULL,
+    10: "username" VARCHAR(32) NOT NULL,
+    11: "display_name" VARCHAR(100) NOT NULL,
+    12: "avatar_url" VARCHAR(500),
+    13: "public_profile" BOOLEAN NOT NULL DEFAULT true,
+    14: "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    15: 
+    16: CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+    17: );
+    18: 
+  +159
+
+... +80390
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "admin/general|../../../admin|server slug|sanitize" harmony-frontend harmony-backend tests
+```
+
+Output:
+
+```text
+145 matches in 43F:
+
+[file] harmony-backend/src/dev/mockSeed.ts (1):
+   357: (server) => `server slug "${server.slug}" already exists with a different id ...
+
+[file] harmony-backend/.../storage/storage.interface.ts (1):
+    13: /** Resolved filename (may differ from input if sanitized/de-duped). */
+
+[file] harmony-backend/.../repositories/metaTag.repository.ts (1):
+    33: * Persist custom override fields as-is. Does NOT sanitize inputs.
+
+[file] harmony-backend/src/routes/admin.metaTag.router.ts (1):
+   195: // Route through service: sanitizes HTML/PII, HTML-encodes text, invalidates ...
+
+[file] harmony-backend/src/routes/public.router.ts (3):
+     7: import { cacheService, CacheKeys, CacheTTL, sanitizeKeySegment } from '../ser...
+    89: `channel:msg:${sanitizeKeySegment(req.params.channelId)}:${sanitizeKeySegment...
+   236: const cacheKey = `server:${sanitizeKeySegment(server.id)}:public_channels`;
+
+[file] harmony-backend/src/services/cache.service.ts (6):
+    21: export function sanitizeKeySegment(segment: string): string {
+    27: channelVisibility: (id: string) => `channel:${sanitizeKeySegment(id)}:visibil...
+    29: `channel:msgs:${sanitizeKeySegment(id)}:page:${page}`,
+    30: serverInfo: (id: string) => `server:${sanitizeKeySegment(id)}:info`,
+    31: metaChannel: (id: string) => `meta:channel:${sanitizeKeySegment(id)}`,
+    32: analysisChannel: (id: string) => `analysis:channel:${sanitizeKeySegment(id)}`,
+
+[file] harmony-backend/.../services/cacheInvalidator.service.ts (5):
+    22: import { cacheService, CacheKeys, sanitizeKeySegment } from './cache.service';
+    55: .invalidate(`server:${sanitizeKeySegment(payload.serverId)}:public_channels`)
+    82: .invalidatePattern(`channel:msgs:${sanitizeKeySegment(payload.channelId)}:*`)
+   111: .invalidatePattern(`channel:msgs:${sanitizeKeySegment(payload.channelId)}:*`)
+   140: .invalidatePattern(`channel:msgs:${sanitizeKeySegment(payload.channelId)}:*`)
+
+[file] harmony-backend/src/services/channel.service.ts (6):
+     4: import { cacheService, CacheKeys, CacheTTL, sanitizeKeySegment } from './cach...
+    99: .invalidate(`server:${sanitizeKeySegment(serverId)}:public_channels`)
+   139: .invalidatePattern(`channel:msgs:${sanitizeKeySegment(channelId)}:*`)
+   144: .invalidate(`server:${sanitizeKeySegment(channel.serverId)}:public_channels`)
+   187: .invalidatePattern(`channel:msgs:${sanitizeKeySegment(channelId)}:*`)
+   195: .invalidate(`server:${sanitizeKeySegment(channel.serverId)}:public_channels`)
+
+[file] harmony-backend/src/services/indexing.service.ts (2):
+    13: import { cacheService, sanitizeKeySegment } from './cache.service';
+    23: serverSitemap: (serverSlug: string) => `sitemap:${sanitizeKeySegment(serverSl...
+
+[file] harmony-backend/src/services/message.service.ts (13):
+     4: import { cacheService, CacheTTL, sanitizeKeySegment } from './cache.service';
+    76: const c = sanitizeKeySegment(cursor ?? 'start');
+    78: `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)...
+   166: `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)...
+   208: `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(message.ch...
+   283: `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(message.ch...
+   292: .invalidatePattern(`thread:msgs:${sanitizeKeySegment(threadCacheId)}:*`)
+   332: `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(updated.ch...
+   364: `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(updated.ch...
+   439: `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)...
+   448: .invalidatePattern(`thread:msgs:${sanitizeKeySegment(parentMessageId)}:*`)
+   481: `thread:msgs:${sanitizeKeySegment(parentMessageId)}` +
+   482: `:cursor:${sanitizeKeySegment(cursor ?? 'start')}:limit:${clampedLimit}`;
+
+[file] harmony-backend/.../metaTag/contentFilter.ts (1):
+    73: sanitizeForHead(text: string): string {
+
+[file] harmony-backend/.../metaTag/descriptionGenerator.ts (5):
+    12: sanitizeText(text: string): string;
+    20: const serverName = this.sanitizeText(channel.serverName);
+    21: const channelName = this.sanitizeText(channel.name);
+    60: sanitizeText(text: string): string {
+    67: return this.sanitizeText(messages[0].content);
+
+[file] harmony-backend/.../metaTag/metaTagService.ts (11):
+    39: function sanitizeChannelContext(channel: ChannelContext): ChannelContext {
+    42: name: TitleGenerator.sanitizeForTitle(channel.name),
+    43: serverName: TitleGenerator.sanitizeForTitle(channel.serverName),
+    48: const safe = sanitizeChannelContext(channel);
+   527: sanitizeCustomOverride(value: string | null | undefined): string | null {
+   544: const sanitized: typeof overrides = {};
+   546: sanitized.customTitle = metaTagService.sanitizeCustomOverride(overrides.custo...
+   549: sanitized.customDescription = metaTagService.sanitizeCustomOverride(
+   554: sanitized.customOgImage = overrides.customOgImage; // URL already validated b...
+   556: if (Object.keys(sanitized).length === 0) {
+   561: const updated = await metaTagRepository.updateCustomOverrides(channelId, sani...
+
+[file] harmony-backend/.../metaTag/titleGenerator.ts (4):
+    14: sanitizeForTitle(text: string): string;
+    24: return this.truncateWithEllipsis(this.sanitizeForTitle(raw));
+    29: return this.truncateWithEllipsis(this.sanitizeForTitle(raw));
+    44: sanitizeForTitle(text: string): string {
+
+[file] harmony-backend/src/services/reaction.service.ts (2):
+     3: import { cacheService, sanitizeKeySegment } from './cache.service';
+    61: return `reactions:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(messag...
+
+[file] harmony-backend/src/services/voice.service.ts (3):
+    32: function sanitizeSegment(segment: string): string {
+    38: return `voice:channel:${sanitizeSegment(channelId)}:participants`;
+    43: return `voice:user:${sanitizeSegment(userId)}:voice`;
+
+[file] harmony-backend/tests/cache.service.test.ts (6):
+     9: import { cacheService, CacheKeys, CacheTTL, CacheEntry, sanitizeKeySegment } ...
+    44: describe('sanitizeKeySegment', () => {
+    46: expect(sanitizeKeySegment('abc*def')).toBe('abcdef');
+    47: expect(sanitizeKeySegment('abc?def')).toBe('abcdef');
+    48: expect(sanitizeKeySegment('abc[0]def')).toBe('abc0def');
+    53: expect(sanitizeKeySegment(uuid)).toBe(uuid);
+
+[file] harmony-backend/tests/channel.service.events.test.ts (1):
+    57: sanitizeKeySegment: (s: string) => s,
+
+[file] harmony-backend/tests/channel.service.test.ts (2):
+    42: sanitizeKeySegment: (s: string) => s,
+   175: it('CS-4: throws NOT_FOUND when server slug does not match any server', async...
+
+[file] harmony-backend/tests/contentFilter.test.ts (22):
+     7: *  - XSS / HTML attribute injection escaping via sanitizeForHead
+    30: sanitizeKeySegment: (s: string) => s.replace(/[*?\[\]]/g, ''),
+   137: describe('ContentFilter.sanitizeForHead — attribute injection prevention', ()...
+   140: const result = ContentFilter.sanitizeForHead(malicious);
+   151: const result = ContentFilter.sanitizeForHead(injection);
+   161: const result = ContentFilter.sanitizeForHead(injection);
+   171: expect(ContentFilter.sanitizeForHead(input)).toBe('hello world');
+   202: it.each(XSS_FIXTURES)('sanitizeForHead blocks $label', ({ input }) => {
+   203: const output = ContentFilter.sanitizeForHead(input);
+   216: const safe = ContentFilter.sanitizeForHead(maliciousTitle);
+   224: const safe = ContentFilter.sanitizeForHead(maliciousDesc);
+   261: it('sanitizeCustomOverride strips HTML and escapes for <head>', () => {
+   262: const result = metaTagService.sanitizeCustomOverride('<b>Hello</b> & "world"');
+   266: it('sanitizeCustomOverride returns null for null input', () => {
+   267: expect(metaTagService.sanitizeCustomOverride(null)).toBeNull();
+   268: expect(metaTagService.sanitizeCustomOverride(undefined)).toBeNull();
+   271: it('sanitizeCustomOverride filters PII before encoding', () => {
+   272: const result = metaTagService.sanitizeCustomOverride('Contact admin@corp.com ...
+   277: it('sanitizeCustomOverride blocks tag-splitting profanity bypass', () => {
+   279: const result = metaTagService.sanitizeCustomOverride('f<b>u</b>ck this');
+   285: it('sanitizeCustomOverride blocks tag-splitting email bypass', () => {
+   286: const result = metaTagService.sanitizeCustomOverride('alice@<b>example</b>.co...
+
+[file] harmony-backend/tests/events.router.member.test.ts (1):
+    72: sanitizeKeySegment: (s: string) => s,
+
+[file] harmony-backend/tests/events.router.server.test.ts (1):
+    69: sanitizeKeySegment: (s: string) => s,
+
+[file] harmony-backend/tests/events.router.sse-server-updated.test.ts (1):
+    65: sanitizeKeySegment: (s: string) => s,
+
+[file] harmony-backend/tests/events.router.status.test.ts (1):
+    72: sanitizeKeySegment: (s: string) => s,
+
+[file] harmony-backend/tests/events.router.test.ts (1):
+    66: sanitizeKeySegment: (s: string) => s,
+
+[file] harmony-backend/tests/events.router.visibility.test.ts (1):
+    72: sanitizeKeySegment: (s: string) => s,
+
+[file] harmony-backend/tests/message.service.events.test.ts (1):
+    74: sanitizeKeySegment: (s: string) => s,
+
+[file] harmony-backend/tests/metaTagService.test.ts (6):
+    24: sanitizeKeySegment: (s: string) => s.replace(/[*?\[\]]/g, ''),
+    90: it('sanitizeForTitle strips HTML tags', () => {
+    91: const result = TitleGenerator.sanitizeForTitle('<b>Hello</b> <em>world</em>');
+    95: it('sanitizeForTitle collapses whitespace', () => {
+    96: const result = TitleGenerator.sanitizeForTitle('foo   bar\n  baz');
+   369: it('sanitizes customTitle and customDescription before persisting', async () ...
+
+[file] harmony-backend/tests/mock-seed.test.ts (1):
+    38: it('preserves server slugs and derives public visibility from channel data', ...
+
+[file] harmony-backend/tests/public.router.test.ts (6):
+    69: sanitizeKeySegment: (s: string) => s.replace(/[*?[\]]/g, ''),
+   143: it('returns 404 when the server slug does not exist', async () => {
+   152: it('CWE-862: returns 404 for a private server slug (isPublic filter enforced)...
+   204: it('returns 404 when the server slug does not exist', async () => {
+   660: it('PR-33: returns 404 and never calls cacheService.getOrRevalidate when serv...
+   809: it('PR-44: returns 404 when the server slug does not exist', async () => {
+
+[file] harmony-frontend/.../__tests__/channelService.test.ts (1):
+   262: it('encodes server slug in URL', async () => {
+
+[file] harmony-frontend/.../__tests__/frontend-logger.test.ts (3):
+     1: import { buildFrontendLogEntry, sanitizeLogMetadata } from '../lib/frontend-l...
+     5: const fields = sanitizeLogMetadata({
+    24: it('sanitizes route-like fields and only keeps safe error details', () => {
+
+[file] harmony-frontend/.../__tests__/runtime-config.test.ts (1):
+    39: expect(getChannelUrl('server slug', 'general chat')).toBe(
+
+[file] harmony-frontend/src/app/channels/actions.ts (4):
+    19: let sanitizedDescription: string | undefined;
+    21: sanitizedDescription = undefined;
+    24: sanitizedDescription = descTrimmed || undefined;
+    30: const server = await createServer({ name: trimmed, description: sanitizedDesc...
+
+[file] harmony-frontend/.../[channelSlug]/actions.ts (4):
+    46: const sanitizedPatch: Partial<Pick<Channel, 'name' | 'topic'>> = {};
+    52: sanitizedPatch.name = trimmed;
+    56: sanitizedPatch.topic = patch.topic;
+    60: await updateChannel(channel.id, server.id, sanitizedPatch);
+
+[file] harmony-frontend/.../[serverSlug]/actions.ts (6):
+    29: const sanitizedPatch: Partial<Pick<Server, 'name' | 'description' | 'icon' | ...
+    36: sanitizedPatch.name = trimmed;
+    40: sanitizedPatch.description = patch.description.trim();
+    44: sanitizedPatch.icon = patch.icon.trim();
+    48: sanitizedPatch.isPublic = patch.isPublic;
+    52: await updateServer(server.id, sanitizedPatch);
+
+[file] harmony-frontend/src/components/channel/TopBar.tsx (1):
+   152: /** The server slug, used to build the settings link */
+
+[file] harmony-frontend/src/lib/frontend-logger.ts (2):
+    88: export function sanitizeLogMetadata(
+   123: fields: sanitizeLogMetadata(metadata),
+
+[file] harmony-frontend/src/services/channelService.ts (1):
+    56: * Returns a single channel by server slug + channel slug, or null if not found.
+
+[file] harmony-frontend/src/services/publicApiService.ts (1):
+   119: * Fetch a single public channel by server slug + channel slug.
+
+[file] harmony-frontend/tests/e2e/auth.spec.ts (3):
+    11: function sanitizeIdentifier(value: string) {
+    31: const normalizedProject = sanitizeIdentifier(project.name).slice(0, 8);
+   137: const messageText = `E2E message ${sanitizeIdentifier(testInfo.project.name)}...
+
+[file] harmony-frontend/.../support/stack.shared.mjs (1):
+    88: `Seed snapshot is missing the default join server slug "${DEFAULT_JOIN_SERVER...
+
+[file] tests/integration/public-api.test.ts (1):
+    84: test('SSRAPI-5: unknown server slug returns 404', async () => {
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "generateMetadata" harmony-frontend/src/app
+```
+
+Output:
+
+```text
+1 matches in 1F:
+
+[file] harmony-frontend/.../[channelSlug]/page.tsx (1):
+    40: export async function generateMetadata({ params }: PageProps): Promise<Metadata>...
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "buildChannelTitle|serverName|channelName|TitleGenerator|metaTag" harmony-frontend/src harmony-backend/src
+```
+
+Output:
+
+```text
+122 matches in 26F:
+
+[file] harmony-backend/src/app.ts (1):
+    14: import { adminMetaTagRouter } from './routes/admin.metaTag.router';
+
+[file] harmony-backend/.../repositories/metaTag.repository.ts (2):
+    23: export const metaTagRepository = {
+    34: * Callers must go through metaTagService.setCustomOverrides to satisfy AC-8 /...
+
+[file] harmony-backend/src/routes/admin.metaTag.router.ts (11):
+    17: import { metaTagRepository } from '../repositories/metaTag.repository';
+    18: import { metaTagService } from '../services/metaTag/metaTagService';
+    24: import type { MetaTagPreview } from '../services/metaTag/types';
+    32: const metaTagOverrideSchema = z.object({
+    93: record: NonNullable<Awaited<ReturnType<typeof metaTagRepository.findByChannel...
+   142: const record = await metaTagRepository.findByChannelId(channelId);
+   167: const parsed = metaTagOverrideSchema.safeParse(req.body);
+   189: const existing = await metaTagRepository.findByChannelId(channelId);
+   197: const updated = await metaTagService.setCustomOverrides(channelId, overrides);
+   264: await metaTagService.enqueueAdminJob(channelId, jobId);
+   294: const job = await metaTagService.getAdminJobStatus(channelId, jobId);
+
+[file] harmony-backend/src/routes/public.router.ts (2):
+     9: import { metaTagService } from '../services/metaTag/metaTagService';
+   351: const preview = await metaTagService.getMetaTagsForPreview(channel.id);
+
+[file] harmony-backend/.../metaTag/descriptionGenerator.ts (5):
+    20: const serverName = this.sanitizeText(channel.serverName);
+    21: const channelName = this.sanitizeText(channel.name);
+    22: const suffix = ` — Join the discussion on ${serverName}.`;
+    25: const base = `Discussions in #${channelName} on ${serverName}. Join today.`;
+    30: const prefix = `${serverName} › #${channelName}: `;
+
+[file] harmony-backend/.../metaTag/metaTagService.ts (32):
+     6: import { TitleGenerator } from './titleGenerator';
+    10: import { MetaTagCache } from './metaTagCache';
+    12: import { metaTagRepository } from '../../repositories/metaTag.repository';
+    24: import { metaTagUpdateQueue } from '../../workers/metaTagUpdate.queue';
+    42: name: TitleGenerator.sanitizeForTitle(channel.name),
+    43: serverName: TitleGenerator.sanitizeForTitle(channel.serverName),
+    49: const title = `${safe.name} — ${safe.serverName}`;
+    50: const description = `Discussions in #${safe.name} on ${safe.serverName}.`;
+    53: topics: [TitleGenerator.truncateWithEllipsis(title)],
+    59: title: TitleGenerator.truncateWithEllipsis(title),
+   116: serverName: channel.server.name,
+   138: ogSiteName: channel.serverName,
+   301: serverName: channel.server.name,
+   303: canonicalUrl: metaTagService.buildCanonicalUrl(channel.server.slug, channel.s...
+   313: const tags = await metaTagService.generateMetaTagsFromContext(channelCtx, msg...
+   315: await metaTagRepository.saveGeneratedFields(channelId, {
+   359: export const metaTagService = {
+   369: const rawTitle = TitleGenerator.generateFromThread(messages, channel);
+   420: await metaTagRepository.deleteByChannelId(channelId).catch(() => undefined);
+   425: const generated = await metaTagService.generateMetaTagsFromContext(channel, m...
+   430: const rowsUpdated = await metaTagRepository.saveGeneratedFields(channelId, {
+   446: ? await metaTagRepository.findByChannelId(channelId)
+   459: const created = await metaTagRepository.create({
+   497: const tags = await metaTagService.generateMetaTagsFromContext(channel, messag...
+   520: return metaTagService.generateMetaTags(channelId);
+  +7
+
+[file] harmony-backend/.../metaTag/structuredDataGenerator.ts (7):
+    13: headline: `${channel.name} — ${channel.serverName}`,
+    14: description: `Discussions in #${channel.name} on ${channel.serverName}.`,
+    35: name: channel.serverName,
+    58: // Spec §9.1.5: generateWebPage(channel, metaTags)
+    59: generateWebPage(channel: ChannelContext, metaTags: MetaTagSet): StructuredData {
+    63: headline: metaTags.title,
+    64: description: metaTags.description,
+
+[file] harmony-backend/.../metaTag/titleGenerator.ts (9):
+     1: // CL-C2.2 TitleGenerator — generates SEO-optimized titles (AC-2: ≤60 chars)
+     6: const CHANNEL_TEMPLATE = '{channelName} — {serverName}';
+     8: export const TitleGenerator: IMetaTagGenerator & {
+    20: const raw = CHANNEL_TEMPLATE.replace('{channelName}', channel.name).replace(
+    21: '{serverName}',
+    22: channel.serverName,
+    28: const raw = `${message.content} — ${channel.serverName}`;
+    60: throw new Error('TitleGenerator.generate() not yet implemented — wired by M4'...
+    63: throw new Error('TitleGenerator.validate() not yet implemented — wired by M4'...
+
+[file] harmony-backend/src/services/metaTag/types.ts (1):
+    95: serverName: string;
+
+[file] harmony-backend/src/worker.ts (1):
+    20: import { startMetaTagUpdatePipeline, stopMetaTagUpdatePipeline } from './work...
+
+[file] harmony-backend/src/workers/eventListener.ts (5):
+     7: import { metaTagUpdateQueue } from './metaTagUpdate.queue';
+    15: await metaTagUpdateQueue.scheduleUpdate({
+    22: await metaTagUpdateQueue.scheduleUpdate({
+    29: await metaTagUpdateQueue.scheduleUpdate({
+    42: await metaTagUpdateQueue.scheduleUpdate({
+
+[file] harmony-backend/.../workers/metaTagUpdate.pipeline.ts (4):
+     2: import { metaTagUpdateQueue } from './metaTagUpdate.queue';
+     3: import { startMetaTagUpdateRuntime, stopMetaTagUpdateRuntime } from './metaTa...
+     4: import { startMetaTagUpdateWorker, stopMetaTagUpdateWorker } from './metaTagU...
+    36: await metaTagUpdateQueue.close();
+
+[file] harmony-backend/src/workers/metaTagUpdate.queue.ts (1):
+    83: export const metaTagUpdateQueue = {
+
+[file] harmony-backend/.../workers/metaTagUpdate.worker.ts (3):
+     3: import { metaTagService } from '../services/metaTag/metaTagService';
+     8: } from './metaTagUpdate.queue';
+    18: await metaTagService.generateMetaTags(job.data.channelId, {
+
+[file] harmony-frontend/.../__tests__/issue-238-message-input-aria-label.test.tsx (5):
+     8: * The textarea must have aria-label="Message #<channelName>" so it appears
+    34: channelName: 'general',
+    49: it('aria-label updates when channelName prop changes', () => {
+    50: const { rerender } = render(<MessageInput {...defaultProps} channelName='anno...
+    54: rerender(<MessageInput {...defaultProps} channelName='off-topic' />);
+
+[file] harmony-frontend/.../__tests__/metaTagAdminService.test.ts (2):
+     9: } from '@/services/metaTagAdminService';
+    30: describe('metaTagAdminService', () => {
+
+[file] harmony-frontend/.../[channelSlug]/page.tsx (7):
+    23: const channelName = channel?.name ?? channelSlug;
+    24: const serverName = server?.name ?? serverSlug;
+    25: const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harm...
+    30: `Join ${serverName} on Harmony`;
+    34: serverName,
+    88: const { channel, serverName, title, description } = getSeoContent(
+   108: 'name': serverName,
+
+[file] harmony-frontend/.../[channelSlug]/actions.ts (1):
+    23: } from '@/services/metaTagAdminService';
+
+[file] harmony-frontend/.../channel/GuestChannelView.tsx (1):
+   113: <GuestPromoBanner serverName={server.name} memberCount={memberCount} />
+
+[file] harmony-frontend/.../channel/GuestPromoBanner.tsx (4):
+    26: serverName: string;
+    30: export function GuestPromoBanner({ serverName, memberCount }: GuestPromoBanne...
+    71: {serverName[0].toUpperCase()}
+    76: <p className='truncate text-sm font-semibold text-white'>{serverName}</p>
+
+[file] harmony-frontend/.../channel/MessageInput.tsx (4):
+    26: channelName: string;
+    36: channelName,
+   257: placeholder={`Message #${channelName}`}
+   260: aria-label={`Message #${channelName}`}
+
+[file] harmony-frontend/.../channel/PinnedMessagesPanel.tsx (3):
+    77: channelName: string;
+    85: channelName,
+   150: No pinned messages in #{channelName}.
+
+[file] harmony-frontend/.../channel/SearchModal.tsx (3):
+   100: channelName?: string;
+   111: channelName,
+   227: placeholder={channelName ? `Search messages in #${channelName}` : 'Search mes...
+
+[file] harmony-frontend/.../layout/HarmonyShell.tsx (4):
+   476: channelName={currentChannel.name}
+   483: serverName={currentServer.name}
+   494: channelName={currentChannel.name}
+   525: channelName={currentChannel.name}
+
+[file] harmony-frontend/.../settings/SeoPreviewSection.tsx (1):
+    11: import type { MetaTagJobStatus, MetaTagPreview } from '@/services/metaTagAdmi...
+
+[file] harmony-frontend/src/contexts/VoiceContext.tsx (3):
+    71: joinChannel: (channelId: string, serverId: string, channelName: string) => Pr...
+   252: async (channelId: string, serverId: string, channelName: string) => {
+   275: setConnectedChannelName(channelName);
+
+... +7
+```
+
+#### Tool: exec_command
+
+```sh
+rtk find harmony-frontend/src/app -type f | rg "\[serverSlug\]|\[channelSlug\]|metadata|layout|page"
+```
+
+Output:
+
+```text
+./ error.tsx favicon.ico global-error.tsx globals.css layout.tsx not-found.tsx page.tsx providers.tsx
+auth/login/ page.tsx
+auth/signup/ page.tsx
+c/[serverSlug]/[channelSlug]/ loading.tsx page.tsx
+channels/ actions.ts layout.tsx page.tsx
+channels/[serverSlug]/ page.tsx
+channels/[serverSlug]/[channelSlug]/ loading.tsx page.tsx
+settings/ actions.ts layout.tsx page.tsx
+settings/[serverSlug]/ actions.ts page.tsx settings-access.ts
+settings/[serverSlug]/[channelSlug]/ actions.ts page.tsx updateVisibility.ts
+sitemap/[serverSlug]/ route.ts
+sitemap/[serverSlug].xml/ route.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+Output:
+
+```text
+zsh:1: no matches found: harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/services/metaTag/titleGenerator.ts
+```
+
+Output:
+
+```text
+// CL-C2.2 TitleGenerator — generates SEO-optimized titles (AC-2: ≤60 chars)
+import type { ChannelContext, MessageContext, MetaTagSet, IMetaTagGenerator } from './types';
+
+const MAX_LENGTH = 60;
+
+const CHANNEL_TEMPLATE = '{channelName} — {serverName}';
+
+export const TitleGenerator: IMetaTagGenerator & {
+  maxLength: number;
+  generateFromChannel(channel: ChannelContext): string;
+  generateFromMessage(message: MessageContext, channel: ChannelContext): string;
+  generateFromThread(messages: MessageContext[], channel: ChannelContext): string;
+  truncateWithEllipsis(text: string): string;
+  sanitizeForTitle(text: string): string;
+  applyTemplate(template: string, vars: Record<string, string>): string;
+} = {
+  maxLength: MAX_LENGTH,
+
+  generateFromChannel(channel: ChannelContext): string {
+    const raw = CHANNEL_TEMPLATE.replace('{channelName}', channel.name).replace(
+      '{serverName}',
+      channel.serverName,
+    );
+    return this.truncateWithEllipsis(this.sanitizeForTitle(raw));
+  },
+
+  generateFromMessage(message: MessageContext, channel: ChannelContext): string {
+    const raw = `${message.content} — ${channel.serverName}`;
+    return this.truncateWithEllipsis(this.sanitizeForTitle(raw));
+  },
+
+  generateFromThread(messages: MessageContext[], channel: ChannelContext): string {
+    if (messages.length === 0) {
+      return this.generateFromChannel(channel);
+    }
+    return this.generateFromMessage(messages[0], channel);
+  },
+
+  truncateWithEllipsis(text: string): string {
+    if (text.length <= MAX_LENGTH) return text;
+    return text.slice(0, MAX_LENGTH - 1).trimEnd() + '…';
+  },
+
+  sanitizeForTitle(text: string): string {
+    return text
+      .replace(/<[^>]*>/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  },
+
+  applyTemplate(template: string, vars: Record<string, string>): string {
+    return Object.entries(vars).reduce(
+      (result, [key, value]) => result.replaceAll(`{${key}}`, value),
+      template,
+    );
+  },
+
+  // CL-I1 stubs — full generate/validate wired by M4
+  generate(): MetaTagSet {
+    throw new Error('TitleGenerator.generate() not yet implemented — wired by M4');
+  },
+  validate(): boolean {
+    throw new Error('TitleGenerator.validate() not yet implemented — wired by M4');
+  },
+};
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/services/metaTag/metaTagService.ts
+```
+
+Output:
+
+```text
+Total output lines: 656
+
+// CL-C2.1 MetaTagService — facade for meta tag generation, caching, and invalidation
+import { createHash } from 'crypto';
+import { Prisma, type GeneratedMetaTags } from '@prisma/client';
+import { prisma } from '../../db/prisma';
+import { redis } from '../../db/redis';
+import { TitleGenerator } from './titleGenerator';
+import { DescriptionGenerator } from './descriptionGenerator';
+import { OpenGraphGenerator } from './openGraphGenerator';
+import { StructuredDataGenerator } from './structuredDataGenerator';
+import { MetaTagCache } from './metaTagCache';
+import { ContentFilter } from './contentFilter';
+import { metaTagRepository } from '../../repositories/metaTag.repository';
+import type {
+  MetaTagSet,
+  ChannelContext,
+  ChannelVisibility,
+  MessageContext,
+  MetaTagPreview,
+  MetaTagJobStatus,
+  ContentAnalysis,
+  StructuredData,
+} from './types';
+import { createLogger } from '../../lib/logger';
+import { metaTagUpdateQueue } from '../../workers/metaTagUpdate.queue';
+
+const logger = createLogger({ component: 'meta-tag-service' });
+
+const BASE_URL = process.env.BASE_URL ?? 'https://harmony.chat';
+const META_TAG_SCHEMA_VERSION = 1;
+const META_TAG_MESSAGE_LIMIT = 20;
+
+// Spec §9.1.1 visibility → robots mapping
+function getRobotsDirective(visibility: ChannelVisibility | undefined): string {
+  if (visibility === 'PUBLIC_NO_INDEX') return 'noindex, follow';
+  if (visibility === 'PRIVATE') return 'noindex, nofollow';
+  return 'index, follow'; // PUBLIC_INDEXABLE or unset
+}
+
+function sanitizeChannelContext(channel: ChannelContext): ChannelContext {
+  return {
+    ...channel,
+    name: TitleGenerator.sanitizeForTitle(channel.name),
+    serverName: TitleGenerator.sanitizeForTitle(channel.serverName),
+  };
+}
+
+function buildFallbackTags(channel: ChannelContext): MetaTagSet {
+  const safe = sanitizeChannelContext(channel);
+  const title = `${safe.name} — ${safe.serverName}`;
+  const description = `Discussions in #${safe.name} on ${safe.serverName}.`;
+  const analysis: ContentAnalysis = {
+    keywords: [],
+    topics: [TitleGenerator.truncateWithEllipsis(title)],
+    summary: DescriptionGenerator.enforceLength(description),
+    sentiment: 'neutral',
+    readingLevel: 'basic',
+  };
+  return {
+    title: TitleGenerator.truncateWithEllipsis(title),
+    description: DescriptionGenerator.enforceLength(description),
+    canonical: safe.canonicalUrl,
+    robots: getRobotsDirective(safe.visibility),
+    openGraph: OpenGraphGenerator.generateOGTags(safe, {}, analysis),
+    twitter: OpenGraphGenerator.generateTwitterCard(safe, {}, analysis),
+    structuredData: StructuredDataGenerator.generateDiscussionForum(safe, [], {}),
+    keywords: [],
+    needsRegeneration: true,
+  };
+}
+
+function applyPersistedOverrides(
+  tags: MetaTagSet,
+  record: Pick<GeneratedMetaTags, 'customTitle' | 'customDescription' | 'customOgImage'> | null,
+): MetaTagSet {
+  if (!record) return tags;
+
+  const title = record.customTitle ?? tags.title;
+  const description = record.customDescription ?? tags.description;
+  const image = record.customOgImage ?? tags.openGraph.ogImage;
+
+  return {
+    ...tags,
+    title,
+    description,
+    openGraph: {
+      ...tags.openGraph,
+      ogTitle: title,
+      ogDescription: description,
+      ogImage: image,
+    },
+    twitter: {
+      ...tags.twitter,
+      title,
+      description,
+      image,
+    },
+  };
+}
+
+function buildChannelContext(channel: {
+  id: string;
+  name: string;
+  slug: string;
+  topic: string | null;
+  visibility: ChannelVisibility;
+  server: {
+    name: string;
+    slug: string;
+  };
+}): ChannelContext {
+  return {
+    id: channel.id,
+    name: channel.name,
+    slug: channel.slug,
+    topic: channel.topic,
+    serverName: channel.server.name,
+    serverSlug: channel.server.slug,
+    canonicalUrl: `${BASE_URL}/c/${encodeURIComponent(channel.server.slug)}/${encodeURIComponent(channel.slug)}`,
+    visibility: channel.visibility,
+  };
+}
+
+function buildPersistedMetaTagSet(
+  channel: ChannelContext,
+  record: GeneratedMetaTags,
+): MetaTagSet {
+  const baseTags: MetaTagSet = {
+    title: record.title,
+    description: record.description,
+    canonical: channel.canonicalUrl,
+    robots: getRobotsDirective(channel.visibility),
+    openGraph: {
+      ogTitle: record.title,
+      ogDescription: record.description,
+      ogImage: record.ogImage ?? `${BASE_URL}/og-default.png`,
+      ogType: 'article',
+      ogUrl: channel.canonicalUrl,
+      ogSiteName: channel.serverName,
+    },
+    twitter: {
+      card: record.twitterCard,
+      title: record.title,
+      description: record.description,
+      image: record.ogImage ?? `${BASE_URL}/og-default.png`,
+      site: '@harmonychat',
+    },
+    structuredData: record.structuredData as StructuredData,
+    keywords: record.keywords
+      .split(',')
+      .map((keyword) => keyword.trim())
+      .filter(Boolean),
+    needsRegeneration: record.needsRegeneration,
+  };
+
+  return applyPersistedOverrides(baseTags, record);
+}
+
+function buildContentHash(channel: ChannelContext, messages: MessageContext[]): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        visibility: channel.visibility ?? 'PUBLIC_INDEXABLE',
+        topic: channel.topic ?? null,
+        messages: messages.map((message) => ({
+          content: message.content,
+          createdAt: message.createdAt.toISOString(),
+          authorDisplayName: message.authorDisplayName ?? null,
+        })),
+      }),
+    )
+    .digest('hex');
+}
+
+function mapQueueStateToStatus(state: string): MetaTagJobStatus['status'] {
+  if (state === 'completed') return 'succeeded';
+  if (state === 'failed') return 'failed';
+  if (state === 'active') return 'processing';
+  return 'queued';
+}
+
+// ─── Admin Redis job helpers (distinct from BullMQ-based scheduleRegeneration) ────
+
+const ADMIN_JOB_TTL_SECONDS = 86400; // 24 hours
+
+function adminJobKey(jobId: string): string {
+  return `meta-tag:job:${jobId}`;
+}
+
+async function storeAdminJob(job: MetaTagJobStatus): Promise<void> {
+  await redis.set(adminJobKey(job.jobId), JSON.stringify(job), 'EX', ADMIN_JOB_TTL_SECONDS);
+}
+
+async function getAdminJob(jobId: string): Promise<MetaTagJobStatus | null> {
+  const raw = await redis.get(adminJobKey(jobId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as MetaTagJobStatus;
+  } catch {
+    logger.warn({ jobId, key: adminJobKey(jobId) }, 'Failed to parse admin meta-tag job from Redis — treating as not found');
+    return null;
+  }
+}
+
+async function loadGenerationInputs(channelId: string): Promise<{
+  channel: ChannelContext;
+  persisted: GeneratedMetaTags | null;
+  messages: MessageContext[];
+}> {
+  const channel = await prisma.channel.findUnique({
+    where: { id: channelId },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      topic: true,
+      visibility: true,
+      server: {
+        select: {
+          name: true,
+          slug: true,
+        },
+      },
+      generatedMetaTags: true,
+    },
+  });
+
+  if (!channel) {
+    throw new Error(`Channel ${channelId} not found`);
+  }
+
+  const messages = await prisma.message.findMany({
+    where: {
+      channelId,
+      isDeleted: false,
+    },
+    take: META_TAG_MESSAGE_LIMIT,
+    orderBy: {
+      createdAt: 'asc',
+    },
+    select: {
+      content: true,
+      createdAt: true,
+      author: {
+        select: {
+          displayName: true,
+        },
+      },
+    },
+  });
+
+  return {
+    channel: buildChannelContext(channel),
+    persisted: channel.generatedMetaTags,
+    messages: messages.map((message) => ({
+      content: message.content,
+      createdAt: message.createdAt,
+      authorDisplayName: message.author.displayName,
+    })),
+  };
+}
+
+/**
+ * Runs meta tag regeneration for an admin-initiated job stored in Redis as `queued`.
+ * Transitions: queued → processing → succeeded | failed.
+ * Exported for direct use in tests.
+ */
+export async function processAdminRegenerationJob(channelId: string, jobId: string): Promise<void> {
+  const startedAt = new Date…1348 tokens truncated…el);
+    }
+
+    const generated = await metaTagService.generateMetaTagsFromContext(channel, messages);
+    const contentHash = buildContentHash(channel, messages);
+    const generatedAt = new Date();
+
+    if (persisted) {
+      const rowsUpdated = await metaTagRepository.saveGeneratedFields(channelId, {
+        title: generated.title,
+        description: generated.description,
+        ogTitle: generated.openGraph.ogTitle,
+        ogDescription: generated.openGraph.ogDescription,
+        ogImage: generated.openGraph.ogImage,
+        twitterCard: generated.twitter.card,
+        keywords: generated.keywords.join(','),
+        structuredData: generated.structuredData as Prisma.InputJsonValue,
+        contentHash,
+        needsRegeneration: generated.needsRegeneration ?? false,
+        generatedAt,
+        schemaVersion: META_TAG_SCHEMA_VERSION,
+      });
+
+      const record = rowsUpdated > 0
+        ? await metaTagRepository.findByChannelId(channelId)
+        : persisted;
+      const finalTags = buildPersistedMetaTagSet(channel, record ?? persisted);
+
+      if (finalTags.needsRegeneration) {
+        await MetaTagCache.invalidate(channelId);
+      } else {
+        await MetaTagCache.set(channelId, finalTags);
+      }
+
+      return finalTags;
+    }
+
+    const created = await metaTagRepository.create({
+      channelId,
+      title: generated.title,
+      description: generated.description,
+      ogTitle: generated.openGraph.ogTitle,
+      ogDescription: generated.openGraph.ogDescription,
+      ogImage: generated.openGraph.ogImage,
+      twitterCard: generated.twitter.card,
+      keywords: generated.keywords.join(','),
+      structuredData: generated.structuredData as Prisma.InputJsonValue,
+      contentHash,
+      needsRegeneration: generated.needsRegeneration ?? false,
+      generatedAt,
+      schemaVersion: META_TAG_SCHEMA_VERSION,
+    });
+
+    const finalTags = buildPersistedMetaTagSet(channel, created);
+    if (finalTags.needsRegeneration) {
+      await MetaTagCache.invalidate(channelId);
+    } else {
+      await MetaTagCache.set(channelId, finalTags);
+    }
+
+    return finalTags;
+  },
+
+  /**
+   * Cache-backed generation from pre-resolved context (used internally and in unit tests).
+   * Production callers should prefer the spec-aligned getOrGenerateCached(channelId).
+   */
+  async getOrGenerateCachedFromContext(
+    channel: ChannelContext,
+    messages: MessageContext[],
+    ttl?: number,
+  ): Promise<MetaTagSet> {
+    const cached = await MetaTagCache.get(channel.id);
+    if (cached) return cached;
+
+    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);
+    // Do not cache fallback tags — a transient failure must not poison the cache for the full TTL
+    if (!tags.needsRegeneration) {
+      await MetaTagCache.set(channel.id, tags, ttl);
+    }
+    return tags;
+  },
+
+  /**
+   * Spec-aligned stub: getOrGenerateCached(channelId).
+   * Full implementation wired by M4 (MetaTagUpdateWorker, issue #354).
+   */
+  async getOrGenerateCached(channelId: string): Promise<MetaTagSet> {
+    const cached = await MetaTagCache.get(channelId);
+    if (cached) return cached;
+
+    const { channel, persisted } = await loadGenerationInputs(channelId);
+    if (persisted && !persisted.needsRegeneration) {
+      const tags = buildPersistedMetaTagSet(channel, persisted);
+      await MetaTagCache.set(channelId, tags);
+      return tags;
+    }
+
+    return metaTagService.generateMetaTags(channelId);
+  },
+
+  async invalidateCache(channelId: string): Promise<void> {
+    await MetaTagCache.invalidate(channelId);
+  },
+
+  sanitizeCustomOverride(value: string | null | undefined): string | null {
+    if (value == null) return null;
+    const stripped = value
+      .replace(/<[^>]*>/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return ContentFilter.escapeHtml(ContentFilter.filterContent(stripped));
+  },
+
+  async setCustomOverrides(
+    channelId: string,
+    overrides: {
+      customTitle?: string | null;
+      customDescription?: string | null;
+      customOgImage?: string | null;
+    },
+  ) {
+    const sanitized: typeof overrides = {};
+    if (overrides.customTitle !== undefined) {
+      sanitized.customTitle = metaTagService.sanitizeCustomOverride(overrides.customTitle);
+    }
+    if (overrides.customDescription !== undefined) {
+      sanitized.customDescription = metaTagService.sanitizeCustomOverride(
+        overrides.customDescription,
+      );
+    }
+    if (overrides.customOgImage !== undefined) {
+      sanitized.customOgImage = overrides.customOgImage; // URL already validated by Zod
+    }
+    if (Object.keys(sanitized).length === 0) {
+      const existing = await metaTagRepository.findByChannelId(channelId);
+      if (!existing) throw new Error(`Meta tags not found for channel ${channelId}`);
+      return existing;
+    }
+    const updated = await metaTagRepository.updateCustomOverrides(channelId, sanitized);
+    await MetaTagCache.invalidate(channelId);
+    return updated;
+  },
+  async scheduleRegeneration(
+    channelId: string,
+    priority: 'high' | 'normal' | 'low' = 'normal',
+    idempotencyKey?: string,
+  ): Promise<{ jobId: string; status: 'queued' | 'deduplicated' }> {
+    return metaTagUpdateQueue.scheduleUpdate({
+      channelId,
+      triggeredBy: 'manual',
+      priority,
+      idempotencyKey,
+    });
+  },
+
+  async getRegenerationJobStatus(
+    channelId: string,
+    jobId: string,
+  ): Promise<MetaTagJobStatus> {
+    const job = await metaTagUpdateQueue.getJob(jobId);
+    if (!job || job.data.channelId !== channelId) {
+      throw new Error(`Meta tag regeneration job ${jobId} not found for channel ${channelId}`);
+    }
+
+    const state = await job.getState();
+    return {
+      jobId,
+      channelId,
+      status: mapQueueStateToStatus(state),
+      attempts: job.attemptsMade,
+      startedAt: job.processedOn ? new Date(job.processedOn).toISOString() : null,
+      completedAt: job.finishedOn ? new Date(job.finishedOn).toISOString() : null,
+      errorCode: null,
+      errorMessage: job.failedReason ?? null,
+    };
+  },
+
+  async getMetaTagsForPreview(channelId: string): Promise<MetaTagPreview> {
+    const tags = await metaTagService.getOrGenerateCached(channelId);
+    const { persisted } = await loadGenerationInputs(channelId);
+
+    return {
+      title: tags.title,
+      description: tags.description,
+      ogTitle: tags.openGraph.ogTitle,
+      ogDescription: tags.openGraph.ogDescription,
+      ogImage: tags.openGraph.ogImage,
+      keywords: tags.keywords,
+      generatedAt: persisted?.generatedAt.toISOString() ?? new Date().toISOString(),
+      isCustom: Boolean(
+        persisted?.customTitle ||
+        persisted?.customDescription ||
+        persisted?.customOgImage,
+      ),
+      generatedTitle: persisted?.title ?? tags.title,
+      generatedDescription: persisted?.description ?? tags.description,
+      customTitle: persisted?.customTitle ?? null,
+      customDescription: persisted?.customDescription ?? null,
+      customOgImage: persisted?.customOgImage ?? null,
+      searchPreview: {
+        title: tags.title,
+        description: tags.description,
+        url: tags.canonical,
+      },
+      socialPreview: {
+        title: tags.openGraph.ogTitle,
+        description: tags.openGraph.ogDescription,
+        image: tags.openGraph.ogImage,
+      },
+    };
+  },
+
+  buildCanonicalUrl(serverSlug: string, channelSlug: string): string {
+    return `${BASE_URL}/c/${encodeURIComponent(serverSlug)}/${encodeURIComponent(channelSlug)}`;
+  },
+
+  async enqueueAdminJob(channelId: string, jobId: string): Promise<void> {
+    await storeAdminJob({
+      jobId,
+      channelId,
+      status: 'queued',
+      attempts: 0,
+      startedAt: null,
+      completedAt: null,
+      errorCode: null,
+      errorMessage: null,
+    });
+    setImmediate(() => void processAdminRegenerationJob(channelId, jobId));
+  },
+
+  async getAdminJobStatus(channelId: string, jobId: string): Promise<MetaTagJobStatus | null> {
+    return getAdminJob(jobId);
+  },
+};
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx'
+```
+
+Output:
+
+```text
+import type { Metadata } from 'next';
+import { GuestChannelView } from '@/components/channel/GuestChannelView';
+import {
+  fetchPublicServer,
+  fetchPublicChannel,
+  fetchPublicMetaTags,
+} from '@/services/publicApiService';
+import { ChannelVisibility } from '@/types';
+import { getChannelUrl } from '@/lib/runtime-config';
+
+interface PageProps {
+  params: Promise<{ serverSlug: string; channelSlug: string }>;
+}
+
+function getSeoContent(
+  serverSlug: string,
+  channelSlug: string,
+  server: Awaited<ReturnType<typeof fetchPublicServer>>,
+  channelResult: Awaited<ReturnType<typeof fetchPublicChannel>>,
+  publicMetaTags: Awaited<ReturnType<typeof fetchPublicMetaTags>>,
+) {
+  const channel = channelResult && !channelResult.isPrivate ? channelResult.channel : null;
+  const channelName = channel?.name ?? channelSlug;
+  const serverName = server?.name ?? serverSlug;
+  const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+  const description =
+    publicMetaTags?.description ??
+    channel?.topic ??
+    server?.description ??
+    `Join ${serverName} on Harmony`;
+
+  return {
+    channel,
+    serverName,
+    title,
+    description,
+  };
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { serverSlug, channelSlug } = await params;
+  const [server, channelResult, publicMetaTags] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+    fetchPublicMetaTags(serverSlug, channelSlug),
+  ]);
+
+  const { channel, title, description } = getSeoContent(
+    serverSlug,
+    channelSlug,
+    server,
+    channelResult,
+    publicMetaTags,
+  );
+  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+  const canonicalUrl = getChannelUrl(serverSlug, channelSlug);
+
+  return {
+    title,
+    description,
+    robots: { index: isIndexable, follow: true },
+    alternates: { canonical: canonicalUrl },
+    openGraph: {
+      title: publicMetaTags?.ogTitle ?? title,
+      description: publicMetaTags?.ogDescription ?? description,
+      type: 'website',
+      url: canonicalUrl,
+      ...(publicMetaTags?.ogImage ? { images: [{ url: publicMetaTags.ogImage }] } : {}),
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  };
+}
+
+export default async function GuestChannelPage({ params }: PageProps) {
+  const { serverSlug, channelSlug } = await params;
+
+  // Fetch data for JSON-LD; React cache deduplicates these within the same render pass
+  const [server, channelResult, publicMetaTags] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+    fetchPublicMetaTags(serverSlug, channelSlug),
+  ]);
+
+  const { channel, serverName, title, description } = getSeoContent(
+    serverSlug,
+    channelSlug,
+    server,
+    channelResult,
+    publicMetaTags,
+  );
+  const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+
+  const jsonLd = isIndexable
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'DiscussionForumPosting',
+        'name': title,
+        'headline': title,
+        'url': getChannelUrl(serverSlug, channelSlug),
+        'description': description,
+        'text': description,
+        'author': {
+          '@type': 'Organization',
+          'name': serverName,
+        },
+        ...(channel?.createdAt && { datePublished: channel.createdAt }),
+      }
+    : null;
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type='application/ld+json'
+          // Escape </script> breakout sequences per OWASP JSON-LD injection guidance
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(jsonLd)
+              .replace(/</g, '\\u003c')
+              .replace(/>/g, '\\u003e')
+              .replace(/&/g, '\\u0026'),
+          }}
+        />
+      )}
+      <GuestChannelView serverSlug={serverSlug} channelSlug={channelSlug} />
+    </>
+  );
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/services/publicApiService.ts
+```
+
+Output:
+
+```text
+/**
+ * publicApiService — server-side service for the backend public REST API.
+ * Uses fetch (not the axios api-client) so it can be called from React Server
+ * Components, generateMetadata, and other server-only contexts.
+ * React `cache` is used for request deduplication within a single render pass.
+ */
+
+import { cache } from 'react';
+import type { Server, Channel, Message } from '@/types';
+import { ChannelType, ChannelVisibility } from '@/types';
+import { API_CONFIG, CACHE_DURATION } from '@/lib/constants';
+
+type PublicServer = Omit<Server, 'ownerId'>;
+
+// ─── Response shapes from the backend ─────────────────────────────────────────
+
+interface PublicServerResponse {
+  id: string;
+  name: string;
+  slug: string;
+  iconUrl?: string;
+  description?: string;
+  memberCount: number;
+  createdAt: string;
+}
+
+interface PublicChannelResponse {
+  id: string;
+  name: string;
+  slug: string;
+  serverId: string;
+  type: string;
+  visibility: string;
+  topic?: string | null;
+  position: number;
+  createdAt: string;
+}
+
+interface PublicMessageResponse {
+  id: string;
+  content: string;
+  createdAt: string;
+  editedAt?: string | null;
+  author: { id: string; username: string };
+}
+
+interface PublicMessagesApiResponse {
+  messages: PublicMessageResponse[];
+  page: number;
+  pageSize: number;
+}
+
+export interface PublicMetaTagResponse {
+  title: string;
+  description: string;
+  ogTitle: string;
+  ogDescription: string;
+  ogImage: string;
+  generatedAt: string;
+  visibility: string;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function mapChannelType(type: string): ChannelType {
+  switch (type) {
+    case 'VOICE':
+      return ChannelType.VOICE;
+    case 'ANNOUNCEMENT':
+      return ChannelType.ANNOUNCEMENT;
+    default:
+      return ChannelType.TEXT;
+  }
+}
+
+function mapChannelVisibility(visibility: string): ChannelVisibility {
+  switch (visibility) {
+    case 'PUBLIC_NO_INDEX':
+      return ChannelVisibility.PUBLIC_NO_INDEX;
+    case 'PRIVATE':
+      return ChannelVisibility.PRIVATE;
+    default:
+      return ChannelVisibility.PUBLIC_INDEXABLE;
+  }
+}
+
+// ─── Public API functions ──────────────────────────────────────────────────────
+
+/**
+ * Fetch public server info by slug.
+ * Returns null on any error or if the server is not found (404).
+ * Deduplicated within a single render pass via React `cache`.
+ */
+export const fetchPublicServer = cache(async (serverSlug: string): Promise<PublicServer | null> => {
+  try {
+    const res = await fetch(
+      `${API_CONFIG.BASE_URL}/api/public/servers/${encodeURIComponent(serverSlug)}`,
+      { next: { revalidate: CACHE_DURATION.PUBLIC_API_REVALIDATE } },
+    );
+    if (!res.ok) return null;
+
+    const data: PublicServerResponse = await res.json();
+    const server: PublicServer = {
+      id: data.id,
+      name: data.name,
+      slug: data.slug,
+      icon: data.iconUrl,
+      description: data.description,
+      memberCount: data.memberCount,
+      createdAt: data.createdAt,
+    };
+    return server;
+  } catch {
+    return null;
+  }
+});
+
+/**
+ * Fetch a single public channel by server slug + channel slug.
+ * - Returns null if the server or channel does not exist (404).
+ * - Returns `{ isPrivate: true }` if the channel is PRIVATE (403).
+ * - Returns `{ channel, isPrivate: false }` on success (200).
+ * Deduplicated within a single render pass via React `cache`.
+ */
+export const fetchPublicChannel = cache(
+  async (
+    serverSlug: string,
+    channelSlug: string,
+  ): Promise<{ channel: Channel; isPrivate: false } | { isPrivate: true } | null> => {
+    try {
+      const res = await fetch(
+        `${API_CONFIG.BASE_URL}/api/public/servers/${encodeURIComponent(serverSlug)}/channels/${encodeURIComponent(channelSlug)}`,
+        {
+          // Visibility changes must be reflected immediately in guest page access
+          // control and metadata. Caching this fetch causes the public page to
+          // keep serving stale indexable/private state after a toggle.
+          cache: 'no-store',
+        },
+      );
+
+      if (res.status === 404) return null;
+      if (res.status === 403) return { isPrivate: true };
+      if (!res.ok) return null;
+
+      const data: PublicChannelResponse = await res.json();
+      const channel: Channel = {
+        id: data.id,
+        name: data.name,
+        slug: data.slug,
+        serverId: data.serverId,
+        type: mapChannelType(data.type),
+        visibility: mapChannelVisibility(data.visibility),
+        topic: data.topic ?? undefined,
+        position: data.position,
+        createdAt: data.createdAt,
+      };
+      return { channel, isPrivate: false };
+    } catch {
+      return null;
+    }
+  },
+);
+
+/**
+ * Fetch paginated public messages for a channel.
+ * Returns an empty list on error.
+ */
+export async function fetchPublicMessages(
+  channelId: string,
+  page = 1,
+): Promise<{ messages: Message[]; hasMore: boolean }> {
+  try {
+    const res = await fetch(
+      `${API_CONFIG.BASE_URL}/api/public/channels/${encodeURIComponent(channelId)}/messages?page=${page}`,
+    );
+    if (!res.ok) return { messages: [], hasMore: false };
+
+    const data: PublicMessagesApiResponse = await res.json();
+    const messages: Message[] = data.messages.map(m => ({
+      id: m.id,
+      channelId,
+      authorId: m.author.id,
+      author: { id: m.author.id, username: m.author.username },
+      content: m.content,
+      timestamp: m.createdAt,
+      editedAt: m.editedAt ?? undefined,
+    }));
+    return { messages, hasMore: messages.length >= data.pageSize };
+  } catch {
+    return { messages: [], hasMore: false };
+  }
+}
+
+/**
+ * Returns true if the channel is publicly accessible (not PRIVATE and not missing).
+ */
+export async function isChannelGuestAccessible(
+  serverSlug: string,
+  channelSlug: string,
+): Promise<boolean> {
+  const result = await fetchPublicChannel(serverSlug, channelSlug);
+  return result !== null && !result.isPrivate;
+}
+
+export const fetchPublicMetaTags = cache(
+  async (serverSlug: string, channelSlug: string): Promise<PublicMetaTagResponse | null> => {
+    try {
+      const res = await fetch(
+        `${API_CONFIG.BASE_URL}/api/public/servers/${encodeURIComponent(serverSlug)}/channels/${encodeURIComponent(channelSlug)}/meta-tags`,
+        {
+          cache: 'no-store',
+        },
+      );
+
+      if (!res.ok) return null;
+      return (await res.json()) as PublicMetaTagResponse;
+    } catch {
+      return null;
+    }
+  },
+);
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:04:59.344Z
+
+The frontend fallback does use the raw route slug when metadata fetches miss, but the report could also be coming from persisted backend meta tags. I’m checking both the public route and seed data so I can prove which layer is actually producing `../../../admin`.
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "\.\.\/\.\.\/\.\.\/admin|admin/general|serverName:|title:" harmony-backend/src harmony-backend/tests harmony-frontend/src harmony-frontend/tests tests
+```
+
+Output:
+
+```text
+57 matches in 19F:
+
+[file] harmony-backend/.../repositories/metaTag.repository.ts (2):
+     9: title: string;
+    65: title: fields.title,
+
+[file] harmony-backend/src/routes/admin.metaTag.router.ts (1):
+   121: socialPreview: { title: ogTitle, description: ogDescription, image: ogImage },
+
+[file] harmony-backend/.../metaTag/metaTagService.ts (12):
+    43: serverName: TitleGenerator.sanitizeForTitle(channel.serverName),
+    59: title: TitleGenerator.truncateWithEllipsis(title),
+   116: serverName: channel.server.name,
+   128: title: record.title,
+   142: title: record.title,
+   301: serverName: channel.server.name,
+   316: title: tags.title,
+   431: title: generated.title,
+   461: title: generated.title,
+   605: title: tags.title,
+   623: title: tags.title,
+   628: title: tags.openGraph.ogTitle,
+
+[file] harmony-backend/.../metaTag/openGraphGenerator.ts (1):
+    41: title: analysis.topics[0] ?? channel.name,
+
+[file] harmony-backend/src/services/metaTag/types.ts (6):
+    14: title: string;
+    34: title: string;
+    59: title: string;
+    72: searchPreview: { title: string; description: string; url: string };
+    73: socialPreview: { title: string; description: string; image: string };
+    95: serverName: string;
+
+[file] harmony-backend/tests/admin.metaTag.router.test.ts (2):
+   127: title: 'Generated Title',
+   217: title: META_TAG_RECORD.title,
+
+[file] harmony-backend/tests/contentFilter.test.ts (1):
+   237: serverName: 'Tech Help',
+
+[file] harmony-backend/tests/metaTag.repository.test.ts (3):
+    21: title: 'Generated Title',
+   119: title: 'Regenerated Title',
+   185: title: 'Updated Again',
+
+[file] harmony-backend/tests/metaTagService.test.ts (6):
+    49: serverName: 'Game Dev Hub',
+    83: serverName: 'An Extremely Long Server Name That Will Overflow',
+   103: serverName: 'My Server',
+   207: const fakeSet = { title: 'Cached Title' } as never;
+   215: const tags = { title: 'T' } as never;
+   262: const cachedTags = { title: 'Cached', needsRegeneration: false } as never;
+
+[file] harmony-frontend/.../__tests__/SeoPreviewSection.test.tsx (9):
+    29: title: 'Generated title',
+    43: title: 'Generated title',
+    48: title: 'Generated title',
+    72: title: 'Custom title',
+    79: title: 'Custom title',
+    84: title: 'Custom title',
+   158: title: 'Regenerated title',
+   163: title: 'Regenerated title',
+   168: title: 'Regenerated title',
+
+[file] harmony-frontend/.../__tests__/channel-page-metadata.test.ts (3):
+   109: title: 'general - Harmony HQ | Harmony',
+   121: title: 'general - Harmony HQ | Harmony',
+   152: title: 'Custom SEO Title',
+
+[file] harmony-frontend/.../__tests__/public-channel-metadata.test.ts (2):
+    48: title: 'Custom SEO Title',
+    64: title: 'Custom OG Title',
+
+[file] harmony-frontend/.../[channelSlug]/page.tsx (1):
+    64: title: publicMetaTags?.ogTitle ?? title,
+
+[file] harmony-frontend/src/app/layout.tsx (1):
+    15: title: APP_NAME,
+
+[file] harmony-frontend/.../channel/GuestPromoBanner.tsx (1):
+    26: serverName: string;
+
+[file] harmony-frontend/src/components/channel/TopBar.tsx (1):
+   123: title: string;
+
+[file] harmony-frontend/.../services/metaTagAdminService.ts (3):
+     5: title: string;
+    18: searchPreview: { title: string; description: string; url: string };
+    19: socialPreview: { title: string; description: string; image: string };
+
+[file] harmony-frontend/src/services/publicApiService.ts (1):
+    54: title: string;
+
+[file] harmony-frontend/.../support/stack.shared.mjs (1):
+   117: serverName: defaultJoinServer.name,
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/src/routes/public.router.ts
+```
+
+Output:
+
+```text
+import { Router, Request, Response } from 'express';
+import type { Store } from 'express-rate-limit';
+import { prisma } from '../db/prisma';
+import { ChannelVisibility } from '@prisma/client';
+import { createLogger } from '../lib/logger';
+import { cacheMiddleware } from '../middleware/cache.middleware';
+import { cacheService, CacheKeys, CacheTTL, sanitizeKeySegment } from '../services/cache.service';
+import { createPublicRateLimiter } from '../middleware/rate-limit.middleware';
+import { metaTagService } from '../services/metaTag/metaTagService';
+
+const logger = createLogger({ component: 'public-router' });
+
+/**
+ * Factory so createApp() can inject a rate-limit store (e.g. a mock in tests
+ * or a RedisStore in production) without requiring a real Redis connection in
+ * every test that imports the public router.
+ */
+export function createPublicRouter(store?: Store) {
+  const router = Router();
+
+  // Redis-backed rate limiting per Issue #318: 100 req/min per IP, shared across replicas
+  router.use(createPublicRateLimiter(store));
+
+  /**
+   * GET /api/public/channels/:channelId/messages
+   * Returns paginated messages for a PUBLIC_INDEXABLE channel.
+   * Uses cache middleware with stale-while-revalidate.
+   */
+  router.get(
+    '/channels/:channelId/messages',
+    cacheMiddleware({
+      ttl: CacheTTL.channelMessages,
+      staleTtl: CacheTTL.channelMessages, // keep stale data for an extra TTL window
+      keyFn: (req: Request) =>
+        CacheKeys.channelMessages(req.params.channelId, Number(req.query.page) || 1),
+    }),
+    async (req: Request, res: Response) => {
+      try {
+        const { channelId } = req.params;
+        const page = Math.max(1, Number(req.query.page) || 1);
+        const pageSize = 50;
+
+        const channel = await prisma.channel.findUnique({
+          where: { id: channelId },
+          select: { id: true, visibility: true },
+        });
+
+        if (!channel || channel.visibility !== ChannelVisibility.PUBLIC_INDEXABLE) {
+          res.status(404).json({ error: 'Channel not found' });
+          return;
+        }
+
+        const messages = await prisma.message.findMany({
+          where: { channelId, isDeleted: false },
+          orderBy: { createdAt: 'desc' },
+          skip: (page - 1) * pageSize,
+          take: pageSize,
+          select: {
+            id: true,
+            content: true,
+            createdAt: true,
+            editedAt: true,
+            author: { select: { id: true, username: true } },
+          },
+        });
+
+        res.set('Cache-Control', `public, max-age=${CacheTTL.channelMessages}`);
+        res.json({ messages, page, pageSize });
+      } catch (err) {
+        logger.error({ err, channelId: req.params.channelId }, 'Public messages route failed');
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Internal server error' });
+        }
+      }
+    },
+  );
+
+  /**
+   * GET /api/public/channels/:channelId/messages/:messageId
+   * Returns a single message from a PUBLIC_INDEXABLE channel.
+   * Uses cache middleware with stale-while-revalidate.
+   */
+  router.get(
+    '/channels/:channelId/messages/:messageId',
+    cacheMiddleware({
+      ttl: CacheTTL.channelMessages,
+      staleTtl: CacheTTL.channelMessages,
+      keyFn: (req: Request) =>
+        `channel:msg:${sanitizeKeySegment(req.params.channelId)}:${sanitizeKeySegment(req.params.messageId)}`,
+    }),
+    async (req: Request, res: Response) => {
+      try {
+        const { channelId, messageId } = req.params;
+
+        const channel = await prisma.channel.findUnique({
+          where: { id: channelId },
+          select: { id: true, visibility: true },
+        });
+
+        if (!channel || channel.visibility !== ChannelVisibility.PUBLIC_INDEXABLE) {
+          res.status(404).json({ error: 'Channel not found' });
+          return;
+        }
+
+        const message = await prisma.message.findFirst({
+          where: { id: messageId, channelId, isDeleted: false },
+          select: {
+            id: true,
+            content: true,
+            createdAt: true,
+            editedAt: true,
+            author: { select: { id: true, username: true } },
+          },
+        });
+
+        if (!message) {
+          res.status(404).json({ error: 'Message not found' });
+          return;
+        }
+
+        res.set('Cache-Control', `public, max-age=${CacheTTL.channelMessages}`);
+        res.json(message);
+      } catch (err) {
+        logger.error(
+          { err, channelId: req.params.channelId, messageId: req.params.messageId },
+          'Public message route failed',
+        );
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Internal server error' });
+        }
+      }
+    },
+  );
+
+  /**
+   * GET /api/public/servers
+   * Returns a list of public servers ordered by member count (desc).
+   * Used by the home page to discover a default public channel to show visitors.
+   */
+  router.get('/servers', async (_req: Request, res: Response) => {
+    try {
+      const servers = await prisma.server.findMany({
+        where: { isPublic: true },
+        orderBy: { memberCount: 'desc' },
+        take: 20,
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          iconUrl: true,
+          description: true,
+          memberCount: true,
+          createdAt: true,
+        },
+      });
+      res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+      res.json(servers);
+    } catch (err) {
+      logger.error({ err }, 'Public servers list route failed');
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
+   * GET /api/public/servers/:serverSlug
+   * Returns public server info. Uses getOrRevalidate for SWR.
+   * Cache key: server:{serverId}:info per §4.4.
+   */
+  router.get('/servers/:serverSlug', async (req: Request, res: Response) => {
+    try {
+      const server = await prisma.server.findUnique({
+        where: { slug: req.params.serverSlug, isPublic: true },
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          iconUrl: true,
+          description: true,
+          memberCount: true,
+          createdAt: true,
+        },
+      });
+
+      if (!server) {
+        res.status(404).json({ error: 'Server not found' });
+        return;
+      }
+
+      const cacheKey = CacheKeys.serverInfo(server.id);
+      const cacheOpts = { ttl: CacheTTL.serverInfo, staleTtl: CacheTTL.serverInfo };
+
+      // Check cache state for X-Cache header
+      let xCache = 'MISS';
+      try {
+        const entry = await cacheService.get(cacheKey);
+        if (entry) {
+          xCache = cacheService.isStale(entry, CacheTTL.serverInfo) ? 'STALE' : 'HIT';
+        }
+      } catch (err) {
+        logger.warn({ err, cacheKey }, 'Failed to inspect public server cache state');
+      }
+
+      const data = await cacheService.getOrRevalidate(
+        cacheKey,
+        async () => server, // fetcher — server already fetched from DB above
+        cacheOpts,
+      );
+
+      res.set('X-Cache', xCache);
+      res.set('X-Cache-Key', cacheKey);
+      res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+      res.json(data);
+    } catch (err) {
+      logger.error({ err, serverSlug: req.params.serverSlug }, 'Public server route failed');
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
+   * GET /api/public/servers/:serverSlug/channels
+   * Returns public channels for a server. Uses getOrRevalidate for SWR.
+   * Cache key: server:{serverId}:public_channels per §4.4.
+   */
+  router.get('/servers/:serverSlug/channels', async (req: Request, res: Response) => {
+    try {
+      const server = await prisma.server.findUnique({
+        where: { slug: req.params.serverSlug, isPublic: true },
+        select: { id: true },
+      });
+
+      if (!server) {
+        res.status(404).json({ error: 'Server not found' });
+        return;
+      }
+
+      const cacheKey = `server:${sanitizeKeySegment(server.id)}:public_channels`;
+      const cacheOpts = { ttl: CacheTTL.serverInfo, staleTtl: CacheTTL.serverInfo };
+
+      const fetcher = async () => {
+        const channels = await prisma.channel.findMany({
+          where: { serverId: server.id, visibility: ChannelVisibility.PUBLIC_INDEXABLE },
+          orderBy: { position: 'asc' },
+          select: { id: true, name: true, slug: true, type: true, topic: true },
+        });
+        return { channels };
+      };
+
+      // Check cache state for X-Cache header
+      let xCache = 'MISS';
+      try {
+        const entry = await cacheService.get(cacheKey);
+        if (entry) {
+          xCache = cacheService.isStale(entry, CacheTTL.serverInfo) ? 'STALE' : 'HIT';
+        }
+      } catch (err) {
+        logger.warn({ err, cacheKey }, 'Failed to inspect public channel cache state');
+      }
+
+      const data = await cacheService.getOrRevalidate(cacheKey, fetcher, cacheOpts);
+
+      res.set('X-Cache', xCache);
+      res.set('X-Cache-Key', cacheKey);
+      res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+      res.json(data);
+    } catch (err) {
+      logger.error({ err, serverSlug: req.params.serverSlug }, 'Public channels route failed');
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
+   * GET /api/public/servers/:serverSlug/channels/:channelSlug
+   * Returns channel info by slug. Returns 403 for PRIVATE channels, 404 if not found.
+   * Supports PUBLIC_INDEXABLE and PUBLIC_NO_INDEX channels for guest access.
+   */
+  router.get('/servers/:serverSlug/channels/:channelSlug', async (req: Request, res: Response) => {
+    try {
+      const server = await prisma.server.findUnique({
+        where: { slug: req.params.serverSlug, isPublic: true },
+        select: { id: true },
+      });
+
+      if (!server) {
+        res.status(404).json({ error: 'Server not found' });
+        return;
+      }
+
+      const channel = await prisma.channel.findFirst({
+        where: { serverId: server.id, slug: req.params.channelSlug },
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          serverId: true,
+          type: true,
+          visibility: true,
+          topic: true,
+          position: true,
+          createdAt: true,
+        },
+      });
+
+      if (!channel) {
+        res.status(404).json({ error: 'Channel not found' });
+        return;
+      }
+
+      if (channel.visibility === ChannelVisibility.PRIVATE) {
+        res.status(403).json({ error: 'Channel is private' });
+        return;
+      }
+
+      res.set('Cache-Control', `public, max-age=${CacheTTL.serverInfo}`);
+      res.json(channel);
+    } catch (err) {
+      logger.error(
+        { err, serverSlug: req.params.serverSlug, channelSlug: req.params.channelSlug },
+        'Public channel route failed',
+      );
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
+   * GET /api/public/servers/:serverSlug/channels/:channelSlug/meta-tags
+   * Returns the persisted/generated metadata for guest-accessible channels so
+   * the frontend generateMetadata path reads the same SEO source of truth that
+   * admins preview and edit.
+   */
+  router.get(
+    '/servers/:serverSlug/channels/:channelSlug/meta-tags',
+    async (req: Request, res: Response) => {
+      try {
+        const channel = await prisma.channel.findFirst({
+          where: {
+            slug: req.params.channelSlug,
+            server: { slug: req.params.serverSlug },
+            visibility: { not: ChannelVisibility.PRIVATE },
+          },
+          select: {
+            id: true,
+            visibility: true,
+          },
+        });
+
+        if (!channel) {
+          res.status(404).json({ error: 'Channel not found' });
+          return;
+        }
+
+        const preview = await metaTagService.getMetaTagsForPreview(channel.id);
+        res.set('Cache-Control', 'public, max-age=60');
+        res.json({
+          ...preview,
+          visibility: channel.visibility,
+        });
+      } catch (err) {
+        logger.error(
+          { err, serverSlug: req.params.serverSlug, channelSlug: req.params.channelSlug },
+          'Public meta tags route failed',
+        );
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Internal server error' });
+        }
+      }
+    },
+  );
+
+  return router;
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "slug: 'admin'|name: '\.\.\/\.\.\/\.\.\/admin'|slug.*admin|name.*admin" harmony-backend/src/dev harmony-backend/prisma harmony-backend/tests
+```
+
+Output:
+
+```text
+95 matches in 6F:
+
+[file] harmony-backend/src/dev/mock-seed-data.json (83):
+     5: "username": "alice_admin",
+   406: "username": "alice_admin",
+   518: "username": "alice_admin",
+   632: "username": "alice_admin",
+   759: "username": "alice_admin",
+   884: "username": "alice_admin",
+   935: "username": "alice_admin",
+   964: "username": "alice_admin",
+   992: "username": "alice_admin",
+  1005: "username": "alice_admin",
+  1047: "username": "alice_admin",
+  1087: "username": "alice_admin",
+  1115: "username": "alice_admin",
+  1271: "username": "alice_admin",
+  1375: "username": "alice_admin",
+  1401: "username": "alice_admin",
+  1543: "username": "alice_admin",
+  1832: "username": "alice_admin",
+  1858: "username": "alice_admin",
+  2040: "username": "alice_admin",
+  2248: "username": "alice_admin",
+  2274: "username": "alice_admin",
+  2300: "username": "alice_admin",
+  2326: "username": "alice_admin",
+  2352: "username": "alice_admin",
+  +58
+
+[file] harmony-backend/tests/admin.utils.test.ts (1):
+    66: it('includes the username "admin"', () => {
+
+[file] harmony-backend/tests/auth.service.test.ts (3):
+   121: username: 'admin',
+   366: username: 'admin',
+   385: username: 'admin',
+
+[file] harmony-backend/tests/auth.test.ts (4):
+   174: username: 'notadmin',
+   189: username: 'notadmin',
+   198: it('rejects registration with the reserved username "admin"', async () => {
+   204: username: 'admin',
+
+[file] harmony-backend/tests/channel.getAuditLog.test.ts (1):
+    42: username: `gal-admin-${ts}`,
+
+[file] harmony-backend/tests/mock-seed.test.ts (3):
+    64: const alice = data.users.find((u) => u.username === 'alice_admin');
+    65: const others = data.users.filter((u) => u.username !== 'alice_admin');
+    71: const alice = data.users.find((user) => user.username === 'alice_admin');
+
+... +58
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+zsh:1: no matches found: harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/__tests__/channel-page-metadata.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/__tests__/public-channel-metadata.test.ts
+```
+
+Output:
+
+```text
+zsh:1: no matches found: harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/__tests__/public-channel-metadata.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk find harmony-frontend/src/app/c -type f | sort
+```
+
+Output:
+
+```text
+
+2F 1D:
+[serverSlug]/[channelSlug]/ loading.tsx page.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -l "channel-page-metadata|generateMetadata\(|Custom SEO Title|general - Harmony HQ | Harmony" harmony-frontend/src harmony-frontend/tests
+```
+
+Output:
+
+```text
+grep: parentheses not balanced
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "general - Harmony HQ \| Harmony|Custom SEO Title|fetchPublicMetaTags" harmony-frontend/src harmony-frontend/tests
+```
+
+Output:
+
+```text
+48 matches in 19F:
+
+[file] harmony-frontend/.../__tests__/channel-page-metadata.test.ts (15):
+    15: fetchPublicMetaTags: jest.fn().mockResolvedValue(null),
+    27: fetchPublicMetaTags,
+    33: const mockFetchPublicMetaTags = fetchPublicMetaTags as jest.Mock;
+    91: expect(meta.title).toBe('general - Harmony HQ | Harmony');
+   109: title: 'general - Harmony HQ | Harmony',
+   121: title: 'general - Harmony HQ | Harmony',
+   137: 'name': 'general - Harmony HQ | Harmony',
+   138: 'headline': 'general - Harmony HQ | Harmony',
+   152: title: 'Custom SEO Title',
+   168: name: 'Custom SEO Title',
+   169: headline: 'Custom SEO Title',
+   185: name: 'general - fallback-server | Harmony',
+   186: headline: 'general - fallback-server | Harmony',
+   243: expect(meta.title).toBe('my-channel - my-server | Harmony');
+   248: expect(meta.description).toBe('Join my-server on Harmony');
+
+[file] harmony-frontend/.../__tests__/issue-242-join-server-fix.test.ts (1):
+   223: // This allows HarmonyShell to broadcast to other tabs via notifyServerJoined.
+
+[file] harmony-frontend/.../__tests__/private-channel-pane-lock.test.tsx (2):
+     3: import { HarmonyShell } from '@/components/layout/HarmonyShell';
+   140: function renderShell(overrides?: Partial<React.ComponentProps<typeof HarmonyS...
+
+[file] harmony-frontend/.../__tests__/public-channel-metadata.test.ts (6):
+     4: fetchPublicMetaTags,
+    12: fetchPublicMetaTags: jest.fn(),
+    17: const mockFetchPublicMetaTags = fetchPublicMetaTags as jest.MockedFunction<
+    18: typeof fetchPublicMetaTags
+    48: title: 'Custom SEO Title',
+    61: expect(metadata.title).toBe('Custom SEO Title');
+
+[file] harmony-frontend/.../[channelSlug]/page.tsx (6):
+     6: fetchPublicMetaTags,
+    20: publicMetaTags: Awaited<ReturnType<typeof fetchPublicMetaTags>>,
+    25: const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harm...
+    30: `Join ${serverName} on Harmony`;
+    45: fetchPublicMetaTags(serverSlug, channelSlug),
+    85: fetchPublicMetaTags(serverSlug, channelSlug),
+
+[file] harmony-frontend/.../channel/ChannelPageContent.tsx (1):
+     6: import { HarmonyShell } from '@/components/layout/HarmonyShell';
+
+[file] harmony-frontend/.../channel/GuestHeader.tsx (1):
+    17: {/* Harmony logo wordmark */}
+
+[file] harmony-frontend/.../channel/GuestPromoBanner.tsx (1):
+     3: * Non-intrusive sticky bottom banner encouraging guests to join Harmony.
+
+[file] harmony-frontend/.../channel/SearchModal.tsx (1):
+   144: // #c23: Ctrl+K/Cmd+K toggling is handled exclusively by HarmonyShell to avoid
+
+[file] harmony-frontend/.../layout/EmptyShell.tsx (1):
+    91: // Fallback guest user — mirrors the pattern used in HarmonyShell.
+
+[file] harmony-frontend/.../layout/HarmonyShell.tsx (4):
+     2: * Layout: HarmonyShell
+    53: export interface HarmonyShellProps {
+    74: export function HarmonyShell({
+    84: }: HarmonyShellProps) {
+
+[file] harmony-frontend/.../server-rail/BrowseServersModal.tsx (1):
+    40: /** URL base path for channel navigation — matches HarmonyShell basePath. */
+
+[file] harmony-frontend/.../server-rail/ServerRail.tsx (1):
+   110: // parent re-render (e.g. search/menu toggles in HarmonyShell).
+
+[file] harmony-frontend/.../settings/UserSettingsPage.tsx (2):
+   328: You will be signed out of Harmony. Your session data will be cleared.
+   438: ← Back to Harmony
+
+[file] harmony-frontend/src/contexts/VoiceContext.tsx (1):
+   147: // voiceChannelIds itself changes reference on every setLocalChannels call in...
+
+[file] harmony-frontend/src/lib/api-client.ts (1):
+    63: * API Client for Harmony backend.
+
+[file] harmony-frontend/src/lib/trpc-client.ts (1):
+     2: * Server-side tRPC/API client for calling the Harmony backend.
+
+[file] harmony-frontend/src/services/publicApiService.ts (1):
+   205: export const fetchPublicMetaTags = cache(
+
+[file] harmony-frontend/.../support/stack.shared.mjs (1):
+    71: `Missing E2E seed snapshot at ${seedPath}. Ensure the Harmony backend mock se...
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -l "general - Harmony HQ \| Harmony" harmony-frontend
+```
+
+Output:
+
+```text
+grep: harmony-frontend: Is a directory
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -l "Custom SEO Title" harmony-frontend
+```
+
+Output:
+
+```text
+grep: harmony-frontend: Is a directory
+```
+
+#### Tool: exec_command
+
+```sh
+rg --files harmony-frontend | rg 'channel-page-metadata|public-channel-metadata'
+```
+
+Output:
+
+```text
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read 'harmony-frontend/src/app/channels/[serverSlug]/[channelSlug]/__tests__/channel-page-metadata.test.ts'
+```
+
+Output:
+
+```text
+cat: harmony-frontend/src/app/channels/[serverSlug]/[channelSlug]/__tests__/channel-page-metadata.test.ts: No such file or directory (os error 2)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/__tests__/public-channel-metadata.test.ts'
+```
+
+Output:
+
+```text
+cat: harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/__tests__/public-channel-metadata.test.ts: No such file or directory (os error 2)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+/**
+ * Unit tests for generateMetadata in the public channel page.
+ * Issue #357 — Sprint 5 (M1 PublicChannelPage + generateMetadata integration)
+ */
+
+const mockCache = jest.fn(<T extends (...args: never[]) => unknown>(fn: T): T => fn);
+jest.mock('react', () => {
+  const actualReact = jest.requireActual('react');
+  return { ...actualReact, cache: mockCache };
+});
+
+jest.mock('@/services/publicApiService', () => ({
+  fetchPublicServer: jest.fn(),
+  fetchPublicChannel: jest.fn(),
+  fetchPublicMetaTags: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/components/channel/GuestChannelView', () => ({
+  GuestChannelView: () => null,
+}));
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import GuestChannelPage, { generateMetadata } from '@/app/c/[serverSlug]/[channelSlug]/page';
+import {
+  fetchPublicServer,
+  fetchPublicChannel,
+  fetchPublicMetaTags,
+} from '@/services/publicApiService';
+import { ChannelType, ChannelVisibility } from '@/types';
+
+const mockFetchPublicServer = fetchPublicServer as jest.Mock;
+const mockFetchPublicChannel = fetchPublicChannel as jest.Mock;
+const mockFetchPublicMetaTags = fetchPublicMetaTags as jest.Mock;
+
+const originalEnv = process.env;
+
+function makeParams(
+  serverSlug = 'harmony-hq',
+  channelSlug = 'general',
+): { params: Promise<{ serverSlug: string; channelSlug: string }> } {
+  return { params: Promise.resolve({ serverSlug, channelSlug }) };
+}
+
+function makeServer(overrides = {}) {
+  return {
+    id: 'srv-1',
+    name: 'Harmony HQ',
+    slug: 'harmony-hq',
+    description: 'A public server',
+    memberCount: 10,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeChannel(visibility: ChannelVisibility, overrides = {}) {
+  return {
+    id: 'ch-1',
+    name: 'general',
+    slug: 'general',
+    serverId: 'srv-1',
+    type: ChannelType.TEXT,
+    visibility,
+    topic: 'Welcome to general',
+    position: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  process.env = { ...originalEnv, NEXT_PUBLIC_BASE_URL: 'https://harmony.chat' };
+  jest.resetAllMocks();
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({
+      channel: makeChannel(ChannelVisibility.PUBLIC_INDEXABLE),
+      isPrivate: false,
+    });
+  });
+
+  it('sets title and description from channel and server data', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.title).toBe('general - Harmony HQ | Harmony');
+    expect(meta.description).toBe('Welcome to general');
+  });
+
+  it('sets robots to index, follow', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.robots).toEqual({ index: true, follow: true });
+  });
+
+  it('sets canonical URL using the frontend domain', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta.alternates?.canonical).toBe('https://harmony.chat/c/harmony-hq/general');
+  });
+
+  it('includes Open Graph tags', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta).toMatchObject({
+      openGraph: {
+        title: 'general - Harmony HQ | Harmony',
+        type: 'website',
+        url: 'https://harmony.chat/c/harmony-hq/general',
+      },
+    });
+  });
+
+  it('includes Twitter card tags', async () => {
+    const meta = await generateMetadata(makeParams());
+    expect(meta).toMatchObject({
+      twitter: {
+        card: 'summary',
+        title: 'general - Harmony HQ | Harmony',
+        description: 'Welcome to general',
+      },
+    });
+  });
+
+  it('renders JSON-LD with author, text, and headline for rich results', async () => {
+    const page = await GuestChannelPage(makeParams());
+    const html = renderToStaticMarkup(page);
+    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+
+    expect(ldMatch).not.toBeNull();
+    const jsonLd = JSON.parse(ldMatch![1]);
+    expect(jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'DiscussionForumPosting',
+      'name': 'general - Harmony HQ | Harmony',
+      'headline': 'general - Harmony HQ | Harmony',
+      'description': 'Welcome to general',
+      'text': 'Welcome to general',
+      'author': {
+        '@type': 'Organization',
+        'name': 'Harmony HQ',
+      },
+      'url': 'https://harmony.chat/c/harmony-hq/general',
+      'datePublished': '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('reuses persisted SEO metadata in JSON-LD when present', async () => {
+    mockFetchPublicMetaTags.mockResolvedValue({
+      title: 'Custom SEO Title',
+      description: 'Custom SEO Description',
+      ogTitle: 'Custom OG Title',
+      ogDescription: 'Custom OG Description',
+      ogImage: 'https://example.com/custom.png',
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      visibility: 'PUBLIC_INDEXABLE',
+    });
+
+    const page = await GuestChannelPage(makeParams());
+    const html = renderToStaticMarkup(page);
+    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+
+    expect(ldMatch).not.toBeNull();
+    const jsonLd = JSON.parse(ldMatch![1]);
+    expect(jsonLd).toMatchObject({
+      name: 'Custom SEO Title',
+      headline: 'Custom SEO Title',
+      description: 'Custom SEO Description',
+      text: 'Custom SEO Description',
+    });
+  });
+
+  it('uses the same server-name fallback for JSON-LD author as the page metadata', async () => {
+    mockFetchPublicServer.mockResolvedValue(null);
+
+    const page = await GuestChannelPage(makeParams('fallback-server', 'general'));
+    const html = renderToStaticMarkup(page);
+    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+
+    expect(ldMatch).not.toBeNull();
+    const jsonLd = JSON.parse(ldMatch![1]);
+    expect(jsonLd).toMatchObject({
+      name: 'general - fallback-server | Harmony',
+      headline: 'general - fallback-server | Harmony',
+      description: 'Welcome to general',
+      text: 'Welcome to general',
+      author: {
+        '@type': 'Organization',
+        'name': 'fallback-server',
+      },
+    });
+  });
+});
+
+describe('generateMetadata — PUBLIC_NO_INDEX channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({
+      channel: makeChannel(ChannelVisibility.PUBLIC_NO_INDEX, { topic: 'Staff updates' }),
+      isPrivate: false,
+    });
+  });
+
+  it('sets robots to noindex, follow', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'staff'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('still includes Twitter card tags', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'staff'));
+    expect(meta).toMatchObject({ twitter: { card: 'summary' } });
+    expect(meta.twitter?.title).toBeTruthy();
+  });
+});
+
+describe('generateMetadata — PRIVATE channel', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(makeServer());
+    mockFetchPublicChannel.mockResolvedValue({ isPrivate: true });
+  });
+
+  it('sets robots to noindex, follow', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'secret'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('falls back to the slug for title when channel data is unavailable', async () => {
+    const meta = await generateMetadata(makeParams('harmony-hq', 'secret'));
+    expect(meta.title).toContain('secret');
+  });
+});
+
+describe('generateMetadata — API fallback (both fetches return null)', () => {
+  beforeEach(() => {
+    mockFetchPublicServer.mockResolvedValue(null);
+    mockFetchPublicChannel.mockResolvedValue(null);
+  });
+
+  it('falls back to slugs for title', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.title).toBe('my-channel - my-server | Harmony');
+  });
+
+  it('falls back to a template description', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.description).toBe('Join my-server on Harmony');
+  });
+
+  it('still sets canonical URL and Twitter card', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.alternates?.canonical).toBe('https://harmony.chat/c/my-server/my-channel');
+    expect(meta).toMatchObject({ twitter: { card: 'summary' } });
+  });
+
+  it('sets robots to noindex when channel is unknown', async () => {
+    const meta = await generateMetadata(makeParams('my-server', 'my-channel'));
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/__tests__/public-channel-metadata.test.ts
+```
+
+Output:
+
+```text
+import { generateMetadata } from '@/app/c/[serverSlug]/[channelSlug]/page';
+import {
+  fetchPublicChannel,
+  fetchPublicMetaTags,
+  fetchPublicServer,
+} from '@/services/publicApiService';
+import { ChannelType, ChannelVisibility } from '@/types';
+
+jest.mock('@/services/publicApiService', () => ({
+  fetchPublicServer: jest.fn(),
+  fetchPublicChannel: jest.fn(),
+  fetchPublicMetaTags: jest.fn(),
+}));
+
+const mockFetchPublicServer = fetchPublicServer as jest.MockedFunction<typeof fetchPublicServer>;
+const mockFetchPublicChannel = fetchPublicChannel as jest.MockedFunction<typeof fetchPublicChannel>;
+const mockFetchPublicMetaTags = fetchPublicMetaTags as jest.MockedFunction<
+  typeof fetchPublicMetaTags
+>;
+
+describe('public channel metadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prefers persisted SEO metadata over the fallback public channel values', async () => {
+    mockFetchPublicServer.mockResolvedValue({
+      id: 'server-1',
+      name: 'Game Dev Hub',
+      slug: 'game-dev-hub',
+      createdAt: '2026-04-23T00:00:00.000Z',
+    });
+    mockFetchPublicChannel.mockResolvedValue({
+      isPrivate: false,
+      channel: {
+        id: 'channel-1',
+        serverId: 'server-1',
+        name: 'unity',
+        slug: 'unity',
+        type: ChannelType.TEXT,
+        visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+        topic: 'Fallback topic',
+        position: 0,
+        createdAt: '2026-04-23T00:00:00.000Z',
+      },
+    });
+    mockFetchPublicMetaTags.mockResolvedValue({
+      title: 'Custom SEO Title',
+      description: 'Custom SEO Description',
+      ogTitle: 'Custom OG Title',
+      ogDescription: 'Custom OG Description',
+      ogImage: 'https://example.com/custom.png',
+      generatedAt: '2026-04-23T00:00:00.000Z',
+      visibility: 'PUBLIC_INDEXABLE',
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ serverSlug: 'game-dev-hub', channelSlug: 'unity' }),
+    });
+
+    expect(metadata.title).toBe('Custom SEO Title');
+    expect(metadata.description).toBe('Custom SEO Description');
+    expect(metadata.openGraph).toMatchObject({
+      title: 'Custom OG Title',
+      description: 'Custom OG Description',
+      images: [{ url: 'https://example.com/custom.png' }],
+    });
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "\.\.\/\.\.\/\.\.\/admin" harmony-backend/src/dev/mock-seed-data.json harmony-backend/src/dev/mockSeed.ts harmony-backend/prisma
+```
+
+Output:
+
+```text
+0 matches for '\.\.\/\.\.\/\.\.\/admin'
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "sanitizeForTitle" harmony-backend/tests/metaTagService.test.ts harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+4 matches in 1F:
+
+[file] harmony-backend/tests/metaTagService.test.ts (4):
+    90: it('sanitizeForTitle strips HTML tags', () => {
+    91: const result = TitleGenerator.sanitizeForTitle('<b>Hello</b> <em>world</em>');
+    95: it('sanitizeForTitle collapses whitespace', () => {
+    96: const result = TitleGenerator.sanitizeForTitle('foo   bar\n  baz');
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:05:37.968Z
+
+I haven’t found that exact string in seed data, which makes this look like unsanitized server display data flowing through metadata generation rather than a literal fixture. I’m tightening the repro with a regression test around path-like server names/slugs now.
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-backend/tests/metaTagService.test.ts
+```
+
+Output:
+
+```text
+/**
+ * Unit tests for M2 Meta Tag Generation Service skeleton — Issue #350
+ *
+ * Covers AC-2 (length limits), sanitization, template application,
+ * and AC-9 (fallback on failure, needsRegeneration=true).
+ *
+ * MetaTagCache uses Redis via cacheService — mocked here for unit speed.
+ */
+
+jest.mock('../src/services/cache.service', () => ({
+  cacheService: {
+    get: jest.fn(),
+    set: jest.fn(),
+    invalidate: jest.fn(),
+    getOrRevalidate: jest.fn(),
+  },
+  CacheKeys: {
+    metaChannel: (id: string) => `meta:channel:${id}`,
+    channelVisibility: (id: string) => `channel:${id}:visibility`,
+    channelMessages: (id: string, page: number) => `channel:msgs:${id}:page:${page}`,
+    serverInfo: (id: string) => `server:${id}:info`,
+    analysisChannel: (id: string) => `analysis:channel:${id}`,
+  },
+  sanitizeKeySegment: (s: string) => s.replace(/[*?\[\]]/g, ''),
+}));
+
+const scheduleUpdateMock = jest.fn();
+
+jest.mock('../src/workers/metaTagUpdate.queue', () => ({
+  metaTagUpdateQueue: {
+    scheduleUpdate: scheduleUpdateMock,
+  },
+}));
+
+import { TitleGenerator } from '../src/services/metaTag/titleGenerator';
+import { DescriptionGenerator } from '../src/services/metaTag/descriptionGenerator';
+import { MetaTagCache } from '../src/services/metaTag/metaTagCache';
+import { metaTagService } from '../src/services/metaTag/metaTagService';
+import { cacheService } from '../src/services/cache.service';
+import type { ChannelContext, MessageContext } from '../src/services/metaTag/types';
+
+const mockCacheService = cacheService as jest.Mocked<typeof cacheService>;
+
+const channel: ChannelContext = {
+  id: 'chan-001',
+  name: 'unity-physics-help',
+  slug: 'unity-physics-help',
+  topic: 'Ask about Unity physics',
+  serverName: 'Game Dev Hub',
+  serverSlug: 'game-dev-hub',
+  canonicalUrl: 'https://harmony.chat/c/game-dev-hub/unity-physics-help',
+};
+
+const messages: MessageContext[] = [
+  { content: 'How do I handle collision detection in Unity?', createdAt: new Date() },
+  { content: 'Use OnCollisionEnter for physics-based collisions.', createdAt: new Date() },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  scheduleUpdateMock.mockResolvedValue({
+    jobId: 'meta-tag-update:chan-001:channel',
+    status: 'queued',
+  });
+});
+
+// ─── TitleGenerator ──────────────────────────────────────────────────────────
+
+describe('TitleGenerator', () => {
+  it('maxLength is 60', () => {
+    expect(TitleGenerator.maxLength).toBe(60);
+  });
+
+  it('generateFromChannel produces title ≤60 chars', () => {
+    const title = TitleGenerator.generateFromChannel(channel);
+    expect(title.length).toBeLessThanOrEqual(60);
+  });
+
+  it('truncates long titles with ellipsis and stays ≤60 chars', () => {
+    const longChannel: ChannelContext = {
+      ...channel,
+      name: 'this-is-a-very-long-channel-name-that-exceeds-limits',
+      serverName: 'An Extremely Long Server Name That Will Overflow',
+    };
+    const title = TitleGenerator.generateFromChannel(longChannel);
+    expect(title.length).toBeLessThanOrEqual(60);
+    expect(title.endsWith('…')).toBe(true);
+  });
+
+  it('sanitizeForTitle strips HTML tags', () => {
+    const result = TitleGenerator.sanitizeForTitle('<b>Hello</b> <em>world</em>');
+    expect(result).toBe('Hello world');
+  });
+
+  it('sanitizeForTitle collapses whitespace', () => {
+    const result = TitleGenerator.sanitizeForTitle('foo   bar\n  baz');
+    expect(result).toBe('foo bar baz');
+  });
+
+  it('applyTemplate replaces template variables', () => {
+    const result = TitleGenerator.applyTemplate('{channelName} on {serverName}', {
+      channelName: 'general',
+      serverName: 'My Server',
+    });
+    expect(result).toBe('general on My Server');
+  });
+
+  it('generateFromThread falls back to channel when no messages', () => {
+    const title = TitleGenerator.generateFromThread([], channel);
+    expect(title).toBe(TitleGenerator.generateFromChannel(channel));
+  });
+
+  it('generateFromMessage uses first message content', () => {
+    const title = TitleGenerator.generateFromMessage(messages[0], channel);
+    expect(title.length).toBeLessThanOrEqual(60);
+    expect(title).toContain('Game Dev Hub');
+  });
+});
+
+// ─── DescriptionGenerator ───────────────────────────────────────────────────
+
+describe('DescriptionGenerator', () => {
+  it('maxLength is 160', () => {
+    expect(DescriptionGenerator.maxLength).toBe(160);
+  });
+
+  it('minLength is 50', () => {
+    expect(DescriptionGenerator.minLength).toBe(50);
+  });
+
+  it('generateFromMessages produces description 50-160 chars', () => {
+    const desc = DescriptionGenerator.generateFromMessages(messages, channel);
+    expect(desc.length).toBeGreaterThanOrEqual(50);
+    expect(desc.length).toBeLessThanOrEqual(160);
+  });
+
+  it('truncates long descriptions to ≤160 chars with ellipsis', () => {
+    const longMessages: MessageContext[] = [
+      {
+        content: 'A'.repeat(200),
+        createdAt: new Date(),
+      },
+    ];
+    const desc = DescriptionGenerator.generateFromMessages(longMessages, channel);
+    expect(desc.length).toBeLessThanOrEqual(160);
+    expect(desc.endsWith('…')).toBe(true);
+  });
+
+  it('returns text unchanged when within valid range', () => {
+    const valid = 'A'.repeat(80);
+    expect(DescriptionGenerator.enforceLength(valid)).toBe(valid);
+  });
+
+  it('AC-2: generateFromMessages produces ≥50 chars even for a very short message', () => {
+    const shortMessages: MessageContext[] = [{ content: 'hi', createdAt: new Date() }];
+    const desc = DescriptionGenerator.generateFromMessages(shortMessages, channel);
+    expect(desc.length).toBeGreaterThanOrEqual(50);
+    expect(desc.length).toBeLessThanOrEqual(160);
+  });
+
+  it('extractKeyPhrases returns non-empty array for non-empty content', () => {
+    const content = messages.map((m) => m.content).join(' ');
+    const phrases = DescriptionGenerator.extractKeyPhrases(content, 5);
+    expect(Array.isArray(phrases)).toBe(true);
+    expect(phrases.length).toBeGreaterThan(0);
+  });
+
+  it('extractKeyPhrases respects maxPhrases limit', () => {
+    const content = messages.map((m) => m.content).join(' ');
+    const phrases = DescriptionGenerator.extractKeyPhrases(content, 2);
+    expect(phrases.length).toBeLessThanOrEqual(2);
+  });
+
+  it('summarizeThread returns empty string for no messages', () => {
+    const summary = DescriptionGenerator.summarizeThread([]);
+    expect(summary).toBe('');
+  });
+
+  it('summarizeThread returns first message content for non-empty messages', () => {
+    const summary = DescriptionGenerator.summarizeThread(messages);
+    expect(summary.length).toBeGreaterThan(0);
+  });
+
+  it('generateFromMessages includes channel info for empty messages', () => {
+    const desc = DescriptionGenerator.generateFromMessages([], channel);
+    expect(desc).toContain(channel.name);
+    expect(desc.length).toBeGreaterThanOrEqual(50);
+    expect(desc.length).toBeLessThanOrEqual(160);
+  });
+});
+
+// ─── MetaTagCache ────────────────────────────────────────────────────────────
+
+describe('MetaTagCache', () => {
+  it('ttl defaults to 3600', () => {
+    expect(MetaTagCache.ttl).toBe(3600);
+  });
+
+  it('get returns null on cache miss', async () => {
+    mockCacheService.get.mockResolvedValue(null);
+    const result = await MetaTagCache.get('chan-001');
+    expect(result).toBeNull();
+    expect(mockCacheService.get).toHaveBeenCalledWith('meta:channel:chan-001');
+  });
+
+  it('get returns cached data on hit', async () => {
+    const fakeSet = { title: 'Cached Title' } as never;
+    mockCacheService.get.mockResolvedValue({ data: fakeSet, createdAt: Date.now() });
+    const result = await MetaTagCache.get('chan-001');
+    expect(result).toEqual(fakeSet);
+  });
+
+  it('set calls cacheService.set with correct key and ttl', async () => {
+    mockCacheService.set.mockResolvedValue(undefined);
+    const tags = { title: 'T' } as never;
+    await MetaTagCache.set('chan-001', tags, 1800);
+    expect(mockCacheService.set).toHaveBeenCalledWith('meta:channel:chan-001', tags, { ttl: 1800 });
+  });
+
+  it('invalidate calls cacheService.invalidate with correct key', async () => {
+    mockCacheService.invalidate.mockResolvedValue(undefined);
+    await MetaTagCache.invalidate('chan-001');
+    expect(mockCacheService.invalidate).toHaveBeenCalledWith('meta:channel:chan-001');
+  });
+});
+
+// ─── MetaTagService ──────────────────────────────────────────────────────────
+
+describe('metaTagService', () => {
+  it('generateMetaTagsFromContext returns valid MetaTagSet', async () => {
+    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);
+    expect(tags.title.length).toBeGreaterThan(0);
+    expect(tags.title.length).toBeLessThanOrEqual(60);
+    expect(tags.description.length).toBeGreaterThanOrEqual(50);
+    expect(tags.description.length).toBeLessThanOrEqual(160);
+    expect(tags.canonical).toBe(channel.canonicalUrl);
+    expect(tags.needsRegeneration).toBe(false);
+  });
+
+  it('generateMetaTagsFromContext sets robots to index, follow', async () => {
+    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);
+    expect(tags.robots).toBe('index, follow');
+  });
+
+  it('generateMetaTagsFromContext includes openGraph and twitter tags', async () => {
+    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);
+    expect(tags.openGraph.ogTitle).toBeDefined();
+    expect(tags.twitter.card).toBeDefined();
+  });
+
+  it('AC-9: returns fallback with needsRegeneration=true on generation error', async () => {
+    const spy = jest.spyOn(TitleGenerator, 'generateFromThread').mockImplementation(() => {
+      throw new Error('NLP timeout');
+    });
+    const tags = await metaTagService.generateMetaTagsFromContext(channel, messages);
+    spy.mockRestore();
+    expect(tags.needsRegeneration).toBe(true);
+    expect(tags.title.length).toBeGreaterThan(0);
+  });
+
+  it('getOrGenerateCachedFromContext returns cache hit without regenerating', async () => {
+    const cachedTags = { title: 'Cached', needsRegeneration: false } as never;
+    mockCacheService.get.mockResolvedValue({ data: cachedTags, createdAt: Date.now() });
+
+    const tags = await metaTagService.getOrGenerateCachedFromContext(channel, messages);
+    expect(tags).toEqual(cachedTags);
+    expect(mockCacheService.set).not.toHaveBeenCalled();
+  });
+
+  it('scheduleRegeneration delegates to the queue adapter with priority and idempotency', async () => {
+    const result = await metaTagService.scheduleRegeneration('chan-001', 'high', 'manual-refresh');
+
+    expect(scheduleUpdateMock).toHaveBeenCalledWith({
+      channelId: 'chan-001',
+      triggeredBy: 'manual',
+      priority: 'high',
+      idempotencyKey: 'manual-refresh',
+    });
+    expect(result).toEqual({
+      jobId: 'meta-tag-update:chan-001:channel',
+      status: 'queued',
+    });
+  });
+
+  it('getOrGenerateCachedFromContext generates and caches on miss', async () => {
+    mockCacheService.get.mockResolvedValue(null);
+    mockCacheService.set.mockResolvedValue(undefined);
+
+    const tags = await metaTagService.getOrGenerateCachedFromContext(channel, messages);
+    expect(tags.title.length).toBeGreaterThan(0);
+    expect(mockCacheService.set).toHaveBeenCalled();
+  });
+
+  it('getOrGenerateCachedFromContext does not cache fallback tags on generation failure', async () => {
+    mockCacheService.get.mockResolvedValue(null);
+    const spy = jest.spyOn(TitleGenerator, 'generateFromThread').mockImplementation(() => {
+      throw new Error('NLP timeout');
+    });
+
+    const tags = await metaTagService.getOrGenerateCachedFromContext(channel, messages);
+    spy.mockRestore();
+
+    expect(tags.needsRegeneration).toBe(true);
+    expect(mockCacheService.set).not.toHaveBeenCalled();
+  });
+
+  it('invalidateCache delegates to MetaTagCache.invalidate', async () => {
+    mockCacheService.invalidate.mockResolvedValue(undefined);
+    await metaTagService.invalidateCache('chan-001');
+    expect(mockCacheService.invalidate).toHaveBeenCalledWith('meta:channel:chan-001');
+  });
+
+  it('buildCanonicalUrl constructs correct path', () => {
+    const url = metaTagService.buildCanonicalUrl('game-dev-hub', 'unity-physics-help');
+    expect(url).toContain('/c/game-dev-hub/unity-physics-help');
+  });
+
+  it('buildCanonicalUrl encodes reserved characters in slug segments', () => {
+    const url = metaTagService.buildCanonicalUrl('my server', 'q&a channel');
+    expect(url).toContain('/c/my%20server/q%26a%20channel');
+    expect(url).not.toContain(' ');
+    expect(url).not.toContain('&');
+  });
+
+  it('generateMetaTagsFromContext emits index,follow for PUBLIC_INDEXABLE', async () => {
+    const tags = await metaTagService.generateMetaTagsFromContext(
+      { ...channel, visibility: 'PUBLIC_INDEXABLE' },
+      messages,
+    );
+    expect(tags.robots).toBe('index, follow');
+  });
+
+  it('generateMetaTagsFromContext emits noindex,follow for PUBLIC_NO_INDEX', async () => {
+    const tags = await metaTagService.generateMetaTagsFromContext(
+      { ...channel, visibility: 'PUBLIC_NO_INDEX' },
+      messages,
+    );
+    expect(tags.robots).toBe('noindex, follow');
+  });
+
+  it('generateMetaTagsFromContext emits noindex,nofollow for PRIVATE', async () => {
+    const tags = await metaTagService.generateMetaTagsFromContext(
+      { ...channel, visibility: 'PRIVATE' },
+      messages,
+    );
+    expect(tags.robots).toBe('noindex, nofollow');
+  });
+});
+
+// ─── setCustomOverrides (AC-8 write path) ─────────────────────────────────────
+
+jest.mock('../src/repositories/metaTag.repository', () => ({
+  metaTagRepository: {
+    findByChannelId: jest.fn().mockResolvedValue({ channelId: 'chan-001' }),
+    updateCustomOverrides: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { metaTagRepository } from '../src/repositories/metaTag.repository';
+
+const mockMetaTagRepo = metaTagRepository as jest.Mocked<typeof metaTagRepository>;
+
+describe('metaTagService.setCustomOverrides — AC-8 write-path sanitization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCacheService.invalidate.mockResolvedValue(undefined);
+  });
+
+  it('sanitizes customTitle and customDescription before persisting', async () => {
+    await metaTagService.setCustomOverrides('chan-001', {
+      customTitle: '<script>alert(1)</script>My Title',
+      customDescription: 'Contact us at admin@corp.com for help',
+    });
+
+    expect(mockMetaTagRepo.updateCustomOverrides).toHaveBeenCalledWith(
+      'chan-001',
+      expect.objectContaining({
+        customTitle: expect.not.stringContaining('<script>'),
+        customDescription: expect.not.stringContaining('@'),
+      }),
+    );
+  });
+
+  it('passes null overrides through as null', async () => {
+    await metaTagService.setCustomOverrides('chan-001', {
+      customTitle: null,
+      customDescription: null,
+    });
+
+    expect(mockMetaTagRepo.updateCustomOverrides).toHaveBeenCalledWith(
+      'chan-001',
+      expect.objectContaining({ customTitle: null, customDescription: null }),
+    );
+  });
+
+  it('invalidates the cache after persisting', async () => {
+    await metaTagService.setCustomOverrides('chan-001', { customTitle: 'Clean Title' });
+    expect(mockCacheService.invalidate).toHaveBeenCalledWith('meta:channel:chan-001');
+  });
+
+  it('does not clear customOgImage when the field is omitted', async () => {
+    await metaTagService.setCustomOverrides('chan-001', {
+      customTitle: 'Clean Title',
+    });
+
+    expect(mockMetaTagRepo.updateCustomOverrides).toHaveBeenCalledWith(
+      'chan-001',
+      expect.not.objectContaining({ customOgImage: null }),
+    );
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony",
+  "private": true,
+  "scripts": {
+    "test": "node ./scripts/run-root-jest.cjs",
+    "jest": "node ./scripts/run-root-jest.cjs",
+    "test:backend": "npm --prefix harmony-backend test --",
+    "test:frontend": "npm --prefix harmony-frontend test --",
+    "test:integration": "npm --prefix tests/integration test",
+    "test:integration:cloud": "npm --prefix tests/integration run test:cloud"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/package.json
+```
+
+Output:
+
+```text
+{
+  "name": "harmony-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "build:local-e2e": "NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next build",
+    "start:local-e2e": "PORT=3000 NEXT_PUBLIC_API_URL=http://localhost:4000 NEXT_PUBLIC_BASE_URL=http://localhost:3000 next start",
+    "test": "jest --forceExit",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "lint": "eslint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "axios": "^1.13.5",
+    "clsx": "^2.1.1",
+    "next": "16.1.6",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.4.1",
+    "twilio-video": "3.0.0-preview.3"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@playwright/test": "^1.55.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "16.1.6",
+    "eslint-config-prettier": "^10.1.8",
+    "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.3.0",
+    "prettier": "^3.8.1",
+    "tailwindcss": "^4",
+    "ts-jest": "^29.4.6",
+    "typescript": "5.9.3"
+  }
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/lib/frontend-logger.ts
+```
+
+Output:
+
+```text
+type FrontendLogLevel = 'info' | 'warn' | 'error';
+type FrontendRuntime = 'browser' | 'next-server';
+type FrontendLogValue = string | number | boolean;
+
+export interface FrontendLogEntry {
+  service: 'frontend';
+  runtime: FrontendRuntime;
+  level: FrontendLogLevel;
+  message: string;
+  timestamp: string;
+  fields: Record<string, FrontendLogValue>;
+}
+
+export interface FrontendLogger {
+  info: (message: string, metadata?: Record<string, unknown>) => void;
+  warn: (message: string, metadata?: Record<string, unknown>) => void;
+  error: (message: string, metadata?: Record<string, unknown>) => void;
+}
+
+const PATH_FIELDS = new Set(['route', 'target']);
+const ALLOWED_METADATA_KEYS = new Set([
+  'attempt',
+  'component',
+  'correlationId',
+  'digest',
+  'errorCode',
+  'errorName',
+  'event',
+  'feature',
+  'method',
+  'operation',
+  'phase',
+  'procedure',
+  'reason',
+  'requestId',
+  'retryCount',
+  'route',
+  'scope',
+  'source',
+  'statusCode',
+  'target',
+  'transport',
+]);
+
+function detectRuntime(): FrontendRuntime {
+  return typeof window === 'undefined' ? 'next-server' : 'browser';
+}
+
+function toSafePath(value: string): string {
+  try {
+    if (/^https?:\/\//.test(value)) {
+      return new URL(value).pathname || '/';
+    }
+  } catch {}
+
+  const [withoutQuery] = value.split(/[?#]/, 1);
+  return withoutQuery || '/';
+}
+
+function toSafeLogValue(key: string, value: unknown): FrontendLogValue | undefined {
+  if (typeof value === 'string') {
+    return PATH_FIELDS.has(key) ? toSafePath(value) : value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  return undefined;
+}
+
+function extractSafeErrorFields(error: unknown): Record<string, FrontendLogValue> {
+  if (!error || typeof error !== 'object') {
+    return {};
+  }
+
+  const candidate = error as Record<string, unknown>;
+  const safeFields: Record<string, FrontendLogValue> = {};
+
+  if (typeof candidate.name === 'string') safeFields.errorName = candidate.name;
+  if (typeof candidate.code === 'string') safeFields.errorCode = candidate.code;
+  if (typeof candidate.digest === 'string') safeFields.digest = candidate.digest;
+  if (typeof candidate.status === 'number') safeFields.statusCode = candidate.status;
+
+  return safeFields;
+}
+
+export function sanitizeLogMetadata(
+  metadata: Record<string, unknown> = {},
+): Record<string, FrontendLogValue> {
+  const safeFields: Record<string, FrontendLogValue> = {};
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (key === 'error' || key === 'err') {
+      Object.assign(safeFields, extractSafeErrorFields(value));
+      continue;
+    }
+
+    if (!ALLOWED_METADATA_KEYS.has(key)) {
+      continue;
+    }
+
+    const safeValue = toSafeLogValue(key, value);
+    if (safeValue !== undefined) {
+      safeFields[key] = safeValue;
+    }
+  }
+
+  return safeFields;
+}
+
+export function buildFrontendLogEntry(
+  level: FrontendLogLevel,
+  message: string,
+  metadata: Record<string, unknown> = {},
+): FrontendLogEntry {
+  return {
+    service: 'frontend',
+    runtime: detectRuntime(),
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    fields: sanitizeLogMetadata(metadata),
+  };
+}
+
+function writeLog(
+  level: FrontendLogLevel,
+  message: string,
+  metadata?: Record<string, unknown>,
+): void {
+  const entry = buildFrontendLogEntry(level, message, metadata);
+  const writer = console[level] ?? console.error;
+  writer('[frontend]', entry);
+}
+
+export function createFrontendLogger(bindings: Record<string, unknown> = {}): FrontendLogger {
+  return {
+    info(message, metadata) {
+      writeLog('info', message, { ...bindings, ...metadata });
+    },
+    warn(message, metadata) {
+      writeLog('warn', message, { ...bindings, ...metadata });
+    },
+    error(message, metadata) {
+      writeLog('error', message, { ...bindings, ...metadata });
+    },
+  };
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "sanitize.*slug|sanitize.*title|sanitize.*metadata|path-like" harmony-frontend/src harmony-backend/src
+```
+
+Output:
+
+```text
+1 matches in 1F:
+
+[file] harmony-frontend/src/lib/frontend-logger.ts (1):
+   123: fields: sanitizeLogMetadata(metadata),
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:06:06.896Z
+
+I’ve narrowed it to the metadata path, and the current tests only cover benign fallbacks. I’m creating the task scratchpad, opening the issue audit comment, and then I’ll add a red test for the path-like server name case before touching the implementation.
+
+#### Tool: exec_command
+
+```sh
+git switch -c codex/issue-484-sanitize-channel-title
+```
+
+Output:
+
+```text
+fatal: cannot lock ref 'refs/heads/codex/issue-484-sanitize-channel-title': Unable to create '/Users/allen/repos/Harmony/.git/refs/heads/codex/issue-484-sanitize-channel-title.lock': Operation not permitted
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue comment 484 --body "**[AI Agent — Starting]**
+
+I’m reproducing the reported channel-title metadata issue first, then I’ll add a regression test and patch the metadata path if the bug is valid.
+
+Next step: confirm whether the unsafe value is coming from the public metadata fetch or the frontend fallback path."
+```
+
+Output:
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/484#issuecomment-4338273533
+```
+
+#### Tool: exec_command
+
+```sh
+git switch -c codex/issue-484-sanitize-channel-title
+```
+
+Output:
+
+```text
+Switched to a new branch 'codex/issue-484-sanitize-channel-title'
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:06:43.783Z
+
+I’m at the red-test step now. I’m adding one frontend regression around the fallback metadata path and one backend sanitization regression so both the immediate bug and the persisted SEO path are covered.
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+> jest --forceExit --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts
+sh: jest: command not found
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- --runInBand --runTestsByPath tests/metaTagService.test.ts
+```
+
+Output:
+
+```text
+> jest --runInBand --runTestsByPath tests/metaTagService.test.ts
+sh: jest: command not found
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:07:04.710Z
+
+The new regressions are in place, but the targeted Jest runs failed immediately because `jest` isn’t installed in the current worktree environment. I’m checking whether dependencies are missing entirely or if the repo expects a different runtime path before I proceed.
+
+#### Tool: exec_command
+
+```sh
+rtk ls harmony-frontend/node_modules
+```
+
+Output:
+
+```text
+ls: harmony-frontend/node_modules: No such file or directory
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls harmony-backend/node_modules
+```
+
+Output:
+
+```text
+ls: harmony-backend/node_modules: No such file or directory
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls node_modules
+```
+
+Output:
+
+```text
+ls: node_modules: No such file or directory
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:07:31.928Z
+
+I’ve patched the likely bug path and the backend SEO sanitizer. To verify properly I need to install the frontend and backend dependencies in this worktree, since there are no local `node_modules` yet.
+
+#### Tool: exec_command
+
+```sh
+npm ci
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+npm ci
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 26260,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 5000
+}
+```
+
+Output:
+
+```text
+Chunk ID: a6f6f3
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 311
+Output:
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated whatwg-encoding@3.1.1: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+added 704 packages, and audited 705 packages in 6s
+
+187 packages are looking for funding
+  run `npm fund` for details
+
+10 vulnerabilities (5 moderate, 4 high, 1 critical)
+
+To address issues that do not require attention, run:
+  npm audit fix
+
+To address all issues, run:
+  npm audit fix --force
+
+Run `npm audit` for details.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 40427,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 5000
+}
+```
+
+Output:
+
+```text
+Chunk ID: f53c95
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 211
+Output:
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated scmp@2.1.0: Just use Node.js's crypto.timingSafeEqual()
+
+added 695 packages, and audited 696 packages in 4s
+
+110 packages are looking for funding
+  run `npm fund` for details
+
+11 vulnerabilities (7 moderate, 3 high, 1 critical)
+
+To address all issues, run:
+  npm audit fix
+
+Run `npm audit` for details.
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-backend test -- --runInBand --runTestsByPath tests/metaTagService.test.ts
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 21641,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 352ef3
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 105
+Output:
+> jest --forceExit --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts
+Test Suites: 1 passed, 1 total
+Tests:       17 passed, 17 total
+Snapshots:   0 total
+Time:        0.532 s
+Ran all test suites within paths "src/__tests__/channel-page-metadata.test.ts".
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 29300,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 2b2c88
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 761
+Output:
+> jest --runInBand --runTestsByPath tests/metaTagService.test.ts
+PASS tests/metaTagService.test.ts
+  TitleGenerator
+    ✓ maxLength is 60 (1 ms)
+    ✓ generateFromChannel produces title ≤60 chars (1 ms)
+    ✓ truncates long titles with ellipsis and stays ≤60 chars
+    ✓ sanitizeForTitle strips HTML tags
+    ✓ sanitizeForTitle collapses whitespace
+    ✓ sanitizeForTitle removes dot-segment path prefixes
+    ✓ applyTemplate replaces template variables
+    ✓ generateFromThread falls back to channel when no messages
+    ✓ generateFromMessage uses first message content
+  DescriptionGenerator
+    ✓ maxLength is 160
+    ✓ minLength is 50
+    ✓ generateFromMessages produces description 50-160 chars
+    ✓ truncates long descriptions to ≤160 chars with ellipsis
+    ✓ returns text unchanged when within valid range
+    ✓ AC-2: generateFromMessages produces ≥50 chars even for a very short message
+    ✓ extractKeyPhrases returns non-empty array for non-empty content
+    ✓ extractKeyPhrases respects maxPhrases limit
+    ✓ summarizeThread returns empty string for no messages
+    ✓ summarizeThread returns first message content for non-empty messages
+    ✓ generateFromMessages includes channel info for empty messages
+  MetaTagCache
+    ✓ ttl defaults to 3600
+    ✓ get returns null on cache miss (1 ms)
+    ✓ get returns cached data on hit
+    ✓ set calls cacheService.set with correct key and ttl
+    ✓ invalidate calls cacheService.invalidate with correct key
+  metaTagService
+    ✓ generateMetaTagsFromContext returns valid MetaTagSet (1 ms)
+    ✓ generateMetaTagsFromContext sets robots to index, follow
+    ✓ generateMetaTagsFromContext includes openGraph and twitter tags
+    ✓ AC-9: returns fallback with needsRegeneration=true on generation error (1 ms)
+    ✓ getOrGenerateCachedFromContext returns cache hit without regenerating
+    ✓ scheduleRegeneration delegates to the queue adapter with priority and idempotency
+    ✓ getOrGenerateCachedFromContext generates and caches on miss
+    ✓ getOrGenerateCachedFromContext does not cache fallback tags on generation failure
+    ✓ invalidateCache delegates to MetaTagCache.invalidate (1 ms)
+    ✓ buildCanonicalUrl constructs correct path
+    ✓ buildCanonicalUrl encodes reserved characters in slug segments
+    ✓ generateMetaTagsFromContext emits index,follow for PUBLIC_INDEXABLE
+    ✓ generateMetaTagsFromContext emits noindex,follow for PUBLIC_NO_INDEX
+    ✓ generateMetaTagsFromContext emits noindex,nofollow for PRIVATE
+  metaTagService.setCustomOverrides — AC-8 write-path sanitization
+    ✓ sanitizes customTitle and customDescription before persisting (1 ms)
+    ✓ passes null overrides through as null
+    ✓ invalidates the cache after persisting
+    ✓ does not clear customOgImage when the field is omitted
+Test Suites: 1 passed, 1 total
+Tests:       43 passed, 43 total
+Snapshots:   0 total
+Time:        2.202 s
+Ran all test suites within paths "tests/metaTagService.test.ts".
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:07:59.383Z
+
+The regressions pass with the patch. I’m running the cleanup and verification pass now: format the touched files, then lint/typecheck the affected packages before I prepare the PR.
+
+#### Tool: exec_command
+
+```sh
+npm --prefix harmony-frontend exec prettier --write src/app/c/[serverSlug]/[channelSlug]/page.tsx src/__tests__/channel-page-metadata.test.ts && npm --prefix harmony-backend exec prettier --write src/services/metaTag/titleGenerator.ts tests/metaTagService.test.ts && npm --prefix . exec prettier --write tasks/todo.md
+```
+
+Output:
+
+```text
+zsh:1: no matches found: src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+npm --prefix harmony-frontend exec prettier --write 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+npm warn "src/app/c/[serverSlug]/[channelSlug]/page.tsx" is being parsed as a normal command line argument.
+npm warn Unknown cli config "--write". This will stop working in the next major version of npm.
+[error] No files matching the pattern were found: "src/app/c/[serverSlug]/[channelSlug]/page.tsx".
+[error] No files matching the pattern were found: "src/__tests__/channel-page-metadata.test.ts".
+```
+
+#### Tool: exec_command
+
+```sh
+npm --prefix harmony-backend exec prettier --write src/services/metaTag/titleGenerator.ts tests/metaTagService.test.ts
+```
+
+Output:
+
+```text
+npm warn "src/services/metaTag/titleGenerator.ts" is being parsed as a normal command line argument.
+npm warn Unknown cli config "--write". This will stop working in the next major version of npm.
+[error] No files matching the pattern were found: "src/services/metaTag/titleGenerator.ts".
+[error] No files matching the pattern were found: "tests/metaTagService.test.ts".
+```
+
+#### Tool: exec_command
+
+```sh
+npm exec prettier --write tasks/todo.md
+```
+
+Output:
+
+```text
+npm warn "tasks/todo.md" is being parsed as a normal command line argument.
+npm warn Unknown cli config "--write". This will stop working in the next major version of npm.
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 14020,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 4759ea
+Wall time: 5.0015 seconds
+Process running with session ID 14020
+Original token count: 0
+Output:
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 14020,
+  "chars": "\u0003",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+write_stdin failed: stdin is closed for this session; rerun exec_command with tty=true to keep stdin open
+```
+
+#### Tool: exec_command
+
+```sh
+npm exec -- prettier --write 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+[warn] jsxBracketSameLine is deprecated.
+src/app/c/[serverSlug]/[channelSlug]/page.tsx 73ms
+src/__tests__/channel-page-metadata.test.ts 31ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+npm exec -- prettier --write src/services/metaTag/titleGenerator.ts tests/metaTagService.test.ts
+```
+
+Output:
+
+```text
+src/services/metaTag/titleGenerator.ts 63ms (unchanged)
+tests/metaTagService.test.ts 40ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+npx prettier --write tasks/todo.md
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 71189,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 2000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 61c0e0
+Wall time: 5.0004 seconds
+Process running with session ID 71189
+Original token count: 0
+Output:
+```
+
+#### Tool: exec_command
+
+```sh
+npm run lint -- 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 lint
+> eslint src/app/c/[serverSlug]/[channelSlug]/page.tsx src/__tests__/channel-page-metadata.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+npm run lint -- src/services/metaTag/titleGenerator.ts tests/metaTagService.test.ts
+```
+
+Output:
+
+```text
+
+> harmony-backend@0.1.0 lint
+> eslint src tests src/services/metaTag/titleGenerator.ts tests/metaTagService.test.ts
+```
+
+#### Tool: exec_command
+
+```sh
+npm run build
+```
+
+Output:
+
+```text
+
+> harmony-backend@0.1.0 build
+> tsc
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 82155,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 5000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 2bfe77
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 84021,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 5000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 23a3bd
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 70
+Output:
+
+/Users/allen/.codex/worktrees/20cf/Harmony/harmony-backend/tests/events.router.sse-server-updated.test.ts
+  83:10  warning  'sseGetWithEvent' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+
+✖ 1 problem (0 errors, 1 warning)
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 60714,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 5000
+}
+```
+
+Output:
+
+```text
+Chunk ID: bd9dca
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:09:00.518Z
+
+The changed-package verification is clean except for one pre-existing backend ESLint warning in an unrelated SSE test file. I’m running a frontend build now to cover the typecheck side before I wrap this into a PR.
+
+#### Tool: exec_command
+
+```sh
+npm run build
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 build
+> next build
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 54547,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: c4cc44
+Wall time: 5.0013 seconds
+Process running with session ID 54547
+Original token count: 56
+Output:
+▲ Next.js 16.1.6 (Turbopack)
+
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+  Creating an optimized production build ...
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 54547,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: a97d5d
+Wall time: 5.0016 seconds
+Process running with session ID 54547
+Original token count: 0
+Output:
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 54547,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: f23524
+Wall time: 0.0000 seconds
+Process exited with code 1
+Original token count: 120
+Output:
+Turbopack build encountered 1 warnings:
+[next]/internal/font/google/inter_fe8b9d92.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap
+
+
+
+> Build error occurred
+Error: Turbopack build failed with 1 errors:
+[next]/internal/font/google/inter_fe8b9d92.module.css
+next/font: error:
+Failed to fetch `Inter` from Google Fonts.
+
+
+    at ignore-listed frames
+```
+
+#### Tool: exec_command
+
+```sh
+npm run build
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 build
+> next build
+
+▲ Next.js 16.1.6 (Turbopack)
+
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+  Creating an optimized production build ...
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 16779,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 6ae998
+Wall time: 2.9394 seconds
+Process exited with code 0
+Original token count: 413
+Output:
+(node:1444) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/tailwind.config.ts?id=1777403372007 is not specified and it doesn't parse as CommonJS.
+Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
+To eliminate this warning, add "type": "module" to /Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/package.json.
+(Use `node --trace-warnings ...` to show where the warning was created)
+✓ Compiled successfully in 2.2s
+  Running TypeScript ...
+  Collecting page data using 9 workers ...
+  Generating static pages using 9 workers (0/11) ...
+  Generating static pages using 9 workers (2/11) 
+  Generating static pages using 9 workers (5/11) 
+  Generating static pages using 9 workers (8/11) 
+✓ Generating static pages using 9 workers (11/11) in 173.1ms
+  Finalizing page optimization ...
+
+Route (app)                               Revalidate  Expire
+┌ ○ /                                             1m      1y
+├ ○ /_not-found
+├ ƒ /api/attachments/upload
+├ ○ /auth/login
+├ ○ /auth/signup
+├ ƒ /c/[serverSlug]/[channelSlug]
+├ ƒ /channels
+├ ƒ /channels/[serverSlug]
+├ ƒ /channels/[serverSlug]/[channelSlug]
+├ ○ /robots.txt                                   1h      1y
+├ ƒ /settings
+├ ƒ /settings/[serverSlug]
+├ ƒ /settings/[serverSlug]/[channelSlug]
+├ ƒ /sitemap.xml
+├ ƒ /sitemap/[serverSlug]
+└ ○ /sitemap/[serverSlug].xml                     5m      1y
+
+
+ƒ Proxy (Middleware)
+
+○  (Static)   prerendered as static content
+ƒ  (Dynamic)  server-rendered on demand
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ M harmony-backend/src/services/metaTag/titleGenerator.ts
+ M harmony-backend/tests/metaTagService.test.ts
+ M harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+ M harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+rtk diff --stat
+```
+
+Output:
+
+```text
+diff: unrecognized option `--stat'
+usage: diff [-aBbdilpTtw] [-c | -e | -f | -n | -q | -u] [--ignore-case]
+            [--no-ignore-case] [--normal] [--strip-trailing-cr] [--tabsize]
+            [-I pattern] [-F pattern] [-L label] file1 file2
+       diff [-aBbdilpTtw] [-I pattern] [-L label] [--ignore-case]
+            [--no-ignore-case] [--normal] [--strip-trailing-cr] [--tabsize]
+            [-F pattern] -C number file1 file2
+       diff [-aBbdiltw] [-I pattern] [--ignore-case] [--no-ignore-case]
+            [--normal] [--strip-trailing-cr] [--tabsize] -D string file1 file2
+       diff [-aBbdilpTtw] [-I pattern] [-L label] [--ignore-case]
+            [--no-ignore-case] [--normal] [--tabsize] [--strip-trailing-cr]
+            [-F pattern] -U number file1 file2
+       diff [-aBbdilNPprsTtw] [-c | -e | -f | -n | -q | -u] [--ignore-case]
+            [--no-ignore-case] [--normal] [--tabsize] [-I pattern] [-L label]
+            [-F pattern] [-S name] [-X file] [-x pattern] dir1 dir2
+       diff [-aBbditwW] [--expand-tabs] [--ignore-all-space]
+            [--ignore-blank-lines] [--ignore-case] [--minimal]
+            [--no-ignore-file-name-case] [--strip-trailing-cr]
+            [--suppress-common-lines] [--tabsize] [--text] [--width]
+            -y | --side-by-side file1 file2
+       diff [--help] [--version]
+```
+
+#### Tool: exec_command
+
+```sh
+rtk diff -- harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx harmony-frontend/src/__tests__/channel-page-metadata.test.ts harmony-backend/src/services/metaTag/titleGenerator.ts harmony-backend/tests/metaTagService.test.ts tasks/todo.md
+```
+
+Output:
+
+```text
+zsh:1: no matches found: harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:09:50.985Z
+
+The patch is limited to four code/test files. I’m doing the final diff review now, then I’ll update the issue, commit with the required co-author trailer, push, and open the PR.
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat
+```
+
+Output:
+
+```text
+.../src/services/metaTag/titleGenerator.ts         |  7 +++++-
+ harmony-backend/tests/metaTagService.test.ts       |  5 +++++
+ .../src/__tests__/channel-page-metadata.test.ts    | 25 ++++++++++++++++++++++
+ .../src/app/c/[serverSlug]/[channelSlug]/page.tsx  | 18 ++++++++++++++--
+ 4 files changed, 52 insertions(+), 3 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff -- 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx' harmony-frontend/src/__tests__/channel-page-metadata.test.ts harmony-backend/src/services/metaTag/titleGenerator.ts harmony-backend/tests/metaTagService.test.ts
+```
+
+Output:
+
+```text
+.../src/services/metaTag/titleGenerator.ts         |  7 +++++-
+ harmony-backend/tests/metaTagService.test.ts       |  5 +++++
+ .../src/__tests__/channel-page-metadata.test.ts    | 25 ++++++++++++++++++++++
+ .../src/app/c/[serverSlug]/[channelSlug]/page.tsx  | 18 ++++++++++++++--
+ 4 files changed, 52 insertions(+), 3 deletions(-)
+
+--- Changes ---
+
+harmony-backend/src/services/metaTag/titleGenerator.ts
+  @@ -43,7 +43,12 @@ export const TitleGenerator: IMetaTagGenerator & {
+  -      .replace(/<[^>]*>/g, '')
+  +      .replace(/<[^>]*>/g, ' ')
+  +      .replace(/\\/g, '/')
+  +      .split('/')
+  +      .map((segment) => segment.trim())
+  +      .filter((segment) => segment.length > 0 && segment !== '.' && segment !== '..')
+  +      .join(' / ')
+         .replace(/\s+/g, ' ')
+         .trim();
+     },
+  +6 -1
+
+harmony-backend/tests/metaTagService.test.ts
+  @@ -97,6 +97,11 @@ describe('TitleGenerator', () => {
+  +  it('sanitizeForTitle removes dot-segment path prefixes', () => {
+  +    const result = TitleGenerator.sanitizeForTitle('../../../admin');
+  +    expect(result).toBe('admin');
+  +  });
+  +
+     it('applyTemplate replaces template variables', () => {
+       const result = TitleGenerator.applyTemplate('{channelName} on {serverName}', {
+         channelName: 'general',
+  +5 -0
+
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+  @@ -192,6 +192,31 @@ describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
+  +
+  +  it('sanitizes path-like server names before building fallback metadata', async () => {
+  +    mockFetchPublicServer.mockResolvedValue(
+  +      makeServer({
+  +        name: '../../../admin',
+  +      }),
+  +    );
+  +
+  +    const meta = await generateMetadata(makeParams('admin', 'general'));
+  +    const page = await GuestChannelPage(makeParams('admin', 'general'));
+  +    const html = renderToStaticMarkup(page);
+  +    const ldMatch = html.match(/<script[^>]+type="application\/ld\+json">([\s\S]*?)<\/script>/i);
+  +
+  +    expect(meta.title).toBe('general - admin | Harmony');
+  +    expect(meta.description).toBe('Welcome to general');
+  +    expect(ldMatch).not.toBeNull();
+  +    expect(JSON.parse(ldMatch![1])).toMatchObject({
+  +      author: {
+  +        '@type': 'Organization',
+  +        'name': 'admin',
+  +      },
+  +      name: 'general - admin | Harmony',
+  +      headline: 'general - admin | Harmony',
+  +    });
+  +  });
+   });
+   
+   describe('generateMetadata — PUBLIC_NO_INDEX channel', () => {
+  +25 -0
+
+harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+  @@ -12,6 +12,18 @@ interface PageProps {
+  +function sanitizeMetadataLabel(value: string): string {
+  +  return value
+  +    .replace(/<[^>]*>/g, ' ')
+  +    .replace(/\\/g, '/')
+  +    .split('/')
+  +    .map(segment => segment.trim())
+  +    .filter(segment => segment.length > 0 && segment !== '.' && segment !== '..')
+  +    .join(' / ')
+  +    .replace(/\s+/g, ' ')
+  +    .trim();
+  +}
+  +
+   function getSeoContent(
+     serverSlug: string,
+     channelSlug: string,
+  @@ -20,8 +32,10 @@ function getSeoContent(
+  -  const channelName = channel?.name ?? channelSlug;
+  -  const serverName = server?.name ?? serverSlug;
+  +  const channelName =
+  +    sanitizeMetadataLabel(channel?.name ?? '') || sanitizeMetadataLabel(channelSlug) || 'channel';
+  +  const serverName =
+  +    sanitizeMetadataLabel(server?.name ?? '') || sanitizeMetadataLabel(serverSlug) || 'server';
+     const title = publicMetaTags?.title ?? `${channelName} - ${serverName} | Harmony`;
+     const description =
+       publicMetaTags?.description ??
+  +16 -2
+```
+
+#### Tool: update_plan
+
+- Explanation: Issue reproduced via metadata regression coverage, patch implemented in frontend fallback and backend title sanitizer, and verification is complete. Publishing remains.
+
+- Plan:
+  - [completed] Inspect issue #484 details and current repo/task context
+  - [completed] Reproduce and validate the reported bug locally
+  - [completed] Implement the minimal fix and add/update tests if needed
+  - [completed] Run formatter, typecheck, and relevant tests
+  - [in_progress] Create branch, commit with required co-author, push, and open draft PR if changes are made
+
+Output:
+
+```text
+Plan updated
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read tasks/todo.md
+```
+
+Output:
+
+```text
+# Issue #484
+
+- [ ] Reproduce the unsafe channel title behavior from the metadata path
+- [ ] Add regression coverage for path-like server/channel values in metadata generation
+- [ ] Implement the minimal metadata sanitization fix
+- [ ] Run frontend format, tests, and any required verification
+- [ ] Summarize results on the GitHub issue and publish a PR if code changed
+- [x] Reproduce the unsafe channel title behavior from the metadata path
+- [x] Add regression coverage for path-like server/channel values in metadata generation
+- [x] Implement the minimal metadata sanitization fix
+- [x] Run frontend format, tests, and any required verification
+- [ ] Summarize results on the GitHub issue and publish a PR if code changed
+
+## Review
+
+- Verified the public channel metadata fallback now strips dot-segment path prefixes from
+  server/channel display values before composing the browser title and JSON-LD.
+- Hardened backend meta-tag title sanitization with the same path-segment cleanup so
+  persisted/generated SEO titles do not reintroduce the issue.
+- Verification:
+  `npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts`
+  `npm --prefix harmony-backend test -- --runInBand --runTestsByPath tests/metaTagService.test.ts`
+  `npm --prefix harmony-backend run build`
+  `npm --prefix harmony-frontend run build`
+- Note: `npm --prefix harmony-backend run lint -- ...` surfaced one unrelated pre-existing
+  warning in `harmony-backend/tests/events.router.sse-server-updated.test.ts` for an unused
+  local `sseGetWithEvent`.
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:10:13.124Z
+
+I found one housekeeping mistake in the scratchpad update: the checklist now has duplicate unchecked and checked lines. I’m cleaning that up before I commit so the task record matches the final state.
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ M harmony-backend/src/services/metaTag/titleGenerator.ts
+ M harmony-backend/tests/metaTagService.test.ts
+ M harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+ M harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read tasks/todo.md
+```
+
+Output:
+
+```text
+# Issue #484
+
+- [x] Reproduce the unsafe channel title behavior from the metadata path
+- [x] Add regression coverage for path-like server/channel values in metadata generation
+- [x] Implement the minimal metadata sanitization fix
+- [x] Run frontend format, tests, and any required verification
+- [ ] Summarize results on the GitHub issue and publish a PR if code changed
+
+## Review
+
+- Verified the public channel metadata fallback now strips dot-segment path prefixes from
+  server/channel display values before composing the browser title and JSON-LD.
+- Hardened backend meta-tag title sanitization with the same path-segment cleanup so
+  persisted/generated SEO titles do not reintroduce the issue.
+- Verification:
+  `npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts`
+  `npm --prefix harmony-backend test -- --runInBand --runTestsByPath tests/metaTagService.test.ts`
+  `npm --prefix harmony-backend run build`
+  `npm --prefix harmony-frontend run build`
+- Note: `npm --prefix harmony-backend run lint -- ...` surfaced one unrelated pre-existing
+  warning in `harmony-backend/tests/events.router.sse-server-updated.test.ts` for an unused
+  local `sseGetWithEvent`.
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:10:34.471Z
+
+I’m at the publish step. I’ve reviewed the diff, and I’m staging only the four code/test files that belong to the fix before I commit and open the PR.
+
+#### Tool: exec_command
+
+```sh
+git add harmony-backend/src/services/metaTag/titleGenerator.ts harmony-backend/tests/metaTagService.test.ts harmony-frontend/src/__tests__/channel-page-metadata.test.ts 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx'
+```
+
+Output:
+
+```text
+fatal: Unable to create '/Users/allen/repos/Harmony/.git/worktrees/Harmony1/index.lock': Operation not permitted
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --cached --stat
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+git add harmony-backend/src/services/metaTag/titleGenerator.ts harmony-backend/tests/metaTagService.test.ts harmony-frontend/src/__tests__/channel-page-metadata.test.ts 'harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx'
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --cached --stat
+```
+
+Output:
+
+```text
+.../src/services/metaTag/titleGenerator.ts         |  7 +++++-
+ harmony-backend/tests/metaTagService.test.ts       |  5 +++++
+ .../src/__tests__/channel-page-metadata.test.ts    | 25 ++++++++++++++++++++++
+ .../src/app/c/[serverSlug]/[channelSlug]/page.tsx  | 18 ++++++++++++++--
+ 4 files changed, 52 insertions(+), 3 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+git commit -m "fix: sanitize public channel metadata titles" -m "Co-authored-by: GPT-5.5 <noreply@openai.com>"
+```
+
+Output:
+
+```text
+[codex/issue-484-sanitize-channel-title 330b21f] fix: sanitize public channel metadata titles
+ 4 files changed, 52 insertions(+), 3 deletions(-)
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:10:58.584Z
+
+The fix is committed locally. I’m pushing the branch and opening the GitHub PR now, then I’ll post the completion note back on the issue with the verification summary.
+
+#### Tool: exec_command
+
+```sh
+git push -u origin codex/issue-484-sanitize-channel-title
+```
+
+Output:
+
+```text
+remote: 
+remote: Create a pull request for 'codex/issue-484-sanitize-channel-title' on GitHub by visiting:        
+remote:      https://github.com/CS485-Harmony/Harmony/pull/new/codex/issue-484-sanitize-channel-title        
+remote: 
+To github.com:CS485-Harmony/Harmony.git
+ * [new branch]      codex/issue-484-sanitize-channel-title -> codex/issue-484-sanitize-channel-title
+branch 'codex/issue-484-sanitize-channel-title' set up to track 'origin/codex/issue-484-sanitize-channel-title'.
+```
+
+#### Tool: exec_command
+
+```sh
+gh pr create --draft --title "fix: sanitize public channel metadata titles" --body "## Summary
+- sanitize fallback public channel metadata labels before composing the title, description, and JSON-LD author
+- strip dot-segment path prefixes in backend title sanitization so persisted/generated SEO titles stay safe too
+- add frontend and backend regressions for path-like server names in metadata generation
+
+## Testing
+- npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts
+- npm --prefix harmony-backend test -- --runInBand --runTestsByPath tests/metaTagService.test.ts
+- npm --prefix harmony-backend run build
+- npm --prefix harmony-frontend run build
+
+Closes #484"
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 65701,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 4000
+}
+```
+
+Output:
+
+```text
+Chunk ID: fa155d
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 13
+Output:
+https://github.com/CS485-Harmony/Harmony/pull/513
+```
+
+#### Tool: exec_command
+
+```sh
+gh issue comment 484 --body "**[AI Agent — Complete]**
+
+Verified the bug in the metadata fallback path and fixed it by sanitizing path-like server/channel values before composing the public channel title and JSON-LD author fields. I also hardened backend SEO title sanitization so persisted/generated meta tags strip dot-segment prefixes too.
+
+Verification run:
+- `npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts`
+- `npm --prefix harmony-backend test -- --runInBand --runTestsByPath tests/metaTagService.test.ts`
+- `npm --prefix harmony-backend run build`
+- `npm --prefix harmony-frontend run build`
+
+PR: #513"
+```
+
+Output:
+
+```text
+Test Suites: 1 passed, 1 total
+Tests:       17 passed, 17 total
+Snapshots:   0 total
+Time:        0.42 s, estimated 1 s
+Ran all test suites within paths "src/__tests__/channel-page-metadata.test.ts".
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:11:51.193Z
+
+The first completion-comment command was malformed because the shell interpreted the backticks in the body and ran one of the test commands instead of posting. I’m retrying with a literal body so the issue gets the correct completion note.
+
+#### Tool: exec_command
+
+```sh
+gh issue comment 484 --body '**[AI Agent — Complete]**
+
+Verified the bug in the metadata fallback path and fixed it by sanitizing path-like server/channel values before composing the public channel title and JSON-LD author fields. I also hardened backend SEO title sanitization so persisted/generated meta tags strip dot-segment prefixes too.
+
+Verification run:
+- npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts
+- npm --prefix harmony-backend test -- --runInBand --runTestsByPath tests/metaTagService.test.ts
+- npm --prefix harmony-backend run build
+- npm --prefix harmony-frontend run build
+
+PR: #513'
+```
+
+Output:
+
+```text
+https://github.com/CS485-Harmony/Harmony/issues/484#issuecomment-4338306951
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ok
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git rev-parse --abbrev-ref HEAD
+```
+
+Output:
+
+```text
+codex/issue-484-sanitize-channel-title
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:12:16.963Z
+
+Verified issue #484 and fixed it. The public channel metadata path now sanitizes path-like server/channel values before building the fallback title, description, and JSON-LD author, and the backend title sanitizer now strips dot-segment path prefixes as well. The key changes are in [page.tsx](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx) and [titleGenerator.ts](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-backend/src/services/metaTag/titleGenerator.ts), with regressions added in [channel-page-metadata.test.ts](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/src/__tests__/channel-page-metadata.test.ts) and [metaTagService.test.ts](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-backend/tests/metaTagService.test.ts).
+
+Verification ran with:
+`npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts`
+`npm --prefix harmony-backend test -- --runInBand --runTestsByPath tests/metaTagService.test.ts`
+`npm --prefix harmony-backend run build`
+`npm --prefix harmony-frontend run build`
+
+There is still one unrelated pre-existing backend lint warning for an unused local in `harmony-backend/tests/events.router.sse-server-updated.test.ts`. The fix is pushed on `codex/issue-484-sanitize-channel-title`, and the draft PR is [#513](https://github.com/CS485-Harmony/Harmony/pull/513).
+
+### Turn 2: just to double check, this would also fix the guest view bar on the
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T19:14:23.140Z
+
+```text
+just to double check, this would also fix the guest view bar on the bottom right?
+
+
+<image>
+
+</image>
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:14:30.083Z
+
+I’m checking the guest promo banner code path directly so I can answer from the implementation, not guess.
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/components/channel/GuestPromoBanner.tsx
+```
+
+Output:
+
+```text
+/**
+ * Channel Component: GuestPromoBanner
+ * Non-intrusive sticky bottom banner encouraging guests to join Harmony.
+ * Dismiss state persists for the browser session via sessionStorage.
+ * Based on dev spec C1.4 GuestPromoBanner
+ */
+
+'use client';
+
+import { useState, useCallback, useSyncExternalStore } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth';
+
+const DISMISS_KEY = 'harmony_guest_banner_dismissed';
+
+function isDismissedInStorage(): boolean {
+  try {
+    return sessionStorage.getItem(DISMISS_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+interface GuestPromoBannerProps {
+  serverName: string;
+  memberCount: number;
+}
+
+export function GuestPromoBanner({ serverName, memberCount }: GuestPromoBannerProps) {
+  const { isAuthenticated } = useAuth();
+  const pathname = usePathname();
+  // useSyncExternalStore with a server snapshot of `true` (hidden) prevents
+  // hydration mismatch: SSR and initial client render both produce null, then
+  // React reconciles with the real client snapshot after hydration — no
+  // setState-in-effect needed.
+  const storageDismissed = useSyncExternalStore(
+    () => () => {},       // sessionStorage has no change events
+    isDismissedInStorage, // client snapshot
+    () => true,           // server snapshot: always hidden
+  );
+
+  // Tracks in-memory dismiss for the current render cycle, covering the case
+  // where sessionStorage.setItem throws (private browsing, etc.).
+  const [manuallyDismissed, setManuallyDismissed] = useState(false);
+
+  const handleDismiss = useCallback(() => {
+    try {
+      sessionStorage.setItem(DISMISS_KEY, 'true');
+    } catch {
+      // sessionStorage unavailable — still dismiss in-memory
+    }
+    setManuallyDismissed(true);
+  }, []);
+
+  if (storageDismissed || manuallyDismissed || isAuthenticated) return null;
+
+  const returnUrl = encodeURIComponent(pathname);
+
+  return (
+    <aside
+      aria-label='Join server promotion'
+      className='sticky bottom-0 z-20 border-t border-[#2a2d31] bg-[#2f3136] px-4 py-3 shadow-lg'
+    >
+      <div className='mx-auto flex max-w-4xl items-center gap-3'>
+        {/* Server icon — first letter avatar */}
+        <div
+          className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#5865f2] text-sm font-bold text-white'
+          aria-hidden='true'
+        >
+          {serverName[0].toUpperCase()}
+        </div>
+
+        {/* Server info */}
+        <div className='min-w-0 flex-1'>
+          <p className='truncate text-sm font-semibold text-white'>{serverName}</p>
+          <p className='text-xs text-gray-400'>{memberCount.toLocaleString()} members</p>
+        </div>
+
+        {/* CTAs */}
+        <div className='flex shrink-0 items-center gap-2'>
+          <Link
+            href={`/auth/signup?returnUrl=${returnUrl}`}
+            className='inline-flex h-8 items-center justify-center rounded-md bg-[#5865f2] px-3 text-sm font-medium text-white transition-colors hover:bg-[#4752c4]'
+          >
+            <span className='hidden sm:inline'>Create Account</span>
+            <span className='sm:hidden'>Join</span>
+          </Link>
+          <Link
+            href={`/auth/login?returnUrl=${returnUrl}`}
+            className='inline-flex h-8 items-center justify-center rounded-md border border-white/20 bg-[#40444b] px-3 text-sm font-medium text-gray-200 transition-colors hover:bg-[#3d4148]'
+          >
+            Log In
+          </Link>
+          <button
+            type='button'
+            onClick={handleDismiss}
+            className='ml-1 rounded p-1 text-gray-400 transition-colors hover:bg-[#40444b] hover:text-white'
+            aria-label='Dismiss banner'
+          >
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              width='16'
+              height='16'
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+              strokeWidth='2'
+              strokeLinecap='round'
+              strokeLinejoin='round'
+              aria-hidden='true'
+              focusable='false'
+            >
+              <line x1='18' y1='6' x2='6' y2='18' />
+              <line x1='6' y1='6' x2='18' y2='18' />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "GuestPromoBanner|serverName=|server\.name|memberCount" harmony-frontend/src/components harmony-frontend/src/app harmony-frontend/src/services
+```
+
+Output:
+
+```text
+34 matches in 12F:
+
+[file] harmony-frontend/src/components/README.md (1):
+    31: - `GuestPromoBanner.tsx` - Guest user promo banner (C1.4)
+
+[file] harmony-frontend/.../channel/ChannelSidebar.tsx (1):
+   235: <span className='truncate'>{server.name}</span>
+
+[file] harmony-frontend/.../channel/GuestChannelView.tsx (3):
+    19: import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+   100: const memberCount = server.memberCount ?? 0;
+   113: <GuestPromoBanner serverName={server.name} memberCount={memberCount} />
+
+[file] harmony-frontend/.../channel/GuestHeader.tsx (1):
+    26: <span className='min-w-0 flex-1 truncate text-sm font-semibold text-white'>{s...
+
+[file] harmony-frontend/.../channel/GuestPromoBanner.tsx (6):
+     2: * Channel Component: GuestPromoBanner
+     5: * Based on dev spec C1.4 GuestPromoBanner
+    25: interface GuestPromoBannerProps {
+    27: memberCount: number;
+    30: export function GuestPromoBanner({ serverName, memberCount }: GuestPromoBanne...
+    77: <p className='text-xs text-gray-400'>{memberCount.toLocaleString()} members</p>
+
+[file] harmony-frontend/.../layout/HarmonyShell.tsx (4):
+    19: import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+   482: <GuestPromoBanner
+   483: serverName={currentServer.name}
+   484: memberCount={currentServer.memberCount ?? members.length}
+
+[file] harmony-frontend/.../server-rail/BrowseServersModal.tsx (6):
+    27: memberCount: number;
+    63: const initials = server.name
+    78: alt={server.name}
+    91: <p className='truncate font-semibold text-white'>{server.name}</p>
+    96: {server.memberCount.toLocaleString()} member{server.memberCount !== 1 ? 's' :...
+   200: showToast({ message: `Joined ${server.name}!`, type: 'success' });
+
+[file] harmony-frontend/.../server-rail/CreateServerModal.tsx (1):
+   104: showToast({ message: `Server "${server.name}" created!`, type: 'success' });
+
+[file] harmony-frontend/.../server-rail/ServerRail.tsx (4):
+    39: const initials = server.name
+    50: title={server.name}
+    51: aria-label={server.name}
+    72: alt={server.name}
+
+[file] harmony-frontend/.../settings/ServerSettingsPage.tsx (4):
+    46: const [name, setName] = useState(server.name);
+    60: setName(server.name);
+   205: Permanently deletes <span className='font-semibold text-white'>{server.name}<...
+   268: const [displayName, setDisplayName] = useState(server.name);
+
+[file] harmony-frontend/src/services/publicApiService.ts (2):
+    23: memberCount: number;
+   109: memberCount: data.memberCount,
+
+[file] harmony-frontend/src/services/serverService.ts (1):
+    31: memberCount: (raw.memberCount as number | undefined) ?? 0,
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:14:36.322Z
+
+No. The PR does not fix that bottom-right guest banner.
+
+That banner still renders the raw server name from `server.name` in [GuestPromoBanner.tsx](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/src/components/channel/GuestPromoBanner.tsx) and it is passed through directly from [GuestChannelView.tsx](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/src/components/channel/GuestChannelView.tsx:113). The change I made only covers metadata/title generation in [page.tsx](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx) plus backend meta-tag title sanitization in [titleGenerator.ts](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-backend/src/services/metaTag/titleGenerator.ts).
+
+So if you want that UI element fixed too, that’s a separate frontend display sanitization change. I can patch that next.
+
+### Turn 3: fix that too in this
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T19:14:46.479Z
+
+```text
+fix that too in this PR
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:14:55.561Z
+
+I’m patching the guest UI path in the same branch now. First I’m checking where the guest-facing server name is rendered so I can fix it consistently instead of only masking one component.
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/components/channel/GuestChannelView.tsx
+```
+
+Output:
+
+```text
+/**
+ * GuestChannelView — simplified layout for anonymous public channel access.
+ * No ServerRail, no ChannelSidebar, no MessageInput.
+ * Wraps content in VisibilityGuard so PRIVATE channels show AccessDeniedPage.
+ * Ref: dev-spec-guest-public-channel-view.md — M1, C1.1 PublicChannelPage
+ */
+
+import { notFound } from 'next/navigation';
+import {
+  fetchPublicServer,
+  fetchPublicChannel,
+  fetchPublicMessages,
+} from '@/services/publicApiService';
+import { getChannels } from '@/services/channelService';
+import { TrpcHttpError } from '@/lib/trpc-errors';
+import { AuthRedirect } from '@/components/channel/AuthRedirect';
+import { VisibilityGuard } from '@/components/channel/VisibilityGuard';
+import { MessageList } from '@/components/channel/MessageList';
+import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+import { GuestHeader } from '@/components/channel/GuestHeader';
+import { PrivateChannelLockedPane } from '@/components/channel/PrivateChannelLockedPane';
+import type { Channel } from '@/types';
+
+// ─── Channel Header ───────────────────────────────────────────────────────────
+
+function ChannelHeader({ channel }: { channel: Channel }) {
+  return (
+    <div className='flex shrink-0 items-center gap-2 border-b border-black/20 bg-[#36393f] px-4 py-3'>
+      <svg
+        className='h-5 w-5 shrink-0 text-gray-400'
+        viewBox='0 0 24 24'
+        fill='currentColor'
+        aria-hidden='true'
+        focusable='false'
+      >
+        <path d='M5.88657 21C5.57547 21 5.3399 20.7189 5.39427 20.4126L6.00001 17H2.59511C2.28449 17 2.04905 16.7198 2.10259 16.4138L2.27759 15.4138C2.31946 15.1746 2.52722 15 2.77011 15H6.35001L7.41001 9H4.00511C3.69449 9 3.45905 8.71977 3.51259 8.41381L3.68759 7.41381C3.72946 7.17456 3.93722 7 4.18011 7H7.76001L8.39677 3.41262C8.43914 3.17391 8.64664 3 8.88907 3H9.87344C10.1845 3 10.4201 3.28107 10.3657 3.58738L9.76001 7H15.76L16.3968 3.41262C16.4391 3.17391 16.6466 3 16.8891 3H17.8734C18.1845 3 18.4201 3.28107 18.3657 3.58738L17.76 7H21.1649C21.4755 7 21.711 7.28023 21.6574 7.58619L21.4824 8.58619C21.4406 8.82544 21.2328 9 20.9899 9H17.41L16.35 15H19.7549C20.0655 15 20.301 15.2802 20.2474 15.5862L20.0724 16.5862C20.0306 16.8254 19.8228 17 19.5799 17H16L15.3632 20.5874C15.3209 20.8261 15.1134 21 14.871 21H13.8866C13.5755 21 13.3399 20.7189 13.3943 20.4126L14 17H8.00001L7.36325 20.5874C7.32088 20.8261 7.11337 21 6.87094 21H5.88657ZM9.41001 9L8.35001 15H14.35L15.41 9H9.41001Z' />
+      </svg>
+      <h1 className='text-sm font-semibold text-white'>{channel.name}</h1>
+      {channel.topic && (
+        <>
+          <span className='text-gray-600' aria-hidden='true'>
+            |
+          </span>
+          <p className='truncate text-sm text-gray-400'>{channel.topic}</p>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface GuestChannelViewProps {
+  serverSlug: string;
+  channelSlug: string;
+}
+
+export async function GuestChannelView({ serverSlug, channelSlug }: GuestChannelViewProps) {
+  const [server, channelResult] = await Promise.all([
+    fetchPublicServer(serverSlug),
+    fetchPublicChannel(serverSlug, channelSlug),
+  ]);
+
+  if (!server || !channelResult) notFound();
+
+  // Check if the authenticated user is a member of this server.
+  // Only redirect members to the full /channels/ view; non-members stay here
+  // so we don't create a redirect loop (ChannelPageContent → /c/ → /channels/ → loop).
+  //
+  // Error handling:
+  //   - Success  → confirmed member; redirect to /channels/
+  //   - 403      → confirmed non-member (valid token, no ServerMember row); stay on guest view
+  //   - 401/other → expired/invalid token; membership unknown — still render AuthRedirect so
+  //                 the client can redirect after the token is refreshed client-side.
+  //                 If the user turns out not to be a member, ChannelPageContent will redirect
+  //                 back here with a valid token and we'll get a 403, stopping any loop.
+  let isMember = false;
+  try {
+    await getChannels(server.id);
+    isMember = true;
+  } catch (err: unknown) {
+    // trpcQuery throws TrpcHttpError — check status directly rather than parsing
+    // the message string, which would couple us to the error format in trpc-client.
+    isMember = !(err instanceof TrpcHttpError && err.status === 403);
+  }
+
+  if (channelResult.isPrivate) {
+    return (
+      <div className='flex h-screen flex-col overflow-hidden bg-[#36393f] font-sans'>
+        {isMember && <AuthRedirect to={`/channels/${serverSlug}/${channelSlug}`} />}
+        <GuestHeader server={server} />
+        <PrivateChannelLockedPane mode='guest' />
+      </div>
+    );
+  }
+
+  const { channel } = channelResult;
+  const { messages } = await fetchPublicMessages(channel.id);
+  const sortedMessages = [...messages].reverse();
+  const memberCount = server.memberCount ?? 0;
+
+  return (
+    <div className='flex h-screen flex-col overflow-hidden bg-[#36393f] font-sans'>
+      {isMember && <AuthRedirect to={`/channels/${serverSlug}/${channelSlug}`} />}
+      <GuestHeader server={server} />
+
+      <VisibilityGuard visibility={channel.visibility} isLoading={false}>
+        <div className='flex flex-1 flex-col overflow-hidden'>
+          <ChannelHeader channel={channel} />
+
+          <div className='flex flex-1 flex-col overflow-hidden'>
+            <MessageList key={channel.id} channel={channel} messages={sortedMessages} />
+            <GuestPromoBanner serverName={server.name} memberCount={memberCount} />
+          </div>
+        </div>
+      </VisibilityGuard>
+    </div>
+  );
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/components/channel/GuestHeader.tsx
+```
+
+Output:
+
+```text
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth';
+import type { Server } from '@/types';
+
+type PublicServer = Omit<Server, 'ownerId'>;
+
+export function GuestHeader({ server }: { server: PublicServer }) {
+  const { isAuthenticated } = useAuth();
+  const pathname = usePathname();
+  const returnUrl = encodeURIComponent(pathname);
+
+  return (
+    <header className='flex h-14 shrink-0 items-center gap-3 border-b border-black/20 bg-[#2f3136] px-4'>
+      {/* Harmony logo wordmark */}
+      <span className='text-lg font-bold text-[#5865f2]'>Harmony</span>
+
+      {/* Divider */}
+      <span className='text-gray-600' aria-hidden='true'>
+        /
+      </span>
+
+      {/* Server name — min-w-0 flex-1 prevents overflow when CTAs are present */}
+      <span className='min-w-0 flex-1 truncate text-sm font-semibold text-white'>{server.name}</span>
+
+      {/* Auth CTAs — hidden for authenticated users (e.g. non-member 403 path) */}
+      {!isAuthenticated && (
+        <div className='flex shrink-0 items-center gap-2'>
+          <Link
+            href={`/auth/signup?returnUrl=${returnUrl}`}
+            className='inline-flex h-7 items-center justify-center rounded-md bg-[#5865f2] px-3 text-xs font-medium text-white transition-colors hover:bg-[#4752c4]'
+          >
+            <span className='hidden sm:inline'>Create Account</span>
+            <span className='sm:hidden'>Join</span>
+          </Link>
+          <Link
+            href={`/auth/login?returnUrl=${returnUrl}`}
+            className='inline-flex h-7 items-center justify-center rounded-md border border-white/20 bg-[#40444b] px-3 text-xs font-medium text-gray-200 transition-colors hover:bg-[#3d4148]'
+          >
+            Log In
+          </Link>
+        </div>
+      )}
+    </header>
+  );
+}
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "server\.name|serverName" harmony-frontend/src/components/channel
+```
+
+Output:
+
+```text
+7 matches in 4F:
+
+[file] harmony-frontend/.../channel/ChannelSidebar.tsx (1):
+   235: <span className='truncate'>{server.name}</span>
+
+[file] harmony-frontend/.../channel/GuestChannelView.tsx (1):
+   113: <GuestPromoBanner serverName={server.name} memberCount={memberCount} />
+
+[file] harmony-frontend/.../channel/GuestHeader.tsx (1):
+    26: <span className='min-w-0 flex-1 truncate text-sm font-semibold text-white'>{s...
+
+[file] harmony-frontend/.../channel/GuestPromoBanner.tsx (4):
+    26: serverName: string;
+    30: export function GuestPromoBanner({ serverName, memberCount }: GuestPromoBanne...
+    71: {serverName[0].toUpperCase()}
+    76: <p className='truncate text-sm font-semibold text-white'>{serverName}</p>
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:15:01.710Z
+
+The same raw `server.name` is used in both the guest header and the bottom promo banner. I’m extracting a small frontend sanitizer and wiring both components to it so the guest page stays internally consistent.
+
+#### Tool: exec_command
+
+```sh
+rg --files harmony-frontend/src | rg 'GuestPromoBanner|GuestHeader|__tests__'
+```
+
+Output:
+
+```text
+harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+harmony-frontend/src/__tests__/useServerEvents.test.tsx
+harmony-frontend/src/__tests__/public-channel-metadata.test.ts
+harmony-frontend/src/__tests__/server-settings-access.test.ts
+harmony-frontend/src/__tests__/SeoPreviewSection.test.tsx
+harmony-frontend/src/__tests__/publicApiService.test.ts
+harmony-frontend/src/__tests__/trpc-client.test.ts
+harmony-frontend/src/__tests__/VisibilityToggle.test.tsx
+harmony-frontend/src/__tests__/useChannelEvents.test.tsx
+harmony-frontend/src/__tests__/VisibilityGuard.test.tsx
+harmony-frontend/src/__tests__/private-channel-pane-lock.test.tsx
+harmony-frontend/src/__tests__/channelService.test.ts
+harmony-frontend/src/__tests__/authService.test.ts
+harmony-frontend/src/__tests__/middleware.test.ts
+harmony-frontend/src/__tests__/seo-routes.test.ts
+harmony-frontend/src/__tests__/runtime-config.test.ts
+harmony-frontend/src/__tests__/issue-238-message-input-aria-label.test.tsx
+harmony-frontend/src/__tests__/serverService.test.ts
+harmony-frontend/src/__tests__/metaTagAdminService.test.ts
+harmony-frontend/src/__tests__/useServerListSync.test.tsx
+harmony-frontend/src/__tests__/frontend-logger.test.ts
+harmony-frontend/src/__tests__/utils.test.ts
+harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts
+harmony-frontend/src/components/channel/GuestPromoBanner.tsx
+harmony-frontend/src/components/channel/GuestHeader.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "GuestPromoBanner|GuestHeader" harmony-frontend/src/__tests__ harmony-frontend/src/components
+```
+
+Output:
+
+```text
+15 matches in 6F:
+
+[file] harmony-frontend/.../__tests__/private-channel-pane-lock.test.tsx (2):
+    79: jest.mock('@/components/channel/GuestPromoBanner', () => ({
+    80: GuestPromoBanner: () => <div>Guest promo banner</div>,
+
+[file] harmony-frontend/src/components/README.md (1):
+    31: - `GuestPromoBanner.tsx` - Guest user promo banner (C1.4)
+
+[file] harmony-frontend/.../channel/GuestChannelView.tsx (5):
+    19: import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+    20: import { GuestHeader } from '@/components/channel/GuestHeader';
+    91: <GuestHeader server={server} />
+   105: <GuestHeader server={server} />
+   113: <GuestPromoBanner serverName={server.name} memberCount={memberCount} />
+
+[file] harmony-frontend/.../channel/GuestHeader.tsx (1):
+    10: export function GuestHeader({ server }: { server: PublicServer }) {
+
+[file] harmony-frontend/.../channel/GuestPromoBanner.tsx (4):
+     2: * Channel Component: GuestPromoBanner
+     5: * Based on dev spec C1.4 GuestPromoBanner
+    25: interface GuestPromoBannerProps {
+    30: export function GuestPromoBanner({ serverName, memberCount }: GuestPromoBanne...
+
+[file] harmony-frontend/.../layout/HarmonyShell.tsx (2):
+    19: import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+   482: <GuestPromoBanner
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/__tests__/utils.test.ts
+```
+
+Output:
+
+```text
+import type { AxiosError } from 'axios';
+import {
+  cn,
+  formatDate,
+  formatMessageTimestamp,
+  formatRelativeTime,
+  formatTimeOnly,
+  getChannelUrl,
+  getUserErrorMessage,
+  truncate,
+} from '../lib/utils';
+
+describe('utils', () => {
+  describe('cn', () => {
+    it('merges conditional and conflicting Tailwind classes', () => {
+      expect(cn('px-2 py-1', false && 'hidden', 'px-4')).toBe('py-1 px-4');
+    });
+  });
+
+  describe('formatDate', () => {
+    it('formats string and Date inputs consistently', () => {
+      const date = new Date(2026, 2, 30, 12, 0, 0);
+
+      expect(formatDate(date)).toBe('March 30, 2026');
+      expect(formatDate(date.toISOString())).toBe('March 30, 2026');
+    });
+  });
+
+  describe('formatRelativeTime', () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date(2026, 2, 30, 12, 0, 0));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('returns just now for timestamps under one minute old', () => {
+      expect(formatRelativeTime(new Date(2026, 2, 30, 11, 59, 30))).toBe('just now');
+    });
+
+    it('returns minutes for timestamps under one hour old', () => {
+      expect(formatRelativeTime(new Date(2026, 2, 30, 11, 15, 0))).toBe('45m ago');
+    });
+
+    it('returns hours for timestamps under one day old', () => {
+      expect(formatRelativeTime(new Date(2026, 2, 30, 9, 0, 0))).toBe('3h ago');
+    });
+
+    it('returns days for timestamps under one week old', () => {
+      expect(formatRelativeTime(new Date(2026, 2, 27, 12, 0, 0))).toBe('3d ago');
+    });
+
+    it('falls back to a formatted date for older timestamps', () => {
+      expect(formatRelativeTime(new Date(2026, 2, 20, 12, 0, 0))).toBe('March 20, 2026');
+    });
+  });
+
+  describe('formatMessageTimestamp', () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date(2026, 2, 30, 12, 0, 0));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('returns an empty string for invalid dates', () => {
+      expect(formatMessageTimestamp('not-a-date')).toBe('');
+    });
+
+    it('formats same-day timestamps as Today', () => {
+      expect(formatMessageTimestamp(new Date(2026, 2, 30, 9, 5, 0))).toMatch(/^Today at /);
+    });
+
+    it('formats previous-day timestamps as Yesterday', () => {
+      expect(formatMessageTimestamp(new Date(2026, 2, 29, 9, 5, 0))).toMatch(/^Yesterday at /);
+    });
+
+    it('formats older timestamps as a date', () => {
+      expect(formatMessageTimestamp(new Date(2026, 2, 20, 9, 5, 0))).toBe('3/20/2026');
+    });
+  });
+
+  describe('formatTimeOnly', () => {
+    it('returns an empty string for invalid dates', () => {
+      expect(formatTimeOnly('not-a-date')).toBe('');
+    });
+
+    it('formats valid timestamps as time-only output', () => {
+      expect(formatTimeOnly(new Date(2026, 2, 30, 15, 42, 0))).toBe('3:42 PM');
+    });
+  });
+
+  describe('getUserErrorMessage', () => {
+    it('joins validation detail messages from Axios errors', () => {
+      const err = {
+        isAxiosError: true,
+        response: {
+          data: {
+            details: [{ message: 'Name is required' }, { message: 'Topic is too long' }],
+          },
+        },
+      } as AxiosError;
+
+      expect(getUserErrorMessage(err)).toBe('Name is required. Topic is too long');
+    });
+
+    it('returns string API errors when they are not generic validation failures', () => {
+      const err = {
+        isAxiosError: true,
+        response: { data: { error: 'Forbidden' } },
+      } as AxiosError;
+
+      expect(getUserErrorMessage(err)).toBe('Forbidden');
+    });
+
+    it('prefers nested API error messages for structured errors', () => {
+      const err = {
+        isAxiosError: true,
+        response: { data: { error: { message: 'Nested problem' } } },
+      } as AxiosError;
+
+      expect(getUserErrorMessage(err)).toBe('Nested problem');
+    });
+
+    it('falls back to response.message when error is the generic validation marker', () => {
+      const err = {
+        isAxiosError: true,
+        response: { data: { error: 'Validation failed', message: 'Email is invalid' } },
+      } as AxiosError;
+
+      expect(getUserErrorMessage(err)).toBe('Email is invalid');
+    });
+
+    it('returns the provided fallback for generic HTTP status errors', () => {
+      expect(
+        getUserErrorMessage(new Error('Request failed with status code 403'), 'Try again'),
+      ).toBe('Try again');
+    });
+
+    it('returns ordinary Error messages directly', () => {
+      expect(getUserErrorMessage(new Error('Channel not found'))).toBe('Channel not found');
+    });
+
+    it('returns the fallback for unknown error shapes', () => {
+      expect(getUserErrorMessage({ nope: true }, 'Fallback message')).toBe('Fallback message');
+    });
+  });
+
+  describe('truncate', () => {
+    it('returns the original text when it already fits', () => {
+      expect(truncate('hello', 5)).toBe('hello');
+    });
+
+    it('adds an ellipsis when the text exceeds the limit', () => {
+      expect(truncate('hello world', 5)).toBe('hello...');
+    });
+  });
+
+  describe('getChannelUrl', () => {
+    const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
+    afterEach(() => {
+      process.env.NEXT_PUBLIC_BASE_URL = originalBaseUrl;
+    });
+
+    it('uses the configured base URL when present', () => {
+      process.env.NEXT_PUBLIC_BASE_URL = 'https://harmony.example';
+
+      expect(getChannelUrl('server', 'general')).toBe('https://harmony.example/c/server/general');
+    });
+
+    it('falls back to localhost when no base URL is configured', () => {
+      delete process.env.NEXT_PUBLIC_BASE_URL;
+
+      expect(getChannelUrl('server', 'general')).toBe('http://localhost:3000/c/server/general');
+    });
+  });
+});
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls harmony-frontend/src/lib
+```
+
+Output:
+
+```text
+api-client.ts  10.6K
+auth-constants.ts  258B
+constants.ts  1.6K
+frontend-logger.ts  3.8K
+passwordAuth.ts  1.4K
+runtime-config.ts  1.3K
+seo-sitemap.ts  592B
+sitemap-response.ts  1.3K
+trpc-client.ts  7.5K
+trpc-errors.ts  825B
+utils.ts  4.7K
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/lib/utils.ts
+```
+
+Output:
+
+```text
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+import { isAxiosError } from 'axios';
+import { getChannelUrl as getCanonicalChannelUrl } from './runtime-config';
+
+/**
+ * Utility function to merge Tailwind CSS classes
+ * Combines clsx and tailwind-merge for optimal class handling
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+/**
+ * Format a date to a human-readable string
+ */
+export function formatDate(date: Date | string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Format a timestamp to relative time (e.g., "2 hours ago")
+ */
+export function formatRelativeTime(date: Date | string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  const now = new Date();
+  const diffInSeconds = Math.floor((now.getTime() - d.getTime()) / 1000);
+
+  if (diffInSeconds < 60) return 'just now';
+  if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}m ago`;
+  if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}h ago`;
+  if (diffInSeconds < 604800) return `${Math.floor(diffInSeconds / 86400)}d ago`;
+
+  return formatDate(d);
+}
+
+/**
+ * Format a message timestamp in Discord style:
+ *   - Same day   → "Today at 3:42 PM"
+ *   - Yesterday  → "Yesterday at 3:42 PM"
+ *   - Older      → "2/20/2026"
+ *
+ * Note: "Today" / "Yesterday" comparisons use toDateString(), which operates
+ * in the viewer's local browser timezone. A message sent just before midnight
+ * UTC may appear as "Today" or "Yesterday" differently across timezones —
+ * this is expected behaviour (same as Discord) and is intentional.
+ */
+export function formatMessageTimestamp(date: Date | string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  if (isNaN(d.getTime())) return '';
+  const now = new Date();
+  const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+
+  if (d.toDateString() === now.toDateString()) return `Today at ${time}`;
+
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (d.toDateString() === yesterday.toDateString()) return `Yesterday at ${time}`;
+
+  return d.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric', year: 'numeric' });
+}
+
+/**
+ * Format a timestamp as time-only (e.g. "3:42 PM").
+ * Returns "" for invalid dates rather than throwing a RangeError.
+ * Used in the compact message variant where only the time is shown on hover.
+ */
+export function formatTimeOnly(date: Date | string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  if (isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+}
+
+/**
+ * Extracts a user-friendly error message from an unknown caught value.
+ *
+ * Handles:
+ *   - Axios errors: reads `response.data.error` (string or object with `.message`)
+ *   - tRPC HTTP errors embedded in axios: `response.data.error.message`
+ *   - Plain Error instances with a message
+ *   - Falls back to the provided `fallback` string
+ */
+export function getUserErrorMessage(
+  err: unknown,
+  fallback = 'Something went wrong. Please try again.',
+): string {
+  if (isAxiosError(err)) {
+    const data = err.response?.data;
+    if (data) {
+      // Validation errors: { error: "Validation failed", details: [{ message: "..." }] }
+      if (Array.isArray(data.details) && data.details.length > 0) {
+        const messages = data.details.map((d: { message?: string }) => d.message).filter(Boolean);
+        if (messages.length > 0) return messages.join('. ');
+      }
+      // REST endpoints: { error: "Invalid credentials" }
+      if (typeof data.error === 'string' && data.error !== 'Validation failed') return data.error;
+      // tRPC endpoints: { error: { message: "..." } }
+      if (typeof data.error?.message === 'string') return data.error.message;
+      // Some endpoints: { message: "..." }
+      if (typeof data.message === 'string') return data.message;
+    }
+  }
+  if (err instanceof Error && err.message) {
+    // Filter out raw axios status messages like "Request failed with status code 401"
+    if (/^Request failed with status code \d+$/.test(err.message)) return fallback;
+    return err.message;
+  }
+  return fallback;
+}
+
+/**
+ * Truncate text to a specified length
+ */
+export function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength) + '...';
+}
+
+/**
+ * Generate a canonical URL for a public channel
+ */
+export function getChannelUrl(serverSlug: string, channelSlug: string): string {
+  return getCanonicalChannelUrl(serverSlug, channelSlug);
+}
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:15:17.732Z
+
+I’m editing the frontend components now. I’m using a shared label sanitizer with a display fallback so the banner text and its avatar initial cannot render raw `../` segments or an empty string.
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "useAuth|usePathname|next/navigation" harmony-frontend/src/__tests__
+```
+
+Output:
+
+```text
+13 matches in 5F:
+
+[file] harmony-frontend/.../__tests__/VisibilityGuard.test.tsx (4):
+    15: jest.mock('next/navigation', () => ({
+    17: usePathname: () => '/test-server/general',
+    22: jest.mock('../hooks/useAuth', () => ({
+    23: useAuth: () => mockUseAuth(),
+
+[file] harmony-frontend/.../__tests__/issue-242-join-server-fix.test.ts (2):
+    71: jest.mock('next/navigation', () => ({
+    79: import 'next/navigation'; // ensure the mock is applied
+
+[file] harmony-frontend/.../__tests__/private-channel-pane-lock.test.tsx (3):
+    10: jest.mock('@/hooks/useAuth', () => ({
+    11: useAuth: () => mockUseAuth(),
+    14: jest.mock('next/navigation', () => ({
+
+[file] harmony-frontend/.../__tests__/server-settings-access.test.ts (1):
+    12: jest.mock('next/navigation', () => ({
+
+[file] harmony-frontend/.../__tests__/useServerListSync.test.tsx (3):
+     7: * BroadcastChannel and next/navigation are mocked to avoid browser/framework
+    14: // ─── Mock next/navigation ─────────────────────────────────────────────────...
+    18: jest.mock('next/navigation', () => ({
+```
+
+#### Tool: exec_command
+
+```sh
+rtk read harmony-frontend/src/__tests__/private-channel-pane-lock.test.tsx
+```
+
+Output:
+
+```text
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { HarmonyShell } from '@/components/layout/HarmonyShell';
+import { ChannelType, ChannelVisibility } from '@/types';
+import type { Channel, Message, Server, User } from '@/types';
+
+const mockUseAuth = jest.fn();
+const mockUseServerEvents = jest.fn();
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('@/contexts/VoiceContext', () => ({
+  VoiceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/hooks/useServerEvents', () => ({
+  useServerEvents: (options: unknown) => mockUseServerEvents(options),
+}));
+
+jest.mock('@/hooks/useServerListSync', () => ({
+  useServerListSync: () => ({
+    notifyServerCreated: jest.fn(),
+    notifyServerJoined: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/server-rail/ServerRail', () => ({
+  ServerRail: () => <div>Server rail</div>,
+}));
+
+jest.mock('@/components/channel/ChannelSidebar', () => ({
+  ChannelSidebar: () => <div>Channel sidebar</div>,
+}));
+
+jest.mock('@/components/channel/TopBar', () => ({
+  TopBar: ({
+    onSearchOpen,
+    onPinsOpen,
+    disableMessageActions,
+  }: {
+    onSearchOpen?: () => void;
+    onPinsOpen?: () => void;
+    disableMessageActions?: boolean;
+  }) => (
+    <div>
+      <div>Top bar</div>
+      <button onClick={onSearchOpen} disabled={disableMessageActions}>
+        Search
+      </button>
+      <button onClick={onPinsOpen} disabled={disableMessageActions}>
+        Pinned messages
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/channel/MessageList', () => ({
+  MessageList: () => <div>Message list</div>,
+}));
+
+jest.mock('@/components/channel/MessageInput', () => ({
+  MessageInput: () => <div>Message input</div>,
+}));
+
+jest.mock('@/components/channel/MembersSidebar', () => ({
+  MembersSidebar: () => <div>Members sidebar</div>,
+}));
+
+jest.mock('@/components/channel/PinnedMessagesPanel', () => ({
+  PinnedMessagesPanel: () => <div>Pinned messages panel</div>,
+}));
+
+jest.mock('@/components/channel/GuestPromoBanner', () => ({
+  GuestPromoBanner: () => <div>Guest promo banner</div>,
+}));
+
+jest.mock('@/components/channel/CreateChannelModal', () => ({
+  CreateChannelModal: () => null,
+}));
+
+jest.mock('@/components/server-rail/BrowseServersModal', () => ({
+  BrowseServersModal: () => null,
+}));
+
+jest.mock('@/components/server-rail/CreateServerModal', () => ({
+  CreateServerModal: () => null,
+}));
+
+jest.mock('@/components/channel/SearchModal', () => ({
+  SearchModal: () => <div>Search modal</div>,
+}));
+
+const server: Server = {
+  id: 'server-1',
+  name: 'Product',
+  slug: 'product',
+  ownerId: 'owner-1',
+  memberCount: 3,
+  createdAt: '2026-04-16T12:00:00.000Z',
+};
+
+const channel: Channel = {
+  id: 'channel-1',
+  name: 'Roadmap',
+  slug: 'roadmap',
+  serverId: 'server-1',
+  type: ChannelType.TEXT,
+  visibility: ChannelVisibility.PRIVATE,
+  position: 0,
+  createdAt: '2026-04-16T12:00:00.000Z',
+};
+
+const members: User[] = [
+  {
+    id: 'member-1',
+    username: 'alex',
+    displayName: 'Alex',
+    status: 'online',
+    role: 'member',
+  },
+];
+
+const messages: Message[] = [
+  {
+    id: 'message-1',
+    channelId: 'channel-1',
+    authorId: 'member-1',
+    author: { id: 'member-1', username: 'alex' },
+    content: 'Hello',
+    timestamp: '2026-04-16T12:00:00.000Z',
+  },
+];
+
+function renderShell(overrides?: Partial<React.ComponentProps<typeof HarmonyShell>>) {
+  return render(
+    <HarmonyShell
+      servers={[server]}
+      currentServer={server}
+      channels={[channel]}
+      allChannels={[channel]}
+      currentChannel={channel}
+      messages={messages}
+      members={members}
+      {...overrides}
+    />,
+  );
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches: true,
+      media: '(min-width: 640px)',
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    isAdmin: () => false,
+  });
+});
+
+describe('Issue #338 — private channel denial keeps the shell mounted', () => {
+  it('renders the standard shell by default', () => {
+    renderShell();
+
+    expect(screen.getByText('Server rail')).toBeInTheDocument();
+    expect(screen.getByText('Channel sidebar')).toBeInTheDocument();
+    expect(screen.getByText('Top bar')).toBeInTheDocument();
+    expect(screen.getByText('Message list')).toBeInTheDocument();
+    expect(screen.getByText('Message input')).toBeInTheDocument();
+  });
+
+  it('replaces only the message pane when a locked private-channel pane is supplied', () => {
+    renderShell({
+      lockedMessagePane: <div>Private channel lock panel</div>,
+    });
+
+    expect(screen.getByText('Server rail')).toBeInTheDocument();
+    expect(screen.getByText('Channel sidebar')).toBeInTheDocument();
+    expect(screen.getByText('Top bar')).toBeInTheDocument();
+    expect(screen.getByText('Private channel lock panel')).toBeInTheDocument();
+    expect(screen.queryByText('Message list')).not.toBeInTheDocument();
+    expect(screen.queryByText('Message input')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pinned messages panel')).not.toBeInTheDocument();
+    expect(screen.queryByText('Search modal')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Search' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Pinned messages' })).toBeDisabled();
+    // Message callbacks must be undefined when the channel is locked so stale
+    // real-time messages do not accumulate in locked state.
+    expect(mockUseServerEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onMessageCreated: undefined,
+        onMessageEdited: undefined,
+        onMessageDeleted: undefined,
+      }),
+    );
+  });
+});
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:16:10.663Z
+
+The guest UI sanitization patch is in. I added direct frontend tests for both the guest header and the bottom promo banner so this is covered at the component level, not just through the metadata path.
+
+#### Tool: exec_command
+
+```sh
+npm exec -- prettier --write src/lib/utils.ts src/components/channel/GuestHeader.tsx src/components/channel/GuestPromoBanner.tsx src/__tests__/utils.test.ts src/__tests__/guest-server-name-sanitization.test.tsx
+```
+
+Output:
+
+```text
+[warn] jsxBracketSameLine is deprecated.
+src/lib/utils.ts 37ms
+src/components/channel/GuestHeader.tsx 5ms
+src/components/channel/GuestPromoBanner.tsx 6ms
+src/__tests__/utils.test.ts 8ms (unchanged)
+src/__tests__/guest-server-name-sanitization.test.tsx 2ms (unchanged)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts src/__tests__/utils.test.ts src/__tests__/guest-server-name-sanitization.test.tsx
+```
+
+Output:
+
+```text
+> jest --forceExit --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts src/__tests__/utils.test.ts src/__tests__/guest-server-name-sanitization.test.tsx
+Test Suites: 3 passed, 3 total
+Tests:       46 passed, 46 total
+Snapshots:   0 total
+Time:        0.662 s, estimated 1 s
+Ran all test suites within paths "src/__tests__/channel-page-metadata.test.ts", "src/__tests__/utils.test.ts", "src/__tests__/guest-server-name-sanitization.test.tsx".
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
+```
+
+#### Tool: exec_command
+
+```sh
+npm run lint -- src/components/channel/GuestHeader.tsx src/components/channel/GuestPromoBanner.tsx src/lib/utils.ts src/__tests__/utils.test.ts src/__tests__/guest-server-name-sanitization.test.tsx src/app/c/[serverSlug]/[channelSlug]/page.tsx src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+zsh:1: no matches found: src/app/c/[serverSlug]/[channelSlug]/page.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+npm run build
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 build
+> next build
+
+▲ Next.js 16.1.6 (Turbopack)
+
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+  Creating an optimized production build ...
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:16:27.823Z
+
+The test pass is clean. I hit the usual zsh globbing problem on the lint command for the route file, and I’m rerunning lint with quoted paths while the full frontend build continues.
+
+#### Tool: exec_command
+
+```sh
+npm run lint -- src/components/channel/GuestHeader.tsx src/components/channel/GuestPromoBanner.tsx src/lib/utils.ts src/__tests__/utils.test.ts src/__tests__/guest-server-name-sanitization.test.tsx 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' src/__tests__/channel-page-metadata.test.ts
+```
+
+Output:
+
+```text
+
+> harmony-frontend@0.1.0 lint
+> eslint src/components/channel/GuestHeader.tsx src/components/channel/GuestPromoBanner.tsx src/lib/utils.ts src/__tests__/utils.test.ts src/__tests__/guest-server-name-sanitization.test.tsx src/app/c/[serverSlug]/[channelSlug]/page.tsx src/__tests__/channel-page-metadata.test.ts
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 7487,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 6000
+}
+```
+
+Output:
+
+```text
+Chunk ID: ab47dd
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 414
+Output:
+(node:10298) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/tailwind.config.ts?id=1777403782860 is not specified and it doesn't parse as CommonJS.
+Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
+To eliminate this warning, add "type": "module" to /Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/package.json.
+(Use `node --trace-warnings ...` to show where the warning was created)
+✓ Compiled successfully in 1900.9ms
+  Running TypeScript ...
+  Collecting page data using 9 workers ...
+  Generating static pages using 9 workers (0/11) ...
+  Generating static pages using 9 workers (2/11) 
+  Generating static pages using 9 workers (5/11) 
+  Generating static pages using 9 workers (8/11) 
+✓ Generating static pages using 9 workers (11/11) in 148.0ms
+  Finalizing page optimization ...
+
+Route (app)                               Revalidate  Expire
+┌ ○ /                                             1m      1y
+├ ○ /_not-found
+├ ƒ /api/attachments/upload
+├ ○ /auth/login
+├ ○ /auth/signup
+├ ƒ /c/[serverSlug]/[channelSlug]
+├ ƒ /channels
+├ ƒ /channels/[serverSlug]
+├ ƒ /channels/[serverSlug]/[channelSlug]
+├ ○ /robots.txt                                   1h      1y
+├ ƒ /settings
+├ ƒ /settings/[serverSlug]
+├ ƒ /settings/[serverSlug]/[channelSlug]
+├ ƒ /sitemap.xml
+├ ƒ /sitemap/[serverSlug]
+└ ○ /sitemap/[serverSlug].xml                     5m      1y
+
+
+ƒ Proxy (Middleware)
+
+○  (Static)   prerendered as static content
+ƒ  (Dynamic)  server-rendered on demand
+```
+
+#### Tool: write_stdin
+
+```json
+{
+  "session_id": 12015,
+  "chars": "",
+  "yield_time_ms": 1000,
+  "max_output_tokens": 5000
+}
+```
+
+Output:
+
+```text
+Chunk ID: 34da64
+Wall time: 0.0000 seconds
+Process exited with code 0
+Original token count: 0
+Output:
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:16:40.610Z
+
+The guest UI fix is verified: the guest header and the bottom promo banner now sanitize the displayed server name, and the frontend build still passes. I’m staging the delta and pushing one more commit onto PR #513.
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short
+```
+
+Output:
+
+```text
+ M harmony-frontend/src/__tests__/utils.test.ts
+ M harmony-frontend/src/components/channel/GuestHeader.tsx
+ M harmony-frontend/src/components/channel/GuestPromoBanner.tsx
+ M harmony-frontend/src/lib/utils.ts
+?? harmony-frontend/src/__tests__/guest-server-name-sanitization.test.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --stat
+```
+
+Output:
+
+```text
+harmony-frontend/src/__tests__/utils.test.ts              | 15 +++++++++++++++
+ harmony-frontend/src/components/channel/GuestHeader.tsx   |  6 +++++-
+ .../src/components/channel/GuestPromoBanner.tsx           | 10 ++++++----
+ harmony-frontend/src/lib/utils.ts                         | 12 ++++++++++++
+ 4 files changed, 38 insertions(+), 5 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+git add harmony-frontend/src/lib/utils.ts harmony-frontend/src/components/channel/GuestHeader.tsx harmony-frontend/src/components/channel/GuestPromoBanner.tsx harmony-frontend/src/__tests__/utils.test.ts harmony-frontend/src/__tests__/guest-server-name-sanitization.test.tsx
+```
+
+Output:
+
+```text
+
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --cached --stat
+```
+
+Output:
+
+```text
+.../guest-server-name-sanitization.test.tsx        | 50 ++++++++++++++++++++++
+ harmony-frontend/src/__tests__/utils.test.ts       | 15 +++++++
+ .../src/components/channel/GuestHeader.tsx         |  6 ++-
+ .../src/components/channel/GuestPromoBanner.tsx    | 10 +++--
+ harmony-frontend/src/lib/utils.ts                  | 12 ++++++
+ 5 files changed, 88 insertions(+), 5 deletions(-)
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git diff --cached -- harmony-frontend/src/lib/utils.ts harmony-frontend/src/components/channel/GuestHeader.tsx harmony-frontend/src/components/channel/GuestPromoBanner.tsx harmony-frontend/src/__tests__/utils.test.ts harmony-frontend/src/__tests__/guest-server-name-sanitization.test.tsx
+```
+
+Output:
+
+```text
+.../guest-server-name-sanitization.test.tsx        | 50 ++++++++++++++++++++++
+ harmony-frontend/src/__tests__/utils.test.ts       | 15 +++++++
+ .../src/components/channel/GuestHeader.tsx         |  6 ++-
+ .../src/components/channel/GuestPromoBanner.tsx    | 10 +++--
+ harmony-frontend/src/lib/utils.ts                  | 12 ++++++
+ 5 files changed, 88 insertions(+), 5 deletions(-)
+
+--- Changes ---
+
+harmony-frontend/src/__tests__/guest-server-name-sanitization.test.tsx
+  @@ -0,0 +1,50 @@
+  +import { render, screen } from '@testing-library/react';
+  +import '@testing-library/jest-dom';
+  +import { GuestHeader } from '@/components/channel/GuestHeader';
+  +import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
+  +
+  +const mockUseAuth = jest.fn();
+  +
+  +jest.mock('@/hooks/useAuth', () => ({
+  +  useAuth: () => mockUseAuth(),
+  +}));
+  +
+  +jest.mock('next/navigation', () => ({
+  +  usePathname: () => '/c/admin/general',
+  +}));
+  +
+  +describe('guest server name sanitization', () => {
+  +  beforeEach(() => {
+  +    jest.clearAllMocks();
+  +    mockUseAuth.mockReturnValue({
+  +      user: null,
+  +      isAuthenticated: false,
+  +      isLoading: false,
+  +      isAdmin: () => false,
+  +    });
+  +  });
+  +
+  +  it('sanitizes the guest header server label', () => {
+  +    render(
+  +      <GuestHeader
+  +        server={{
+  +          id: 'server-1',
+  +          name: '../../../admin',
+  +          slug: 'admin',
+  +          createdAt: '2026-04-28T00:00:00.000Z',
+  +        }}
+  +      />,
+  +    );
+  +
+  +    expect(screen.getByText('admin')).toBeInTheDocument();
+  +    expect(screen.queryByText('../../../admin')).not.toBeInTheDocument();
+  +  });
+  +
+  +  it('sanitizes the guest promo banner label and avatar initial', () => {
+  +    render(<GuestPromoBanner serverName='../../../admin' memberCount={2} />);
+  +
+  +    expect(screen.getByText('admin')).toBeInTheDocument();
+  +    expect(screen.queryByText('../../../admin')).not.toBeInTheDocument();
+  +    expect(screen.getByText('A')).toBeInTheDocument();
+  +  });
+  +});
+  +50 -0
+
+harmony-frontend/src/__tests__/utils.test.ts
+  @@ -7,6 +7,7 @@ import {
+  +  sanitizeDisplayLabel,
+     truncate,
+   } from '../lib/utils';
+   
+  @@ -158,6 +159,20 @@ describe('utils', () => {
+  +  describe('sanitizeDisplayLabel', () => {
+  +    it('removes dot-segment path prefixes', () => {
+  +      expect(sanitizeDisplayLabel('../../../admin')).toBe('admin');
+  +    });
+  +
+  +    it('normalizes slash-separated names without preserving traversal segments', () => {
+  +      expect(sanitizeDisplayLabel(' ../ community // general ')).toBe('community / general');
+  +    });
+  +
+  +    it('strips HTML and collapses whitespace', () => {
+  +      expect(sanitizeDisplayLabel('<b>Game</b>   Dev\nHub')).toBe('Game Dev Hub');
+  +    });
+  +  });
+  +
+     describe('getChannelUrl', () => {
+       const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+   
+  +15 -0
+
+harmony-frontend/src/components/channel/GuestHeader.tsx
+  @@ -3,6 +3,7 @@
+  +import { sanitizeDisplayLabel } from '@/lib/utils';
+   import type { Server } from '@/types';
+   
+   type PublicServer = Omit<Server, 'ownerId'>;
+  @@ -11,6 +12,7 @@ export function GuestHeader({ server }: { server: PublicServer }) {
+  +  const safeServerName = sanitizeDisplayLabel(server.name) || 'Server';
+   
+     return (
+       <header className='flex h-14 shrink-0 items-center gap-3 border-b border-black/20 bg-[#2f3136] px-4'>
+  @@ -23,7 +25,9 @@ export function GuestHeader({ server }: { server: PublicServer }) {
+  -      <span className='min-w-0 flex-1 truncate text-sm font-semibold text-white'>{server.name}</span>
+  +      <span className='min-w-0 flex-1 truncate text-sm font-semibold text-white'>
+  +        {safeServerName}
+  +      </span>
+   
+         {/* Auth CTAs — hidden for authenticated users (e.g. non-member 403 path) */}
+         {!isAuthenticated && (
+  +5 -1
+
+harmony-frontend/src/components/channel/GuestPromoBanner.tsx
+  @@ -11,6 +11,7 @@ import { useState, useCallback, useSyncExternalStore } from 'react';
+  +import { sanitizeDisplayLabel } from '@/lib/utils';
+   
+   const DISMISS_KEY = 'harmony_guest_banner_dismissed';
+   
+  @@ -30,14 +31,15 @@ interface GuestPromoBannerProps {
+  +  const safeServerName = sanitizeDisplayLabel(serverName) || 'Server';
+     // useSyncExternalStore with a server snapshot of `true` (hidden) prevents
+     // hydration mismatch: SSR and initial client render both produce null, then
+     // React reconciles with the real client snapshot after hydration — no
+     // setState-in-effect needed.
+     const storageDismissed = useSyncExternalStore(
+  -    () => () => {},       // sessionStorage has no change events
+  +    () => () => {}, // sessionStorage has no change events
+       isDismissedInStorage, // client snapshot
+  -    () => true,           // server snapshot: always hidden
+  +    () => true, // server snapshot: always hidden
+     );
+   
+     // Tracks in-memory dismiss for the current render cycle, covering the case
+  @@ -68,12 +70,12 @@ export function GuestPromoBanner({ serverName, memberCount }: GuestPromoBannerPr
+  -          {serverName[0].toUpperCase()}
+  +          {safeServerName[0].toUpperCase()}
+           </div>
+   
+           {/* Server info */}
+           <div className='min-w-0 flex-1'>
+  -          <p className='truncate text-sm font-semibold text-white'>{serverName}</p>
+  +          <p className='truncate text-sm font-semibold text-white'>{safeServerName}</p>
+             <p className='text-xs text-gray-400'>{memberCount.toLocaleString()} members</p>
+           </div>
+   
+  +6 -4
+
+harmony-frontend/src/lib/utils.ts
+  @@ -121,6 +121,18 @@ export function truncate(text: string, maxLength: number): string {
+  +export function sanitizeDisplayLabel(text: string): string {
+  +  return text
+  +    .replace(/<[^>]*>/g, ' ')
+  +    .replace(/\\/g, '/')
+  +    .split('/')
+  +    .map(segment => segment.trim())
+  +    .filter(segment => segment.length > 0 && segment !== '.' && segment !== '..')
+  +    .join(' / ')
+  +    .replace(/\s+/g, ' ')
+  +    .trim();
+  +}
+  +
+   /**
+    * Generate a canonical URL for a public channel
+    */
+  +12 -0
+```
+
+#### Tool: exec_command
+
+```sh
+git commit -m "fix: sanitize guest server labels" -m "Co-authored-by: GPT-5.5 <noreply@openai.com>"
+```
+
+Output:
+
+```text
+[codex/issue-484-sanitize-channel-title 89190cf] fix: sanitize guest server labels
+ 5 files changed, 88 insertions(+), 5 deletions(-)
+ create mode 100644 harmony-frontend/src/__tests__/guest-server-name-sanitization.test.tsx
+```
+
+#### Tool: exec_command
+
+```sh
+git push
+```
+
+Output:
+
+```text
+To github.com:CS485-Harmony/Harmony.git
+   330b21f..89190cf  codex/issue-484-sanitize-channel-title -> codex/issue-484-sanitize-channel-title
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T19:17:33.261Z
+
+Yes. PR #513 now also fixes the guest UI display path.
+
+I added shared frontend label sanitization in [utils.ts](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/src/lib/utils.ts) and applied it to both [GuestHeader.tsx](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/src/components/channel/GuestHeader.tsx) and [GuestPromoBanner.tsx](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/src/components/channel/GuestPromoBanner.tsx), so the bottom-right guest banner and the guest header no longer render raw values like `../../../admin`. There’s also a direct regression test in [guest-server-name-sanitization.test.tsx](/Users/allen/.codex/worktrees/20cf/Harmony/harmony-frontend/src/__tests__/guest-server-name-sanitization.test.tsx).
+
+Verification I ran:
+`npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts src/__tests__/utils.test.ts src/__tests__/guest-server-name-sanitization.test.tsx`
+`npm --prefix harmony-frontend run lint -- src/components/channel/GuestHeader.tsx src/components/channel/GuestPromoBanner.tsx src/lib/utils.ts src/__tests__/utils.test.ts src/__tests__/guest-server-name-sanitization.test.tsx 'src/app/c/[serverSlug]/[channelSlug]/page.tsx' src/__tests__/channel-page-metadata.test.ts`
+`npm --prefix harmony-frontend run build`
+
+PR #513 is updated with commit `89190cf`.
+
+### Turn 4: [$codex-conversation-exporter](/Users/allen/repos/codex-logs-export/skil
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T22:57:56.943Z
+
+```text
+[$codex-conversation-exporter](/Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md) 019dd579-c2d3-7350-a286-448f5cb9cae2 to my final logs folder and push
+```
+
+_No assistant or tool activity recorded after this prompt._
+
+### Turn 5: <skill> <name>codex-conversation-exporter</name>
+
+#### 👤 User Prompt
+
+- Time: 2026-04-28T22:57:56.943Z
+
+````text
+<skill>
+<name>codex-conversation-exporter</name>
+<path>/Users/allen/repos/codex-logs-export/skills/codex-conversation-exporter/SKILL.md</path>
+---
+name: codex-conversation-exporter
+description: Export Codex session logs to Markdown using the local codex-export CLI instead of reconstructing transcripts with model tokens.
+---
+
+# Codex Conversation Exporter
+
+Use this skill when the user asks to export Codex logs, save a Codex conversation, convert a session to Markdown, or archive a transcript locally.
+
+## Rules
+
+- Prefer the local `codex-export` CLI over reconstructing a transcript in-model.
+- If the user has not identified a session, run `codex-export list` first and show the relevant candidates.
+- Default to messages plus tool activity.
+- Include hidden system/developer prompts only when the user explicitly asks for them.
+- Write to a user-visible path unless the user asks for stdout or another destination.
+- Report the output path back to the user after a file export.
+
+## Command patterns
+
+List recent sessions:
+
+```bash
+codex-export list
+codex-export list --limit 10
+codex-export list --since 2026-03-30
+```
+
+Export by thread id:
+
+```bash
+codex-export export <thread-id>
+codex-export export <thread-id> --out ~/Desktop
+codex-export export <thread-id> --messages-only
+codex-export export <thread-id> --all
+codex-export export <thread-id> --include-hidden-prompts
+codex-export export <thread-id> --stdout
+```
+
+Export by rollout path:
+
+```bash
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl
+codex-export export --path ~/.codex/sessions/.../rollout-*.jsonl --out ~/Desktop
+```
+
+## Flag guide
+
+- `--out <file-or-dir>` writes to a specific file or directory.
+- `--stdout` prints the Markdown instead of writing a file.
+- `--messages-only` omits tool calls and tool outputs.
+- `--all` includes low-level tool metadata and raw wrappers that are hidden by default.
+- `--include-hidden-prompts` includes developer/system prompt layers.
+- `--since <date>` filters `list` results.
+- `--limit <n>` caps `list` results.
+
+## Agent behavior
+
+When the user says "export this conversation" without a thread id:
+
+1. Run `codex-export list`.
+2. Identify the most likely current session from title, cwd, and recency.
+3. Export it with the default mode unless the user requested a different output.
+4. Return the exact file path written.
+
+`codex-log-export` remains available as a compatibility alias.
+
+</skill>
+````
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T22:58:07.824Z
+
+I’m using the `codex-conversation-exporter` skill. First I’m locating the established Harmony final-logs destination from memory and the repo so I can export thread `019dd579-c2d3-7350-a286-448f5cb9cae2` to the right folder before pushing it.
+
+#### Tool: exec_command
+
+```sh
+rtk grep -n "final logs|llm-logs|final/|codex-export export" /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+21 matches in 7F:
+
+[file] /Users/allen/.codex/memories/MEMORY.md (15):
+   205: - codex-conversation-exporter, codex-export export, llm-logs/acabrera04-logs/...
+   215: - codex-export export, llm-logs/acabrera04-logs/acabrera04-deployment, logs/a...
+   225: - acabrera04-extra, extra bucket, llm-logs/acabrera04-logs, user-scoped log n...
+   245: - Review Avanish's latest PR, PR #457, feature/issue-423-local-e2e-scripts, l...
+   255: - codex-export export, 019dc7b7-88d5-73f0-a613-09b11df3e903, llm-logs/acabrer...
+   259: - when the user says `<thread-id>, <thread-id> to llm-logs/acabrera04-logs/fi...
+   261: - when the user explicitly asked for `[$codex-conversation-exporter](...) 019...
+   267: - when the user says to put an export "to the PR branch and push it" after a ...
+   271: - `codex-export export <threadId> --out llm-logs/acabrera04-logs/final` can b...
+   274: - `codex-export export <threadId> --out <dir>` writes a single Markdown expor...
+   277: - The stable deployment-log destination is `llm-logs/acabrera04-logs/acabrera...
+   278: - `codex-export export <thread_id> --out <folder>` creates one markdown expor...
+   279: - The `extra` bucket lives under the same user namespace as `llm-logs/acabrer...
+   283: - The exported PR-review log from thread `019dbafe-8c33-7970-a41b-6c984b61be2...
+   284: - The issue #363 export produced `llm-logs/acabrera04-logs/final/2026-04-26-c...
+
+[file] 184 (1):
+     0: Exporting Codex conversations into Harmony `llm-logs` folders, either on the ...
+
+[file] 187 (1):
+     0: Export two Codex conversations to `llm-logs/acabrera04-logs/final` and push t...
+
+[file] 191 (1):
+     0: 13:08+00:00, thread_id=019dbc10-c896-7f60-920d-191e50d53b4f, two explicit thr...
+
+[file] 195 (1):
+     0: export codex conversation logs, rejected (fetch first), git rebase origin/cod...
+
+[file] 197 (1):
+     0: Export PR #443 conversation log to `llm-logs/acabrera04-logs/final` on the PR...
+
+[file] 247 (1):
+     0: Export the issue #363 conversation log to `llm-logs/acabrera04-logs/final` an...
+```
+
+#### Tool: exec_command
+
+```sh
+rtk find llm-logs -maxdepth 3 -type d | sort
+```
+
+Output:
+
+```text
+
+./ acabrera04-logs backend cicd declanblanc dev-specs docs_agentsMD fardeeni-backend fardeeni-tests frontend general issues-37-31-30 mockups planning pr56
+22F 3D:
+acabrera04-logs/ acabrera04-backend acabrera04-deployment acabrera04-extra acabrera04-tests extra final
+mockups/ channel-visibility-toggle guest-public-channel-view
+```
+
+#### Tool: exec_command
+
+```sh
+rtk git status --short --branch
+```
+
+Output:
+
+```text
+## codex/issue-484-sanitize-channel-title...origin/codex/issue-484-sanitize-channel-title
+```
+
+#### Tool: exec_command
+
+```sh
+sed -n '255,285p' /Users/allen/.codex/memories/MEMORY.md
+```
+
+Output:
+
+```text
+- codex-export export, 019dc7b7-88d5-73f0-a613-09b11df3e903, llm-logs/acabrera04-logs/final, 2026-04-26-complete-issue-363-019dc7b7.md, codex/issue-363-readme-deployer-pass, push, rejected (fetch first), git fetch origin codex/issue-363-readme-deployer-pass, git rebase origin/codex/issue-363-readme-deployer-pass
+
+## User preferences
+
+- when the user says `<thread-id>, <thread-id> to llm-logs/acabrera04-logs/final and push` -> use the exporter directly on each provided id, preserve the exact destination path, and treat the export as a real branch artifact that must be committed and pushed [Task 1]
+- when the user already supplied explicit thread IDs for a log export -> do not ask for clarification or reconstruct the conversation manually; export those IDs directly [Task 1]
+- when the user explicitly asked for `[$codex-conversation-exporter](...) 019dabb8-56c4-7e63-bbdb-d18101c2c726 to the PR branch under llm-logs/acabrera04-logs/final` -> use the exporter skill, write into that exact `llm-logs/acabrera04-logs/final` location, and treat the export as a branch change that should be committed and pushed [Task 2]
+- the user wanted the artifact on the PR branch rather than just locally -> future similar log-export tasks should end with a git commit and push to the PR branch, not just file creation [Task 1][Task 2]
+- the user said "Keep this on a logs branch, i'll keep returning to it this sprint to push my logs" -> default to a dedicated logs branch for repeated deployment-log exports unless the user explicitly names a PR branch target [Task 3]
+- when the user says a thread id "to my deployment logs" or "to deployment logs", infer the existing deployment-log destination without asking for more path detail [Task 3]
+- when the user says only "<thread-id> to extra", map the bare bucket name into the existing user log hierarchy instead of forcing a full path clarification [Task 4]
+- when the user sends multiple thread IDs in one message for the same destination -> batch the exports, but keep the branch clean and isolate filename collisions before staging [Task 5]
+- when the user says to put an export "to the PR branch and push it" after a review -> preserve the exact `llm-logs/acabrera04-logs/final` destination and move to the actual branch-owning worktree before committing if the review checkout is detached [Task 6]
+
+## Reusable knowledge
+
+- `codex-export export <threadId> --out llm-logs/acabrera04-logs/final` can be run once per explicit thread id, and in this run it produced `2026-04-23-review-pr-460-019dbc10.md` plus `2026-04-23-complete-issue-359-019dbc10.md` under the requested final bucket [Task 1]
+- For branch-local final-log exports on `codex/issue-359-seo-admin-ui`, the working recovery after `rejected (fetch first)` was `git fetch origin codex/issue-359-seo-admin-ui && git rebase origin/codex/issue-359-seo-admin-ui`, then `git push origin codex/issue-359-seo-admin-ui` [Task 1]
+- The export commit used here was `chore: export codex conversation logs`; branch-local export requests should be treated as ordinary content commits on the active PR branch, not as scratch artifacts [Task 1]
+- `codex-export export <threadId> --out <dir>` writes a single Markdown export and prints the exact path. In the PR #443 run the output file was `llm-logs/acabrera04-logs/final/2026-04-20-review-harmony-pr-443-019dabb8.md` [Task 2]
+- If a Harmony worktree is detached but the user wants the export on a PR branch, reattach it before committing. In this run `git switch -C feature/issue-350-meta-tag-service-skeleton pr-443` restored the PR branch target [Task 2]
+- When pushing an export-only commit to a shared PR branch, be ready to `git fetch` and `git rebase origin/<branch>` if the remote advanced. The final pushed branch head here was `2819f80380f86c6ddf67b9997574ea4eb1f5d694` [Task 2]
+- The stable deployment-log destination is `llm-logs/acabrera04-logs/acabrera04-deployment`, and the branch convention used here was `logs/acabrera04-deployment` [Task 3]
+- `codex-export export <thread_id> --out <folder>` creates one markdown export per thread. The filename is derived from thread content/title plus the thread id, so staging only the new markdown file is the right default [Task 3]
+- The `extra` bucket lives under the same user namespace as `llm-logs/acabrera04-logs/acabrera04-extra`, which implies the path convention is user-scoped first, then bucket-scoped [Task 4]
+- If multiple exports collide on the default filename, rename them before `git add`. In this run the two `019d9704...` exports were kept as `2026-04-16-review-pr-373-019d9704-57a6.md` and `2026-04-16-review-pr-375-019d9704-85d3.md` [Task 5]
+- `codex-export list --limit 30` was enough to map a PR URL to the correct thread before exporting, and the repeated verification pattern was `git status --short --branch` plus `git log -1 --oneline --decorate` [Task 3][Task 5]
+- When a Harmony review happened in a detached worktree, `git worktree list` was the fastest way to locate the actual branch-owning checkout before adding the export artifact. In the PR #457 run that pointed to `/Users/allen/.codex/worktrees/57ba/Harmony` on `codex/expand-sonarjs-ci` [Task 6]
+- The exported PR-review log from thread `019dbafe-8c33-7970-a41b-6c984b61be26` landed at `llm-logs/acabrera04-logs/final/2026-04-23-review-avanish-pr-019dbafe.md` and was pushed as commit `fce27df` [Task 6]
+- The issue #363 export produced `llm-logs/acabrera04-logs/final/2026-04-26-complete-issue-363-019dc7b7.md` on branch `codex/issue-363-readme-deployer-pass`; when the first push was rejected, fetching and rebasing onto `origin/codex/issue-363-readme-deployer-pass` was the working recovery [Task 7]
+- Related skill: skills/codex-log-export/SKILL.md
+```
+
+#### Tool: exec_command
+
+```sh
+rtk ls llm-logs/acabrera04-logs/final
+```
+
+Output:
+
+```text
+2026-04-20-review-harmony-pr-443-019dabb8.md  961.9K
+2026-04-23-complete-issue-359-019dbc10.md  803.7K
+2026-04-23-complete-issue-419-019dbaff.md  115.9K
+2026-04-23-review-pr-460-019dbc10.md  633.9K
+2026-04-25-fix-issue-468-019dc607.md  236.4K
+2026-04-25-review-pr-462-019dc5e2.md  410.0K
+2026-04-26-add-google-verification-meta-tag-019dc7ce.md  58.8K
+2026-04-26-complete-issue-363-019dc7b7.md  454.6K
+2026-04-26-fix-476-019dcbbe.md  341.3K
+2026-04-27-review-pr-477-019dd0a2.md  418.4K
+```
+
+#### 🤖 gpt-5.4 (medium)
+
+- Time: 2026-04-28T22:58:17.016Z
+
+I found the established destination: `llm-logs/acabrera04-logs/final`. I’m exporting the exact thread there now, then I’ll commit the new markdown file on the current PR branch and push it.
+
+#### Tool: exec_command
+
+```sh
+codex-export export 019dd579-c2d3-7350-a286-448f5cb9cae2 --out llm-logs/acabrera04-logs/final
+```


### PR DESCRIPTION
## Summary
- sanitize fallback public channel metadata labels before composing the title, description, and JSON-LD author
- strip dot-segment path prefixes in backend title sanitization so persisted/generated SEO titles stay safe too
- add frontend and backend regressions for path-like server names in metadata generation

## Testing
- npm --prefix harmony-frontend test -- --runInBand --runTestsByPath src/__tests__/channel-page-metadata.test.ts
- npm --prefix harmony-backend test -- --runInBand --runTestsByPath tests/metaTagService.test.ts
- npm --prefix harmony-backend run build
- npm --prefix harmony-frontend run build

Closes #484