### PR TITLE
feat: emoji picker for message input (#498)

### DIFF
--- a/harmony-frontend/package-lock.json
+++ b/harmony-frontend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@emoji-mart/data": "^1.2.1",
-        "@emoji-mart/react": "^1.1.1",
         "axios": "^1.13.5",
         "clsx": "^2.1.1",
         "emoji-mart": "^5.6.0",
@@ -741,16 +740,6 @@
       "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
       "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==",
       "license": "MIT"
-    },
-    "node_modules/@emoji-mart/react": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
-      "integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "emoji-mart": "^5.2",
-        "react": "^16.8 || ^17 || ^18"
-      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",

--- a/harmony-frontend/package-lock.json
+++ b/harmony-frontend/package-lock.json
@@ -8,8 +8,11 @@
       "name": "harmony-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@emoji-mart/data": "^1.2.1",
+        "@emoji-mart/react": "^1.1.1",
         "axios": "^1.13.5",
         "clsx": "^2.1.1",
+        "emoji-mart": "^5.6.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -19,6 +22,7 @@
       "devDependencies": {
         "@playwright/test": "^1.55.0",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -730,6 +734,22 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emoji-mart/data": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
+      "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==",
+      "license": "MIT"
+    },
+    "node_modules/@emoji-mart/react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "emoji-mart": "^5.2",
+        "react": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2266,7 +2286,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -2658,7 +2678,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2679,7 +2698,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2769,8 +2787,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4606,7 +4623,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4649,8 +4665,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4692,6 +4707,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
+    },
+    "node_modules/emoji-mart": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
+      "integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -8356,7 +8377,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9153,7 +9173,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -9172,7 +9192,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -9185,6 +9205,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9265,7 +9286,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9281,7 +9301,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9294,8 +9313,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/harmony-frontend/package.json
+++ b/harmony-frontend/package.json
@@ -16,8 +16,11 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@emoji-mart/data": "^1.2.1",
+    "@emoji-mart/react": "^1.1.1",
     "axios": "^1.13.5",
     "clsx": "^2.1.1",
+    "emoji-mart": "^5.6.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
@@ -25,8 +28,9 @@
     "twilio-video": "3.0.0-preview.3"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4",
     "@playwright/test": "^1.55.0",
+    "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/harmony-frontend/package.json
+++ b/harmony-frontend/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@emoji-mart/data": "^1.2.1",
-    "@emoji-mart/react": "^1.1.1",
     "axios": "^1.13.5",
     "clsx": "^2.1.1",
     "emoji-mart": "^5.6.0",

--- a/harmony-frontend/src/__tests__/issue-498-emoji-picker.test.tsx
+++ b/harmony-frontend/src/__tests__/issue-498-emoji-picker.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * issue-498-emoji-picker.test.tsx
+ *
+ * Tests for issue #498: emoji picker button in MessageInput.
+ * Verifies that the emoji button is rendered, toggles the picker dialog,
+ * and that selecting an emoji inserts it into the textarea.
+ */
+
+// ─── Module-level mock variables ─────────────────────────────────────────────
+
+const mockSendMessageAction = jest.fn();
+
+// ─── Jest module mocks ────────────────────────────────────────────────────────
+
+jest.mock('@/app/actions/sendMessage', () => ({
+  sendMessageAction: mockSendMessageAction,
+}));
+
+// Mock next/dynamic to render children synchronously in tests
+jest.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: (importFn: () => Promise<{ default: React.ComponentType<unknown> }>) => {
+    let ResolvedComponent: React.ComponentType<unknown> | null = null;
+
+    const DynamicWrapper = (props: Record<string, unknown>) => {
+      if (!ResolvedComponent) {
+        throw new Error('Dynamic component not resolved — use mockResolvedValue in beforeEach');
+      }
+      return <ResolvedComponent {...props} />;
+    };
+
+    // Trigger the import so tests can intercept it
+    importFn().then(mod => {
+      ResolvedComponent = mod.default;
+    });
+
+    return DynamicWrapper;
+  },
+}));
+
+// Mock EmojiPickerPopover so tests don't need to load emoji-mart's full bundle
+jest.mock('@/components/channel/EmojiPickerPopover', () => ({
+  EmojiPickerPopover: ({ onEmojiSelect }: { onEmojiSelect: (e: { native: string }) => void }) => (
+    <div data-testid='emoji-picker'>
+      <button
+        type='button'
+        data-testid='emoji-option'
+        onClick={() => onEmojiSelect({ native: '😀' })}
+      >
+        😀
+      </button>
+    </div>
+  ),
+}));
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MessageInput } from '../components/channel/MessageInput';
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Issue #498 — MessageInput: emoji picker', () => {
+  const defaultProps = {
+    channelId: 'ch-1',
+    channelName: 'general',
+    serverId: 'srv-1',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the emoji button', () => {
+    render(<MessageInput {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /emoji/i })).toBeInTheDocument();
+  });
+
+  it('emoji button has aria-expanded=false initially', () => {
+    render(<MessageInput {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /emoji/i });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('clicking the emoji button opens the picker dialog', async () => {
+    render(<MessageInput {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /emoji/i });
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: /emoji picker/i })).toBeInTheDocument();
+    });
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('clicking the emoji button again closes the picker', async () => {
+    render(<MessageInput {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /emoji/i });
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    await waitFor(() => expect(screen.getByRole('dialog', { name: /emoji picker/i })).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /emoji picker/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('selecting an emoji inserts it into the textarea and closes the picker', async () => {
+    render(<MessageInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox', { name: 'Message #general' });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /emoji/i }));
+    });
+
+    await waitFor(() => expect(screen.getByTestId('emoji-option')).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('emoji-option'));
+    });
+
+    expect((textarea as HTMLTextAreaElement).value).toBe('😀');
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /emoji picker/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('inserts emoji at cursor position in existing text', async () => {
+    render(<MessageInput {...defaultProps} />);
+    const textarea = screen.getByRole('textbox', { name: 'Message #general' }) as HTMLTextAreaElement;
+
+    // Type some text
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'Hello World' } });
+    });
+
+    // Place cursor between "Hello" and " World"
+    textarea.setSelectionRange(5, 5);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /emoji/i }));
+    });
+
+    await waitFor(() => expect(screen.getByTestId('emoji-option')).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('emoji-option'));
+    });
+
+    expect(textarea.value).toBe('Hello😀 World');
+  });
+
+  it('picker is not shown in read-only mode', () => {
+    render(<MessageInput {...defaultProps} isReadOnly />);
+    expect(screen.queryByRole('button', { name: /emoji/i })).not.toBeInTheDocument();
+  });
+
+  it('clicking outside the picker closes it', async () => {
+    render(
+      <div>
+        <MessageInput {...defaultProps} />
+        <div data-testid='outside'>Outside</div>
+      </div>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /emoji/i }));
+    });
+
+    await waitFor(() => expect(screen.getByRole('dialog', { name: /emoji picker/i })).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByTestId('outside'));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /emoji picker/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/harmony-frontend/src/components/channel/EmojiPickerPopover.tsx
+++ b/harmony-frontend/src/components/channel/EmojiPickerPopover.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+/**
+ * EmojiPickerPopover
+ * Thin wrapper around emoji-mart's Picker so it can be lazy-loaded.
+ * Only rendered when the user opens the emoji panel in MessageInput.
+ */
+
+import Picker from '@emoji-mart/react';
+import data from '@emoji-mart/data';
+
+export interface EmojiPickerPopoverProps {
+  onEmojiSelect: (emoji: { native: string }) => void;
+}
+
+export function EmojiPickerPopover({ onEmojiSelect }: EmojiPickerPopoverProps) {
+  return (
+    <Picker
+      data={data}
+      onEmojiSelect={onEmojiSelect}
+      theme='dark'
+      previewPosition='none'
+      skinTonePosition='none'
+      maxFrequentRows={2}
+    />
+  );
+}

--- a/harmony-frontend/src/components/channel/EmojiPickerPopover.tsx
+++ b/harmony-frontend/src/components/channel/EmojiPickerPopover.tsx
@@ -2,11 +2,13 @@
 
 /**
  * EmojiPickerPopover
- * Thin wrapper around emoji-mart's Picker so it can be lazy-loaded.
- * Only rendered when the user opens the emoji panel in MessageInput.
+ * Mounts the vanilla emoji-mart Picker into a div ref so it works with
+ * React 19 without the @emoji-mart/react wrapper (which only supports React ≤18).
+ * Only rendered client-side via next/dynamic { ssr: false }.
  */
 
-import Picker from '@emoji-mart/react';
+import { useEffect, useRef } from 'react';
+import { Picker } from 'emoji-mart';
 import data from '@emoji-mart/data';
 
 export interface EmojiPickerPopoverProps {
@@ -14,14 +16,31 @@ export interface EmojiPickerPopoverProps {
 }
 
 export function EmojiPickerPopover({ onEmojiSelect }: EmojiPickerPopoverProps) {
-  return (
-    <Picker
-      data={data}
-      onEmojiSelect={onEmojiSelect}
-      theme='dark'
-      previewPosition='none'
-      skinTonePosition='none'
-      maxFrequentRows={2}
-    />
-  );
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const picker = new (Picker as any)({
+      data,
+      onEmojiSelect,
+      theme: 'dark',
+      previewPosition: 'none',
+      skinTonePosition: 'none',
+      maxFrequentRows: 2,
+    });
+
+    el.appendChild(picker);
+
+    return () => {
+      if (el.contains(picker)) el.removeChild(picker);
+    };
+    // onEmojiSelect is stable (useCallback in parent) — intentionally omitted
+    // from deps to avoid remounting the picker on every keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <div ref={containerRef} />;
 }

--- a/harmony-frontend/src/components/channel/MessageInput.tsx
+++ b/harmony-frontend/src/components/channel/MessageInput.tsx
@@ -2,16 +2,26 @@
  * Channel Component: MessageInput
  * Message composition bar at the bottom of the channel view.
  * Supports multi-line input, Enter-to-send, character limit, file attachments,
- * and read-only guest state.
+ * emoji picker, and read-only guest state.
  * Ref: dev-spec-guest-public-channel-view.md — M3, CL-C3
  */
 
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
+import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
 import { sendMessageAction } from '@/app/actions/sendMessage';
 import type { Message, AttachmentInput } from '@/types';
+
+// Lazy-load the heavy emoji picker bundle so it doesn't block the initial render
+const EmojiPickerPopover = dynamic(
+  () =>
+    import('@/components/channel/EmojiPickerPopover').then(m => ({
+      default: m.EmojiPickerPopover,
+    })),
+  { ssr: false },
+);
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -43,16 +53,31 @@ export function MessageInput({
   const [sendError, setSendError] = useState<string | null>(null);
   const [pendingAttachments, setPendingAttachments] = useState<AttachmentInput[]>([]);
   const [isUploading, setIsUploading] = useState(false);
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const emojiPickerRef = useRef<HTMLDivElement>(null);
 
   // On channel switch: clear draft, clear attachments, clear any send error, and autofocus
   useEffect(() => {
     setValue('');
     setSendError(null);
     setPendingAttachments([]);
+    setShowEmojiPicker(false);
     textareaRef.current?.focus();
   }, [channelId]);
+
+  // Close picker when clicking outside the popover
+  useEffect(() => {
+    if (!showEmojiPicker) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (emojiPickerRef.current && !emojiPickerRef.current.contains(e.target as Node)) {
+        setShowEmojiPicker(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showEmojiPicker]);
 
   // Auto-resize: grow up to ~8 lines, then scroll
   useEffect(() => {
@@ -66,55 +91,76 @@ export function MessageInput({
     fileInputRef.current?.click();
   };
 
-  const handleFileChange = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) return;
+  const handleFileChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
 
-      // Reset the input so selecting the same file again triggers onChange
-      e.target.value = '';
+    // Reset the input so selecting the same file again triggers onChange
+    e.target.value = '';
 
-      setIsUploading(true);
-      setSendError(null);
+    setIsUploading(true);
+    setSendError(null);
 
-      try {
-        const formData = new FormData();
-        formData.append('file', file);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
 
-        const res = await fetch('/api/attachments/upload', {
-          method: 'POST',
-          body: formData,
-        });
+      const res = await fetch('/api/attachments/upload', {
+        method: 'POST',
+        body: formData,
+      });
 
-        if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          const msg =
-            typeof body?.error === 'string'
-              ? body.error
-              : res.status === 401
-                ? 'You must be logged in to upload files.'
-                : res.status === 413
-                  ? 'File is too large (max 25 MB).'
-                  : 'Upload failed. Unsupported file type or server error.';
-          setSendError(msg);
-          return;
-        }
-
-        const attachment = (await res.json()) as AttachmentInput;
-        setPendingAttachments(prev => [...prev, attachment]);
-      } catch {
-        setSendError('Upload failed. Please try again.');
-      } finally {
-        setIsUploading(false);
-        textareaRef.current?.focus();
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        const msg =
+          typeof body?.error === 'string'
+            ? body.error
+            : res.status === 401
+              ? 'You must be logged in to upload files.'
+              : res.status === 413
+                ? 'File is too large (max 25 MB).'
+                : 'Upload failed. Unsupported file type or server error.';
+        setSendError(msg);
+        return;
       }
-    },
-    [],
-  );
+
+      const attachment = (await res.json()) as AttachmentInput;
+      setPendingAttachments(prev => [...prev, attachment]);
+    } catch {
+      setSendError('Upload failed. Please try again.');
+    } finally {
+      setIsUploading(false);
+      textareaRef.current?.focus();
+    }
+  }, []);
 
   const removeAttachment = (index: number) => {
     setPendingAttachments(prev => prev.filter((_, i) => i !== index));
   };
+
+  const handleEmojiSelect = useCallback(
+    (emoji: { native: string }) => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      const start = textarea.selectionStart ?? value.length;
+      const end = textarea.selectionEnd ?? value.length;
+      const next = value.slice(0, start) + emoji.native + value.slice(end);
+
+      if (next.length <= MAX_CHARS) {
+        setValue(next);
+        // Restore focus and move cursor after the inserted emoji
+        requestAnimationFrame(() => {
+          const pos = start + emoji.native.length;
+          textarea.focus();
+          textarea.setSelectionRange(pos, pos);
+        });
+      }
+
+      setShowEmojiPicker(false);
+    },
+    [value],
+  );
 
   const handleSend = useCallback(async () => {
     const trimmed = value.trim();
@@ -137,7 +183,16 @@ export function MessageInput({
       setIsSending(false);
       textareaRef.current?.focus();
     }
-  }, [value, isSending, isUploading, isReadOnly, channelId, serverId, onMessageSent, pendingAttachments]);
+  }, [
+    value,
+    isSending,
+    isUploading,
+    isReadOnly,
+    channelId,
+    serverId,
+    onMessageSent,
+    pendingAttachments,
+  ]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Enter sends; Shift+Enter inserts a newline
@@ -171,7 +226,7 @@ export function MessageInput({
   const isAtLimit = remaining <= 0;
 
   return (
-    <div className='flex-shrink-0 px-4 pb-6 pt-2'>
+    <div className='relative flex-shrink-0 px-4 pb-6 pt-2'>
       {sendError && (
         <p className='mb-1 px-1 text-xs text-red-400' role='alert'>
           {sendError}
@@ -290,27 +345,42 @@ export function MessageInput({
           </button>
 
           {/* Emoji button */}
-          <button
-            type='button'
-            title='Emoji (coming soon)'
-            aria-label='Emoji'
-            className='flex h-8 w-8 items-center justify-center rounded text-gray-400 transition-colors hover:bg-white/10 hover:text-gray-200'
-          >
-            <svg
-              className='h-5 w-5'
-              viewBox='0 0 24 24'
-              fill='none'
-              stroke='currentColor'
-              strokeWidth={2}
-              strokeLinecap='round'
-              strokeLinejoin='round'
+          <div ref={emojiPickerRef} className='relative'>
+            <button
+              type='button'
+              title='Emoji'
+              aria-label='Emoji'
+              aria-expanded={showEmojiPicker}
+              aria-haspopup='dialog'
+              onClick={() => setShowEmojiPicker(prev => !prev)}
+              className='flex h-8 w-8 items-center justify-center rounded text-gray-400 transition-colors hover:bg-white/10 hover:text-gray-200'
             >
-              <circle cx='12' cy='12' r='10' />
-              <path d='M8 13s1.5 2 4 2 4-2 4-2' />
-              <line x1='9' y1='9' x2='9.01' y2='9' />
-              <line x1='15' y1='9' x2='15.01' y2='9' />
-            </svg>
-          </button>
+              <svg
+                className='h-5 w-5'
+                viewBox='0 0 24 24'
+                fill='none'
+                stroke='currentColor'
+                strokeWidth={2}
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              >
+                <circle cx='12' cy='12' r='10' />
+                <path d='M8 13s1.5 2 4 2 4-2 4-2' />
+                <line x1='9' y1='9' x2='9.01' y2='9' />
+                <line x1='15' y1='9' x2='15.01' y2='9' />
+              </svg>
+            </button>
+
+            {showEmojiPicker && (
+              <div
+                role='dialog'
+                aria-label='Emoji picker'
+                className='absolute bottom-full right-0 z-50 mb-2'
+              >
+                <EmojiPickerPopover onEmojiSelect={handleEmojiSelect} />
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Installs \`emoji-mart\`, \`@emoji-mart/react\`, and \`@emoji-mart/data\` (lazy-loaded via \`next/dynamic\` to avoid blocking initial render)
- Adds \`EmojiPickerPopover\` — a thin wrapper component around the emoji-mart \`Picker\` with dark theme
- Updates \`MessageInput\` to wire the emoji button: click toggles the picker popover above the toolbar, selecting an emoji inserts it at the current cursor position, picker closes on selection or outside click, and resets on channel switch
- Fixes the pre-existing missing \`@testing-library/dom\` dev dependency that was breaking all frontend Jest tests

## Behaviour

| Action | Result |
|--------|--------|
| Click emoji button | Dark emoji picker opens above compose bar |
| Click emoji button again | Picker closes |
| Click outside picker | Picker closes |
| Select an emoji | Inserted at cursor position, focus returns to textarea |
| Switch channels | Picker closes, draft cleared |
| Read-only channel | No emoji button rendered |
| At char limit | Emoji insert is blocked |

## Test plan

- [x] \`npx jest\` — 344 tests pass (8 new tests in \`issue-498-emoji-picker.test.tsx\`)
- [x] \`npx tsc --noEmit\` — no type errors
- [ ] Manual: open a channel, click the emoji button, select an emoji, verify it appears in the compose box at cursor position

Closes #498