### PR TITLE
feat: push notifications for messages and mentions (#487)

### DIFF
--- a/harmony-backend/.env.example
+++ b/harmony-backend/.env.example
@@ -57,6 +57,13 @@ AWS_SECRET_ACCESS_KEY=your-r2-secret-access-key
 S3_BUCKET=harmony-attachments
 R2_PUBLIC_URL=https://pub-changeme.r2.dev
 
+# Web Push / VAPID — required for browser push notifications (issue #487)
+# Generate keys once with: npx web-push generate-vapid-keys
+# VAPID_SUBJECT must be a mailto: address or your public URL.
+VAPID_PUBLIC_KEY=your-vapid-public-key
+VAPID_PRIVATE_KEY=your-vapid-private-key
+VAPID_SUBJECT=mailto:admin@harmony.chat
+
 # Twilio Voice (Programmable Video) — set these for real voice; omit for mock mode
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_API_KEY=SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/harmony-backend/package-lock.json
+++ b/harmony-backend/package-lock.json
@@ -25,6 +25,7 @@
         "rate-limit-redis": "^4.3.1",
         "serverless-http": "^3.2.0",
         "twilio": "^5.13.0",
+        "web-push": "^3.6.7",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -37,6 +38,7 @@
         "@types/multer": "^2.1.0",
         "@types/node": "^20.17.19",
         "@types/supertest": "^6.0.2",
+        "@types/web-push": "^3.6.4",
         "@typescript-eslint/eslint-plugin": "^8.26.0",
         "@typescript-eslint/parser": "^8.26.0",
         "dotenv": "^17.3.1",
@@ -3875,6 +3877,16 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -4272,6 +4284,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4455,6 +4479,12 @@
       "bin": {
         "bcrypt": "bin/bcrypt"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -6308,6 +6338,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7664,6 +7703,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -7684,7 +7729,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9616,6 +9660,47 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/which": {

--- a/harmony-backend/package.json
+++ b/harmony-backend/package.json
@@ -37,6 +37,7 @@
     "rate-limit-redis": "^4.3.1",
     "serverless-http": "^3.2.0",
     "twilio": "^5.13.0",
+    "web-push": "^3.6.7",
     "zod": "^3.24.2"
   },
   "devDependencies": {
@@ -49,6 +50,7 @@
     "@types/multer": "^2.1.0",
     "@types/node": "^20.17.19",
     "@types/supertest": "^6.0.2",
+    "@types/web-push": "^3.6.4",
     "@typescript-eslint/eslint-plugin": "^8.26.0",
     "@typescript-eslint/parser": "^8.26.0",
     "dotenv": "^17.3.1",

--- a/harmony-backend/prisma/migrations/20260428000000_add_push_notifications/migration.sql
+++ b/harmony-backend/prisma/migrations/20260428000000_add_push_notifications/migration.sql
@@ -1,0 +1,45 @@
+-- CreateEnum
+CREATE TYPE "notification_level" AS ENUM ('ALL', 'MENTIONS', 'NONE');
+
+-- CreateTable: push_subscriptions
+CREATE TABLE "push_subscriptions" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "user_id" UUID NOT NULL,
+    "endpoint" VARCHAR(2048) NOT NULL,
+    "p256dh" VARCHAR(512) NOT NULL,
+    "auth" VARCHAR(128) NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "push_subscriptions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "push_subscriptions_endpoint_key" ON "push_subscriptions"("endpoint");
+CREATE INDEX "idx_push_subscriptions_user" ON "push_subscriptions"("user_id");
+
+ALTER TABLE "push_subscriptions" ADD CONSTRAINT "push_subscriptions_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: notification_preferences
+CREATE TABLE "notification_preferences" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "user_id" UUID NOT NULL,
+    "server_id" UUID,
+    "channel_id" UUID,
+    "level" "notification_level" NOT NULL DEFAULT 'MENTIONS',
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notification_preferences_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "idx_notification_prefs_unique"
+    ON "notification_preferences"("user_id", "server_id", "channel_id");
+CREATE INDEX "idx_notification_prefs_user" ON "notification_preferences"("user_id");
+
+ALTER TABLE "notification_preferences" ADD CONSTRAINT "notification_preferences_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "notification_preferences" ADD CONSTRAINT "notification_preferences_server_id_fkey"
+    FOREIGN KEY ("server_id") REFERENCES "servers"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "notification_preferences" ADD CONSTRAINT "notification_preferences_channel_id_fkey"
+    FOREIGN KEY ("channel_id") REFERENCES "channels"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/harmony-backend/prisma/schema.prisma
+++ b/harmony-backend/prisma/schema.prisma
@@ -12,6 +12,15 @@ datasource db {
 
 // ─── Enums ───────────────────────────────────────────────────────────────────
 
+/// Notification level for a channel or server.
+enum NotificationLevel {
+  ALL
+  MENTIONS
+  NONE
+
+  @@map("notification_level")
+}
+
 /// Canonical visibility states for a channel.
 /// Preserve these values exactly — referenced across all specs.
 enum ChannelVisibility {
@@ -67,13 +76,15 @@ model User {
   status        UserStatus @default(OFFLINE)
   createdAt     DateTime   @default(now()) @map("created_at") @db.Timestamptz
 
-  messages           Message[]
-  reactions          MessageReaction[]
-  visibilityAuditLog VisibilityAuditLog[] @relation("AuditActor")
-  refreshTokens      RefreshToken[]
-  ownedServers       Server[]             @relation("ServerOwner")
-  serverMemberships  ServerMember[]
-  createdInvites     ServerInvite[]       @relation("InviteCreator")
+  messages                Message[]
+  reactions               MessageReaction[]
+  visibilityAuditLog      VisibilityAuditLog[]      @relation("AuditActor")
+  refreshTokens           RefreshToken[]
+  ownedServers            Server[]                  @relation("ServerOwner")
+  serverMemberships       ServerMember[]
+  createdInvites          ServerInvite[]            @relation("InviteCreator")
+  pushSubscriptions       PushSubscription[]
+  notificationPreferences NotificationPreference[]
 
   @@map("users")
 }
@@ -106,7 +117,8 @@ model Server {
   owner    User      @relation("ServerOwner", fields: [ownerId], references: [id])
   channels Channel[]
   members  ServerMember[]
-  invites  ServerInvite[]
+  invites                 ServerInvite[]
+  notificationPreferences NotificationPreference[]
 
   // idx_servers_slug is pinned via map: on the @unique above.
   // idx_servers_public (partial WHERE is_public = TRUE) is added in the
@@ -145,6 +157,7 @@ model Channel {
   messages          Message[]
   auditLog          VisibilityAuditLog[]
   generatedMetaTags GeneratedMetaTags?
+  notificationPreferences NotificationPreference[]
 
   // Composite unique — one slug per server
   @@unique([serverId, slug], map: "idx_channels_server_slug")
@@ -286,4 +299,38 @@ model GeneratedMetaTags {
   // idx_meta_tags_needs_regen (partial WHERE needs_regeneration = TRUE) exists in the init SQL migration.
   // idx_meta_tags_generated (generated_at) is added as raw SQL in 20260418000000_add_meta_tag_overrides.
   @@map("generated_meta_tags")
+}
+
+/// Web Push API subscription endpoint for a user's browser/device.
+model PushSubscription {
+  id        String   @id @default(uuid()) @db.Uuid
+  userId    String   @map("user_id") @db.Uuid
+  endpoint  String   @unique @db.VarChar(2048)
+  p256dh    String   @db.VarChar(512)
+  auth      String   @db.VarChar(128)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId], map: "idx_push_subscriptions_user")
+  @@map("push_subscriptions")
+}
+
+/// Per-user notification level override for a server or channel.
+/// Hierarchy: channel override > server override > global default (MENTIONS).
+model NotificationPreference {
+  id        String            @id @default(uuid()) @db.Uuid
+  userId    String            @map("user_id") @db.Uuid
+  serverId  String?           @map("server_id") @db.Uuid
+  channelId String?           @map("channel_id") @db.Uuid
+  level     NotificationLevel @default(MENTIONS)
+  updatedAt DateTime          @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  user    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  server  Server?  @relation(fields: [serverId], references: [id], onDelete: Cascade)
+  channel Channel? @relation(fields: [channelId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, serverId, channelId], map: "idx_notification_prefs_unique")
+  @@index([userId], map: "idx_notification_prefs_user")
+  @@map("notification_preferences")
 }

--- a/harmony-backend/src/services/message.service.ts
+++ b/harmony-backend/src/services/message.service.ts
@@ -6,6 +6,7 @@ import { permissionService } from './permission.service';
 import { eventBus, EventChannels } from '../events/eventBus';
 import { channelRepository } from '../repositories/channel.repository';
 import { messageRepository } from '../repositories/message.repository';
+import { pushNotificationService } from './pushNotification.service';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -146,7 +147,7 @@ export const messageService = {
   async sendMessage(input: SendMessageInput) {
     const { serverId, channelId, authorId, content, attachments } = input;
 
-    await requireChannelInServer(channelId, serverId);
+    const channel = await requireChannelInServer(channelId, serverId);
 
     const message = await messageRepository.create({
       channel: { connect: { id: channelId } },
@@ -185,6 +186,35 @@ export const messageService = {
           'Failed to publish message created event',
         ),
       );
+
+    // Dispatch push notifications fire-and-forget
+    (async () => {
+      try {
+        const [author, server] = await Promise.all([
+          prisma.user.findUnique({ where: { id: authorId }, select: { username: true } }),
+          prisma.server.findUnique({ where: { id: serverId }, select: { slug: true } }),
+        ]);
+        if (!author || !server) return;
+
+        const ctx = {
+          authorId,
+          channelId,
+          serverId,
+          channelName: channel.name,
+          authorUsername: author.username,
+          serverSlug: server.slug,
+          channelSlug: channel.slug,
+          content,
+        };
+
+        await Promise.all([
+          pushNotificationService.notifyMentions(ctx),
+          pushNotificationService.notifyNewMessage(ctx),
+        ]);
+      } catch (err) {
+        logger.warn({ err, messageId: message.id }, 'Push notification dispatch failed');
+      }
+    })();
 
     return message;
   },

--- a/harmony-backend/src/services/pushNotification.service.ts
+++ b/harmony-backend/src/services/pushNotification.service.ts
@@ -1,0 +1,203 @@
+import webpush from 'web-push';
+import { prisma } from '../db/prisma';
+import { createLogger } from '../lib/logger';
+import { NotificationLevel } from '@prisma/client';
+
+const logger = createLogger({ component: 'push-notification-service' });
+
+// Lazily initialise VAPID so the service can be imported even without keys set
+// (e.g. in test environments).
+let vapidReady = false;
+
+function ensureVapid() {
+  if (vapidReady) return;
+  const { VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY, VAPID_SUBJECT } = process.env;
+  if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY || !VAPID_SUBJECT) {
+    logger.warn('VAPID env vars not set — push notifications disabled');
+    return;
+  }
+  webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
+  vapidReady = true;
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  icon?: string;
+  tag?: string;
+  data?: Record<string, unknown>;
+}
+
+// ─── Mention parsing ──────────────────────────────────────────────────────────
+
+/** Extract @username handles from message content. */
+export function parseMentionedUsernames(content: string): string[] {
+  const matches = content.match(/@([a-zA-Z0-9_]{1,32})/g) ?? [];
+  return [...new Set(matches.map((m) => m.slice(1)))];
+}
+
+// ─── Notification level resolution ───────────────────────────────────────────
+
+/**
+ * Resolve the effective notification level for a user in a channel.
+ * Priority: channel pref > server pref > global default (MENTIONS).
+ */
+async function resolveLevel(
+  userId: string,
+  channelId: string,
+  serverId: string,
+): Promise<NotificationLevel> {
+  const prefs = await prisma.notificationPreference.findMany({
+    where: {
+      userId,
+      OR: [
+        { channelId },
+        { serverId, channelId: null },
+        { serverId: null, channelId: null },
+      ],
+    },
+  });
+
+  const channelPref = prefs.find((p) => p.channelId === channelId);
+  if (channelPref) return channelPref.level;
+
+  const serverPref = prefs.find((p) => p.serverId === serverId && p.channelId === null);
+  if (serverPref) return serverPref.level;
+
+  const globalPref = prefs.find((p) => p.serverId === null && p.channelId === null);
+  if (globalPref) return globalPref.level;
+
+  return NotificationLevel.MENTIONS; // system default
+}
+
+// ─── Core send ────────────────────────────────────────────────────────────────
+
+async function sendToUser(userId: string, payload: PushPayload): Promise<void> {
+  ensureVapid();
+  if (!vapidReady) return;
+
+  const subs = await prisma.pushSubscription.findMany({ where: { userId } });
+  if (subs.length === 0) return;
+
+  const body = JSON.stringify(payload);
+
+  await Promise.allSettled(
+    subs.map(async (sub) => {
+      try {
+        await webpush.sendNotification(
+          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+          body,
+        );
+      } catch (err: unknown) {
+        const status = (err as { statusCode?: number }).statusCode;
+        if (status === 404 || status === 410) {
+          // Subscription is gone — clean it up
+          await prisma.pushSubscription.delete({ where: { id: sub.id } }).catch(() => {});
+        } else {
+          logger.warn({ err, userId, endpoint: sub.endpoint }, 'Failed to send push notification');
+        }
+      }
+    }),
+  );
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export const pushNotificationService = {
+  /**
+   * Notify users who are mentioned in a message.
+   * Does not notify the author themselves.
+   */
+  async notifyMentions(opts: {
+    content: string;
+    authorId: string;
+    channelId: string;
+    serverId: string;
+    channelName: string;
+    authorUsername: string;
+    serverSlug: string;
+    channelSlug: string;
+  }): Promise<void> {
+    const { content, authorId, channelId, serverId, channelName, authorUsername, serverSlug, channelSlug } = opts;
+    const usernames = parseMentionedUsernames(content);
+    if (usernames.length === 0) return;
+
+    const mentionedUsers = await prisma.user.findMany({
+      where: { username: { in: usernames } },
+      select: { id: true, username: true },
+    });
+
+    const targets = mentionedUsers.filter((u) => u.id !== authorId);
+    if (targets.length === 0) return;
+
+    const frontendBase = process.env.BASE_URL ?? '';
+
+    await Promise.allSettled(
+      targets.map(async (target) => {
+        const level = await resolveLevel(target.id, channelId, serverId);
+        if (level === NotificationLevel.NONE) return;
+
+        await sendToUser(target.id, {
+          title: `${authorUsername} mentioned you in #${channelName}`,
+          body: content.length > 120 ? content.slice(0, 117) + '…' : content,
+          tag: `mention:${channelId}`,
+          data: {
+            url: `${frontendBase}/c/${serverSlug}/${channelSlug}`,
+            channelId,
+            serverId,
+          },
+        });
+      }),
+    );
+  },
+
+  /**
+   * Notify server members about a new message (for channels set to ALL level).
+   * Skips the author and handles DMs (no serverId lookup needed if caller passes members).
+   */
+  async notifyNewMessage(opts: {
+    authorId: string;
+    channelId: string;
+    serverId: string;
+    channelName: string;
+    authorUsername: string;
+    content: string;
+    serverSlug: string;
+    channelSlug: string;
+  }): Promise<void> {
+    const { authorId, channelId, serverId, channelName, authorUsername, content, serverSlug, channelSlug } = opts;
+
+    // Only notify members who have push subscriptions to avoid unnecessary DB work
+    const subscribedMembers = await prisma.serverMember.findMany({
+      where: {
+        serverId,
+        userId: { not: authorId },
+        user: { pushSubscriptions: { some: {} } },
+      },
+      select: { userId: true },
+    });
+
+    if (subscribedMembers.length === 0) return;
+
+    const frontendBase = process.env.BASE_URL ?? '';
+    const preview = content.length > 120 ? content.slice(0, 117) + '…' : content;
+
+    await Promise.allSettled(
+      subscribedMembers.map(async ({ userId }) => {
+        const level = await resolveLevel(userId, channelId, serverId);
+        if (level !== NotificationLevel.ALL) return;
+
+        await sendToUser(userId, {
+          title: `#${channelName}`,
+          body: `${authorUsername}: ${preview}`,
+          tag: `msg:${channelId}`,
+          data: {
+            url: `${frontendBase}/c/${serverSlug}/${channelSlug}`,
+            channelId,
+            serverId,
+          },
+        });
+      }),
+    );
+  },
+};

--- a/harmony-backend/src/trpc/router.ts
+++ b/harmony-backend/src/trpc/router.ts
@@ -9,6 +9,7 @@ import { voiceRouter } from './routers/voice.router';
 import { reactionRouter } from './routers/reaction.router';
 import { inviteRouter } from './routers/invite.router';
 import { permissionRouter } from './routers/permission.router';
+import { notificationRouter } from './routers/notification.router';
 
 export const appRouter = router({
   health: publicProcedure.query(() => {
@@ -24,6 +25,7 @@ export const appRouter = router({
   reaction: reactionRouter,
   invite: inviteRouter,
   permission: permissionRouter,
+  notification: notificationRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/harmony-backend/src/trpc/routers/notification.router.ts
+++ b/harmony-backend/src/trpc/routers/notification.router.ts
@@ -46,7 +46,7 @@ export const notificationRouter = router({
     .mutation(async ({ ctx, input }) => {
       await prisma.pushSubscription.upsert({
         where: { endpoint: input.endpoint },
-        update: { p256dh: input.p256dh, auth: input.auth },
+        update: { p256dh: input.p256dh, auth: input.auth, userId: ctx.userId! },
         create: { userId: ctx.userId!, ...input },
       });
       return { success: true };

--- a/harmony-backend/src/trpc/routers/notification.router.ts
+++ b/harmony-backend/src/trpc/routers/notification.router.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+import { NotificationLevel } from '@prisma/client';
+import { TRPCError } from '@trpc/server';
+import { router, authedProcedure } from '../init';
+import { prisma } from '../../db/prisma';
+
+const NotificationLevelSchema = z.nativeEnum(NotificationLevel);
+
+/** Upsert helper for nullable-field compound unique constraints. */
+async function upsertPref(
+  userId: string,
+  serverId: string | null,
+  channelId: string | null,
+  level: NotificationLevel,
+) {
+  const existing = await prisma.notificationPreference.findFirst({
+    where: { userId, serverId: serverId ?? null, channelId: channelId ?? null },
+  });
+  if (existing) {
+    return prisma.notificationPreference.update({ where: { id: existing.id }, data: { level } });
+  }
+  return prisma.notificationPreference.create({
+    data: { userId, serverId, channelId, level },
+  });
+}
+
+export const notificationRouter = router({
+  /** Return the VAPID public key so the frontend can subscribe. */
+  getVapidPublicKey: authedProcedure.query(() => {
+    const key = process.env.VAPID_PUBLIC_KEY;
+    if (!key) {
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Push notifications not configured' });
+    }
+    return { vapidPublicKey: key };
+  }),
+
+  /** Register a Web Push subscription for the current user. */
+  subscribe: authedProcedure
+    .input(
+      z.object({
+        endpoint: z.string().url().max(2048),
+        p256dh: z.string().max(512),
+        auth: z.string().max(128),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await prisma.pushSubscription.upsert({
+        where: { endpoint: input.endpoint },
+        update: { p256dh: input.p256dh, auth: input.auth },
+        create: { userId: ctx.userId!, ...input },
+      });
+      return { success: true };
+    }),
+
+  /** Remove a push subscription (e.g., when the user disables notifications). */
+  unsubscribe: authedProcedure
+    .input(z.object({ endpoint: z.string().url().max(2048) }))
+    .mutation(async ({ ctx, input }) => {
+      await prisma.pushSubscription.deleteMany({
+        where: { endpoint: input.endpoint, userId: ctx.userId! },
+      });
+      return { success: true };
+    }),
+
+  /** List all push subscriptions for the current user. */
+  listSubscriptions: authedProcedure.query(async ({ ctx }) => {
+    return prisma.pushSubscription.findMany({
+      where: { userId: ctx.userId! },
+      select: { id: true, endpoint: true, createdAt: true },
+    });
+  }),
+
+  /** Get notification preferences for the current user. */
+  getPreferences: authedProcedure.query(async ({ ctx }) => {
+    return prisma.notificationPreference.findMany({
+      where: { userId: ctx.userId! },
+    });
+  }),
+
+  /** Set the global notification level (no server or channel scope). */
+  setGlobalLevel: authedProcedure
+    .input(z.object({ level: NotificationLevelSchema }))
+    .mutation(async ({ ctx, input }) => {
+      return upsertPref(ctx.userId!, null, null, input.level);
+    }),
+
+  /** Set notification level for a server (overrides global). */
+  setServerLevel: authedProcedure
+    .input(z.object({ serverId: z.string().uuid(), level: NotificationLevelSchema }))
+    .mutation(async ({ ctx, input }) => {
+      const member = await prisma.serverMember.findUnique({
+        where: { userId_serverId: { userId: ctx.userId!, serverId: input.serverId } },
+      });
+      if (!member) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not a member of this server' });
+      }
+      return upsertPref(ctx.userId!, input.serverId, null, input.level);
+    }),
+
+  /** Set notification level for a channel (overrides server & global). */
+  setChannelLevel: authedProcedure
+    .input(
+      z.object({
+        channelId: z.string().uuid(),
+        serverId: z.string().uuid(),
+        level: NotificationLevelSchema,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const member = await prisma.serverMember.findUnique({
+        where: { userId_serverId: { userId: ctx.userId!, serverId: input.serverId } },
+      });
+      if (!member) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not a member of this server' });
+      }
+      return upsertPref(ctx.userId!, input.serverId, input.channelId, input.level);
+    }),
+});

--- a/harmony-frontend/public/sw.js
+++ b/harmony-frontend/public/sw.js
@@ -1,0 +1,45 @@
+/* Harmony service worker — handles Web Push notifications */
+
+self.addEventListener('push', (event) => {
+  if (!event.data) return;
+
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: 'Harmony', body: event.data.text() };
+  }
+
+  const { title = 'Harmony', body = '', icon = '/icon-192.png', tag, data } = payload;
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon,
+      tag,
+      data,
+      badge: '/icon-72.png',
+    }),
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  const url = event.notification.data?.url ?? '/';
+
+  event.waitUntil(
+    clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((windowClients) => {
+        for (const client of windowClients) {
+          if (client.url === url && 'focus' in client) {
+            return client.focus();
+          }
+        }
+        if (clients.openWindow) {
+          return clients.openWindow(url);
+        }
+      }),
+  );
+});

--- a/harmony-frontend/src/components/settings/ChannelSettingsPage.tsx
+++ b/harmony-frontend/src/components/settings/ChannelSettingsPage.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/app/settings/[serverSlug]/[channelSlug]/actions';
 import { VisibilityToggle } from '@/components/channel/VisibilityToggle';
 import { SeoPreviewSection } from '@/components/settings/SeoPreviewSection';
+import { apiClient } from '@/lib/api-client';
 import type { Channel } from '@/types';
 import type { AuditLogEntry, AuditLogPage } from '@/services/channelService';
 import { ChannelVisibility } from '@/types';
@@ -30,13 +31,91 @@ const BG = {
 
 // ─── Sidebar sections ─────────────────────────────────────────────────────────
 
-type Section = 'overview' | 'permissions' | 'visibility' | 'seo';
+type NotifLevel = 'ALL' | 'MENTIONS' | 'NONE';
+
+const NOTIF_LABELS: Record<NotifLevel, string> = {
+  ALL: 'All Messages',
+  MENTIONS: 'Mentions Only',
+  NONE: 'Muted',
+};
+
+function ChannelNotificationsSection({ channel, serverId }: { channel: Channel; serverId: string }) {
+  const [level, setLevel] = useState<NotifLevel>('MENTIONS');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiClient
+      .trpcQuery<{ level: NotifLevel }[]>('notification.getPreferences')
+      .then((prefs) => {
+        const pref = prefs.find(
+          (p: { channelId?: string | null; level: NotifLevel }) => p.channelId === channel.id,
+        );
+        if (pref) setLevel(pref.level);
+      })
+      .catch(() => {});
+  }, [channel.id]);
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      await apiClient.trpcMutation('notification.setChannelLevel', {
+        channelId: channel.id,
+        serverId,
+        level,
+      });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className='space-y-4'>
+      <h2 className='text-lg font-semibold text-white'>Notification Settings</h2>
+      <p className='text-sm text-gray-400'>
+        Choose which messages in <span className='font-medium text-gray-200'>#{channel.name}</span>{' '}
+        trigger a push notification for you.
+      </p>
+      <div className='flex items-center gap-3'>
+        <select
+          value={level}
+          onChange={(e) => setLevel(e.target.value as NotifLevel)}
+          disabled={saving}
+          className='rounded bg-[#1e1f22] px-3 py-1.5 text-sm text-gray-200 border border-[#3d4148] focus:outline-none focus:border-indigo-500 disabled:opacity-50'
+        >
+          {(Object.keys(NOTIF_LABELS) as NotifLevel[]).map((l) => (
+            <option key={l} value={l}>
+              {NOTIF_LABELS[l]}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={save}
+          disabled={saving}
+          className='rounded px-3 py-1.5 text-sm bg-indigo-600 hover:bg-indigo-700 text-white font-medium disabled:opacity-50 transition-colors'
+        >
+          {saving ? 'Saving…' : saved ? 'Saved!' : 'Save'}
+        </button>
+      </div>
+      {error && <p className='text-xs text-red-400'>{error}</p>}
+    </div>
+  );
+}
+
+type Section = 'overview' | 'permissions' | 'visibility' | 'seo' | 'notifications';
 
 const SECTIONS: { id: Section; label: string }[] = [
   { id: 'overview', label: 'Overview' },
   { id: 'permissions', label: 'Permissions' },
   { id: 'visibility', label: 'Visibility' },
   { id: 'seo', label: 'SEO Preview' },
+  { id: 'notifications', label: 'Notifications' },
 ];
 
 // ─── Overview section ─────────────────────────────────────────────────────────
@@ -680,6 +759,9 @@ export function ChannelSettingsPage({
               channelSlug={channel.slug}
               canManageSeo={canManageSeo}
             />
+          )}
+          {activeSection === 'notifications' && (
+            <ChannelNotificationsSection channel={channel} serverId={channel.serverId} />
           )}
         </div>
       </main>

--- a/harmony-frontend/src/components/settings/NotificationSettingsSection.tsx
+++ b/harmony-frontend/src/components/settings/NotificationSettingsSection.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { usePushNotifications } from '@/hooks/usePushNotifications';
+import { apiClient } from '@/lib/api-client';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type NotificationLevel = 'ALL' | 'MENTIONS' | 'NONE';
+
+interface NotificationPreference {
+  id: string;
+  serverId: string | null;
+  channelId: string | null;
+  level: NotificationLevel;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const LEVEL_LABELS: Record<NotificationLevel, string> = {
+  ALL: 'All Messages',
+  MENTIONS: 'Mentions Only',
+  NONE: 'Muted',
+};
+
+const LEVEL_DESC: Record<NotificationLevel, string> = {
+  ALL: 'Notify me for every message',
+  MENTIONS: 'Only notify when I am @mentioned',
+  NONE: 'No notifications',
+};
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function LevelSelect({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: NotificationLevel;
+  onChange: (v: NotificationLevel) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value as NotificationLevel)}
+      disabled={disabled}
+      className='rounded bg-[#1e1f22] px-3 py-1.5 text-sm text-gray-200 border border-[#3d4148] focus:outline-none focus:border-indigo-500 disabled:opacity-50'
+    >
+      {(Object.keys(LEVEL_LABELS) as NotificationLevel[]).map((level) => (
+        <option key={level} value={level}>
+          {LEVEL_LABELS[level]}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function NotificationSettingsSection() {
+  const { permissionState, isSubscribed, isLoading: pushLoading, error: pushError, enable, disable } =
+    usePushNotifications();
+
+  const [globalLevel, setGlobalLevel] = useState<NotificationLevel>('MENTIONS');
+  const [prefs, setPrefs] = useState<NotificationPreference[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiClient
+      .trpcQuery<NotificationPreference[]>('notification.getPreferences')
+      .then((data) => {
+        const global = data.find((p) => p.serverId === null && p.channelId === null);
+        if (global) setGlobalLevel(global.level);
+        setPrefs(data);
+      })
+      .catch(() => {});
+  }, []);
+
+  async function handleSaveGlobal() {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await apiClient.trpcMutation('notification.setGlobalLevel', { level: globalLevel });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const isUnsupported = permissionState === 'unsupported';
+
+  return (
+    <div className='space-y-8'>
+      {/* Push notification toggle */}
+      <section>
+        <h3 className='text-base font-semibold text-white mb-1'>Browser Push Notifications</h3>
+        <p className='text-sm text-gray-400 mb-4'>
+          Receive notifications even when Harmony is not open in your browser.
+        </p>
+
+        {isUnsupported ? (
+          <p className='text-sm text-yellow-400'>
+            Push notifications are not supported in this browser.
+          </p>
+        ) : (
+          <div className='flex items-center gap-4'>
+            <button
+              onClick={isSubscribed ? disable : enable}
+              disabled={pushLoading}
+              className={`rounded px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
+                isSubscribed
+                  ? 'bg-red-600 hover:bg-red-700 text-white'
+                  : 'bg-indigo-600 hover:bg-indigo-700 text-white'
+              }`}
+            >
+              {pushLoading
+                ? 'Please wait…'
+                : isSubscribed
+                  ? 'Disable Push Notifications'
+                  : 'Enable Push Notifications'}
+            </button>
+
+            {permissionState === 'denied' && (
+              <span className='text-sm text-red-400'>
+                Notifications blocked. Please allow them in browser settings.
+              </span>
+            )}
+            {permissionState === 'granted' && isSubscribed && (
+              <span className='text-sm text-green-400'>Push notifications are active.</span>
+            )}
+            {pushError && <span className='text-sm text-red-400'>{pushError}</span>}
+          </div>
+        )}
+      </section>
+
+      {/* Global notification level */}
+      <section>
+        <h3 className='text-base font-semibold text-white mb-1'>Default Notification Level</h3>
+        <p className='text-sm text-gray-400 mb-3'>
+          Controls which messages trigger a notification. Channel and server overrides take
+          priority.
+        </p>
+
+        <div className='flex items-center gap-3'>
+          <LevelSelect value={globalLevel} onChange={setGlobalLevel} disabled={saving} />
+          <button
+            onClick={handleSaveGlobal}
+            disabled={saving}
+            className='rounded px-3 py-1.5 text-sm bg-indigo-600 hover:bg-indigo-700 text-white font-medium disabled:opacity-50 transition-colors'
+          >
+            {saving ? 'Saving…' : saved ? 'Saved!' : 'Save'}
+          </button>
+        </div>
+        <p className='mt-1.5 text-xs text-gray-500'>{LEVEL_DESC[globalLevel]}</p>
+        {saveError && <p className='mt-1 text-xs text-red-400'>{saveError}</p>}
+      </section>
+
+      {/* Per-server/channel overrides (read-only list) */}
+      {prefs.filter((p) => p.serverId !== null).length > 0 && (
+        <section>
+          <h3 className='text-base font-semibold text-white mb-3'>Server &amp; Channel Overrides</h3>
+          <p className='text-sm text-gray-400 mb-3'>
+            Change per-channel levels from the channel settings page.
+          </p>
+          <ul className='space-y-2'>
+            {prefs
+              .filter((p) => p.serverId !== null)
+              .map((pref) => (
+                <li
+                  key={pref.id}
+                  className='flex items-center justify-between rounded bg-[#1e1f22] px-3 py-2 text-sm text-gray-300'
+                >
+                  <span className='truncate mr-4'>
+                    {pref.channelId ? `Channel override` : `Server override`}
+                    <span className='ml-2 text-xs text-gray-500 font-mono'>
+                      {pref.channelId ?? pref.serverId}
+                    </span>
+                  </span>
+                  <span
+                    className={`shrink-0 font-medium ${
+                      pref.level === 'NONE'
+                        ? 'text-red-400'
+                        : pref.level === 'ALL'
+                          ? 'text-green-400'
+                          : 'text-yellow-400'
+                    }`}
+                  >
+                    {LEVEL_LABELS[pref.level]}
+                  </span>
+                </li>
+              ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/harmony-frontend/src/components/settings/UserSettingsPage.tsx
+++ b/harmony-frontend/src/components/settings/UserSettingsPage.tsx
@@ -14,6 +14,7 @@ import { getUserErrorMessage } from '@/lib/utils';
 import { cn } from '@/lib/utils';
 import type { UserStatus } from '@/types';
 import { isChannelGuestAccessible } from '@/app/settings/actions';
+import { NotificationSettingsSection } from './NotificationSettingsSection';
 
 // ─── Discord colour tokens ────────────────────────────────────────────────────
 
@@ -44,10 +45,11 @@ const ALL_STATUSES: UserStatus[] = ['online', 'idle', 'dnd', 'offline'];
 
 // ─── Sidebar sections ─────────────────────────────────────────────────────────
 
-type Section = 'account' | 'logout';
+type Section = 'account' | 'notifications' | 'logout';
 
 const SECTIONS: { id: Section; label: string; danger?: boolean }[] = [
   { id: 'account', label: 'My Account' },
+  { id: 'notifications', label: 'Notifications' },
   { id: 'logout', label: 'Log Out', danger: true },
 ];
 
@@ -482,6 +484,7 @@ export function UserSettingsPage({ returnTo }: { returnTo?: string }) {
         <div className='p-4 sm:p-8'>
           <div className='mx-auto max-w-xl'>
             {activeSection === 'account' && <AccountSection />}
+            {activeSection === 'notifications' && <NotificationSettingsSection />}
             {activeSection === 'logout' && <LogoutSection returnTo={returnTo} />}
           </div>
         </div>

--- a/harmony-frontend/src/hooks/usePushNotifications.ts
+++ b/harmony-frontend/src/hooks/usePushNotifications.ts
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { apiClient } from '@/lib/api-client';
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  return Uint8Array.from([...rawData].map((char) => char.charCodeAt(0)));
+}
+
+export type PushPermissionState = 'unsupported' | 'default' | 'granted' | 'denied';
+
+export interface UsePushNotificationsReturn {
+  permissionState: PushPermissionState;
+  isSubscribed: boolean;
+  isLoading: boolean;
+  error: string | null;
+  enable: () => Promise<void>;
+  disable: () => Promise<void>;
+}
+
+export function usePushNotifications(): UsePushNotificationsReturn {
+  const [permissionState, setPermissionState] = useState<PushPermissionState>('default');
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Check current subscription state on mount
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('serviceWorker' in navigator) || !('PushManager' in window)) {
+      setPermissionState('unsupported');
+      return;
+    }
+
+    setPermissionState(Notification.permission as PushPermissionState);
+
+    navigator.serviceWorker.ready.then(async (reg) => {
+      const sub = await reg.pushManager.getSubscription();
+      setIsSubscribed(!!sub);
+    }).catch(() => {});
+  }, []);
+
+  const enable = useCallback(async () => {
+    if (permissionState === 'unsupported') return;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // Fetch VAPID public key from the backend
+      const { vapidPublicKey } = await apiClient.trpcQuery<{ vapidPublicKey: string }>(
+        'notification.getVapidPublicKey',
+      );
+
+      const permission = await Notification.requestPermission();
+      setPermissionState(permission as PushPermissionState);
+      if (permission !== 'granted') {
+        setError('Notification permission denied');
+        return;
+      }
+
+      // Register service worker if not already registered
+      const reg = await navigator.serviceWorker.register('/sw.js', { scope: '/' });
+      await navigator.serviceWorker.ready;
+
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        applicationServerKey: urlBase64ToUint8Array(vapidPublicKey) as any,
+      });
+
+      const json = sub.toJSON();
+      await apiClient.trpcMutation('notification.subscribe', {
+        endpoint: json.endpoint,
+        p256dh: json.keys?.p256dh ?? '',
+        auth: json.keys?.auth ?? '',
+      });
+
+      setIsSubscribed(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to enable notifications');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [permissionState]);
+
+  const disable = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) {
+        await apiClient.trpcMutation('notification.unsubscribe', { endpoint: sub.endpoint });
+        await sub.unsubscribe();
+      }
+      setIsSubscribed(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to disable notifications');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { permissionState, isSubscribed, isLoading, error, enable, disable };
+}


### PR DESCRIPTION
## Summary

- **Web Push API (VAPID)** backend: `web-push` package + VAPID key config via env vars, `pushNotification.service.ts` handles mention detection, per-user notification level resolution, and fire-and-forget push dispatch after every `sendMessage`
- **Database**: two new Prisma models — `PushSubscription` (stores browser push endpoints per user) and `NotificationPreference` (per-user, per-server, per-channel notification level: `ALL | MENTIONS | NONE`), migration `20260428000000_add_push_notifications`
- **tRPC**: new `notification` router with `subscribe`, `unsubscribe`, `listSubscriptions`, `getPreferences`, `setGlobalLevel`, `setServerLevel`, `setChannelLevel`
- **Service worker** (`public/sw.js`): handles `push` events to show browser notifications and `notificationclick` to focus/open the relevant channel
- **Frontend hook** (`usePushNotifications`): manages service-worker registration, VAPID subscription lifecycle, permission state
- **UI**: `NotificationSettingsSection` in User Settings (global enable/disable + default level), `ChannelNotificationsSection` in Channel Settings (per-channel mute/level override)

## Closes

Resolves #487

## Test plan

- [ ] Run `npx web-push generate-vapid-keys` and set `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` in `.env`
- [ ] Run migration: `npx prisma migrate deploy`
- [ ] Open User Settings → Notifications → click "Enable Push Notifications", grant permission
- [ ] Send a message mentioning yourself in another tab — verify browser notification appears
- [ ] Set a channel to "All Messages" → send any message → verify notification fires
- [ ] Mute a channel (`NONE`) → verify no notification
- [ ] Disable push (unsubscribe) → verify no further notifications
- [ ] Backend unit tests: `npm test` in `harmony-backend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)