### PR TITLE
fix: apply prisma migrations before Railway boot

### DIFF
--- a/harmony-backend/start.sh
+++ b/harmony-backend/start.sh
@@ -4,6 +4,11 @@
 # omit or set SERVICE_ROLE=api on the backend-api service.
 set -e
 
+# Deploys can advance application code ahead of the shared Railway Postgres
+# schema. Apply pending Prisma migrations before either service boots so
+# request handlers do not come up against an out-of-date production schema.
+npx prisma migrate deploy
+
 if [ "${SERVICE_ROLE}" = "worker" ]; then
   exec node dist/worker.js
 else


### PR DESCRIPTION
## Summary
- run `npx prisma migrate deploy` in the Railway backend bootstrap before either service starts
- prevent `backend-api` and `backend-worker` from booting against a stale production schema
- make the production root cause explicit in the PR context

## Root Cause
The remaining cloud integration failure is coming from the live Railway backend, not from the Jest harness in PR #522.

Railway runtime logs show Prisma `P2022` on `GET /api/public/servers/:serverSlug/channels/:channelSlug/meta-tags` because production is missing the `generated_meta_tags` override columns expected by the deployed code, including `custom_title`.

## Verification
- `bash -n harmony-backend/start.sh`
- reproduced the failing cloud SEO smoke path against the deployed frontend/backend URLs
- inspected the latest failed GitHub Actions cloud integration run
- inspected Railway runtime logs to confirm the production schema mismatch