### PR TITLE
ci: gate cloud smoke on deploys and narrow required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,36 +19,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect non-log changes
+      - name: Detect relevant code/test changes
         id: changes
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            non_log:
-              - '!llm-logs/**'
-              - '**'
+            relevant:
+              - 'harmony-frontend/**'
+              - 'harmony-backend/**'
+              - 'tests/**'
 
-      - name: Skip frontend lint/build for llm-logs-only changes
-        if: steps.changes.outputs.non_log != 'true'
-        run: echo "llm-logs-only change detected; skipping frontend lint/build."
+      - name: Skip frontend lint/build for non-code changes
+        if: steps.changes.outputs.relevant != 'true'
+        run: echo "No changes under harmony-frontend/, harmony-backend/, or tests/; skipping frontend lint/build."
 
       - uses: actions/setup-node@v4
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-frontend/package-lock.json
 
       - name: Install dependencies
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm ci
 
       - name: Lint
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm run lint
 
       - name: Build
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm run build
 
   backend-lint-build:
@@ -60,38 +61,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect non-log changes
+      - name: Detect relevant code/test changes
         id: changes
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            non_log:
-              - '!llm-logs/**'
-              - '**'
+            relevant:
+              - 'harmony-frontend/**'
+              - 'harmony-backend/**'
+              - 'tests/**'
 
-      - name: Skip backend lint/build for llm-logs-only changes
-        if: steps.changes.outputs.non_log != 'true'
-        run: echo "llm-logs-only change detected; skipping backend lint/build."
+      - name: Skip backend lint/build for non-code changes
+        if: steps.changes.outputs.relevant != 'true'
+        run: echo "No changes under harmony-frontend/, harmony-backend/, or tests/; skipping backend lint/build."
 
       - uses: actions/setup-node@v4
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-backend/package-lock.json
 
       - name: Install dependencies
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm ci
 
       - name: Lint
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm run lint
 
       - name: Generate Prisma client
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npx prisma generate
 
       - name: Build
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,10 @@ jobs:
           filters: |
             relevant:
               - 'harmony-frontend/**'
-              - 'harmony-backend/**'
-              - 'tests/**'
 
       - name: Skip frontend lint/build for non-code changes
         if: steps.changes.outputs.relevant != 'true'
-        run: echo "No changes under harmony-frontend/, harmony-backend/, or tests/; skipping frontend lint/build."
+        run: echo "No changes under harmony-frontend/; skipping frontend lint/build."
 
       - uses: actions/setup-node@v4
         if: steps.changes.outputs.relevant == 'true'
@@ -67,13 +65,11 @@ jobs:
         with:
           filters: |
             relevant:
-              - 'harmony-frontend/**'
               - 'harmony-backend/**'
-              - 'tests/**'
 
       - name: Skip backend lint/build for non-code changes
         if: steps.changes.outputs.relevant != 'true'
-        run: echo "No changes under harmony-frontend/, harmony-backend/, or tests/; skipping backend lint/build."
+        run: echo "No changes under harmony-backend/; skipping backend lint/build."
 
       - uses: actions/setup-node@v4
         if: steps.changes.outputs.relevant == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,26 +28,26 @@ jobs:
               - 'harmony-frontend/**'
 
       - name: Skip frontend lint/build for non-code changes
-        if: steps.changes.outputs.relevant != 'true'
+        if: steps.changes.outputs.relevant != 'true' && github.event_name != 'workflow_dispatch'
         run: echo "No changes under harmony-frontend/; skipping frontend lint/build."
 
       - uses: actions/setup-node@v4
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-frontend/package-lock.json
 
       - name: Install dependencies
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npm ci
 
       - name: Lint
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npm run lint
 
       - name: Build
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npm run build
 
   backend-lint-build:
@@ -68,28 +68,28 @@ jobs:
               - 'harmony-backend/**'
 
       - name: Skip backend lint/build for non-code changes
-        if: steps.changes.outputs.relevant != 'true'
+        if: steps.changes.outputs.relevant != 'true' && github.event_name != 'workflow_dispatch'
         run: echo "No changes under harmony-backend/; skipping backend lint/build."
 
       - uses: actions/setup-node@v4
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-backend/package-lock.json
 
       - name: Install dependencies
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npm ci
 
       - name: Lint
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npm run lint
 
       - name: Generate Prisma client
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npx prisma generate
 
       - name: Build
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,19 +19,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Detect non-log changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            non_log:
+              - '!llm-logs/**'
+              - '**'
+
+      - name: Skip frontend lint/build for llm-logs-only changes
+        if: steps.changes.outputs.non_log != 'true'
+        run: echo "llm-logs-only change detected; skipping frontend lint/build."
+
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.non_log == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-frontend/package-lock.json
 
       - name: Install dependencies
+        if: steps.changes.outputs.non_log == 'true'
         run: npm ci
 
       - name: Lint
+        if: steps.changes.outputs.non_log == 'true'
         run: npm run lint
 
       - name: Build
+        if: steps.changes.outputs.non_log == 'true'
         run: npm run build
 
   backend-lint-build:
@@ -43,20 +60,38 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Detect non-log changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            non_log:
+              - '!llm-logs/**'
+              - '**'
+
+      - name: Skip backend lint/build for llm-logs-only changes
+        if: steps.changes.outputs.non_log != 'true'
+        run: echo "llm-logs-only change detected; skipping backend lint/build."
+
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.non_log == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-backend/package-lock.json
 
       - name: Install dependencies
+        if: steps.changes.outputs.non_log == 'true'
         run: npm ci
 
       - name: Lint
+        if: steps.changes.outputs.non_log == 'true'
         run: npm run lint
 
       - name: Generate Prisma client
+        if: steps.changes.outputs.non_log == 'true'
         run: npx prisma generate
 
       - name: Build
+        if: steps.changes.outputs.non_log == 'true'
         run: npm run build

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -43,38 +43,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect non-log changes
+      - name: Detect relevant code/test changes
         id: changes
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            non_log:
-              - '!llm-logs/**'
-              - '**'
+            relevant:
+              - 'harmony-frontend/**'
+              - 'harmony-backend/**'
+              - 'tests/**'
 
-      - name: Skip backend tests for llm-logs-only changes
-        if: steps.changes.outputs.non_log != 'true'
-        run: echo "llm-logs-only change detected; skipping backend tests."
+      - name: Skip backend tests for non-code changes
+        if: steps.changes.outputs.relevant != 'true'
+        run: echo "No changes under harmony-frontend/, harmony-backend/, or tests/; skipping backend tests."
 
       - uses: actions/setup-node@v4
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-backend/package-lock.json
 
       - name: Install dependencies
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm ci
 
       - name: Generate Prisma client
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npx prisma generate
 
       - name: Run migrations
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npx prisma migrate deploy
 
       - name: Run backend tests
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm test

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -49,13 +49,11 @@ jobs:
         with:
           filters: |
             relevant:
-              - 'harmony-frontend/**'
               - 'harmony-backend/**'
-              - 'tests/**'
 
       - name: Skip backend tests for non-code changes
         if: steps.changes.outputs.relevant != 'true'
-        run: echo "No changes under harmony-frontend/, harmony-backend/, or tests/; skipping backend tests."
+        run: echo "No changes under harmony-backend/; skipping backend tests."
 
       - uses: actions/setup-node@v4
         if: steps.changes.outputs.relevant == 'true'

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -52,28 +52,28 @@ jobs:
               - 'harmony-backend/**'
 
       - name: Skip backend tests for non-code changes
-        if: steps.changes.outputs.relevant != 'true'
+        if: steps.changes.outputs.relevant != 'true' && github.event_name != 'workflow_dispatch'
         run: echo "No changes under harmony-backend/; skipping backend tests."
 
       - uses: actions/setup-node@v4
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-backend/package-lock.json
 
       - name: Install dependencies
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npm ci
 
       - name: Generate Prisma client
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npx prisma generate
 
       - name: Run migrations
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npx prisma migrate deploy
 
       - name: Run backend tests
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npm test

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -43,20 +43,38 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Detect non-log changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            non_log:
+              - '!llm-logs/**'
+              - '**'
+
+      - name: Skip backend tests for llm-logs-only changes
+        if: steps.changes.outputs.non_log != 'true'
+        run: echo "llm-logs-only change detected; skipping backend tests."
+
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.non_log == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-backend/package-lock.json
 
       - name: Install dependencies
+        if: steps.changes.outputs.non_log == 'true'
         run: npm ci
 
       - name: Generate Prisma client
+        if: steps.changes.outputs.non_log == 'true'
         run: npx prisma generate
 
       - name: Run migrations
+        if: steps.changes.outputs.non_log == 'true'
         run: npx prisma migrate deploy
 
       - name: Run backend tests
+        if: steps.changes.outputs.non_log == 'true'
         run: npm test

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -17,30 +17,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect non-log changes
+      - name: Detect relevant code/test changes
         id: changes
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            non_log:
-              - '!llm-logs/**'
-              - '**'
+            relevant:
+              - 'harmony-frontend/**'
+              - 'harmony-backend/**'
+              - 'tests/**'
 
-      - name: Skip frontend tests for llm-logs-only changes
-        if: steps.changes.outputs.non_log != 'true'
-        run: echo "llm-logs-only change detected; skipping frontend tests."
+      - name: Skip frontend tests for non-code changes
+        if: steps.changes.outputs.relevant != 'true'
+        run: echo "No changes under harmony-frontend/, harmony-backend/, or tests/; skipping frontend tests."
 
       - uses: actions/setup-node@v4
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-frontend/package-lock.json
 
       - name: Install dependencies
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm ci
 
       - name: Run frontend tests
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm test

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -24,12 +24,10 @@ jobs:
           filters: |
             relevant:
               - 'harmony-frontend/**'
-              - 'harmony-backend/**'
-              - 'tests/**'
 
       - name: Skip frontend tests for non-code changes
         if: steps.changes.outputs.relevant != 'true'
-        run: echo "No changes under harmony-frontend/, harmony-backend/, or tests/; skipping frontend tests."
+        run: echo "No changes under harmony-frontend/; skipping frontend tests."
 
       - uses: actions/setup-node@v4
         if: steps.changes.outputs.relevant == 'true'

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -17,14 +17,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Detect non-log changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            non_log:
+              - '!llm-logs/**'
+              - '**'
+
+      - name: Skip frontend tests for llm-logs-only changes
+        if: steps.changes.outputs.non_log != 'true'
+        run: echo "llm-logs-only change detected; skipping frontend tests."
+
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.non_log == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-frontend/package-lock.json
 
       - name: Install dependencies
+        if: steps.changes.outputs.non_log == 'true'
         run: npm ci
 
       - name: Run frontend tests
+        if: steps.changes.outputs.non_log == 'true'
         run: npm test

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -26,20 +26,20 @@ jobs:
               - 'harmony-frontend/**'
 
       - name: Skip frontend tests for non-code changes
-        if: steps.changes.outputs.relevant != 'true'
+        if: steps.changes.outputs.relevant != 'true' && github.event_name != 'workflow_dispatch'
         run: echo "No changes under harmony-frontend/; skipping frontend tests."
 
       - uses: actions/setup-node@v4
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: harmony-frontend/package-lock.json
 
       - name: Install dependencies
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npm ci
 
       - name: Run frontend tests
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: npm test

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -98,23 +98,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect non-log changes
+      - name: Detect relevant code/test changes
         id: changes
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            non_log:
-              - '!llm-logs/**'
-              - '**'
+            relevant:
+              - 'harmony-frontend/**'
+              - 'harmony-backend/**'
+              - 'tests/**'
 
-      - name: Skip integration tests for llm-logs-only changes
-        if: steps.changes.outputs.non_log != 'true'
-        run: echo "llm-logs-only change detected; skipping local integration tests."
+      - name: Skip integration tests for non-code changes
+        if: steps.changes.outputs.relevant != 'true'
+        run: echo "No changes under harmony-frontend/, harmony-backend/, or tests/; skipping local integration tests."
 
       # ── Backend setup ──────────────────────────────────────────────────────
 
       - name: Set up Node.js (backend)
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -122,27 +123,27 @@ jobs:
           cache-dependency-path: harmony-backend/package-lock.json
 
       - name: Install backend dependencies
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: harmony-backend
         run: npm ci
 
       - name: Generate Prisma client
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: harmony-backend
         run: npx prisma generate
 
       - name: Run database migrations
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: harmony-backend
         run: npx prisma migrate deploy
 
       - name: Seed mock dataset
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: harmony-backend
         run: npm run db:seed:mock
 
       - name: Start backend API
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: harmony-backend
         env:
           PORT: "4000"
@@ -152,12 +153,12 @@ jobs:
       # cache is never invalidated after visibility changes (VIS-1 test would fail).
       # No PORT override: worker.ts defaults to 4100 via parsePortEnv(4100).
       - name: Start backend worker
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: harmony-backend
         run: npx tsx src/worker.ts > /tmp/backend-worker.log 2>&1 &
 
       - name: Wait for backend API to be ready
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           echo "Waiting for backend API on port 4000..."
           for i in $(seq 1 30); do
@@ -177,7 +178,7 @@ jobs:
       # must be running on port 3000 for those tests to pass.
 
       - name: Set up Node.js (frontend)
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -185,12 +186,12 @@ jobs:
           cache-dependency-path: harmony-frontend/package-lock.json
 
       - name: Install frontend dependencies
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: harmony-frontend
         run: npm ci
 
       - name: Build frontend
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: harmony-frontend
         env:
           NODE_ENV: production
@@ -199,7 +200,7 @@ jobs:
         run: npm run build
 
       - name: Start frontend
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: harmony-frontend
         env:
           NODE_ENV: production
@@ -209,7 +210,7 @@ jobs:
         run: npm run start > /tmp/frontend.log 2>&1 &
 
       - name: Wait for frontend to be ready
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           echo "Waiting for Next.js frontend on port 3000..."
           for i in $(seq 1 30); do
@@ -227,7 +228,7 @@ jobs:
       # ── Integration test suite ─────────────────────────────────────────────
 
       - name: Set up Node.js (integration tests)
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -235,12 +236,12 @@ jobs:
           cache-dependency-path: tests/integration/package-lock.json
 
       - name: Install integration test dependencies
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: tests/integration
         run: npm ci
 
       - name: Run integration tests (local target)
-        if: steps.changes.outputs.non_log == 'true'
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: tests/integration
         env:
           TEST_TARGET: local
@@ -249,7 +250,7 @@ jobs:
         run: npm test 2>&1 | tee /tmp/integration-test-output.log; exit ${PIPESTATUS[0]}
 
       - name: Upload integration test output
-        if: always() && steps.changes.outputs.non_log == 'true'
+        if: always() && steps.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-output
@@ -257,7 +258,7 @@ jobs:
           retention-days: 7
 
       - name: Upload service logs on failure
-        if: failure() && steps.changes.outputs.non_log == 'true'
+        if: failure() && steps.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: service-logs

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -21,7 +21,9 @@
 #
 # ─── Cloud-target usage (GitHub Actions) ────────────────────────────────────
 # The "Run Cloud Integration Tests" job uses the `cloud-integration-tests`
-# GitHub Actions environment. Configure these environment-scoped settings:
+# GitHub Actions environment. On `main`, it waits for the live deploy statuses
+# for the pushed commit (Vercel frontend + Railway backend services) before
+# hitting the shared cloud URLs. Configure these environment-scoped settings:
 #   vars.CLOUD_TEST_BACKEND_URL    required (deployed backend base URL)
 #   vars.CLOUD_TEST_FRONTEND_URL   required (deployed frontend base URL)
 #   vars.CLOUD_TEST_SERVER_SLUG      optional (defaults to test code fallback)
@@ -241,6 +243,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: cloud-integration-tests
+    permissions:
+      contents: read
+      statuses: read
     env:
       TEST_TARGET: cloud
       BACKEND_URL: ${{ vars.CLOUD_TEST_BACKEND_URL }}
@@ -267,6 +272,50 @@ jobs:
           if [ "$missing" -ne 0 ]; then
             exit 1
           fi
+
+      - name: Wait for successful frontend and backend deployments
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          required_contexts=(
+            "Vercel"
+            "overflowing-luck - Harmony backend-api"
+            "overflowing-luck - backend-worker"
+          )
+
+          deadline=$(( $(date +%s) + 1800 ))
+
+          while true; do
+            statuses_json=$(gh api "repos/${REPO}/commits/${SHA}/status")
+
+            if python3 -c $'import json\nimport sys\n\npayload = json.loads(sys.argv[1])\nrequired = sys.argv[2:]\nstatuses = {entry[\"context\"]: entry[\"state\"] for entry in payload.get(\"statuses\", [])}\n\nmissing = [context for context in required if context not in statuses]\nfailed = [f\"{context}={statuses[context]}\" for context in required if statuses.get(context) in {\"error\", \"failure\"}]\npending = [f\"{context}={statuses.get(context, \'missing\')}\" for context in required if statuses.get(context) not in {\"success\", \"error\", \"failure\"}]\n\nif failed:\n    print(\"FAILED \" + \", \".join(failed))\n    sys.exit(2)\nif missing or pending:\n    print(\"PENDING \" + \", \".join(missing + pending))\n    sys.exit(1)\nprint(\"READY\")' "$statuses_json" "${required_contexts[@]}"
+            then
+              rc=0
+            else
+              rc=$?
+            fi
+
+            if [ "$rc" -eq 0 ]; then
+              echo "Deployment contexts are green for ${SHA}."
+              break
+            fi
+
+            if [ "$rc" -eq 2 ]; then
+              echo "::error title=Deployment failed::A required frontend/backend deployment status reported failure for ${SHA}."
+              exit 1
+            fi
+
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error title=Deployment wait timed out::Timed out waiting for Vercel and Railway deployment statuses on ${SHA}."
+              exit 1
+            fi
+
+            echo "Waiting 20s for frontend/backend deployment statuses on ${SHA}..."
+            sleep 20
+          done
 
       - name: Set up Node.js (integration tests)
         uses: actions/setup-node@v4

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -109,13 +109,13 @@ jobs:
               - 'tests/**'
 
       - name: Skip integration tests for non-code changes
-        if: steps.changes.outputs.relevant != 'true'
+        if: steps.changes.outputs.relevant != 'true' && github.event_name != 'workflow_dispatch'
         run: echo "No changes under harmony-frontend/, harmony-backend/, or tests/; skipping local integration tests."
 
       # ── Backend setup ──────────────────────────────────────────────────────
 
       - name: Set up Node.js (backend)
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -123,27 +123,27 @@ jobs:
           cache-dependency-path: harmony-backend/package-lock.json
 
       - name: Install backend dependencies
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: harmony-backend
         run: npm ci
 
       - name: Generate Prisma client
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: harmony-backend
         run: npx prisma generate
 
       - name: Run database migrations
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: harmony-backend
         run: npx prisma migrate deploy
 
       - name: Seed mock dataset
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: harmony-backend
         run: npm run db:seed:mock
 
       - name: Start backend API
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: harmony-backend
         env:
           PORT: "4000"
@@ -153,12 +153,12 @@ jobs:
       # cache is never invalidated after visibility changes (VIS-1 test would fail).
       # No PORT override: worker.ts defaults to 4100 via parsePortEnv(4100).
       - name: Start backend worker
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: harmony-backend
         run: npx tsx src/worker.ts > /tmp/backend-worker.log 2>&1 &
 
       - name: Wait for backend API to be ready
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           echo "Waiting for backend API on port 4000..."
           for i in $(seq 1 30); do
@@ -178,7 +178,7 @@ jobs:
       # must be running on port 3000 for those tests to pass.
 
       - name: Set up Node.js (frontend)
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -186,12 +186,12 @@ jobs:
           cache-dependency-path: harmony-frontend/package-lock.json
 
       - name: Install frontend dependencies
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: harmony-frontend
         run: npm ci
 
       - name: Build frontend
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: harmony-frontend
         env:
           NODE_ENV: production
@@ -200,7 +200,7 @@ jobs:
         run: npm run build
 
       - name: Start frontend
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: harmony-frontend
         env:
           NODE_ENV: production
@@ -210,7 +210,7 @@ jobs:
         run: npm run start > /tmp/frontend.log 2>&1 &
 
       - name: Wait for frontend to be ready
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           echo "Waiting for Next.js frontend on port 3000..."
           for i in $(seq 1 30); do
@@ -228,7 +228,7 @@ jobs:
       # ── Integration test suite ─────────────────────────────────────────────
 
       - name: Set up Node.js (integration tests)
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -236,12 +236,12 @@ jobs:
           cache-dependency-path: tests/integration/package-lock.json
 
       - name: Install integration test dependencies
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: tests/integration
         run: npm ci
 
       - name: Run integration tests (local target)
-        if: steps.changes.outputs.relevant == 'true'
+        if: steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: tests/integration
         env:
           TEST_TARGET: local
@@ -250,7 +250,7 @@ jobs:
         run: npm test 2>&1 | tee /tmp/integration-test-output.log; exit ${PIPESTATUS[0]}
 
       - name: Upload integration test output
-        if: always() && steps.changes.outputs.relevant == 'true'
+        if: always() && (steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-output
@@ -258,7 +258,7 @@ jobs:
           retention-days: 7
 
       - name: Upload service logs on failure
-        if: failure() && steps.changes.outputs.relevant == 'true'
+        if: failure() && (steps.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-artifact@v4
         with:
           name: service-logs
@@ -285,6 +285,9 @@ jobs:
       CLOUD_TEST_PUBLIC_CHANNELS: ${{ vars.CLOUD_TEST_PUBLIC_CHANNELS }}
       CLOUD_TEST_SERVER_ID: ${{ vars.CLOUD_TEST_SERVER_ID }}
       CLOUD_TEST_ACCESS_TOKEN: ${{ secrets.CLOUD_TEST_ACCESS_TOKEN }}
+      VERCEL_DEPLOYMENT_CONTEXT: ${{ vars.VERCEL_DEPLOYMENT_CONTEXT || 'Vercel' }}
+      RAILWAY_BACKEND_API_CONTEXT: ${{ vars.RAILWAY_BACKEND_API_CONTEXT || 'overflowing-luck - Harmony backend-api' }}
+      RAILWAY_BACKEND_WORKER_CONTEXT: ${{ vars.RAILWAY_BACKEND_WORKER_CONTEXT || 'overflowing-luck - backend-worker' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -310,10 +313,13 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
         run: |
+          # These status-context labels must match the commit-status contexts
+          # reported by Vercel/Railway on main. Override them with repository or
+          # environment variables if either provider/project/service name changes.
           required_contexts=(
-            "Vercel"
-            "overflowing-luck - Harmony backend-api"
-            "overflowing-luck - backend-worker"
+            "$VERCEL_DEPLOYMENT_CONTEXT"
+            "$RAILWAY_BACKEND_API_CONTEXT"
+            "$RAILWAY_BACKEND_WORKER_CONTEXT"
           )
 
           deadline=$(( $(date +%s) + 1800 ))

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -98,9 +98,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Detect non-log changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            non_log:
+              - '!llm-logs/**'
+              - '**'
+
+      - name: Skip integration tests for llm-logs-only changes
+        if: steps.changes.outputs.non_log != 'true'
+        run: echo "llm-logs-only change detected; skipping local integration tests."
+
       # ── Backend setup ──────────────────────────────────────────────────────
 
       - name: Set up Node.js (backend)
+        if: steps.changes.outputs.non_log == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -108,22 +122,27 @@ jobs:
           cache-dependency-path: harmony-backend/package-lock.json
 
       - name: Install backend dependencies
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: harmony-backend
         run: npm ci
 
       - name: Generate Prisma client
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: harmony-backend
         run: npx prisma generate
 
       - name: Run database migrations
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: harmony-backend
         run: npx prisma migrate deploy
 
       - name: Seed mock dataset
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: harmony-backend
         run: npm run db:seed:mock
 
       - name: Start backend API
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: harmony-backend
         env:
           PORT: "4000"
@@ -133,10 +152,12 @@ jobs:
       # cache is never invalidated after visibility changes (VIS-1 test would fail).
       # No PORT override: worker.ts defaults to 4100 via parsePortEnv(4100).
       - name: Start backend worker
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: harmony-backend
         run: npx tsx src/worker.ts > /tmp/backend-worker.log 2>&1 &
 
       - name: Wait for backend API to be ready
+        if: steps.changes.outputs.non_log == 'true'
         run: |
           echo "Waiting for backend API on port 4000..."
           for i in $(seq 1 30); do
@@ -156,6 +177,7 @@ jobs:
       # must be running on port 3000 for those tests to pass.
 
       - name: Set up Node.js (frontend)
+        if: steps.changes.outputs.non_log == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -163,10 +185,12 @@ jobs:
           cache-dependency-path: harmony-frontend/package-lock.json
 
       - name: Install frontend dependencies
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: harmony-frontend
         run: npm ci
 
       - name: Build frontend
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: harmony-frontend
         env:
           NODE_ENV: production
@@ -175,6 +199,7 @@ jobs:
         run: npm run build
 
       - name: Start frontend
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: harmony-frontend
         env:
           NODE_ENV: production
@@ -184,6 +209,7 @@ jobs:
         run: npm run start > /tmp/frontend.log 2>&1 &
 
       - name: Wait for frontend to be ready
+        if: steps.changes.outputs.non_log == 'true'
         run: |
           echo "Waiting for Next.js frontend on port 3000..."
           for i in $(seq 1 30); do
@@ -201,6 +227,7 @@ jobs:
       # ── Integration test suite ─────────────────────────────────────────────
 
       - name: Set up Node.js (integration tests)
+        if: steps.changes.outputs.non_log == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -208,10 +235,12 @@ jobs:
           cache-dependency-path: tests/integration/package-lock.json
 
       - name: Install integration test dependencies
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: tests/integration
         run: npm ci
 
       - name: Run integration tests (local target)
+        if: steps.changes.outputs.non_log == 'true'
         working-directory: tests/integration
         env:
           TEST_TARGET: local
@@ -220,7 +249,7 @@ jobs:
         run: npm test 2>&1 | tee /tmp/integration-test-output.log; exit ${PIPESTATUS[0]}
 
       - name: Upload integration test output
-        if: always()
+        if: always() && steps.changes.outputs.non_log == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-output
@@ -228,7 +257,7 @@ jobs:
           retention-days: 7
 
       - name: Upload service logs on failure
-        if: failure()
+        if: failure() && steps.changes.outputs.non_log == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: service-logs


### PR DESCRIPTION
## Summary
- wait for successful Vercel and Railway deployment statuses before running cloud integration smoke on `main`
- keep required check names stable while fast-pathing them when their owned code paths were untouched
- narrow workflow ownership so frontend checks watch `harmony-frontend/`, backend checks watch `harmony-backend/`, and integration keeps the broader frontend/backend/tests scope

## Verification
- `ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/run-backend-tests.yml .github/workflows/run-frontend-tests.yml .github/workflows/run-integration-tests.yml].each { |f| YAML.load_file(f); puts "YAML OK #{f}" }'`
- inspected live commit status contexts on `main` to wire the deployment wait step to the existing Vercel and Railway signals