### PR TITLE
fix: flip message action dropdown upward when near viewport bottom

### DIFF
--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -145,10 +145,12 @@ function ActionBar({
   const router = useRouter();
   const pathname = usePathname();
   const [isMoreOpen, setIsMoreOpen] = useState(false);
+  const [openUpward, setOpenUpward] = useState(false);
   const [isPinned, setIsPinned] = useState(initialPinned ?? false);
   const [pinState, setPinState] = useState<PinState>('idle');
   const [pinErrorMsg, setPinErrorMsg] = useState('');
   const moreRef = useRef<HTMLDivElement>(null);
+  const moreTriggerRef = useRef<HTMLButtonElement>(null);
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -270,8 +272,15 @@ function ActionBar({
             type='button'
             aria-label='More actions'
             title='More'
+            ref={moreTriggerRef}
             aria-expanded={isMoreOpen}
-            onClick={() => setIsMoreOpen(v => !v)}
+            onClick={() => {
+              if (!isMoreOpen && moreTriggerRef.current) {
+                const rect = moreTriggerRef.current.getBoundingClientRect();
+                setOpenUpward(window.innerHeight - rect.bottom < 180);
+              }
+              setIsMoreOpen(v => !v);
+            }}
             className='flex h-8 w-8 items-center justify-center text-gray-400 hover:text-white hover:bg-white/10 rounded-md transition-colors'
           >
             <svg
@@ -286,7 +295,7 @@ function ActionBar({
           </button>
 
           {isMoreOpen && (
-            <div className='absolute right-0 top-full mt-1 min-w-[160px] rounded-md border border-white/10 bg-[#18191c] py-1 shadow-xl z-20'>
+            <div className={`absolute right-0 min-w-[160px] rounded-md border border-white/10 bg-[#18191c] py-1 shadow-xl z-20 ${openUpward ? 'bottom-full mb-1' : 'top-full mt-1'}`}>
               {isOwnMessage && (
                 <button
                   type='button'


### PR DESCRIPTION
## Summary
- Fixes #526: the More (⋮) context menu on messages was opening downward (`top-full`) and overlapping the message input box for recent messages near the bottom of the viewport
- On click, the trigger button's `getBoundingClientRect().bottom` is compared against `window.innerHeight`; if less than 180px of space remains, the dropdown opens upward (`bottom-full mb-1`) instead of downward (`top-full mt-1`)
- No third-party positioning library needed — single measurement on click, no scroll/resize listeners

## Test plan
- [ ] Open a channel with several messages; hover over the most recent message and click ⋮ — dropdown should appear **above** the button rather than behind the input box
- [ ] For a message in the middle of the list (plenty of space below), dropdown should still open **downward**
- [ ] Works on narrow/short viewports (mobile-width dev tools emulation)
- [ ] All 365 frontend unit tests pass (`npm test` in `harmony-frontend/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)