### PR TITLE
fix: Discord-style inline replies (issue #531)

### DIFF
--- a/harmony-backend/src/repositories/message.repository.ts
+++ b/harmony-backend/src/repositories/message.repository.ts
@@ -20,6 +20,14 @@ const ATTACHMENT_SELECT = {
 export const MESSAGE_INCLUDE = {
   author: { select: AUTHOR_SELECT },
   attachments: { select: ATTACHMENT_SELECT },
+  parent: {
+    select: {
+      id: true,
+      content: true,
+      isDeleted: true,
+      author: { select: AUTHOR_SELECT },
+    },
+  },
 } as const;
 
 export const messageRepository = {

--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -58,6 +58,14 @@ const MESSAGE_SSE_INCLUDE = {
   attachments: {
     select: { id: true, filename: true, url: true, contentType: true },
   },
+  parent: {
+    select: {
+      id: true,
+      content: true,
+      isDeleted: true,
+      author: { select: { id: true, username: true, displayName: true, avatarUrl: true } },
+    },
+  },
 } as const;
 
 // ─── SSE helpers ──────────────────────────────────────────────────────────────
@@ -251,6 +259,15 @@ eventsRouter.get('/channel/:channelId', async (req: Request, res: Response) => {
             timestamp: message.createdAt.toISOString(),
             attachments: message.attachments,
             editedAt: message.editedAt ? message.editedAt.toISOString() : null,
+            parentMessageId: message.parentMessageId,
+            parentMessage: message.parent
+              ? {
+                  id: message.parent.id,
+                  content: message.parent.isDeleted ? '' : message.parent.content,
+                  isDeleted: message.parent.isDeleted,
+                  author: message.parent.author,
+                }
+              : null,
           },
           message.createdAt.toISOString(),
         );
@@ -352,6 +369,15 @@ eventsRouter.get('/channel/:channelId', async (req: Request, res: Response) => {
               timestamp: msg.createdAt.toISOString(),
               attachments: msg.attachments,
               editedAt: msg.editedAt ? msg.editedAt.toISOString() : null,
+              parentMessageId: msg.parentMessageId,
+              parentMessage: msg.parent
+                ? {
+                    id: msg.parent.id,
+                    content: msg.parent.isDeleted ? '' : msg.parent.content,
+                    isDeleted: msg.parent.isDeleted,
+                    author: msg.parent.author,
+                  }
+                : null,
             },
             msg.createdAt.toISOString(),
           ),
@@ -537,6 +563,15 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
             timestamp: message.createdAt.toISOString(),
             attachments: message.attachments,
             editedAt: message.editedAt ? message.editedAt.toISOString() : null,
+            parentMessageId: message.parentMessageId,
+            parentMessage: message.parent
+              ? {
+                  id: message.parent.id,
+                  content: message.parent.isDeleted ? '' : message.parent.content,
+                  isDeleted: message.parent.isDeleted,
+                  author: message.parent.author,
+                }
+              : null,
           },
           message.createdAt.toISOString(),
         );
@@ -748,6 +783,15 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
               timestamp: msg.createdAt.toISOString(),
               attachments: msg.attachments,
               editedAt: msg.editedAt ? msg.editedAt.toISOString() : null,
+              parentMessageId: msg.parentMessageId,
+              parentMessage: msg.parent
+                ? {
+                    id: msg.parent.id,
+                    content: msg.parent.isDeleted ? '' : msg.parent.content,
+                    isDeleted: msg.parent.isDeleted,
+                    author: msg.parent.author,
+                  }
+                : null,
             },
             msg.createdAt.toISOString(),
           ),

--- a/harmony-frontend/src/components/channel/MessageInput.tsx
+++ b/harmony-frontend/src/components/channel/MessageInput.tsx
@@ -12,6 +12,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
 import { sendMessageAction } from '@/app/actions/sendMessage';
+import { createReplyAction } from '@/app/actions/createReply';
 import type { Message, AttachmentInput } from '@/types';
 
 // Lazy-load the heavy emoji picker bundle so it doesn't block the initial render
@@ -39,6 +40,10 @@ export interface MessageInputProps {
   isReadOnly?: boolean;
   /** Called with the newly created message after a successful send */
   onMessageSent?: (message: Message) => void;
+  /** When set, shows a "Replying to X" banner and sends as a reply to this message */
+  replyingTo?: Message | null;
+  /** Called when the user dismisses the reply banner */
+  onCancelReply?: () => void;
 }
 
 export function MessageInput({
@@ -47,6 +52,8 @@ export function MessageInput({
   serverId,
   isReadOnly = false,
   onMessageSent,
+  replyingTo,
+  onCancelReply,
 }: MessageInputProps) {
   const [value, setValue] = useState('');
   const [isSending, setIsSending] = useState(false);
@@ -168,12 +175,26 @@ export function MessageInput({
     setIsSending(true);
     setSendError(null);
     try {
-      const msg = await sendMessageAction(
-        channelId,
-        trimmed,
-        serverId,
-        pendingAttachments.length ? pendingAttachments : undefined,
-      );
+      let msg: Message;
+      if (replyingTo) {
+        const result = await createReplyAction(replyingTo.id, channelId, serverId, trimmed);
+        if (!result.ok) {
+          setSendError(
+            result.forbidden
+              ? "You don't have permission to reply in this channel."
+              : 'Failed to send reply. Please try again.',
+          );
+          return;
+        }
+        msg = result.message;
+      } else {
+        msg = await sendMessageAction(
+          channelId,
+          trimmed,
+          serverId,
+          pendingAttachments.length ? pendingAttachments : undefined,
+        );
+      }
       setValue('');
       setPendingAttachments([]);
       onMessageSent?.(msg);
@@ -192,6 +213,7 @@ export function MessageInput({
     serverId,
     onMessageSent,
     pendingAttachments,
+    replyingTo,
   ]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -227,6 +249,28 @@ export function MessageInput({
 
   return (
     <div className='relative flex-shrink-0 px-4 pb-6 pt-2'>
+      {replyingTo && (
+        <div className='mb-1 flex items-center gap-2 rounded-t bg-[#36393f] px-3 py-1.5 text-xs text-gray-400'>
+          <svg className='h-3.5 w-3.5 flex-shrink-0' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
+            <path d='M10 9V5l-7 7 7 7v-4.1c5 0 8.5 1.6 11 5.1-1-5-4-10-11-11z' />
+          </svg>
+          <span>
+            Replying to{' '}
+            <span className='font-medium text-white'>
+              {replyingTo.author.displayName ?? replyingTo.author.username}
+            </span>
+          </span>
+          <span className='ml-1 truncate text-gray-500'>{replyingTo.content}</span>
+          <button
+            type='button'
+            aria-label='Cancel reply'
+            onClick={onCancelReply}
+            className='ml-auto flex-shrink-0 text-gray-500 hover:text-gray-200 transition-colors'
+          >
+            ✕
+          </button>
+        </div>
+      )}
       {sendError && (
         <p className='mb-1 px-1 text-xs text-red-400' role='alert'>
           {sendError}
@@ -309,7 +353,7 @@ export function MessageInput({
           value={value}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          placeholder={`Message #${channelName}`}
+          placeholder={replyingTo ? `Reply to ${replyingTo.author.displayName ?? replyingTo.author.username}…` : `Message #${channelName}`}
           rows={1}
           disabled={isSending}
           aria-label={`Message #${channelName}`}

--- a/harmony-frontend/src/components/channel/MessageList.tsx
+++ b/harmony-frontend/src/components/channel/MessageList.tsx
@@ -73,9 +73,11 @@ interface MessageListProps {
   serverId?: string;
   /** When true, shows the pin/unpin option on message hover. Grant to MODERATOR+. */
   canPin?: boolean;
+  /** Called when the user clicks Reply on a message. */
+  onReplyClick?: (message: Message) => void;
 }
 
-export function MessageList({ channel, messages, serverId, canPin }: MessageListProps) {
+export function MessageList({ channel, messages, serverId, canPin, onReplyClick }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   // #c7: only auto-scroll when user is already near the bottom
@@ -148,7 +150,7 @@ export function MessageList({ channel, messages, serverId, canPin }: MessageList
             <div key={group.messages[0]?.id || gi}>
               {showDateSeparator && <DateSeparator label={group.dateLabel} />}
               {group.messages.map((msg, mi) => (
-                <MessageItem key={msg.id} message={msg} showHeader={mi === 0} serverId={serverId} canPin={canPin} />
+                <MessageItem key={msg.id} message={msg} showHeader={mi === 0} serverId={serverId} canPin={canPin} onReplyClick={onReplyClick} />
               ))}
             </div>
           );

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -102,6 +102,7 @@ export function HarmonyShell({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   // Local message state so sent messages appear immediately without a page reload
   const [localMessages, setLocalMessages] = useState<Message[]>(messages);
+  const [replyingTo, setReplyingTo] = useState<Message | null>(null);
   // Track previous channel so we can reset localMessages synchronously on channel
   // switch — avoids a one-render flash where old messages show under the new channel header.
   const [prevChannelId, setPrevChannelId] = useState(currentChannel.id);
@@ -110,6 +111,7 @@ export function HarmonyShell({
     setLocalMessages(messages);
     setIsMenuOpen(false);
     setIsPinsOpen(false);
+    setReplyingTo(null);
     // Only auto-close the members sidebar on mobile so desktop keeps it open by default.
     if (typeof window !== 'undefined' && !window.matchMedia('(min-width: 640px)').matches) {
       setIsMembersOpen(false);
@@ -225,11 +227,20 @@ export function HarmonyShell({
   // Other tabs receive the broadcast and call router.refresh(); the current tab
   // navigates to the new server route which re-renders with the updated servers prop.
 
+  const handleReplyClick = useCallback((message: Message) => {
+    setReplyingTo(message);
+  }, []);
+
+  const handleCancelReply = useCallback(() => {
+    setReplyingTo(null);
+  }, []);
+
   const handleMessageSent = useCallback((msg: Message) => {
     // Dedup: the SSE event for the sender's own message can arrive before the tRPC
     // response (Redis pub/sub on the same backend + established SSE connection beats
     // the HTTP round-trip). Without this check, the message would be added twice.
     setLocalMessages(prev => (prev.some(m => m.id === msg.id) ? prev : [...prev, msg]));
+    setReplyingTo(null);
   }, []);
 
   // ── Real-time SSE handlers ────────────────────────────────────────────────
@@ -490,6 +501,7 @@ export function HarmonyShell({
                     messages={localMessages}
                     serverId={currentServer.id}
                     canPin={canPin}
+                    onReplyClick={handleReplyClick}
                   />
                   <MessageInput
                     channelId={currentChannel.id}
@@ -497,6 +509,8 @@ export function HarmonyShell({
                     serverId={currentServer.id}
                     isReadOnly={currentUser.role === 'guest'}
                     onMessageSent={handleMessageSent}
+                    replyingTo={replyingTo}
+                    onCancelReply={handleCancelReply}
                   />
                   {!isAuthLoading && !isAuthenticated && (
                     <GuestPromoBanner

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -9,9 +9,8 @@
  * users with message:pin permission (MODERATOR, ADMIN, OWNER), and "Edit
  * Message" for the message's own author.
  *
- * Threading: top-level messages with replies show a "View N replies" button.
- * Clicking it expands an inline ThreadView showing indented replies and a
- * reply composer.
+ * Replies: messages with a parentMessage show a Discord-style inline reply
+ * banner above the content. Clicking the banner scrolls to the parent message.
  */
 
 'use client';
@@ -24,7 +23,6 @@ import { pinMessageAction, unpinMessageAction } from '@/app/actions/pinMessage';
 import { editMessageAction } from '@/app/actions/editMessage';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/useToast';
-import { ThreadView } from '@/components/message/ThreadView';
 import type { Message, Reaction } from '@/types';
 
 // ─── AttachmentList ───────────────────────────────────────────────────────────
@@ -93,6 +91,43 @@ function ReactionList({ reactions, messageId }: { reactions: Reaction[]; message
         </button>
       ))}
     </div>
+  );
+}
+
+// ─── ReplyBanner ──────────────────────────────────────────────────────────────
+
+function ReplyBanner({ parentMessage }: { parentMessage: NonNullable<Message['parentMessage']> }) {
+  const handleClick = () => {
+    const el = document.querySelector(`[data-message-id="${parentMessage.id}"]`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  const label = parentMessage.isDeleted
+    ? 'Original message deleted'
+    : `${parentMessage.author.displayName ?? parentMessage.author.username}: ${parentMessage.content}`;
+
+  return (
+    <button
+      type='button'
+      onClick={handleClick}
+      title={label}
+      className='mb-0.5 flex min-w-0 items-center gap-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors max-w-full'
+      aria-label={`Jump to replied message from ${parentMessage.author.displayName ?? parentMessage.author.username}`}
+    >
+      <svg className='h-3 w-3 flex-shrink-0 rotate-180' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
+        <path d='M10 9V5l-7 7 7 7v-4.1c5 0 8.5 1.6 11 5.1-1-5-4-10-11-11z' />
+      </svg>
+      {parentMessage.isDeleted ? (
+        <span className='italic text-gray-500'>Original message deleted</span>
+      ) : (
+        <>
+          <span className='font-medium text-gray-300 flex-shrink-0'>
+            {parentMessage.author.displayName ?? parentMessage.author.username}
+          </span>
+          <span className='min-w-0 truncate'>{parentMessage.content}</span>
+        </>
+      )}
+    </button>
   );
 }
 
@@ -336,6 +371,7 @@ export function MessageItem({
   showHeader = true,
   canPin,
   serverId,
+  onReplyClick,
 }: {
   message: Message;
   /** Set to false for grouped follow-up messages from the same author. Hides the avatar and author line. */
@@ -344,6 +380,8 @@ export function MessageItem({
   canPin?: boolean;
   /** Required for pin actions. Passed alongside canPin. */
   serverId?: string;
+  /** Called when the user clicks Reply on this message. */
+  onReplyClick?: (message: Message) => void;
 }) {
   const { user } = useAuth();
   const { showToast } = useToast();
@@ -353,10 +391,6 @@ export function MessageItem({
   const [isSaving, setIsSaving] = useState(false);
   const [localContent, setLocalContent] = useState<string | undefined>(undefined);
   const editTextareaRef = useRef<HTMLTextAreaElement>(null);
-  // Thread state: only top-level messages (no parentMessageId) can have threads
-  const isTopLevel = !message.parentMessageId;
-  const [isThreadOpen, setIsThreadOpen] = useState(false);
-  const [localReplyCount, setLocalReplyCount] = useState(message.replyCount ?? 0);
 
   // Render-phase derived-state reset: when the avatar URL changes (including A→B→A),
   // reset avatarError so the new URL is always attempted.
@@ -440,8 +474,8 @@ export function MessageItem({
   const authorNameClass = 'cursor-pointer font-medium text-white hover:underline';
 
   const handleReplyClick = useCallback(() => {
-    setIsThreadOpen(true);
-  }, []);
+    onReplyClick?.(message);
+  }, [onReplyClick, message]);
 
   const actionBar = (
     <ActionBar
@@ -451,7 +485,7 @@ export function MessageItem({
       initialPinned={!!message.pinned}
       isOwnMessage={isOwnMessage}
       onEditClick={handleEditClick}
-      onReplyClick={isTopLevel ? handleReplyClick : undefined}
+      onReplyClick={handleReplyClick}
     />
   );
 
@@ -491,43 +525,13 @@ export function MessageItem({
     </div>
   );
 
-  // "View N replies" / "Hide replies" button shown on top-level messages with replies
-  const threadToggle =
-    isTopLevel && serverId ? (
-      <button
-        type='button'
-        onClick={() => setIsThreadOpen(v => !v)}
-        className='mt-1 flex items-center gap-1 text-xs text-[#5865f2] hover:underline'
-        aria-expanded={isThreadOpen}
-        aria-label={
-          isThreadOpen
-            ? 'Hide replies'
-            : `View ${localReplyCount} ${localReplyCount === 1 ? 'reply' : 'replies'}`
-        }
-      >
-        <svg className='h-3 w-3' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
-          <path d='M10 9V5l-7 7 7 7v-4.1c5 0 8.5 1.6 11 5.1-1-5-4-10-11-11z' />
-        </svg>
-        {isThreadOpen
-          ? 'Hide replies'
-          : `${localReplyCount} ${localReplyCount === 1 ? 'reply' : 'replies'}`}
-      </button>
-    ) : null;
-
-  // Inline thread view rendered below message content
-  const threadView =
-    isTopLevel && isThreadOpen && serverId ? (
-      <ThreadView
-        parentMessage={message}
-        channelId={message.channelId}
-        serverId={serverId}
-        onReplyCountChange={delta => setLocalReplyCount(c => c + delta)}
-      />
-    ) : null;
-
   if (!showHeader) {
     return (
-      <div className='group relative flex flex-col px-4 py-0.5 hover:bg-white/[0.02]'>
+      <div
+        data-message-id={message.id}
+        className='group relative flex flex-col px-4 py-0.5 hover:bg-white/[0.02]'
+      >
+        {message.parentMessage && <div className='ml-14 pt-1'><ReplyBanner parentMessage={message.parentMessage} /></div>}
         <div className='flex gap-4'>
           {!isEditing && actionBar}
           {/* Spacer aligns content with the 40px avatar of the header row */}
@@ -549,16 +553,18 @@ export function MessageItem({
             )}
             <AttachmentList attachments={message.attachments} />
             <ReactionList reactions={message.reactions ?? []} messageId={message.id} />
-            {localReplyCount > 0 && threadToggle}
           </div>
         </div>
-        {threadView}
       </div>
     );
   }
 
   return (
-    <div className='group relative flex flex-col px-4 py-0.5 hover:bg-white/[0.02]'>
+    <div
+      data-message-id={message.id}
+      className='group relative flex flex-col px-4 py-0.5 hover:bg-white/[0.02]'
+    >
+      {message.parentMessage && <div className='ml-14 pt-1'><ReplyBanner parentMessage={message.parentMessage} /></div>}
       <div className='flex gap-4'>
         {!isEditing && actionBar}
         {/* Avatar */}
@@ -601,10 +607,8 @@ export function MessageItem({
           )}
           <AttachmentList attachments={message.attachments} />
           <ReactionList reactions={message.reactions ?? []} messageId={message.id} />
-          {localReplyCount > 0 && threadToggle}
         </div>
       </div>
-      {threadView}
     </div>
   );
 }

--- a/harmony-frontend/src/services/messageService.ts
+++ b/harmony-frontend/src/services/messageService.ts
@@ -44,6 +44,22 @@ function toFrontendMessage(raw: Record<string, unknown>, fallbackChannelId = '')
       | string
       | null
       | undefined,
+    parentMessage: (() => {
+      const p = (raw.parentMessage ?? raw.parent) as Record<string, unknown> | null | undefined;
+      if (!p) return null;
+      const pa = p.author as Record<string, unknown> | undefined;
+      return {
+        id: p.id as string,
+        content: (p.content ?? '') as string,
+        isDeleted: (p.isDeleted ?? p.is_deleted ?? false) as boolean,
+        author: {
+          id: (pa?.id ?? '') as string,
+          username: (pa?.username ?? '') as string,
+          displayName: (pa?.displayName ?? pa?.display_name) as string | undefined,
+          avatarUrl: (pa?.avatarUrl ?? pa?.avatar_url) as string | undefined,
+        },
+      };
+    })(),
     replyCount:
       typeof raw.replyCount === 'number'
         ? raw.replyCount

--- a/harmony-frontend/src/types/message.ts
+++ b/harmony-frontend/src/types/message.ts
@@ -23,6 +23,13 @@ export interface Message {
   pinned?: boolean;
   /** ID of the parent message when this is a reply; null/undefined for top-level messages. */
   parentMessageId?: string | null;
+  /** Snapshot of the parent message for inline reply preview. Null for top-level messages. */
+  parentMessage?: {
+    id: string;
+    content: string;
+    isDeleted: boolean;
+    author: Author;
+  } | null;
   /** Number of non-deleted replies on a top-level message. */
   replyCount?: number;
 }


### PR DESCRIPTION
## Summary

- **Root cause**: Replies appeared both as standalone messages in the main feed AND in a collapsible ThreadView, causing double display. The backend's `getMessages` query had no `parentMessageId: null` filter, so replies landed in the chronological feed regardless of thread status.
- **Fix**: Replace the thread/collapsible model with Discord-style inline replies. Each reply renders a `ReplyBanner` showing the parent author name and truncated content; clicking the banner scrolls to the parent message via `data-message-id` targeting.
- **Composer**: The "Replying to X" state is lifted to `HarmonyShell` so it can coordinate between `MessageList` (reply click) and `MessageInput` (banner + dispatch). `MessageInput` dispatches to `createReplyAction` when in reply mode.

## Changes

| Layer | What changed |
|---|---|
| Backend `message.repository.ts` | Added `parent` to `MESSAGE_INCLUDE` so all message queries return parent data |
| Backend `events.router.ts` | Added `parentMessageId` + `parentMessage` to all 4 SSE payload sites (channel + server, new + replay) |
| Frontend `types/message.ts` | Added `parentMessage` field to `Message` interface |
| Frontend `messageService.ts` | Added `parentMessage` mapping in `toFrontendMessage` |
| Frontend `MessageItem.tsx` | Removed `ThreadView`; added `ReplyBanner` sub-component; added `data-message-id` attribute to root divs; added `onReplyClick` prop |
| Frontend `MessageList.tsx` | Threads `onReplyClick` callback down to `MessageItem` |
| Frontend `HarmonyShell.tsx` | Lifts `replyingTo` state; wires `handleReplyClick` / `handleCancelReply`; clears on channel switch and after send |
| Frontend `MessageInput.tsx` | Shows "Replying to X" banner; dispatches `createReplyAction` when `replyingTo` is set |

## Known limitation

The public REST endpoint (`GET /api/public/channels/:channelId/messages`) is an ISR-cached SEO path that intentionally omits attachment and parent data to keep cached payloads lean. Unauthenticated visitors viewing a `PUBLIC_INDEXABLE` channel will not see `ReplyBanner` on replies. Authenticated users always go through the tRPC path and get full parent data.

## Test plan

- [ ] Send a message in a channel
- [ ] Click Reply on that message — "Replying to X" banner appears in composer
- [ ] Send the reply — one entry appears in the feed (not two), with `ReplyBanner` above it
- [ ] Click `ReplyBanner` — page scrolls to the parent message
- [ ] Press ✕ in composer banner — reply mode clears
- [ ] Switch channels — reply mode clears automatically
- [ ] Delete parent message — `ReplyBanner` renders "Original message deleted" in italic
- [ ] Frontend tests: 365/365 passing
- [ ] Backend tests: 868/869 passing (1 pre-existing timeout unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)