### PR TITLE
fix(#493): add client-side AuthGuard to /channels and /settings layouts

### DIFF
--- a/harmony-frontend/src/__tests__/AuthGuard.test.tsx
+++ b/harmony-frontend/src/__tests__/AuthGuard.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const mockReplace = jest.fn();
+const mockUseAuth = jest.fn();
+let mockSearchParams = new URLSearchParams('');
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => '/channels/server-1/general',
+  useSearchParams: () => mockSearchParams,
+}));
+
+// Import after mocks are set up
+import { AuthGuard } from '@/components/layout/AuthGuard';
+
+describe('AuthGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams('');
+  });
+
+  it('suppresses children while loading', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: true });
+
+    render(
+      <AuthGuard>
+        <span data-testid="protected">Protected content</span>
+      </AuthGuard>
+    );
+
+    expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('renders children when authenticated', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, isLoading: false });
+
+    render(
+      <AuthGuard>
+        <span data-testid="protected">Protected content</span>
+      </AuthGuard>
+    );
+
+    expect(screen.getByTestId('protected')).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('redirects to login when unauthenticated and not loading', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+    render(
+      <AuthGuard>
+        <span data-testid="protected">Protected content</span>
+      </AuthGuard>
+    );
+
+    expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
+    expect(mockReplace).toHaveBeenCalledWith(
+      '/auth/login?returnUrl=%2Fchannels%2Fserver-1%2Fgeneral'
+    );
+  });
+
+  it('preserves query params in the returnUrl', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+    mockSearchParams = new URLSearchParams('highlight=123');
+
+    render(
+      <AuthGuard>
+        <span data-testid="protected">Protected content</span>
+      </AuthGuard>
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      '/auth/login?returnUrl=%2Fchannels%2Fserver-1%2Fgeneral%3Fhighlight%3D123'
+    );
+  });
+});

--- a/harmony-frontend/src/app/channels/layout.tsx
+++ b/harmony-frontend/src/app/channels/layout.tsx
@@ -1,7 +1,12 @@
-/**
- * AppLayout — wraps all /channels/* authenticated routes.
- * TODO: add authentication guard here (redirect to login if unauthenticated).
- */
-export default function AppLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+import type { ReactNode } from 'react';
+import { AuthGuard } from '@/components/layout/AuthGuard';
+
+/** Wraps all /channels/* authenticated routes. */
+export default function AppLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <AuthGuard />
+      {children}
+    </>
+  );
 }

--- a/harmony-frontend/src/app/channels/layout.tsx
+++ b/harmony-frontend/src/app/channels/layout.tsx
@@ -3,10 +3,5 @@ import { AuthGuard } from '@/components/layout/AuthGuard';
 
 /** Wraps all /channels/* authenticated routes. */
 export default function AppLayout({ children }: { children: ReactNode }) {
-  return (
-    <>
-      <AuthGuard />
-      {children}
-    </>
-  );
+  return <AuthGuard>{children}</AuthGuard>;
 }

--- a/harmony-frontend/src/app/channels/layout.tsx
+++ b/harmony-frontend/src/app/channels/layout.tsx
@@ -1,7 +1,11 @@
-import type { ReactNode } from 'react';
+import { Suspense, type ReactNode } from 'react';
 import { AuthGuard } from '@/components/layout/AuthGuard';
 
 /** Wraps all /channels/* authenticated routes. */
 export default function AppLayout({ children }: { children: ReactNode }) {
-  return <AuthGuard>{children}</AuthGuard>;
+  return (
+    <Suspense>
+      <AuthGuard>{children}</AuthGuard>
+    </Suspense>
+  );
 }

--- a/harmony-frontend/src/app/settings/layout.tsx
+++ b/harmony-frontend/src/app/settings/layout.tsx
@@ -3,10 +3,5 @@ import { AuthGuard } from '@/components/layout/AuthGuard';
 
 /** Wraps all /settings/* authenticated routes. */
 export default function SettingsLayout({ children }: { children: ReactNode }) {
-  return (
-    <>
-      <AuthGuard />
-      {children}
-    </>
-  );
+  return <AuthGuard>{children}</AuthGuard>;
 }

--- a/harmony-frontend/src/app/settings/layout.tsx
+++ b/harmony-frontend/src/app/settings/layout.tsx
@@ -1,7 +1,12 @@
-/**
- * AppLayout for /settings/* routes.
- * TODO: add authentication guard here (redirect to login if unauthenticated).
- */
-export default function SettingsLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+import type { ReactNode } from 'react';
+import { AuthGuard } from '@/components/layout/AuthGuard';
+
+/** Wraps all /settings/* authenticated routes. */
+export default function SettingsLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <AuthGuard />
+      {children}
+    </>
+  );
 }

--- a/harmony-frontend/src/app/settings/layout.tsx
+++ b/harmony-frontend/src/app/settings/layout.tsx
@@ -1,7 +1,11 @@
-import type { ReactNode } from 'react';
+import { Suspense, type ReactNode } from 'react';
 import { AuthGuard } from '@/components/layout/AuthGuard';
 
 /** Wraps all /settings/* authenticated routes. */
 export default function SettingsLayout({ children }: { children: ReactNode }) {
-  return <AuthGuard>{children}</AuthGuard>;
+  return (
+    <Suspense>
+      <AuthGuard>{children}</AuthGuard>
+    </Suspense>
+  );
 }

--- a/harmony-frontend/src/components/layout/AuthGuard.tsx
+++ b/harmony-frontend/src/components/layout/AuthGuard.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth';
+
+/**
+ * Client-side authentication guard for protected route layouts.
+ *
+ * Defense-in-depth layer that catches session expiration during an active
+ * session — the Next.js middleware already handles the server-side check on
+ * initial navigation. Redirects unauthenticated users to /auth/login with a
+ * returnUrl so they land back where they were after signing in.
+ */
+export function AuthGuard() {
+  const { isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace(`/auth/login?returnUrl=${encodeURIComponent(pathname)}`);
+    }
+  }, [isAuthenticated, isLoading, pathname, router]);
+
+  return null;
+}

--- a/harmony-frontend/src/components/layout/AuthGuard.tsx
+++ b/harmony-frontend/src/components/layout/AuthGuard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useRouter, usePathname } from 'next/navigation';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
+import type { ReactNode } from 'react';
 
 /**
  * Client-side authentication guard for protected route layouts.
@@ -11,17 +12,25 @@ import { useAuth } from '@/hooks/useAuth';
  * session — the Next.js middleware already handles the server-side check on
  * initial navigation. Redirects unauthenticated users to /auth/login with a
  * returnUrl so they land back where they were after signing in.
+ *
+ * Suppresses children during the loading window to prevent a flash of
+ * protected content when middleware misses an invalid cookie.
  */
-export function AuthGuard() {
+export function AuthGuard({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
-      router.replace(`/auth/login?returnUrl=${encodeURIComponent(pathname)}`);
+      const fullPath = searchParams.toString()
+        ? `${pathname}?${searchParams.toString()}`
+        : pathname;
+      router.replace(`/auth/login?returnUrl=${encodeURIComponent(fullPath)}`);
     }
-  }, [isAuthenticated, isLoading, pathname, router]);
+  }, [isAuthenticated, isLoading, pathname, router, searchParams]);
 
-  return null;
+  if (isLoading || !isAuthenticated) return null;
+  return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- Creates a new `AuthGuard` client component that checks authentication state on mount and redirects unauthenticated users to `/auth/login` (with `returnUrl` preserved)
- Mounts `AuthGuard` in both `harmony-frontend/src/app/channels/layout.tsx` and `harmony-frontend/src/app/settings/layout.tsx`
- Removes the stale TODO comments from both layouts

The Next.js middleware (`src/middleware.ts`) already provides server-side protection on initial navigation. `AuthGuard` adds a client-side defense-in-depth layer that catches session expiration during an active session — a scenario the middleware cannot catch after the first page load.

Closes #493

## Test plan
- [ ] Log out, navigate to `/channels/...` — should redirect to `/auth/login?returnUrl=...`
- [ ] Log out, navigate to `/settings/...` — should redirect to `/auth/login?returnUrl=...`
- [ ] After login via the redirected URL, verify the `returnUrl` lands you back on the original page
- [ ] Verify authenticated users are unaffected (no redirect occurs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)