### PR TITLE
fix: add prisma generate to Railway buildCommand

### DIFF
--- a/harmony-backend/railway.toml
+++ b/harmony-backend/railway.toml
@@ -1,6 +1,6 @@
 [build]
 builder = "NIXPACKS"
-buildCommand = "npm run build"
+buildCommand = "npx prisma generate && npm run build"
 
 [deploy]
 startCommand = "bash start.sh"


### PR DESCRIPTION
## Summary

- Railway's `buildCommand` was only `npm run build` (`tsc`), with no explicit `prisma generate` step
- The generated Prisma client was being served from Railway's build cache; when that cache was invalidated, a fresh build used a stale client missing fields added by `20260418000000_add_meta_tag_overrides` (`customTitle`, `customDescription`, `customOgImage`)
- `tsc` then failed with property-not-found errors in `admin.metaTag.router.ts` and `metaTagService.ts`, causing the two most recent Railway deploys (`56820887`, `8abf4851`) to fail
- The CI workflow already runs `npx prisma generate` explicitly before building — this PR aligns `railway.toml` with that same pattern

## Test plan

- [ ] Merge triggers a Railway redeploy
- [ ] Railway build log shows `prisma generate` running successfully before `tsc`
- [ ] Railway deployment reaches `success` state
- [ ] Cloud integration tests pass against the newly deployed backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)