### PR TITLE
fix: run prisma generate as part of npm build script

### DIFF
--- a/harmony-backend/nixpacks.toml
+++ b/harmony-backend/nixpacks.toml
@@ -1,0 +1,6 @@
+[phases.install]
+# NODE_ENV=production in the Railway environment causes nixpacks to generate
+# "npm ci --omit=dev", which skips devDependencies. The build requires them
+# (typescript, @types/node, @types/express, etc.), so we override the install
+# command to always include all deps regardless of NODE_ENV.
+cmds = ["npm ci --include=dev"]

--- a/harmony-backend/package.json
+++ b/harmony-backend/package.json
@@ -7,7 +7,7 @@
     "dev:worker": "PORT=4100 tsx watch src/worker.ts",
     "dev:e2e": "NODE_ENV=e2e PORT=4000 tsx src/index.ts",
     "dev:e2e:worker": "NODE_ENV=e2e PORT=4100 tsx src/worker.ts",
-    "build": "tsc",
+    "build": "prisma generate && tsc",
     "start": "node dist/index.js",
     "start:api": "node dist/index.js",
     "start:worker": "node dist/worker.js",

--- a/harmony-backend/railway.toml
+++ b/harmony-backend/railway.toml
@@ -1,6 +1,6 @@
 [build]
 builder = "NIXPACKS"
-buildCommand = "npx prisma generate && npm run build"
+buildCommand = "npm run build"
 
 [deploy]
 startCommand = "bash start.sh"


### PR DESCRIPTION
## Summary

- Reverts `railway.toml` back to `buildCommand = "npm run build"` (the `npx prisma generate &&` prefix introduced in #539 failed with exit code 2 — `npx` cannot reliably resolve the locally-installed `prisma` binary inside nixpacks' restricted build shell)
- Moves `prisma generate` into the `build` npm script in `package.json`: `"build": "prisma generate && tsc"`
- This ensures the Prisma client is regenerated via `./node_modules/.bin/prisma` (always present after the nixpacks install phase) before `tsc` runs, regardless of build cache state

## Test plan

- [ ] Railway build completes without exit code 2
- [ ] `tsc` finds `customTitle`, `customDescription`, `customOgImage` on `GeneratedMetaTags`
- [ ] Railway deployment reaches `success` state
- [ ] Cloud integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)