### PR TITLE
fix: prevent timestamp wrapping causing extra vertical spacing (#536)

### DIFF
--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -545,7 +545,7 @@ export function MessageItem({
           {!isEditing && actionBar}
           {/* Spacer aligns content with the 40px avatar of the header row */}
           <div className='w-10 flex-shrink-0 text-right'>
-            <span className='invisible text-[10px] text-gray-500 group-hover:visible group-focus-within:visible'>
+            <span className='invisible whitespace-nowrap text-[10px] text-gray-500 group-hover:visible group-focus-within:visible'>
               {formatTimeOnly(message.timestamp)}
             </span>
           </div>
@@ -600,7 +600,7 @@ export function MessageItem({
             <span className={authorNameClass}>
               {message.author.displayName ?? message.author.username}
             </span>
-            <span className='text-[11px] text-gray-400'>
+            <span className='whitespace-nowrap text-[11px] text-gray-400'>
               {formatMessageTimestamp(message.timestamp)}
             </span>
             {(message.editedAt || localContent !== undefined) && (


### PR DESCRIPTION
## Summary
- Adds `whitespace-nowrap` to the compact message variant's timestamp span, preventing times like "10:10 PM" from wrapping within the 40px spacer column
- Adds `whitespace-nowrap` to the full header variant's timestamp span to guard against narrow-viewport wrapping
- No layout changes — both fixes are purely typographic constraints on existing elements

## Root Cause
The compact message row uses a `w-10` (40px) spacer div to align content with the avatar above. At `text-[10px]`, a time string like "10:10 PM" exceeds 40px and wraps to a second line, increasing the div's height and adding extra vertical space below that message.

## Test plan
- [x] All 365 frontend unit tests pass
- [ ] Visually verify message rows have consistent spacing regardless of timestamp (e.g., "1:00 AM" vs "10:10 PM")
- [ ] Check across different screen sizes

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)