### PR TITLE
fix: server owner cannot access server or channel settings

### DIFF
--- a/harmony-frontend/src/__tests__/server-settings-access.test.ts
+++ b/harmony-frontend/src/__tests__/server-settings-access.test.ts
@@ -1,5 +1,5 @@
 import { requireServerSettingsAccess } from '@/app/settings/[serverSlug]/settings-access';
-import { getCurrentUser } from '@/services/authService';
+import { getSessionUser } from '@/lib/trpc-client';
 import { getServerAuthenticated, getServerMembersWithRole } from '@/services/serverService';
 
 const mockRedirect = jest.fn((path: string) => {
@@ -14,8 +14,8 @@ jest.mock('next/navigation', () => ({
   notFound: () => mockNotFound(),
 }));
 
-jest.mock('@/services/authService', () => ({
-  getCurrentUser: jest.fn(),
+jest.mock('@/lib/trpc-client', () => ({
+  getSessionUser: jest.fn(),
 }));
 
 jest.mock('@/services/serverService', () => ({
@@ -23,7 +23,7 @@ jest.mock('@/services/serverService', () => ({
   getServerMembersWithRole: jest.fn(),
 }));
 
-const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
+const mockGetSessionUser = getSessionUser as jest.MockedFunction<typeof getSessionUser>;
 const mockGetServerAuthenticated = getServerAuthenticated as jest.MockedFunction<
   typeof getServerAuthenticated
 >;
@@ -42,12 +42,10 @@ describe('requireServerSettingsAccess', () => {
     >;
     mockGetServerAuthenticated.mockResolvedValue(server);
     mockGetServerMembersWithRole.mockResolvedValue([]);
-    mockGetCurrentUser.mockResolvedValue({
+    mockGetSessionUser.mockResolvedValue({
       id: 'owner-1',
       username: 'owner',
       displayName: 'Owner',
-      role: 'member',
-      status: 'online',
       isSystemAdmin: false,
     });
 
@@ -61,12 +59,10 @@ describe('requireServerSettingsAccess', () => {
     >;
     mockGetServerAuthenticated.mockResolvedValue(server);
     mockGetServerMembersWithRole.mockResolvedValue([]);
-    mockGetCurrentUser.mockResolvedValue({
+    mockGetSessionUser.mockResolvedValue({
       id: 'admin-1',
       username: 'admin',
       displayName: 'Admin',
-      role: 'member',
-      status: 'online',
       isSystemAdmin: true,
     });
 
@@ -88,12 +84,10 @@ describe('requireServerSettingsAccess', () => {
         joinedAt: '2026-04-17T00:00:00.000Z',
       },
     ]);
-    mockGetCurrentUser.mockResolvedValue({
+    mockGetSessionUser.mockResolvedValue({
       id: 'admin-member-1',
       username: 'admin-member',
       displayName: 'Admin Member',
-      role: 'member',
-      status: 'online',
       isSystemAdmin: false,
     });
 
@@ -115,12 +109,10 @@ describe('requireServerSettingsAccess', () => {
         joinedAt: '2026-04-17T00:00:00.000Z',
       },
     ]);
-    mockGetCurrentUser.mockResolvedValue({
+    mockGetSessionUser.mockResolvedValue({
       id: 'member-1',
       username: 'member',
       displayName: 'Member',
-      role: 'member',
-      status: 'online',
       isSystemAdmin: false,
     });
 
@@ -144,12 +136,10 @@ describe('requireServerSettingsAccess', () => {
         joinedAt: '2026-04-17T00:00:00.000Z',
       },
     ]);
-    mockGetCurrentUser.mockResolvedValue({
+    mockGetSessionUser.mockResolvedValue({
       id: 'member-1',
       username: 'member',
       displayName: 'Member',
-      role: 'member',
-      status: 'online',
       isSystemAdmin: false,
     });
 

--- a/harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts
+++ b/harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts
@@ -1,11 +1,11 @@
 import { notFound, redirect } from 'next/navigation';
-import { getCurrentUser } from '@/services/authService';
+import { getSessionUser } from '@/lib/trpc-client';
 import { getServerAuthenticated, getServerMembersWithRole } from '@/services/serverService';
 
 type UnauthorizedMode = 'redirect' | 'throw';
 
 function isSettingsAdmin(
-  user: Awaited<ReturnType<typeof getCurrentUser>>,
+  user: Awaited<ReturnType<typeof getSessionUser>>,
   ownerId: string,
 ): boolean {
   return Boolean(user && (user.isSystemAdmin || user.id === ownerId));
@@ -28,7 +28,7 @@ export async function requireServerSettingsAccess(
   const server = await getServerAuthenticated(serverSlug);
   if (!server) notFound();
 
-  const user = await getCurrentUser();
+  const user = await getSessionUser();
   if (isSettingsAdmin(user, server.ownerId)) {
     return server;
   }


### PR DESCRIPTION
## Summary

- `settings-access.ts` was calling `getCurrentUser()` from `authService`, which reads auth tokens from in-memory state and `localStorage` — both unavailable in Next.js Server Components
- As a result, `getCurrentUser()` always returned `null` server-side, causing the permission check to fail and redirect **all** users (including the server owner) away from settings pages
- Fixed by replacing `getCurrentUser()` with `getSessionUser()` from `@/lib/trpc-client`, which reads the httpOnly `auth_token` cookie via Next.js `cookies()` — the correct server-side path

Closes #543

## Test plan

- [ ] Server owner can now open and interact with `/settings/[serverSlug]`
- [ ] Server owner can open and interact with `/settings/[serverSlug]/[channelSlug]`
- [ ] Server admins (non-owner) with admin role still get access via `hasServerAdminAccess`
- [ ] Regular members are still redirected to `/channels/[serverSlug]`
- [ ] All 365 frontend unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)