### PR TITLE
fix: messages no longer persist after page refresh

### DIFF
--- a/harmony-backend/src/services/message.service.ts
+++ b/harmony-backend/src/services/message.service.ts
@@ -127,7 +127,7 @@ export const messageService = {
           { channelId, isDeleted: false },
           clampedLimit + 1,
           cursor,
-          { createdAt: 'asc' },
+          { createdAt: 'desc' },
         );
 
         const hasMore = messages.length > clampedLimit;
@@ -161,16 +161,13 @@ export const messageService = {
         }),
     });
 
-    cacheService
-      .invalidatePattern(
+    try {
+      await cacheService.invalidatePattern(
         `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)}:*`,
-      )
-      .catch((err) =>
-        logger.warn(
-          { err, channelId, serverId },
-          'Failed to invalidate channel message cache after send',
-        ),
       );
+    } catch (err) {
+      logger.warn({ err, channelId, serverId }, 'Failed to invalidate channel message cache after send');
+    }
 
     eventBus
       .publish(EventChannels.MESSAGE_CREATED, {
@@ -434,21 +431,18 @@ export const messageService = {
     });
 
     // Invalidate channel-level and thread-level caches
-    cacheService
-      .invalidatePattern(
+    try {
+      await cacheService.invalidatePattern(
         `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)}:*`,
-      )
-      .catch((err) =>
-        logger.warn(
-          { err, channelId, serverId },
-          'Failed to invalidate channel message cache after reply',
-        ),
       );
-    cacheService
-      .invalidatePattern(`thread:msgs:${sanitizeKeySegment(parentMessageId)}:*`)
-      .catch((err) =>
-        logger.warn({ err, parentMessageId }, 'Failed to invalidate thread cache after reply'),
-      );
+    } catch (err) {
+      logger.warn({ err, channelId, serverId }, 'Failed to invalidate channel message cache after reply');
+    }
+    try {
+      await cacheService.invalidatePattern(`thread:msgs:${sanitizeKeySegment(parentMessageId)}:*`);
+    } catch (err) {
+      logger.warn({ err, parentMessageId }, 'Failed to invalidate thread cache after reply');
+    }
 
     eventBus
       .publish(EventChannels.MESSAGE_CREATED, {

--- a/harmony-frontend/src/services/messageService.ts
+++ b/harmony-frontend/src/services/messageService.ts
@@ -99,9 +99,8 @@ export async function getMessages(
     });
     if (data === null)
       throw new Error(`getMessages: tRPC returned no data for channelId=${channelId}`);
-    // tRPC returns oldest-first; reverse so callers get newest-first.
     return {
-      messages: [...data.messages].reverse().map(m => toFrontendMessage(m, channelId)),
+      messages: data.messages.map(m => toFrontendMessage(m, channelId)),
       hasMore: !!data.nextCursor,
     };
   }


### PR DESCRIPTION
## Summary

- Changed message query sort order from `asc` to `desc` in the backend so messages are returned newest-first directly from the DB, eliminating the need for a client-side reverse
- Converted fire-and-forget cache invalidation calls to `await`-based with try/catch in both `sendMessage` and `sendReply` — previously the cache was invalidated asynchronously, so a page refresh could race ahead of invalidation and serve stale data
- Removed the now-unnecessary `.reverse()` and its stale comment from the frontend `getMessages` service

## Test plan

- [ ] Send a message in a channel, refresh the page — new message should persist
- [ ] Send a reply in a thread, refresh the page — reply should persist
- [ ] Verify message order is correct (newest at bottom) after refresh
- [ ] Confirm no regression in pagination / `hasMore` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)