### PR TITLE
Fix #500: pinned sidebar real-time refresh + close-on-pin

### DIFF
--- a/harmony-frontend/src/components/channel/MessageList.tsx
+++ b/harmony-frontend/src/components/channel/MessageList.tsx
@@ -75,8 +75,6 @@ interface MessageListProps {
   canPin?: boolean;
   /** Called when the user clicks Reply on a message. */
   onReplyClick?: (message: Message) => void;
-  /** Called as soon as the user clicks pin/unpin on a message. */
-  onPinActionStart?: () => void;
   /** Called when the user clicks pin/unpin on a message. */
   onPinToggle?: (messageId: string, pinned: boolean) => void;
 }
@@ -87,7 +85,6 @@ export function MessageList({
   serverId,
   canPin,
   onReplyClick,
-  onPinActionStart,
   onPinToggle,
 }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -169,7 +166,6 @@ export function MessageList({
                   serverId={serverId}
                   canPin={canPin}
                   onReplyClick={onReplyClick}
-                  onPinActionStart={onPinActionStart}
                   onPinToggle={onPinToggle}
                 />
               ))}

--- a/harmony-frontend/src/components/channel/MessageList.tsx
+++ b/harmony-frontend/src/components/channel/MessageList.tsx
@@ -75,9 +75,21 @@ interface MessageListProps {
   canPin?: boolean;
   /** Called when the user clicks Reply on a message. */
   onReplyClick?: (message: Message) => void;
+  /** Called as soon as the user clicks pin/unpin on a message. */
+  onPinActionStart?: () => void;
+  /** Called when the user clicks pin/unpin on a message. */
+  onPinToggle?: (messageId: string, pinned: boolean) => void;
 }
 
-export function MessageList({ channel, messages, serverId, canPin, onReplyClick }: MessageListProps) {
+export function MessageList({
+  channel,
+  messages,
+  serverId,
+  canPin,
+  onReplyClick,
+  onPinActionStart,
+  onPinToggle,
+}: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   // #c7: only auto-scroll when user is already near the bottom
@@ -150,7 +162,16 @@ export function MessageList({ channel, messages, serverId, canPin, onReplyClick 
             <div key={group.messages[0]?.id || gi}>
               {showDateSeparator && <DateSeparator label={group.dateLabel} />}
               {group.messages.map((msg, mi) => (
-                <MessageItem key={msg.id} message={msg} showHeader={mi === 0} serverId={serverId} canPin={canPin} onReplyClick={onReplyClick} />
+                <MessageItem
+                  key={msg.id}
+                  message={msg}
+                  showHeader={mi === 0}
+                  serverId={serverId}
+                  canPin={canPin}
+                  onReplyClick={onReplyClick}
+                  onPinActionStart={onPinActionStart}
+                  onPinToggle={onPinToggle}
+                />
               ))}
             </div>
           );

--- a/harmony-frontend/src/components/channel/PinnedMessagesPanel.tsx
+++ b/harmony-frontend/src/components/channel/PinnedMessagesPanel.tsx
@@ -15,13 +15,7 @@ import type { Message } from '@/types';
 
 function XIcon() {
   return (
-    <svg
-      className='h-4 w-4'
-      viewBox='0 0 24 24'
-      fill='none'
-      stroke='currentColor'
-      strokeWidth={2}
-    >
+    <svg className='h-4 w-4' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth={2}>
       <path d='M18 6 6 18M6 6l12 12' />
     </svg>
   );
@@ -29,13 +23,7 @@ function XIcon() {
 
 function PinIcon() {
   return (
-    <svg
-      className='h-4 w-4'
-      viewBox='0 0 24 24'
-      fill='none'
-      stroke='currentColor'
-      strokeWidth={2}
-    >
+    <svg className='h-4 w-4' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth={2}>
       <path d='M12 17v5' />
       <path d='M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z' />
     </svg>
@@ -76,6 +64,7 @@ export interface PinnedMessagesPanelProps {
   serverId: string;
   channelName: string;
   isOpen: boolean;
+  refreshKey?: number;
   onClose: () => void;
 }
 
@@ -84,6 +73,7 @@ export function PinnedMessagesPanel({
   serverId,
   channelName,
   isOpen,
+  refreshKey = 0,
   onClose,
 }: PinnedMessagesPanelProps) {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -109,8 +99,10 @@ export function PinnedMessagesPanel({
         if (isCurrent) setIsLoading(false);
       }
     })();
-    return () => { isCurrent = false; };
-  }, [isOpen, channelId, serverId]);
+    return () => {
+      isCurrent = false;
+    };
+  }, [isOpen, channelId, serverId, refreshKey]);
 
   return (
     <aside
@@ -137,18 +129,12 @@ export function PinnedMessagesPanel({
 
       {/* Body */}
       <div className='flex-1 overflow-y-auto p-3'>
-        {isLoading && (
-          <p className='text-center text-sm text-gray-400'>Loading…</p>
-        )}
+        {isLoading && <p className='text-center text-sm text-gray-400'>Loading…</p>}
 
-        {!isLoading && error && (
-          <p className='text-center text-sm text-red-400'>{error}</p>
-        )}
+        {!isLoading && error && <p className='text-center text-sm text-red-400'>{error}</p>}
 
         {!isLoading && !error && messages.length === 0 && (
-          <p className='text-center text-sm text-gray-400'>
-            No pinned messages in #{channelName}.
-          </p>
+          <p className='text-center text-sm text-gray-400'>No pinned messages in #{channelName}.</p>
         )}
 
         {!isLoading && !error && messages.length > 0 && (

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -232,10 +232,6 @@ export function HarmonyShell({
     setReplyingTo(message);
   }, []);
 
-  const handlePinActionStart = useCallback(() => {
-    setIsPinsOpen(false);
-  }, []);
-
   const handlePinToggle = useCallback((messageId: string, pinned: boolean) => {
     setLocalMessages(prev =>
       prev.map(message => (message.id === messageId ? { ...message, pinned } : message)),
@@ -503,7 +499,7 @@ export function HarmonyShell({
             isMembersOpen={isMembersOpen}
             onMembersToggle={() => setIsMembersOpen(!isMembersOpen)}
             onSearchOpen={isChannelLocked ? undefined : () => setIsSearchOpen(true)}
-            onPinsOpen={isChannelLocked ? undefined : () => setIsPinsOpen(true)}
+            onPinsOpen={isChannelLocked ? undefined : () => setIsPinsOpen(v => !v)}
             disableMessageActions={isChannelLocked}
             isMenuOpen={isMenuOpen}
             onMenuToggle={() => setIsMenuOpen(v => !v)}
@@ -522,7 +518,6 @@ export function HarmonyShell({
                     serverId={currentServer.id}
                     canPin={canPin}
                     onReplyClick={handleReplyClick}
-                    onPinActionStart={handlePinActionStart}
                     onPinToggle={handlePinToggle}
                   />
                   <MessageInput

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -98,6 +98,7 @@ export function HarmonyShell({
   const setIsMembersOpen = useCallback((val: boolean) => setMembersOverride(val), []);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isPinsOpen, setIsPinsOpen] = useState(false);
+  const [pinsRefreshKey, setPinsRefreshKey] = useState(0);
   // #c25: track mobile channel-sidebar state so aria-expanded on hamburger reflects reality
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   // Local message state so sent messages appear immediately without a page reload
@@ -231,6 +232,17 @@ export function HarmonyShell({
     setReplyingTo(message);
   }, []);
 
+  const handlePinActionStart = useCallback(() => {
+    setIsPinsOpen(false);
+  }, []);
+
+  const handlePinToggle = useCallback((messageId: string, pinned: boolean) => {
+    setLocalMessages(prev =>
+      prev.map(message => (message.id === messageId ? { ...message, pinned } : message)),
+    );
+    setPinsRefreshKey(prev => prev + 1);
+  }, []);
+
   const handleCancelReply = useCallback(() => {
     setReplyingTo(null);
   }, []);
@@ -259,7 +271,15 @@ export function HarmonyShell({
   const handleRealTimeEdited = useCallback(
     (msg: Message) => {
       if (msg.channelId !== currentChannel.id) return;
-      setLocalMessages(prev => prev.map(m => (m.id === msg.id ? msg : m)));
+      let pinStateChanged = false;
+      setLocalMessages(prev =>
+        prev.map(m => {
+          if (m.id !== msg.id) return m;
+          pinStateChanged = Boolean(m.pinned) !== Boolean(msg.pinned);
+          return msg;
+        }),
+      );
+      if (pinStateChanged) setPinsRefreshKey(prev => prev + 1);
     },
     [currentChannel.id],
   );
@@ -502,6 +522,8 @@ export function HarmonyShell({
                     serverId={currentServer.id}
                     canPin={canPin}
                     onReplyClick={handleReplyClick}
+                    onPinActionStart={handlePinActionStart}
+                    onPinToggle={handlePinToggle}
                   />
                   <MessageInput
                     channelId={currentChannel.id}
@@ -527,6 +549,7 @@ export function HarmonyShell({
                 serverId={currentServer.id}
                 channelName={currentChannel.name}
                 isOpen={isPinsOpen}
+                refreshKey={pinsRefreshKey}
                 onClose={() => setIsPinsOpen(false)}
               />
             )}

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -204,7 +204,6 @@ function ActionBar({
   isOwnMessage,
   onEditClick,
   onReplyClick,
-  onPinActionStart,
   onPinToggle,
   onReactionAdd,
 }: {
@@ -216,7 +215,6 @@ function ActionBar({
   isOwnMessage?: boolean;
   onEditClick?: () => void;
   onReplyClick?: () => void;
-  onPinActionStart?: () => void;
   onPinToggle?: (messageId: string, pinned: boolean) => void;
   onReactionAdd?: (emoji: string) => void;
 }) {
@@ -292,7 +290,6 @@ function ActionBar({
   const handlePinToggle = useCallback(async () => {
     if (!serverId) return;
     const nextPinned = !isPinned;
-    onPinActionStart?.();
     setIsMoreOpen(false);
     setPinState('loading');
     const verb = isPinned ? 'unpin' : 'pin';
@@ -328,7 +325,7 @@ function ActionBar({
         setPinErrorMsg('');
       }, 3000);
     }
-  }, [isPinned, messageId, onPinActionStart, onPinToggle, serverId]);
+  }, [isPinned, messageId, onPinToggle, serverId]);
 
   return (
     <div className='absolute -top-3 right-4 z-10 flex items-center rounded-md border border-white/10 bg-[#2f3136] shadow-lg opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto'>
@@ -480,7 +477,6 @@ export function MessageItem({
   canPin,
   serverId,
   onReplyClick,
-  onPinActionStart,
   onPinToggle,
 }: {
   message: Message;
@@ -492,8 +488,6 @@ export function MessageItem({
   serverId?: string;
   /** Called when the user clicks Reply on this message. */
   onReplyClick?: (message: Message) => void;
-  /** Called as soon as the user clicks pin/unpin for this message. */
-  onPinActionStart?: () => void;
   /** Called when the user triggers a pin/unpin action for this message. */
   onPinToggle?: (messageId: string, pinned: boolean) => void;
 }) {
@@ -722,7 +716,6 @@ export function MessageItem({
       isOwnMessage={isOwnMessage}
       onEditClick={handleEditClick}
       onReplyClick={isTopLevel ? handleReplyClick : undefined}
-      onPinActionStart={onPinActionStart}
       onPinToggle={onPinToggle}
       onReactionAdd={handleReactionAdd}
     />

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -114,7 +114,12 @@ function ReplyBanner({ parentMessage }: { parentMessage: NonNullable<Message['pa
       className='mb-0.5 flex min-w-0 items-center gap-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors max-w-full'
       aria-label={`Jump to replied message from ${parentMessage.author.displayName ?? parentMessage.author.username}`}
     >
-      <svg className='h-3 w-3 flex-shrink-0 rotate-180' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
+      <svg
+        className='h-3 w-3 flex-shrink-0 rotate-180'
+        viewBox='0 0 24 24'
+        fill='currentColor'
+        aria-hidden='true'
+      >
         <path d='M10 9V5l-7 7 7 7v-4.1c5 0 8.5 1.6 11 5.1-1-5-4-10-11-11z' />
       </svg>
       {parentMessage.isDeleted ? (
@@ -167,6 +172,8 @@ function ActionBar({
   isOwnMessage,
   onEditClick,
   onReplyClick,
+  onPinActionStart,
+  onPinToggle,
 }: {
   messageId: string;
   serverId?: string;
@@ -175,6 +182,8 @@ function ActionBar({
   isOwnMessage?: boolean;
   onEditClick?: () => void;
   onReplyClick?: () => void;
+  onPinActionStart?: () => void;
+  onPinToggle?: (messageId: string, pinned: boolean) => void;
 }) {
   const { isAuthenticated } = useAuth();
   const router = useRouter();
@@ -210,6 +219,8 @@ function ActionBar({
 
   const handlePinToggle = useCallback(async () => {
     if (!serverId) return;
+    const nextPinned = !isPinned;
+    onPinActionStart?.();
     setIsMoreOpen(false);
     setPinState('loading');
     const verb = isPinned ? 'unpin' : 'pin';
@@ -218,7 +229,8 @@ function ActionBar({
         ? await unpinMessageAction(messageId, serverId)
         : await pinMessageAction(messageId, serverId);
       if (result.ok) {
-        setIsPinned(prev => !prev);
+        setIsPinned(nextPinned);
+        onPinToggle?.(messageId, nextPinned);
         setPinState('success');
         if (successTimerRef.current) clearTimeout(successTimerRef.current);
         successTimerRef.current = setTimeout(() => setPinState('idle'), 2000);
@@ -244,7 +256,7 @@ function ActionBar({
         setPinErrorMsg('');
       }, 3000);
     }
-  }, [isPinned, messageId, serverId]);
+  }, [isPinned, messageId, onPinActionStart, onPinToggle, serverId]);
 
   return (
     <div className='absolute -top-3 right-4 z-10 flex items-center rounded-md border border-white/10 bg-[#2f3136] shadow-lg opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto'>
@@ -330,7 +342,9 @@ function ActionBar({
           </button>
 
           {isMoreOpen && (
-            <div className={`absolute right-0 min-w-[160px] rounded-md border border-white/10 bg-[#18191c] py-1 shadow-xl z-20 ${openUpward ? 'bottom-full mb-1' : 'top-full mt-1'}`}>
+            <div
+              className={`absolute right-0 min-w-[160px] rounded-md border border-white/10 bg-[#18191c] py-1 shadow-xl z-20 ${openUpward ? 'bottom-full mb-1' : 'top-full mt-1'}`}
+            >
               {isOwnMessage && (
                 <button
                   type='button'
@@ -381,6 +395,8 @@ export function MessageItem({
   canPin,
   serverId,
   onReplyClick,
+  onPinActionStart,
+  onPinToggle,
 }: {
   message: Message;
   /** Set to false for grouped follow-up messages from the same author. Hides the avatar and author line. */
@@ -391,6 +407,10 @@ export function MessageItem({
   serverId?: string;
   /** Called when the user clicks Reply on this message. */
   onReplyClick?: (message: Message) => void;
+  /** Called as soon as the user clicks pin/unpin for this message. */
+  onPinActionStart?: () => void;
+  /** Called when the user triggers a pin/unpin action for this message. */
+  onPinToggle?: (messageId: string, pinned: boolean) => void;
 }) {
   const { user } = useAuth();
   const { showToast } = useToast();
@@ -495,6 +515,8 @@ export function MessageItem({
       isOwnMessage={isOwnMessage}
       onEditClick={handleEditClick}
       onReplyClick={handleReplyClick}
+      onPinActionStart={onPinActionStart}
+      onPinToggle={onPinToggle}
     />
   );
 
@@ -540,7 +562,11 @@ export function MessageItem({
         data-message-id={message.id}
         className='group relative flex flex-col px-4 py-0.5 hover:bg-white/[0.02]'
       >
-        {message.parentMessage && <div className='ml-14 pt-1'><ReplyBanner parentMessage={message.parentMessage} /></div>}
+        {message.parentMessage && (
+          <div className='ml-14 pt-1'>
+            <ReplyBanner parentMessage={message.parentMessage} />
+          </div>
+        )}
         <div className='flex gap-4'>
           {!isEditing && actionBar}
           {/* Spacer aligns content with the 40px avatar of the header row */}
@@ -573,7 +599,11 @@ export function MessageItem({
       data-message-id={message.id}
       className='group relative flex flex-col px-4 py-0.5 hover:bg-white/[0.02]'
     >
-      {message.parentMessage && <div className='ml-14 pt-1'><ReplyBanner parentMessage={message.parentMessage} /></div>}
+      {message.parentMessage && (
+        <div className='ml-14 pt-1'>
+          <ReplyBanner parentMessage={message.parentMessage} />
+        </div>
+      )}
       <div className='flex gap-4'>
         {!isEditing && actionBar}
         {/* Avatar */}


### PR DESCRIPTION
## Summary
- fix pinned messages sidebar so it refreshes immediately after successful pin/unpin actions
- keep the pinned sidebar open when pinning/unpinning from message actions
- make the top-bar pinned button a true toggle (open/close)
- trigger sidebar refresh when real-time message edits change `pinned` state
- merge latest `main` and resolve `MessageItem.tsx` conflict while preserving reaction/thread behavior

## Main Changes
- `harmony-frontend/src/components/layout/HarmonyShell.tsx`
- `harmony-frontend/src/components/channel/PinnedMessagesPanel.tsx`
- `harmony-frontend/src/components/channel/MessageList.tsx`
- `harmony-frontend/src/components/message/MessageItem.tsx`

## Verification
- `npx prettier --write src/components/channel/PinnedMessagesPanel.tsx src/components/channel/MessageList.tsx src/components/layout/HarmonyShell.tsx src/components/message/MessageItem.tsx`
- `npx eslint src/components/channel/PinnedMessagesPanel.tsx src/components/channel/MessageList.tsx src/components/layout/HarmonyShell.tsx src/components/message/MessageItem.tsx`
- `npx tsc --noEmit`

## Issue
Closes #500
