### PR TITLE
Add one-command local dev startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ password: HarmonyAdmin123!
 
 ### 3. Start the app for normal local development
 
+One-command startup from repo root:
+
+```bash
+./dev.sh
+```
+
+This script starts Docker (`postgres`, `redis`), applies backend Prisma migrations, then launches backend API, backend worker, and frontend together with shared shutdown on `Ctrl+C`.
+
+Manual startup (three terminals):
+
 Use three terminals:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ password: HarmonyAdmin123!
 One-command startup from repo root:
 
 ```bash
-./dev.sh
+npm run dev
 ```
 
-This script starts Docker (`postgres`, `redis`), applies backend Prisma migrations, then launches backend API, backend worker, and frontend together with shared shutdown on `Ctrl+C`.
+This command runs `./dev.sh`, which starts Docker (`postgres`, `redis`), applies backend Prisma migrations, then launches backend API, backend worker, and frontend together with shared shutdown on `Ctrl+C`.
 
 Manual startup (three terminals):
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,51 +1,72 @@
 #!/usr/bin/env bash
-# dev.sh — start Docker services, backend, and frontend for local development
+# dev.sh — start Docker services, backend API + worker, and frontend for local development
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKEND_DIR="$REPO_ROOT/harmony-backend"
 FRONTEND_DIR="$REPO_ROOT/harmony-frontend"
 
-# ── Docker ────────────────────────────────────────────────────────────────────
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1"
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd npm
+require_cmd npx
+
+# Docker
+
 echo "==> Checking Docker services (postgres, redis)..."
 cd "$BACKEND_DIR"
-
-# Start any services that are not already running
 docker compose up -d
 
 echo "==> Docker services ready."
 
-# ── Prisma migrations ─────────────────────────────────────────────────────────
+# Prisma migrations
+
 echo "==> Applying Prisma migrations..."
-cd "$BACKEND_DIR"
 npx prisma migrate deploy
 echo "==> Migrations up to date."
 
-# ── Backend ───────────────────────────────────────────────────────────────────
-echo "==> Starting backend (npm run dev)..."
-cd "$BACKEND_DIR"
+# Start services
+
+echo "==> Starting backend API (npm run dev)..."
 npm run dev &
 BACKEND_PID=$!
 
-# ── Frontend ──────────────────────────────────────────────────────────────────
+
+echo "==> Starting backend worker (npm run dev:worker)..."
+npm run dev:worker &
+WORKER_PID=$!
+
+
 echo "==> Starting frontend (npm run dev)..."
 cd "$FRONTEND_DIR"
 npm run dev &
 FRONTEND_PID=$!
 
 echo ""
-echo "Backend PID : $BACKEND_PID"
-echo "Frontend PID: $FRONTEND_PID"
+echo "Backend API PID : $BACKEND_PID"
+echo "Backend worker PID: $WORKER_PID"
+echo "Frontend PID    : $FRONTEND_PID"
 echo ""
-echo "Press Ctrl+C to stop both servers."
+echo "Local endpoints:"
+echo "- Frontend: http://localhost:3000"
+echo "- Backend API: http://localhost:4000"
+echo "- Worker health: http://localhost:4100/health"
+echo ""
+echo "Press Ctrl+C to stop all processes."
 
 cleanup() {
   local exit_code="${1:-0}"
   trap - INT TERM EXIT
   echo ""
   echo "Stopping..."
-  kill "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || true
-  wait "$BACKEND_PID" "$FRONTEND_PID" 2>/dev/null || true
+  kill "$BACKEND_PID" "$WORKER_PID" "$FRONTEND_PID" 2>/dev/null || true
+  wait "$BACKEND_PID" "$WORKER_PID" "$FRONTEND_PID" 2>/dev/null || true
   exit "$exit_code"
 }
 
@@ -54,7 +75,7 @@ trap 'cleanup 143' TERM
 trap 'cleanup $?' EXIT
 
 set +e
-wait -n "$BACKEND_PID" "$FRONTEND_PID"
+wait -n "$BACKEND_PID" "$WORKER_PID" "$FRONTEND_PID"
 FIRST_EXIT_CODE=$?
 set -e
 

--- a/dev.sh
+++ b/dev.sh
@@ -34,11 +34,13 @@ echo "==> Migrations up to date."
 # Start services
 
 echo "==> Starting backend API (npm run dev)..."
+cd "$BACKEND_DIR"
 npm run dev &
 BACKEND_PID=$!
 
 
 echo "==> Starting backend worker (npm run dev:worker)..."
+cd "$BACKEND_DIR"
 npm run dev:worker &
 WORKER_PID=$!
 

--- a/dev.sh
+++ b/dev.sh
@@ -75,8 +75,14 @@ trap 'cleanup 143' TERM
 trap 'cleanup $?' EXIT
 
 set +e
-wait -n "$BACKEND_PID" "$WORKER_PID" "$FRONTEND_PID"
-FIRST_EXIT_CODE=$?
-set -e
-
-cleanup "$FIRST_EXIT_CODE"
+while true; do
+  for pid in "$BACKEND_PID" "$WORKER_PID" "$FRONTEND_PID"; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid"
+      FIRST_EXIT_CODE=$?
+      set -e
+      cleanup "$FIRST_EXIT_CODE"
+    fi
+  done
+  sleep 1
+done

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "harmony",
   "private": true,
   "scripts": {
+    "dev": "./dev.sh",
     "test": "node ./scripts/run-root-jest.cjs",
     "jest": "node ./scripts/run-root-jest.cjs",
     "test:backend": "npm --prefix harmony-backend test --",


### PR DESCRIPTION
## Summary
- update `dev.sh` to start Docker services, run `prisma migrate deploy`, and launch backend API + backend worker + frontend together
- add root `npm run dev` that invokes `./dev.sh`
- document one-command local startup in the root README
- make `dev.sh` process monitoring macOS-compatible by replacing `wait -n` with a portable PID-monitor loop

## Verification
- `bash -n dev.sh`
- `git diff --stat`
