### PR TITLE
feat(search): add newest/oldest sort controls to message search

### DIFF
--- a/harmony-frontend/src/__tests__/issue-508-search-sort.test.tsx
+++ b/harmony-frontend/src/__tests__/issue-508-search-sort.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * issue-508-search-sort.test.tsx
+ *
+ * Regression tests for #508: newest/oldest sort controls in SearchModal.
+ * Verifies default ordering (newest first) and that toggling to oldest-first
+ * reorders the same result set correctly.
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { SearchModal } from '../components/channel/SearchModal';
+import type { Message } from '../types';
+
+/* eslint-disable @next/next/no-img-element */
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img alt={props.alt ?? ''} {...props} />
+  ),
+}));
+
+const makeMessage = (id: string, content: string, timestamp: string): Message => ({
+  id,
+  channelId: 'ch-1',
+  authorId: `author-${id}`,
+  author: { id: `author-${id}`, username: `user${id}` },
+  content,
+  timestamp,
+});
+
+// Three messages with distinct timestamps (oldest → newest in array order)
+const MESSAGES: Message[] = [
+  makeMessage('1', 'hello world', '2024-01-01T10:00:00Z'),
+  makeMessage('2', 'hello again', '2024-01-02T10:00:00Z'),
+  makeMessage('3', 'hello there', '2024-01-03T10:00:00Z'),
+];
+
+describe('SearchModal sort controls (issue #508)', () => {
+  const defaultProps = {
+    messages: MESSAGES,
+    isOpen: true,
+    onClose: jest.fn(),
+  };
+
+  it('renders newest-first by default', async () => {
+    render(<SearchModal {...defaultProps} />);
+    await userEvent.type(screen.getByRole('textbox'), 'hello');
+
+    // Wait for debounce (200ms) — userEvent typing is synchronous in jest but
+    // the debounced state update needs a tick; we just query after typing settles.
+    const resultButtons = await screen.findAllByRole('button', { name: /user\d/i });
+    const ids = resultButtons.map(btn => within(btn).getByText(/user\d/).textContent);
+
+    // Newest first: user3 (2024-01-03), user2 (2024-01-02), user1 (2024-01-01)
+    expect(ids).toEqual(['user3', 'user2', 'user1']);
+  });
+
+  it('shows Newest button as active by default', async () => {
+    render(<SearchModal {...defaultProps} />);
+    await userEvent.type(screen.getByRole('textbox'), 'hello');
+
+    await screen.findAllByRole('button', { name: /user\d/i });
+
+    const newestBtn = screen.getByRole('button', { name: 'Newest' });
+    const oldestBtn = screen.getByRole('button', { name: 'Oldest' });
+
+    expect(newestBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(oldestBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('reorders results oldest-first when Oldest is clicked', async () => {
+    render(<SearchModal {...defaultProps} />);
+    await userEvent.type(screen.getByRole('textbox'), 'hello');
+
+    await screen.findAllByRole('button', { name: /user\d/i });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Oldest' }));
+
+    const resultButtons = screen.getAllByRole('button', { name: /user\d/i });
+    const ids = resultButtons.map(btn => within(btn).getByText(/user\d/).textContent);
+
+    // Oldest first: user1 (2024-01-01), user2 (2024-01-02), user3 (2024-01-03)
+    expect(ids).toEqual(['user1', 'user2', 'user3']);
+  });
+
+  it('switches Oldest button to active after toggle', async () => {
+    render(<SearchModal {...defaultProps} />);
+    await userEvent.type(screen.getByRole('textbox'), 'hello');
+
+    await screen.findAllByRole('button', { name: /user\d/i });
+    await userEvent.click(screen.getByRole('button', { name: 'Oldest' }));
+
+    expect(screen.getByRole('button', { name: 'Oldest' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Newest' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('toggles back to newest-first after clicking Newest again', async () => {
+    render(<SearchModal {...defaultProps} />);
+    await userEvent.type(screen.getByRole('textbox'), 'hello');
+
+    await screen.findAllByRole('button', { name: /user\d/i });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Oldest' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Newest' }));
+
+    const resultButtons = screen.getAllByRole('button', { name: /user\d/i });
+    const ids = resultButtons.map(btn => within(btn).getByText(/user\d/).textContent);
+
+    expect(ids).toEqual(['user3', 'user2', 'user1']);
+  });
+});

--- a/harmony-frontend/src/components/channel/SearchModal.tsx
+++ b/harmony-frontend/src/components/channel/SearchModal.tsx
@@ -22,10 +22,20 @@ import type { Message } from '@/types';
 
 // ─── Search logic ─────────────────────────────────────────────────────────────
 
+type SortOrder = 'newest' | 'oldest';
+
 function filterMessages(messages: Message[], query: string): Message[] {
   const q = query.trim().toLowerCase();
   if (!q) return [];
   return messages.filter(m => m.content.toLowerCase().includes(q));
+}
+
+function sortMessages(messages: Message[], order: SortOrder): Message[] {
+  return [...messages].sort((a, b) => {
+    const tA = new Date(a.timestamp).getTime();
+    const tB = new Date(b.timestamp).getTime();
+    return order === 'newest' ? tB - tA : tA - tB;
+  });
 }
 
 // ─── Result item ──────────────────────────────────────────────────────────────
@@ -116,6 +126,7 @@ export function SearchModal({
   const [query, setQuery] = useState('');
   // #c11: debounce search to avoid re-filtering on every keystroke
   const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('newest');
   const inputRef = useRef<HTMLInputElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -126,8 +137,8 @@ export function SearchModal({
 
   // #c40: memoize to avoid re-filtering on unrelated re-renders
   const results = useMemo(
-    () => filterMessages(messages, debouncedQuery),
-    [messages, debouncedQuery],
+    () => sortMessages(filterMessages(messages, debouncedQuery), sortOrder),
+    [messages, debouncedQuery, sortOrder],
   );
 
   // Focus input when opening
@@ -135,9 +146,10 @@ export function SearchModal({
     if (isOpen) {
       setTimeout(() => inputRef.current?.focus(), 0);
     } else {
-      // Resetting query on close is intentional: next open should start clean.
+      // Resetting query and sort on close is intentional: next open should start clean.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setQuery('');
+      setSortOrder('newest');
     }
   }, [isOpen]);
 
@@ -277,9 +289,37 @@ export function SearchModal({
           {/* Result list */}
           {results.length > 0 && (
             <div className='px-2'>
-              <p className='mb-1 px-1 text-xs text-gray-400'>
-                {results.length} result{results.length !== 1 ? 's' : ''}
-              </p>
+              <div className='mb-1 flex items-center justify-between px-1'>
+                <p className='text-xs text-gray-400'>
+                  {results.length} result{results.length !== 1 ? 's' : ''}
+                </p>
+                <div className='flex items-center gap-1' role='group' aria-label='Sort order'>
+                  <button
+                    onClick={() => setSortOrder('newest')}
+                    aria-pressed={sortOrder === 'newest'}
+                    className={cn(
+                      'rounded px-2 py-0.5 text-xs transition-colors',
+                      sortOrder === 'newest'
+                        ? 'bg-indigo-100 font-medium text-indigo-700'
+                        : 'text-gray-400 hover:bg-gray-100 hover:text-gray-600',
+                    )}
+                  >
+                    Newest
+                  </button>
+                  <button
+                    onClick={() => setSortOrder('oldest')}
+                    aria-pressed={sortOrder === 'oldest'}
+                    className={cn(
+                      'rounded px-2 py-0.5 text-xs transition-colors',
+                      sortOrder === 'oldest'
+                        ? 'bg-indigo-100 font-medium text-indigo-700'
+                        : 'text-gray-400 hover:bg-gray-100 hover:text-gray-600',
+                    )}
+                  >
+                    Oldest
+                  </button>
+                </div>
+              </div>
               {results.map(message => (
                 <ResultItem
                   key={message.id}


### PR DESCRIPTION
## Summary
- Adds **Newest** / **Oldest** toggle buttons to the search results header in `SearchModal`
- Results are sorted by timestamp using the selected order before rendering
- Sort defaults to **Newest** and resets on modal close
- Sort controls only appear when there are results — no UI noise on empty/initial state

## Changes
- `harmony-frontend/src/components/channel/SearchModal.tsx`: added `SortOrder` type, `sortMessages` helper, `sortOrder` state, sort toggle buttons in the results header

## Testing
- All 395 existing frontend unit tests pass
- ESLint clean (no errors, no warnings)

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)