### PR TITLE
Fix invite generation crash when creator relation is missing

### DIFF
--- a/harmony-backend/src/repositories/invite.repository.ts
+++ b/harmony-backend/src/repositories/invite.repository.ts
@@ -33,6 +33,15 @@ export const inviteRepository = {
     return client.serverInvite.findUnique({ where: { id } });
   },
 
+  findByIdWithCreator(id: string, client: Client = prisma) {
+    return client.serverInvite.findUnique({
+      where: { id },
+      include: {
+        creator: { select: { id: true, username: true, displayName: true } },
+      },
+    });
+  },
+
   create(data: Prisma.ServerInviteUncheckedCreateInput, client: Client = prisma) {
     return client.serverInvite.create({ data });
   },

--- a/harmony-backend/src/services/invite.service.ts
+++ b/harmony-backend/src/services/invite.service.ts
@@ -41,18 +41,24 @@ export const inviteService = {
     serverId: string,
     creatorId: string,
     opts?: { maxUses?: number; expiresAt?: Date },
-  ): Promise<ServerInvite> {
+  ): Promise<InviteWithCreator> {
     const server = await serverRepository.findByIdSelect(serverId, { id: true });
     if (!server) throw new TRPCError({ code: 'NOT_FOUND', message: 'Server not found' });
 
     const code = generateCode();
-    return inviteRepository.create({
+    const invite = await inviteRepository.create({
       code,
       serverId,
       creatorId,
       maxUses: opts?.maxUses ?? null,
       expiresAt: opts?.expiresAt ?? null,
     });
+
+    const inviteWithCreator = await inviteRepository.findByIdWithCreator(invite.id);
+    if (!inviteWithCreator) {
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to load created invite' });
+    }
+    return inviteWithCreator as InviteWithCreator;
   },
 
   /**

--- a/harmony-backend/tests/invite.service.test.ts
+++ b/harmony-backend/tests/invite.service.test.ts
@@ -1,5 +1,4 @@
 import { PrismaClient } from '@prisma/client';
-import { TRPCError } from '@trpc/server';
 import { redis } from '../src/db/redis';
 import { inviteService } from '../src/services/invite.service';
 
@@ -91,6 +90,11 @@ describe('inviteService (integration)', () => {
       expect(invite.serverId).toBe(publicServerId);
       expect(invite.creatorId).toBe(ownerUserId);
       expect(invite.uses).toBe(0);
+      expect(invite.creator).toMatchObject({
+        id: ownerUserId,
+        displayName: 'Invite Owner',
+      });
+      expect(invite.creator.username).toContain('inv_owner_');
     });
 
     it('creates an invite for a private server', async () => {


### PR DESCRIPTION
## Summary
- fix runtime crash in Server Settings invites after generating a new invite
- make `invite.generate` return invite data with `creator` populated
- keep generated-invite shape consistent with `invite.list`

## Reproduction
1. Open **Server Settings -> Invites**
2. Click **Generate Invite Link**
3. Runtime error occurs in `InviteSection.tsx`:
   `can't access property "displayName", invite.creator is undefined`

## Root Cause
`InviteSection` renders `invite.creator.displayName`, but `invite.generate` returned a raw `ServerInvite` without relation data. The newly generated invite was prepended to local state and rendered immediately, so `invite.creator` was `undefined`.

## Fix
Normalize `invite.generate` response shape:
- create invite
- re-fetch by id with `creator` relation included
- return `InviteWithCreator`

## Validation
- `npm --prefix harmony-backend run build` passed
- `npm --prefix harmony-backend run lint` passed (existing unrelated warnings remain)
- `npm --prefix harmony-backend test -- --runInBand invite` failed locally because Postgres at `localhost:5432` is unavailable in this environment

Closes #557
