### PR TITLE
feat(search): scroll to and highlight matched message on result selection (#507)

### DIFF
--- a/harmony-frontend/src/app/globals.css
+++ b/harmony-frontend/src/app/globals.css
@@ -18,3 +18,12 @@ body {
   color: var(--foreground);
   font-family: var(--font-inter);
 }
+
+@keyframes message-highlight-flash {
+  0% { background-color: rgba(250, 204, 21, 0.25); }
+  100% { background-color: transparent; }
+}
+
+.message-highlight-flash {
+  animation: message-highlight-flash 2s ease-out forwards;
+}

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -577,6 +577,15 @@ export function HarmonyShell({
             channelName={currentChannel.name}
             isOpen={isSearchOpen}
             onClose={() => setIsSearchOpen(false)}
+            onResultSelect={message => {
+              const el = document.querySelector(`[data-message-id="${message.id}"]`);
+              if (!el) return;
+              el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+              el.classList.remove('message-highlight-flash');
+              // Force a reflow so re-selecting the same message re-triggers the animation.
+              void (el as HTMLElement).offsetWidth;
+              el.classList.add('message-highlight-flash');
+            }}
           />
         )}
 


### PR DESCRIPTION
## Summary

- Clicking a search result now scrolls the chat view smoothly to the matched message.
- The target message receives a brief yellow highlight flash so the user can easily identify it after navigation.
- Re-selecting the same result replays the animation (forced reflow pattern).

## Implementation

- Added `@keyframes message-highlight-flash` to `globals.css` — a 2-second ease-out fade from yellow to transparent.
- Wired `onResultSelect` in `HarmonyShell.tsx` using the existing `[data-message-id]` DOM attribute already present on every message row (same pattern used by reply banner jump-to).
- No new state, context, or components needed.

## Test plan

- [ ] Open the search modal (Ctrl+K) in a channel with messages.
- [ ] Type a query and click a result — confirm the chat scrolls to the message and the row briefly flashes yellow.
- [ ] Click the same result again — confirm the highlight replays.
- [ ] Verify all 393 frontend unit tests still pass (`npm test` in `harmony-frontend`).

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)