### PR TITLE
fix: prevent page not found when generating invite links (#547)

### DIFF
--- a/harmony-frontend/src/__tests__/server-settings-access.test.ts
+++ b/harmony-frontend/src/__tests__/server-settings-access.test.ts
@@ -147,9 +147,19 @@ describe('requireServerSettingsAccess', () => {
     expect(mockRedirect).not.toHaveBeenCalled();
   });
 
-  it('delegates missing servers to notFound', async () => {
+  it('delegates missing servers to notFound in redirect mode', async () => {
     mockGetServerAuthenticated.mockResolvedValue(null);
 
     await expect(requireServerSettingsAccess('missing-server')).rejects.toThrow('NOT_FOUND');
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  it('throws a plain error for missing servers in throw mode (no notFound)', async () => {
+    mockGetServerAuthenticated.mockResolvedValue(null);
+
+    await expect(requireServerSettingsAccess('missing-server', 'throw')).rejects.toThrow(
+      'Server not found',
+    );
+    expect(mockNotFound).not.toHaveBeenCalled();
   });
 });

--- a/harmony-frontend/src/app/auth/login/page.tsx
+++ b/harmony-frontend/src/app/auth/login/page.tsx
@@ -14,6 +14,7 @@ function LoginForm() {
   const { login } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const rawReturnUrl = searchParams.get('returnUrl') ?? '';
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -22,9 +23,10 @@ function LoginForm() {
 
     try {
       await login(email, password);
-      const raw = searchParams.get('returnUrl') ?? '';
       const returnUrl =
-        raw.startsWith('/') && !raw.startsWith('//') ? raw.replace(/^\/c\//, '/channels/') : null;
+        rawReturnUrl.startsWith('/') && !rawReturnUrl.startsWith('//')
+          ? rawReturnUrl.replace(/^\/c\//, '/channels/')
+          : null;
       router.push(returnUrl ?? '/channels');
     } catch (err) {
       setError(getUserErrorMessage(err, 'Invalid credentials. Please try again.'));
@@ -96,7 +98,14 @@ function LoginForm() {
 
           <p className='text-sm text-discord-text-muted'>
             Need an account?{' '}
-            <Link href='/auth/signup' className='text-discord-accent hover:underline'>
+            <Link
+              href={
+                rawReturnUrl.startsWith('/') && !rawReturnUrl.startsWith('//')
+                  ? `/auth/signup?returnUrl=${encodeURIComponent(rawReturnUrl)}`
+                  : '/auth/signup'
+              }
+              className='text-discord-accent hover:underline'
+            >
               Register
             </Link>
           </p>

--- a/harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts
+++ b/harmony-frontend/src/app/settings/[serverSlug]/settings-access.ts
@@ -26,7 +26,13 @@ export async function requireServerSettingsAccess(
   mode: UnauthorizedMode = 'redirect',
 ) {
   const server = await getServerAuthenticated(serverSlug);
-  if (!server) notFound();
+  if (!server) {
+    // In server-action mode, notFound() propagates as a page-level 404 that
+    // bypasses the client try-catch. Throw a plain error instead so the
+    // action's caller can surface it as an inline message.
+    if (mode === 'throw') throw new Error('Server not found');
+    notFound();
+  }
 
   const user = await getSessionUser();
   if (isSettingsAdmin(user, server.ownerId)) {


### PR DESCRIPTION
## Summary

- `requireServerSettingsAccess` was calling `notFound()` even in `'throw'` mode (used by all server actions like `generateInviteAction`). In Next.js App Router, `notFound()` inside a server action propagates as a page-level 404 response that bypasses the client `try/catch` — causing the settings page to show 404 instead of an inline error. Fixed by throwing a plain `Error('Server not found')` in `'throw'` mode.
- The login page's "Register" link did not forward `returnUrl`, so new users following an invite link who clicked "Register" were dropped at `/channels` after signup. Fixed by propagating `returnUrl` to `/auth/signup?returnUrl=…`.
- 2 new test cases added to `server-settings-access.test.ts`; all 386 frontend tests pass.

## Test plan

- [ ] Navigate to server settings → Invites → click "Generate Invite Link" — no 404, invite appears inline
- [ ] Open invite link while logged out → redirected to login → click "Register" → after signup, lands back on `/invite/[code]`
- [ ] Open invite link while logged out → log in → lands back on `/invite/[code]`
- [ ] `npm test` in `harmony-frontend/` passes (386 tests)

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)