### PR TITLE
fix(voice): clear stale participant entry after failed voice join

### DIFF
--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -436,7 +436,7 @@ export function HarmonyShell({
   }, [isChannelLocked]);
 
   return (
-    <VoiceProvider serverId={currentServer.id} voiceChannelIds={voiceChannelIds}>
+    <VoiceProvider serverId={currentServer.id} voiceChannelIds={voiceChannelIds} currentUserId={authUser?.id}>
       <div className='flex h-screen overflow-hidden bg-[#202225] font-sans'>
         {/* Skip-to-content: visually hidden, appears on keyboard focus (WCAG 2.4.1) */}
         <a

--- a/harmony-frontend/src/contexts/VoiceContext.tsx
+++ b/harmony-frontend/src/contexts/VoiceContext.tsx
@@ -101,9 +101,15 @@ interface VoiceProviderProps {
   serverId: string;
   /** IDs of all voice channels in the current server. */
   voiceChannelIds: string[];
+  /**
+   * The authenticated user's ID. Used to clean up channelParticipants when
+   * a join fails before a Twilio room is established — at that point
+   * room.localParticipant.identity is not yet available.
+   */
+  currentUserId?: string;
 }
 
-export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProviderProps) {
+export function VoiceProvider({ children, serverId, voiceChannelIds, currentUserId }: VoiceProviderProps) {
   const { showToast } = useToast();
 
   const [connectedChannelId, setConnectedChannelId] = useState<string | null>(null);
@@ -271,6 +277,11 @@ export function VoiceProvider({ children, serverId, voiceChannelIds }: VoiceProv
 
         connectedChannelIdRef.current = channelId;
         connectedServerIdRef.current = serverId;
+        // Set local identity now so leaveChannel() can clean up channelParticipants
+        // even if TwilioVideo.connect subsequently fails (room.localParticipant is
+        // not available until after a successful connect). The Twilio token uses
+        // userId as the identity (voice.service.ts), so this value is authoritative.
+        localParticipantIdentityRef.current = currentUserId ?? null;
         setConnectedChannelId(channelId);
         setConnectedChannelName(channelName);
         setParticipants(initialParticipants);


### PR DESCRIPTION
## Summary

Fixes #492 — when a voice channel join fails after the backend `voice.join` tRPC call succeeds (e.g. microphone access denied, Twilio network error), the sidebar was left showing a stale participant entry for the local user.

**Root cause:** `localParticipantIdentityRef.current` was only assigned from `room.localParticipant.identity` _after_ a successful `TwilioVideo.connect()`. In the failure path, Twilio never connected so the ref stayed `null`, causing the cleanup in `leaveChannel()` to skip the `channelParticipants` filter — leaving a ghost entry in the sidebar.

**Fix:** Add `currentUserId` prop to `VoiceProvider` and set `localParticipantIdentityRef.current = currentUserId` immediately after token validation (before `TwilioVideo.connect`). The Twilio token already uses `userId` as its identity (see `voice.service.ts:152`), so the value is authoritative even before the room connects.

## Changes

- **`VoiceContext.tsx`** — add `currentUserId?: string` to `VoiceProviderProps`; set `localParticipantIdentityRef.current` from it after `voice.join` validation, before the `TwilioVideo.connect` call
- **`HarmonyShell.tsx`** — pass `currentUserId={authUser?.id}` to `VoiceProvider`

## Test plan

- [ ] All 397 frontend tests pass (`npm test` in `harmony-frontend`)
- [ ] Backend voice service tests pass (`voice.service.test.ts`)
- Manual: deny microphone permission in browser → click a voice channel → confirm error toast appears, sidebar shows no stale participant entry, join button re-enables for retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)