### PR TITLE
security: fix HIGH severity issues #425 #426 #427 #429 #430

### DIFF
--- a/harmony-backend/jest.config.js
+++ b/harmony-backend/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  setupFiles: ['dotenv/config'],
+  setupFiles: ['dotenv/config', '<rootDir>/tests/setup-env.ts'],
   roots: ['<rootDir>/tests'],
   testMatch: ['**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'json'],

--- a/harmony-backend/src/lib/admin.utils.ts
+++ b/harmony-backend/src/lib/admin.utils.ts
@@ -1,9 +1,11 @@
 /**
- * Temporary dev-only system admin utilities.
+ * Dev-only system admin utilities.
  *
- * The admin override lets a developer log in as admin@harmony.dev / admin
- * and bypass all permission and ownership checks. Remove this file before
- * deploying to production.
+ * The admin override is only active when BOTH conditions hold:
+ *   NODE_ENV === 'development'  AND  ENABLE_DEV_ADMIN === 'true'
+ *
+ * This ensures the backdoor is never reachable on staging, CI, e2e, or
+ * production environments — only on an explicitly opted-in local machine.
  */
 
 import { prisma } from '../db/prisma';
@@ -19,13 +21,17 @@ export const RESERVED_USERNAMES = new Set<string>(['admin']);
 /** Cached admin user ID to avoid repeated DB lookups. */
 let _adminUserId: string | null = null;
 
+function isDevAdminEnabled(): boolean {
+  return process.env.NODE_ENV === 'development' && process.env.ENABLE_DEV_ADMIN === 'true';
+}
+
 /**
  * Returns true if the given userId belongs to the system admin account.
- * Never returns true in production — this utility is dev/test only.
+ * Only active when NODE_ENV=development AND ENABLE_DEV_ADMIN=true.
  * Caches the result after the first positive lookup.
  */
 export async function isSystemAdmin(userId: string): Promise<boolean> {
-  if (process.env.NODE_ENV === 'production') return false;
+  if (!isDevAdminEnabled()) return false;
   if (_adminUserId === userId) return true;
   const user = await prisma.user.findUnique({
     where: { id: userId },

--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -1,21 +1,26 @@
 /**
  * SSE Router — Issue #180
  *
- * GET /api/events/channel/:channelId?token=<accessToken>
+ * POST /api/events/ticket
+ *   Requires Authorization: Bearer <accessToken>.
+ *   Returns a one-shot nonce stored in Redis for 60 s.
  *
- * Streams real-time message events to authenticated, authorised clients using
- * Server-Sent Events.
+ * GET /api/events/channel/:channelId?ticket=<nonce>
+ * GET /api/events/server/:serverId?ticket=<nonce>
+ * GET /api/events/user?ticket=<nonce>
  *
- * Auth: the browser's native EventSource API cannot send custom headers, so the
- * access token is accepted via a `?token=` query parameter instead of the
- * Authorization header. The token is validated identically to requireAuth.
+ * Streams real-time events using Server-Sent Events.
  *
- * Authorisation: verifies the authenticated user is a member of the server that
- * owns the requested channel, preventing access to PRIVATE channels by non-members.
+ * Auth: EventSource cannot send custom headers, so a short-lived one-shot ticket
+ * is used instead of passing the JWT directly in the query string. The frontend
+ * calls POST /api/events/ticket first, then opens the EventSource with ?ticket=<nonce>.
+ * The nonce is consumed immediately on first use, preventing replay.
  */
 
+import crypto from 'crypto';
 import { Router, Request, Response } from 'express';
 import { prisma } from '../db/prisma';
+import { redis } from '../db/redis';
 import { createLogger } from '../lib/logger';
 import { authService } from '../services/auth.service';
 import { eventBus, EventChannels } from '../events/eventBus';
@@ -49,6 +54,57 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 function isValidUUID(id: string): boolean {
   return UUID_RE.test(id.trim());
 }
+
+// ─── SSE ticket helpers ───────────────────────────────────────────────────────
+
+const TICKET_TTL_SECONDS = 60;
+
+function ticketKey(nonce: string): string {
+  return `sse:ticket:${nonce}`;
+}
+
+/**
+ * Exchange a one-shot nonce for the userId it was issued for, then delete it.
+ * Returns null if the nonce does not exist or has expired.
+ */
+async function redeemTicket(nonce: string): Promise<string | null> {
+  const key = ticketKey(nonce);
+  const userId = await redis.get(key);
+  if (!userId) return null;
+  await redis.del(key);
+  return userId;
+}
+
+// ─── Ticket issuance endpoint ─────────────────────────────────────────────────
+
+/**
+ * POST /api/events/ticket
+ *
+ * Requires Authorization: Bearer <accessToken>.
+ * Returns { ticket: <nonce> } — the nonce must be passed as ?ticket=<nonce>
+ * when opening an SSE connection. The nonce is valid for 60 seconds and can
+ * only be used once.
+ */
+eventsRouter.post('/ticket', async (req: Request, res: Response) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    return;
+  }
+
+  let userId: string;
+  try {
+    const payload = authService.verifyAccessToken(authHeader.slice(7));
+    userId = payload.sub;
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired access token' });
+    return;
+  }
+
+  const nonce = crypto.randomUUID();
+  await redis.set(ticketKey(nonce), userId, 'EX', TICKET_TTL_SECONDS);
+  res.json({ ticket: nonce });
+});
 
 // ─── Prisma select shape (matches frontend Message type) ──────────────────────
 
@@ -191,19 +247,16 @@ eventsRouter.get('/channel/:channelId', async (req: Request, res: Response) => {
     return;
   }
 
-  // ── Auth — accept token via query param (EventSource cannot send headers) ──
-  const token = typeof req.query.token === 'string' ? req.query.token : null;
-  if (!token) {
-    res.status(401).json({ error: 'Missing token query parameter' });
+  // ── Auth — one-shot ticket exchanged via POST /api/events/ticket ─────────
+  const ticket = typeof req.query.ticket === 'string' ? req.query.ticket : null;
+  if (!ticket) {
+    res.status(401).json({ error: 'Missing ticket query parameter' });
     return;
   }
 
-  let userId: string;
-  try {
-    const payload = authService.verifyAccessToken(token);
-    userId = payload.sub;
-  } catch {
-    res.status(401).json({ error: 'Invalid or expired access token' });
+  const userId = await redeemTicket(ticket);
+  if (!userId) {
+    res.status(401).json({ error: 'Invalid or expired SSE ticket' });
     return;
   }
 
@@ -414,14 +467,14 @@ const CHANNEL_SSE_SELECT = {
 // ─── Server-scoped SSE route — channel list updates ───────────────────────────
 
 /**
- * GET /api/events/server/:serverId?token=<accessToken>
+ * GET /api/events/server/:serverId?ticket=<nonce>
  *
  * Streams real-time server events to authenticated, authorised clients using
  * Server-Sent Events. Scoped to a server so all members see the same sidebar,
  * member, message, and server updates regardless of which channel they are viewing.
  *
- * Auth: same token-via-query-param pattern as /channel/:channelId (EventSource cannot
- * send custom headers).
+ * Auth: one-shot ticket pattern — call POST /api/events/ticket first, then
+ * pass the returned nonce as ?ticket=<nonce>.
  *
  * Authorisation: user must be a member of the server.
  */
@@ -433,19 +486,16 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     return;
   }
 
-  // ── Auth ─────────────────────────────────────────────────────────────────
-  const token = typeof req.query.token === 'string' ? req.query.token : null;
-  if (!token) {
-    res.status(401).json({ error: 'Missing token query parameter' });
+  // ── Auth — one-shot ticket ────────────────────────────────────────────────
+  const ticket = typeof req.query.ticket === 'string' ? req.query.ticket : null;
+  if (!ticket) {
+    res.status(401).json({ error: 'Missing ticket query parameter' });
     return;
   }
 
-  let userId: string;
-  try {
-    const payload = authService.verifyAccessToken(token);
-    userId = payload.sub;
-  } catch {
-    res.status(401).json({ error: 'Invalid or expired access token' });
+  const userId = await redeemTicket(ticket);
+  if (!userId) {
+    res.status(401).json({ error: 'Invalid or expired SSE ticket' });
     return;
   }
 
@@ -806,24 +856,21 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
 // ─── User-scoped notification SSE route ──────────────────────────────────────
 
 /**
- * GET /api/events/user?token=<accessToken>
+ * GET /api/events/user?ticket=<nonce>
  *
  * Streams real-time mention notifications to the authenticated user.
  * Each connected client only receives events addressed to their own userId.
  */
 eventsRouter.get('/user', async (req: Request, res: Response) => {
-  const token = typeof req.query.token === 'string' ? req.query.token : null;
-  if (!token) {
-    res.status(401).json({ error: 'Missing token query parameter' });
+  const ticket = typeof req.query.ticket === 'string' ? req.query.ticket : null;
+  if (!ticket) {
+    res.status(401).json({ error: 'Missing ticket query parameter' });
     return;
   }
 
-  let userId: string;
-  try {
-    const payload = authService.verifyAccessToken(token);
-    userId = payload.sub;
-  } catch {
-    res.status(401).json({ error: 'Invalid or expired access token' });
+  const userId = await redeemTicket(ticket);
+  if (!userId) {
+    res.status(401).json({ error: 'Invalid or expired SSE ticket' });
     return;
   }
 

--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -64,15 +64,25 @@ function ticketKey(nonce: string): string {
 }
 
 /**
+ * Atomically read and delete the ticket key so concurrent requests cannot both
+ * redeem the same one-shot nonce. Lua works on all Redis versions (GETDEL alone is 6.2+).
+ */
+const REDEEM_TICKET_LUA = `
+local v = redis.call('GET', KEYS[1])
+if v == false then return false end
+redis.call('DEL', KEYS[1])
+return v
+`;
+
+/**
  * Exchange a one-shot nonce for the userId it was issued for, then delete it.
  * Returns null if the nonce does not exist or has expired.
  */
 async function redeemTicket(nonce: string): Promise<string | null> {
   const key = ticketKey(nonce);
-  const userId = await redis.get(key);
-  if (!userId) return null;
-  await redis.del(key);
-  return userId;
+  const raw = (await redis.eval(REDEEM_TICKET_LUA, 1, key)) as string | boolean | null;
+  if (raw === false || raw == null) return null;
+  return typeof raw === 'string' ? raw : String(raw);
 }
 
 // ─── Ticket issuance endpoint ─────────────────────────────────────────────────

--- a/harmony-backend/src/services/auth.service.ts
+++ b/harmony-backend/src/services/auth.service.ts
@@ -19,20 +19,14 @@ const DEV_ADMIN_PASSWORD_SALT = 'f6f0e4f9f5f841caa4dd4ac4ef0bf9e8';
 
 const ACCESS_SECRET = (() => {
   const value = process.env.JWT_ACCESS_SECRET;
-  // istanbul ignore next -- NODE_ENV guard makes this unreachable in Jest (ts-jest transform cache)
-  if (!value && process.env.NODE_ENV !== 'test') {
-    throw new Error('JWT_ACCESS_SECRET environment variable is not set');
-  }
-  return value ?? 'dev-access-secret-change-in-prod';
+  if (!value) throw new Error('JWT_ACCESS_SECRET environment variable is not set');
+  return value;
 })();
 
 const REFRESH_SECRET = (() => {
   const value = process.env.JWT_REFRESH_SECRET;
-  // istanbul ignore next -- NODE_ENV guard makes this unreachable in Jest (ts-jest transform cache)
-  if (!value && process.env.NODE_ENV !== 'test') {
-    throw new Error('JWT_REFRESH_SECRET environment variable is not set');
-  }
-  return value ?? 'dev-refresh-secret-change-in-prod';
+  if (!value) throw new Error('JWT_REFRESH_SECRET environment variable is not set');
+  return value;
 })();
 
 const ACCESS_EXPIRES_IN = process.env.JWT_ACCESS_EXPIRES_IN ?? '15m';
@@ -172,7 +166,7 @@ export const authService = {
   },
 
   async getLoginPasswordSalt(email: string): Promise<string> {
-    if (process.env.NODE_ENV !== 'production' && email === ADMIN_EMAIL) {
+    if (process.env.NODE_ENV === 'development' && process.env.ENABLE_DEV_ADMIN === 'true' && email === ADMIN_EMAIL) {
       return DEV_ADMIN_PASSWORD_SALT;
     }
 
@@ -248,11 +242,11 @@ export const authService = {
   },
 
   async login(email: string, passwordVerifier: string): Promise<AuthTokens> {
-    // ── Dev-only admin override ────────────────────────────────────────────
-    // Login as admin@harmony.dev / admin to get a system-admin account that
-    // bypasses all permission and ownership checks. Remove before production.
+    // Dev-only admin override — requires NODE_ENV=development AND ENABLE_DEV_ADMIN=true.
+    // Never active on staging, CI, e2e, or production environments.
     if (
-      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV === 'development' &&
+      process.env.ENABLE_DEV_ADMIN === 'true' &&
       email === ADMIN_EMAIL &&
       passwordVerifier === createDevAdminPasswordVerifier()
     ) {

--- a/harmony-backend/src/trpc/init.ts
+++ b/harmony-backend/src/trpc/init.ts
@@ -31,7 +31,7 @@ const t = initTRPC.context<TRPCContext>().create({
       ...shape,
       data: {
         ...shape.data,
-        stack: process.env.NODE_ENV === 'development' ? shape.data.stack : undefined,
+        stack: process.env.NODE_ENV === 'development' && process.env.EXPOSE_STACK === '1' ? shape.data.stack : undefined,
       },
     };
   },

--- a/harmony-backend/src/trpc/routers/message.router.ts
+++ b/harmony-backend/src/trpc/routers/message.router.ts
@@ -1,6 +1,19 @@
 import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
 import { router, withPermission } from '../init';
 import { messageService } from '../../services/message.service';
+
+/**
+ * Returns the base URL that all attachment URLs must start with.
+ * Computed from STORAGE_PROVIDER and the corresponding base URL env var.
+ * Returns null when the base URL is not configured (skips validation).
+ */
+function getAllowedAttachmentBase(): string | null {
+  if (process.env.STORAGE_PROVIDER === 's3') {
+    return process.env.R2_PUBLIC_URL ?? null;
+  }
+  return process.env.LOCAL_UPLOAD_BASE_URL ?? 'http://localhost:4000';
+}
 
 // sizeBytes is accepted as a plain number (JSON-safe).
 // The service layer casts it to BigInt before writing to Prisma.
@@ -44,15 +57,25 @@ export const messageRouter = router({
         { message: 'Message must have content or at least one attachment.' },
       ),
     )
-    .mutation(({ input, ctx }) =>
-      messageService.sendMessage({
+    .mutation(({ input, ctx }) => {
+      if (input.attachments?.length) {
+        const allowedBase = getAllowedAttachmentBase();
+        if (allowedBase) {
+          for (const att of input.attachments) {
+            if (!att.url.startsWith(allowedBase)) {
+              throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid attachment URL' });
+            }
+          }
+        }
+      }
+      return messageService.sendMessage({
         serverId: input.serverId,
         channelId: input.channelId,
         authorId: ctx.userId,
         content: input.content,
         attachments: input.attachments,
-      }),
-    ),
+      });
+    }),
 
   /**
    * Edit the content of a message the caller authored.

--- a/harmony-backend/src/trpc/routers/message.router.ts
+++ b/harmony-backend/src/trpc/routers/message.router.ts
@@ -15,6 +15,30 @@ function getAllowedAttachmentBase(): string | null {
   return process.env.LOCAL_UPLOAD_BASE_URL ?? 'http://localhost:4000';
 }
 
+/**
+ * Reject prefix-stripping tricks (e.g. https://allowed.example.com.evil/...) by
+ * comparing URL origins and, when the allowlist has a path, requiring a path prefix.
+ */
+function isAllowedAttachmentUrl(attUrl: string, allowedBase: string): boolean {
+  let allowed: URL;
+  let candidate: URL;
+  try {
+    allowed = new URL(allowedBase);
+    candidate = new URL(attUrl);
+  } catch {
+    return false;
+  }
+  if (candidate.origin !== allowed.origin) {
+    return false;
+  }
+  const basePath = allowed.pathname.replace(/\/$/, '') || '';
+  if (!basePath) {
+    return true;
+  }
+  const p = candidate.pathname;
+  return p === basePath || p.startsWith(`${basePath}/`);
+}
+
 // sizeBytes is accepted as a plain number (JSON-safe).
 // The service layer casts it to BigInt before writing to Prisma.
 const AttachmentInputSchema = z.object({
@@ -62,7 +86,7 @@ export const messageRouter = router({
         const allowedBase = getAllowedAttachmentBase();
         if (allowedBase) {
           for (const att of input.attachments) {
-            if (!att.url.startsWith(allowedBase)) {
+            if (!isAllowedAttachmentUrl(att.url, allowedBase)) {
               throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid attachment URL' });
             }
           }

--- a/harmony-backend/tests/admin.utils.test.ts
+++ b/harmony-backend/tests/admin.utils.test.ts
@@ -24,15 +24,28 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('isSystemAdmin — production env guard (issue #466)', () => {
-  const originalEnv = process.env.NODE_ENV;
+describe('isSystemAdmin — ENABLE_DEV_ADMIN guard (issue #425)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalEnableDevAdmin = process.env.ENABLE_DEV_ADMIN;
 
   afterEach(() => {
-    Object.defineProperty(process.env, 'NODE_ENV', { value: originalEnv, writable: true });
+    Object.defineProperty(process.env, 'NODE_ENV', { value: originalNodeEnv, writable: true });
+    process.env.ENABLE_DEV_ADMIN = originalEnableDevAdmin;
   });
 
-  it('returns false in production even when the user email matches ADMIN_EMAIL', async () => {
-    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', writable: true });
+  it('returns true only when NODE_ENV=development AND ENABLE_DEV_ADMIN=true', async () => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'development', writable: true });
+    process.env.ENABLE_DEV_ADMIN = 'true';
+    mockPrisma.user.findUnique.mockResolvedValue({ email: ADMIN_EMAIL });
+
+    const result = await isSystemAdmin(ADMIN_USER_ID);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when NODE_ENV=development but ENABLE_DEV_ADMIN is not set', async () => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'development', writable: true });
+    delete process.env.ENABLE_DEV_ADMIN;
     mockPrisma.user.findUnique.mockResolvedValue({ email: ADMIN_EMAIL });
 
     const result = await isSystemAdmin(ADMIN_USER_ID);
@@ -41,15 +54,31 @@ describe('isSystemAdmin — production env guard (issue #466)', () => {
     expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
   });
 
-  it('returns true in test env when the user email matches ADMIN_EMAIL', async () => {
+  it('returns false in test env even when ENABLE_DEV_ADMIN=true', async () => {
+    // NODE_ENV is 'test' by default in Jest — admin override must not activate
+    process.env.ENABLE_DEV_ADMIN = 'true';
     mockPrisma.user.findUnique.mockResolvedValue({ email: ADMIN_EMAIL });
 
     const result = await isSystemAdmin(ADMIN_USER_ID);
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
+    expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
   });
 
-  it('returns false in test env when the user email does not match ADMIN_EMAIL', async () => {
+  it('returns false in production even when ENABLE_DEV_ADMIN=true', async () => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', writable: true });
+    process.env.ENABLE_DEV_ADMIN = 'true';
+    mockPrisma.user.findUnique.mockResolvedValue({ email: ADMIN_EMAIL });
+
+    const result = await isSystemAdmin(ADMIN_USER_ID);
+
+    expect(result).toBe(false);
+    expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns false when email does not match ADMIN_EMAIL', async () => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'development', writable: true });
+    process.env.ENABLE_DEV_ADMIN = 'true';
     mockPrisma.user.findUnique.mockResolvedValue({ email: 'attacker@example.com' });
 
     const result = await isSystemAdmin('attacker-id');

--- a/harmony-backend/tests/auth.service.test.ts
+++ b/harmony-backend/tests/auth.service.test.ts
@@ -358,73 +358,135 @@ describe('authService.login', () => {
     compareSpy.mockRestore();
   });
 
-  it('admin override works in non-production using the derived verifier', async () => {
-    const adminUser = {
-      ...mockUser,
-      id: 'admin-id-001',
-      email: ADMIN_EMAIL,
-      username: 'admin',
-      displayName: 'System Admin',
-    };
-    mockPrisma.user.upsert.mockResolvedValue(adminUser);
+  it('admin override works when NODE_ENV=development and ENABLE_DEV_ADMIN=true', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    process.env.ENABLE_DEV_ADMIN = 'true';
 
-    const adminVerifier = derivePasswordVerifier('admin', DEV_ADMIN_SALT);
-    const result = await authService.login(ADMIN_EMAIL, adminVerifier);
+    try {
+      const adminUser = {
+        ...mockUser,
+        id: 'admin-id-001',
+        email: ADMIN_EMAIL,
+        username: 'admin',
+        displayName: 'System Admin',
+      };
+      mockPrisma.user.upsert.mockResolvedValue(adminUser);
 
-    expect(typeof result.accessToken).toBe('string');
-    expect(mockPrisma.user.upsert).toHaveBeenCalled();
+      const adminVerifier = derivePasswordVerifier('admin', DEV_ADMIN_SALT);
+      const result = await authService.login(ADMIN_EMAIL, adminVerifier);
+
+      expect(typeof result.accessToken).toBe('string');
+      expect(mockPrisma.user.upsert).toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+      delete process.env.ENABLE_DEV_ADMIN;
+    }
   });
 
   it('admin override upserts the expected system-admin fields', async () => {
-    await authService.login(ADMIN_EMAIL, derivePasswordVerifier('admin', DEV_ADMIN_SALT));
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    process.env.ENABLE_DEV_ADMIN = 'true';
 
-    expect(mockPrisma.user.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        create: expect.objectContaining({
-          email: ADMIN_EMAIL,
-          username: 'admin',
-          displayName: 'System Admin',
+    try {
+      await authService.login(ADMIN_EMAIL, derivePasswordVerifier('admin', DEV_ADMIN_SALT));
+
+      expect(mockPrisma.user.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            email: ADMIN_EMAIL,
+            username: 'admin',
+            displayName: 'System Admin',
+          }),
         }),
-      }),
-    );
+      );
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+      delete process.env.ENABLE_DEV_ADMIN;
+    }
   });
 
   it('admin override makes the admin OWNER of every server', async () => {
-    mockPrisma.server.findMany.mockResolvedValue([{ id: 'server-001' }, { id: 'server-002' }]);
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    process.env.ENABLE_DEV_ADMIN = 'true';
 
-    await authService.login(ADMIN_EMAIL, derivePasswordVerifier('admin', DEV_ADMIN_SALT));
+    try {
+      mockPrisma.server.findMany.mockResolvedValue([{ id: 'server-001' }, { id: 'server-002' }]);
 
-    expect(mockPrisma.serverMember.upsert).toHaveBeenCalledTimes(2);
-    for (const [call] of mockPrisma.serverMember.upsert.mock.calls) {
-      expect(call).toEqual(
-        expect.objectContaining({
-          update: { role: 'OWNER' },
-          create: expect.objectContaining({ role: 'OWNER' }),
-        }),
-      );
+      await authService.login(ADMIN_EMAIL, derivePasswordVerifier('admin', DEV_ADMIN_SALT));
+
+      expect(mockPrisma.serverMember.upsert).toHaveBeenCalledTimes(2);
+      for (const [call] of mockPrisma.serverMember.upsert.mock.calls) {
+        expect(call).toEqual(
+          expect.objectContaining({
+            update: { role: 'OWNER' },
+            create: expect.objectContaining({ role: 'OWNER' }),
+          }),
+        );
+      }
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+      delete process.env.ENABLE_DEV_ADMIN;
     }
   });
 
   it('propagates admin upsert failures', async () => {
-    mockPrisma.user.upsert.mockRejectedValue(new Error('DB error during upsert'));
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    process.env.ENABLE_DEV_ADMIN = 'true';
 
-    await expect(
-      authService.login(ADMIN_EMAIL, derivePasswordVerifier('admin', DEV_ADMIN_SALT)),
-    ).rejects.toThrow('DB error during upsert');
+    try {
+      mockPrisma.user.upsert.mockRejectedValue(new Error('DB error during upsert'));
+
+      await expect(
+        authService.login(ADMIN_EMAIL, derivePasswordVerifier('admin', DEV_ADMIN_SALT)),
+      ).rejects.toThrow('DB error during upsert');
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+      delete process.env.ENABLE_DEV_ADMIN;
+    }
   });
 
   it('propagates admin membership upsert failures', async () => {
-    mockPrisma.server.findMany.mockResolvedValue([{ id: 'server-001' }, { id: 'server-002' }]);
-    mockPrisma.serverMember.upsert.mockRejectedValueOnce(new Error('membership upsert failed'));
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    process.env.ENABLE_DEV_ADMIN = 'true';
 
-    await expect(
-      authService.login(ADMIN_EMAIL, derivePasswordVerifier('admin', DEV_ADMIN_SALT)),
-    ).rejects.toThrow('membership upsert failed');
+    try {
+      mockPrisma.server.findMany.mockResolvedValue([{ id: 'server-001' }, { id: 'server-002' }]);
+      mockPrisma.serverMember.upsert.mockRejectedValueOnce(new Error('membership upsert failed'));
+
+      await expect(
+        authService.login(ADMIN_EMAIL, derivePasswordVerifier('admin', DEV_ADMIN_SALT)),
+      ).rejects.toThrow('membership upsert failed');
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+      delete process.env.ENABLE_DEV_ADMIN;
+    }
   });
 
   it('disables admin override in production', async () => {
     const previousNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
+    process.env.ENABLE_DEV_ADMIN = 'true';
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    try {
+      await expect(
+        authService.login(ADMIN_EMAIL, derivePasswordVerifier('admin', DEV_ADMIN_SALT)),
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED', message: 'Invalid credentials' });
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+      delete process.env.ENABLE_DEV_ADMIN;
+    }
+  });
+
+  it('disables admin override when ENABLE_DEV_ADMIN is not set', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    delete process.env.ENABLE_DEV_ADMIN;
     mockPrisma.user.findUnique.mockResolvedValue(null);
 
     try {

--- a/harmony-backend/tests/events.router.member.test.ts
+++ b/harmony-backend/tests/events.router.member.test.ts
@@ -11,9 +11,10 @@ import http from 'http';
 import { createApp } from '../src/app';
 import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
+import { redis } from '../src/db/redis';
+import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 
-const VALID_TOKEN = 'valid-token';
 const VALID_SERVER_ID = '550e8400-e29b-41d4-a716-446655440002';
 const JOINING_USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
@@ -78,6 +79,12 @@ jest.mock('../src/middleware/rate-limit.middleware', () => ({
   createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+jest.mock('../src/db/redis', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Jest mock factory must resolve after hoisting
+  const { redisTicketMockFactory } = require('./helpers/redisTicketJestMock');
+  return redisTicketMockFactory();
+});
+
 // ─── SSE helper ───────────────────────────────────────────────────────────────
 
 function sseGet(
@@ -131,6 +138,7 @@ afterAll((done) => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  seedSseTestTicket(redis as unknown as { set: jest.Mock });
   mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
   (prisma.server.findUnique as jest.Mock).mockResolvedValue({ id: VALID_SERVER_ID });
   (prisma.serverMember.findFirst as jest.Mock).mockResolvedValue({ userId: 'test-user-id' });
@@ -148,7 +156,7 @@ beforeEach(() => {
 // ─── Member event subscriptions ───────────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — member event subscriptions', () => {
-  const sseUrl = (id: string) => `/api/events/server/${id}?token=${VALID_TOKEN}`;
+  const sseUrl = (id: string) => `/api/events/server/${id}?ticket=${SSE_TEST_TICKET}`;
 
   it('subscribes to MEMBER_JOINED and MEMBER_LEFT event channels', async () => {
     await sseGet(httpServer, sseUrl(VALID_SERVER_ID));
@@ -191,7 +199,7 @@ describe('GET /api/events/server/:serverId — member:joined event', () => {
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -255,7 +263,7 @@ describe('GET /api/events/server/:serverId — member:joined event', () => {
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -308,7 +316,7 @@ describe('GET /api/events/server/:serverId — member:joined event', () => {
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -360,7 +368,7 @@ describe('GET /api/events/server/:serverId — member:left event', () => {
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -408,7 +416,7 @@ describe('GET /api/events/server/:serverId — member:left event', () => {
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 

--- a/harmony-backend/tests/events.router.server.test.ts
+++ b/harmony-backend/tests/events.router.server.test.ts
@@ -10,11 +10,12 @@ import request from 'supertest';
 import { createApp } from '../src/app';
 import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
+import { redis } from '../src/db/redis';
 import { createDeferred, waitFor } from './helpers/async';
+import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 import type { ChannelCreatedPayload, MessageCreatedPayload } from '../src/events/eventTypes';
 
-const VALID_TOKEN = 'valid-token';
 const VALID_SERVER_ID = '550e8400-e29b-41d4-a716-446655440001';
 const CREATED_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440009';
 
@@ -80,6 +81,12 @@ jest.mock('../src/middleware/rate-limit.middleware', () => ({
   createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+jest.mock('../src/db/redis', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Jest mock factory must resolve after hoisting
+  const { redisTicketMockFactory } = require('./helpers/redisTicketJestMock');
+  return redisTicketMockFactory();
+});
+
 // ─── SSE helper ───────────────────────────────────────────────────────────────
 
 function sseGet(
@@ -133,6 +140,7 @@ afterAll((done) => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  seedSseTestTicket(redis as unknown as { set: jest.Mock });
   mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
   (prisma.server.findUnique as jest.Mock).mockResolvedValue({ id: VALID_SERVER_ID });
   (prisma.serverMember.findFirst as jest.Mock).mockResolvedValue({ userId: 'test-user-id' });
@@ -155,7 +163,7 @@ beforeEach(() => {
 // ─── SSE headers ──────────────────────────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — SSE headers', () => {
-  const sseUrl = (id: string) => `/api/events/server/${id}?token=${VALID_TOKEN}`;
+  const sseUrl = (id: string) => `/api/events/server/${id}?ticket=${SSE_TEST_TICKET}`;
 
   it('sets Content-Type: text/event-stream', async () => {
     const { headers } = await sseGet(server, sseUrl(VALID_SERVER_ID));
@@ -188,7 +196,7 @@ describe('GET /api/events/server/:serverId — SSE headers', () => {
 });
 
 describe('GET /api/events/server/:serverId — subscription readiness', () => {
-  const sseUrl = `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}`;
+  const sseUrl = `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`;
 
   it('waits for all server-scoped subscriptions before flushing SSE headers', async () => {
     const ready = createDeferred<void>();
@@ -364,7 +372,7 @@ describe('GET /api/events/server/:serverId — Last-Event-ID replay', () => {
   const REPLAY_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440020';
   const REPLAY_MESSAGE_ID = '550e8400-e29b-41d4-a716-446655440021';
   const lastEventId = '2026-04-19T09:59:00.000Z';
-  const sseUrlWithReplay = `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}&lastEventId=${encodeURIComponent(lastEventId)}`;
+  const sseUrlWithReplay = `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}&lastEventId=${encodeURIComponent(lastEventId)}`;
 
   it('replays message:created events missed during the reconnect gap', async () => {
     (prisma.channel.findMany as jest.Mock).mockResolvedValue([{ id: REPLAY_CHANNEL_ID }]);
@@ -509,7 +517,7 @@ describe('GET /api/events/server/:serverId — input validation', () => {
   it('accepts a valid UUID-formatted serverId and returns 200', async () => {
     const { statusCode } = await sseGet(
       server,
-      `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}`,
+      `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
     );
     expect(statusCode).toBe(200);
   });
@@ -518,18 +526,15 @@ describe('GET /api/events/server/:serverId — input validation', () => {
 // ─── Auth ─────────────────────────────────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — auth', () => {
-  it('returns 401 when token is missing', async () => {
+  it('returns 401 when ticket is missing', async () => {
     const res = await request(app).get(`/api/events/server/${VALID_SERVER_ID}`);
     expect(res.status).toBe(401);
   });
 
-  it('returns 401 when token is invalid', async () => {
-    const { authService } = await import('../src/services/auth.service');
-    (authService.verifyAccessToken as jest.Mock).mockImplementationOnce(() => {
-      throw new Error('invalid token');
-    });
-
-    const res = await request(app).get(`/api/events/server/${VALID_SERVER_ID}?token=bad-token`);
+  it('returns 401 when ticket is invalid or already redeemed', async () => {
+    const res = await request(app).get(
+      `/api/events/server/${VALID_SERVER_ID}?ticket=11111111-1111-4111-8111-111111111111`,
+    );
     expect(res.status).toBe(401);
   });
 });
@@ -541,7 +546,7 @@ describe('GET /api/events/server/:serverId — authorisation', () => {
     (prisma.server.findUnique as jest.Mock).mockResolvedValueOnce(null);
 
     const res = await request(app).get(
-      `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}`,
+      `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
     );
     expect(res.status).toBe(404);
   });
@@ -550,7 +555,7 @@ describe('GET /api/events/server/:serverId — authorisation', () => {
     (prisma.serverMember.findFirst as jest.Mock).mockResolvedValueOnce(null);
 
     const res = await request(app).get(
-      `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}`,
+      `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
     );
     expect(res.status).toBe(403);
   });
@@ -565,7 +570,7 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
 
     const res = await request(app).get(
-      `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}`,
+      `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
     );
 
     expect(res.status).toBe(503);
@@ -588,7 +593,7 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
 
     const res = await request(app).get(
-      `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}`,
+      `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
     );
 
     // Headers must NOT have been flushed — client receives a proper 503 JSON response.

--- a/harmony-backend/tests/events.router.sse-server-updated.test.ts
+++ b/harmony-backend/tests/events.router.sse-server-updated.test.ts
@@ -11,9 +11,10 @@ import http from 'http';
 import { createApp } from '../src/app';
 import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
+import { redis } from '../src/db/redis';
+import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 
-const VALID_TOKEN = 'valid-token';
 const VALID_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440001';
 const SERVER_ID = '660e8400-e29b-41d4-a716-446655440001';
 const OTHER_SERVER_ID = '770e8400-e29b-41d4-a716-446655440001';
@@ -70,6 +71,12 @@ jest.mock('../src/services/cache.service', () => ({
 jest.mock('../src/middleware/rate-limit.middleware', () => ({
   createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
+
+jest.mock('../src/db/redis', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Jest mock factory must resolve after hoisting
+  const { redisTicketMockFactory } = require('./helpers/redisTicketJestMock');
+  return redisTicketMockFactory();
+});
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -148,6 +155,7 @@ afterAll((done) => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  seedSseTestTicket(redis as unknown as { set: jest.Mock });
   capturedHandlers.clear();
 
   mockSubscribe.mockImplementation((channel: string, handler: SubscriberHandler) => {
@@ -162,7 +170,7 @@ beforeEach(() => {
 // ─── SERVER_UPDATED subscription ─────────────────────────────────────────────
 
 describe('GET /api/events/channel/:channelId — SERVER_UPDATED subscription', () => {
-  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?token=${VALID_TOKEN}`;
+  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?ticket=${SSE_TEST_TICKET}`;
 
   it('subscribes to SERVER_UPDATED event channel', async () => {
     await new Promise<void>((resolve, reject) => {

--- a/harmony-backend/tests/events.router.status.test.ts
+++ b/harmony-backend/tests/events.router.status.test.ts
@@ -11,9 +11,10 @@ import http from 'http';
 import { createApp } from '../src/app';
 import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
+import { redis } from '../src/db/redis';
+import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 
-const VALID_TOKEN = 'valid-token';
 const VALID_SERVER_ID = '550e8400-e29b-41d4-a716-446655440002';
 const CHANGING_USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-ffffffffffff';
 
@@ -78,6 +79,12 @@ jest.mock('../src/middleware/rate-limit.middleware', () => ({
   createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+jest.mock('../src/db/redis', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Jest mock factory must resolve after hoisting
+  const { redisTicketMockFactory } = require('./helpers/redisTicketJestMock');
+  return redisTicketMockFactory();
+});
+
 // ─── SSE helper ───────────────────────────────────────────────────────────────
 
 function sseGet(
@@ -131,6 +138,7 @@ afterAll((done) => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  seedSseTestTicket(redis as unknown as { set: jest.Mock });
   mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
   (prisma.server.findUnique as jest.Mock).mockResolvedValue({ id: VALID_SERVER_ID });
   (prisma.serverMember.findFirst as jest.Mock).mockResolvedValue({ userId: 'test-user-id' });
@@ -140,7 +148,7 @@ beforeEach(() => {
 // ─── Status event subscription ────────────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — status event subscription', () => {
-  const sseUrl = (id: string) => `/api/events/server/${id}?token=${VALID_TOKEN}`;
+  const sseUrl = (id: string) => `/api/events/server/${id}?ticket=${SSE_TEST_TICKET}`;
 
   it('subscribes to USER_STATUS_CHANGED event channel', async () => {
     await sseGet(httpServer, sseUrl(VALID_SERVER_ID));
@@ -179,7 +187,7 @@ describe('GET /api/events/server/:serverId — member:statusChanged event', () =
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -228,7 +236,7 @@ describe('GET /api/events/server/:serverId — member:statusChanged event', () =
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -277,7 +285,7 @@ describe('GET /api/events/server/:serverId — member:statusChanged event', () =
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}` },
+        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 

--- a/harmony-backend/tests/events.router.test.ts
+++ b/harmony-backend/tests/events.router.test.ts
@@ -14,11 +14,11 @@ import request from 'supertest';
 import { createApp } from '../src/app';
 import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
+import { redis } from '../src/db/redis';
 import { createDeferred, waitFor } from './helpers/async';
+import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 import type { MessageCreatedPayload } from '../src/events/eventTypes';
-
-const VALID_TOKEN = 'valid-token';
 
 // ─── Mock eventBus ─────────────────────────────────────────────────────────────
 
@@ -71,6 +71,12 @@ jest.mock('../src/services/cache.service', () => ({
 jest.mock('../src/middleware/rate-limit.middleware', () => ({
   createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
+
+jest.mock('../src/db/redis', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Jest mock factory must resolve after hoisting
+  const { redisTicketMockFactory } = require('./helpers/redisTicketJestMock');
+  return redisTicketMockFactory();
+});
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -132,6 +138,7 @@ afterAll((done) => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  seedSseTestTicket(redis as unknown as { set: jest.Mock });
   mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
   // Default prisma mocks for auth path through SSE endpoint
   (prisma.channel.findUnique as jest.Mock).mockResolvedValue({ serverId: 'test-server-id' });
@@ -143,7 +150,7 @@ beforeEach(() => {
 
 describe('GET /api/events/channel/:channelId — SSE headers', () => {
   const VALID_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440001';
-  const sseUrl = (id: string) => `/api/events/channel/${id}?token=${VALID_TOKEN}`;
+  const sseUrl = (id: string) => `/api/events/channel/${id}?ticket=${SSE_TEST_TICKET}`;
 
   it('sets Content-Type: text/event-stream', async () => {
     const { headers } = await sseGet(server, sseUrl(VALID_CHANNEL_ID));
@@ -177,7 +184,7 @@ describe('GET /api/events/channel/:channelId — SSE headers', () => {
 
 describe('GET /api/events/channel/:channelId — subscription readiness', () => {
   const VALID_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440001';
-  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?token=${VALID_TOKEN}`;
+  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?ticket=${SSE_TEST_TICKET}`;
 
   it('waits for all subscription handshakes before flushing SSE headers', async () => {
     const ready = createDeferred<void>();
@@ -290,7 +297,7 @@ describe('GET /api/events/channel/:channelId — subscription readiness', () => 
 describe('GET /api/events/channel/:channelId — Last-Event-ID replay', () => {
   const VALID_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440001';
   const lastEventId = '2026-04-19T09:59:00.000Z';
-  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?token=${VALID_TOKEN}&lastEventId=${encodeURIComponent(lastEventId)}`;
+  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?ticket=${SSE_TEST_TICKET}&lastEventId=${encodeURIComponent(lastEventId)}`;
 
   it('replays message:created events missed during the reconnect gap', async () => {
     const missedMessage = {
@@ -353,7 +360,7 @@ describe('GET /api/events/channel/:channelId — input validation', () => {
   it('accepts a valid UUID-formatted channelId and returns 200', async () => {
     const { statusCode } = await sseGet(
       server,
-      `/api/events/channel/550e8400-e29b-41d4-a716-446655440001?token=${VALID_TOKEN}`,
+      `/api/events/channel/550e8400-e29b-41d4-a716-446655440001?ticket=${SSE_TEST_TICKET}`,
     );
     expect(statusCode).toBe(200);
   });
@@ -372,7 +379,7 @@ describe('GET /api/events/channel/:channelId — subscription readiness', () => 
 
     const res = await sseGet(
       server,
-      `/api/events/channel/550e8400-e29b-41d4-a716-446655440001?token=${VALID_TOKEN}`,
+      `/api/events/channel/550e8400-e29b-41d4-a716-446655440001?ticket=${SSE_TEST_TICKET}`,
     );
 
     expect(res.statusCode).toBe(503);

--- a/harmony-backend/tests/events.router.visibility.test.ts
+++ b/harmony-backend/tests/events.router.visibility.test.ts
@@ -11,9 +11,10 @@ import http from 'http';
 import { createApp } from '../src/app';
 import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
+import { redis } from '../src/db/redis';
+import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 
-const VALID_TOKEN = 'valid-token';
 const VALID_SERVER_ID = '550e8400-e29b-41d4-a716-446655440003';
 const CHANNEL_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
 
@@ -77,6 +78,12 @@ jest.mock('../src/services/cache.service', () => ({
 jest.mock('../src/middleware/rate-limit.middleware', () => ({
   createPublicRateLimiter: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
+
+jest.mock('../src/db/redis', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Jest mock factory must resolve after hoisting
+  const { redisTicketMockFactory } = require('./helpers/redisTicketJestMock');
+  return redisTicketMockFactory();
+});
 
 // ─── SSE helper ───────────────────────────────────────────────────────────────
 
@@ -144,6 +151,7 @@ afterAll((done) => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  seedSseTestTicket(redis as unknown as { set: jest.Mock });
   mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
   (prisma.server.findUnique as jest.Mock).mockResolvedValue({ id: VALID_SERVER_ID });
   (prisma.serverMember.findFirst as jest.Mock).mockResolvedValue({ userId: 'test-user-id' });
@@ -154,7 +162,7 @@ beforeEach(() => {
 // ─── VISIBILITY_CHANGED subscription ──────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — visibility subscription', () => {
-  const sseUrl = (id: string) => `/api/events/server/${id}?token=${VALID_TOKEN}`;
+  const sseUrl = (id: string) => `/api/events/server/${id}?ticket=${SSE_TEST_TICKET}`;
 
   it('subscribes to VISIBILITY_CHANGED event channel', async () => {
     await sseGet(httpServer, sseUrl(VALID_SERVER_ID));
@@ -198,7 +206,7 @@ describe('GET /api/events/server/:serverId — channel:visibility-changed event'
         {
           hostname: 'localhost',
           port,
-          path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}`,
+          path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
         },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
@@ -261,7 +269,7 @@ describe('GET /api/events/server/:serverId — channel:visibility-changed event'
         {
           hostname: 'localhost',
           port,
-          path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}`,
+          path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
         },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
@@ -319,7 +327,7 @@ describe('GET /api/events/server/:serverId — channel:visibility-changed event'
         {
           hostname: 'localhost',
           port,
-          path: `/api/events/server/${VALID_SERVER_ID}?token=${VALID_TOKEN}`,
+          path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
         },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));

--- a/harmony-backend/tests/helpers/redisTicketJestMock.ts
+++ b/harmony-backend/tests/helpers/redisTicketJestMock.ts
@@ -1,0 +1,38 @@
+/**
+ * In-memory Redis mock for SSE one-shot ticket redemption (GETDEL / legacy get+del).
+ * Pre-seeds {@link SSE_TEST_TICKET} → {@link SSE_TEST_USER_ID} to match auth mocks.
+ */
+
+export const SSE_TEST_TICKET = '550e8400-e29b-41d4-a716-446655440099';
+export const SSE_TEST_USER_ID = 'test-user-id';
+
+export function redisTicketMockFactory(): { redis: Record<string, jest.Mock> } {
+  const store = new Map<string, string>();
+
+  return {
+    redis: {
+      set: jest.fn((key: string, val: string) => {
+        store.set(key, val);
+        return Promise.resolve('OK');
+      }),
+      eval: jest.fn((_script: string, _numKeys: number, key: string) => {
+        const v = store.get(key);
+        if (v === undefined) return Promise.resolve(false);
+        store.delete(key);
+        return Promise.resolve(v);
+      }),
+      connect: jest.fn().mockResolvedValue(undefined),
+      quit: jest.fn().mockResolvedValue(undefined),
+      get: jest.fn((key: string) => Promise.resolve(store.get(key) ?? null)),
+      del: jest.fn((key: string) => {
+        store.delete(key);
+        return Promise.resolve(1);
+      }),
+    },
+  };
+}
+
+/** Call from test beforeEach so each case gets a fresh one-shot ticket in the mock store. */
+export function seedSseTestTicket(redis: { set: jest.Mock }): void {
+  redis.set(`sse:ticket:${SSE_TEST_TICKET}`, SSE_TEST_USER_ID);
+}

--- a/harmony-backend/tests/setup-env.ts
+++ b/harmony-backend/tests/setup-env.ts
@@ -1,0 +1,6 @@
+/**
+ * Default secrets for tests and CI when .env / workflow env omits them.
+ * Loaded after dotenv/config so local .env still wins when present.
+ */
+process.env.JWT_ACCESS_SECRET ??= 'test-access-secret';
+process.env.JWT_REFRESH_SECRET ??= 'test-refresh-secret';

--- a/harmony-backend/tests/trpc.error-formatter.test.ts
+++ b/harmony-backend/tests/trpc.error-formatter.test.ts
@@ -51,8 +51,27 @@ describe('tRPC errorFormatter — stack trace suppression', () => {
     expect(res.body.error.data.stack).toBeUndefined();
   });
 
-  it('includes stack trace when NODE_ENV is development', async () => {
+  it('includes stack trace when NODE_ENV is development and EXPOSE_STACK=1', async () => {
     process.env.NODE_ENV = 'development';
+    process.env.EXPOSE_STACK = '1';
+    const app = createApp();
+
+    try {
+      const res = await request(app)
+        .get(AUTHED_ENDPOINT)
+        .set('Accept', 'application/json');
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBeDefined();
+      expect(typeof res.body.error.data.stack).toBe('string');
+    } finally {
+      delete process.env.EXPOSE_STACK;
+    }
+  });
+
+  it('omits stack trace when NODE_ENV is development but EXPOSE_STACK is unset', async () => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.EXPOSE_STACK;
     const app = createApp();
 
     const res = await request(app)
@@ -61,6 +80,6 @@ describe('tRPC errorFormatter — stack trace suppression', () => {
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBeDefined();
-    expect(typeof res.body.error.data.stack).toBe('string');
+    expect(res.body.error.data.stack).toBeUndefined();
   });
 });

--- a/harmony-frontend/src/__tests__/useChannelEvents.test.tsx
+++ b/harmony-frontend/src/__tests__/useChannelEvents.test.tsx
@@ -16,6 +16,8 @@ import type { Server } from '../types/server';
 
 jest.mock('../lib/api-client', () => ({
   getAccessToken: jest.fn(() => 'mock-token'),
+  fetchSseTicket: jest.fn(() => Promise.resolve('mock-ticket')),
+  refreshAccessToken: jest.fn(() => Promise.resolve()),
 }));
 
 // ─── Mock EventSource ─────────────────────────────────────────────────────────
@@ -111,6 +113,14 @@ const MOCK_SERVER: Server = {
 
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
+/**
+ * The hooks use an async connect() that awaits fetchSseTicket before creating
+ * the EventSource. Even though the mock resolves immediately, the await still
+ * defers to the microtask queue. flushPromises drains it so the EventSource
+ * exists by the time assertions run.
+ */
+const flushPromises = () => act(async () => {});
+
 const originalEnv = process.env;
 
 beforeEach(() => {
@@ -128,7 +138,7 @@ afterEach(() => {
 // ─── Connection ───────────────────────────────────────────────────────────────
 
 describe('useChannelEvents — connection', () => {
-  it('creates an EventSource with the correct URL', () => {
+  it('creates an EventSource with the correct URL', async () => {
     renderHook(() =>
       useChannelEvents({
         channelId: CHANNEL_ID,
@@ -137,13 +147,14 @@ describe('useChannelEvents — connection', () => {
         onMessageDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     expect(MockEventSource).toHaveBeenCalledWith(
-      `${API_URL}/api/events/channel/${CHANNEL_ID}?token=mock-token`,
+      `${API_URL}/api/events/channel/${CHANNEL_ID}?ticket=mock-ticket`,
     );
   });
 
-  it('does NOT create EventSource when enabled=false', () => {
+  it('does NOT create EventSource when enabled=false', async () => {
     renderHook(() =>
       useChannelEvents({
         channelId: CHANNEL_ID,
@@ -153,11 +164,12 @@ describe('useChannelEvents — connection', () => {
         enabled: false,
       }),
     );
+    await flushPromises();
 
     expect(MockEventSource).not.toHaveBeenCalled();
   });
 
-  it('closes the EventSource on unmount', () => {
+  it('closes the EventSource on unmount', async () => {
     const { unmount } = renderHook(() =>
       useChannelEvents({
         channelId: CHANNEL_ID,
@@ -166,13 +178,14 @@ describe('useChannelEvents — connection', () => {
         onMessageDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     unmount();
 
     expect(mockEventSourceInstance?.close).toHaveBeenCalled();
   });
 
-  it('re-creates EventSource when channelId changes', () => {
+  it('re-creates EventSource when channelId changes', async () => {
     const { rerender } = renderHook(
       ({ channelId }: { channelId: string }) =>
         useChannelEvents({
@@ -183,10 +196,12 @@ describe('useChannelEvents — connection', () => {
         }),
       { initialProps: { channelId: CHANNEL_ID } },
     );
+    await flushPromises();
 
     expect(MockEventSource).toHaveBeenCalledTimes(1);
 
     rerender({ channelId: '550e8400-e29b-41d4-a716-446655440002' });
+    await flushPromises();
 
     expect(MockEventSource).toHaveBeenCalledTimes(2);
   });
@@ -195,7 +210,7 @@ describe('useChannelEvents — connection', () => {
 // ─── Event handling ───────────────────────────────────────────────────────────
 
 describe('useChannelEvents — event handling', () => {
-  it('calls onMessageCreated with parsed message on message:created event', () => {
+  it('calls onMessageCreated with parsed message on message:created event', async () => {
     const onMessageCreated = jest.fn();
 
     renderHook(() =>
@@ -206,6 +221,7 @@ describe('useChannelEvents — event handling', () => {
         onMessageDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('message:created', MOCK_MESSAGE);
@@ -215,7 +231,7 @@ describe('useChannelEvents — event handling', () => {
     expect(onMessageCreated).toHaveBeenCalledWith(MOCK_MESSAGE);
   });
 
-  it('calls onMessageEdited with parsed message on message:edited event', () => {
+  it('calls onMessageEdited with parsed message on message:edited event', async () => {
     const onMessageEdited = jest.fn();
     const editedMessage = {
       ...MOCK_MESSAGE,
@@ -231,6 +247,7 @@ describe('useChannelEvents — event handling', () => {
         onMessageDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('message:edited', editedMessage);
@@ -240,7 +257,7 @@ describe('useChannelEvents — event handling', () => {
     expect(onMessageEdited).toHaveBeenCalledWith(editedMessage);
   });
 
-  it('calls onMessageDeleted with messageId on message:deleted event', () => {
+  it('calls onMessageDeleted with messageId on message:deleted event', async () => {
     const onMessageDeleted = jest.fn();
 
     renderHook(() =>
@@ -251,6 +268,7 @@ describe('useChannelEvents — event handling', () => {
         onMessageDeleted,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('message:deleted', { messageId: 'msg-001' });
@@ -260,7 +278,7 @@ describe('useChannelEvents — event handling', () => {
     expect(onMessageDeleted).toHaveBeenCalledWith('msg-001');
   });
 
-  it('registers event listeners for all three event types', () => {
+  it('registers event listeners for all three event types', async () => {
     renderHook(() =>
       useChannelEvents({
         channelId: CHANNEL_ID,
@@ -269,6 +287,7 @@ describe('useChannelEvents — event handling', () => {
         onMessageDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     const addedTypes = (
       mockEventSourceInstance!.addEventListener.mock.calls as [string, unknown][]
@@ -282,7 +301,7 @@ describe('useChannelEvents — event handling', () => {
 // ─── Edge cases ───────────────────────────────────────────────────────────────
 
 describe('useChannelEvents — edge cases', () => {
-  it('does not throw when receiving malformed JSON in an event', () => {
+  it('does not throw when receiving malformed JSON in an event', async () => {
     const onMessageCreated = jest.fn();
 
     renderHook(() =>
@@ -293,6 +312,7 @@ describe('useChannelEvents — edge cases', () => {
         onMessageDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -318,7 +338,7 @@ describe('useChannelEvents — edge cases', () => {
     );
   });
 
-  it('removes event listeners on unmount', () => {
+  it('removes event listeners on unmount', async () => {
     const { unmount } = renderHook(() =>
       useChannelEvents({
         channelId: CHANNEL_ID,
@@ -327,6 +347,7 @@ describe('useChannelEvents — edge cases', () => {
         onMessageDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     unmount();
 
@@ -337,7 +358,7 @@ describe('useChannelEvents — edge cases', () => {
 // ─── onServerUpdated extension ────────────────────────────────────────────────
 
 describe('useChannelEvents — onServerUpdated', () => {
-  it('calls onServerUpdated with parsed server data when server:updated event fires', () => {
+  it('calls onServerUpdated with parsed server data when server:updated event fires', async () => {
     const onServerUpdated = jest.fn();
 
     renderHook(() =>
@@ -349,6 +370,7 @@ describe('useChannelEvents — onServerUpdated', () => {
         onServerUpdated,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('server:updated', MOCK_SERVER);
@@ -358,7 +380,7 @@ describe('useChannelEvents — onServerUpdated', () => {
     expect(onServerUpdated).toHaveBeenCalledWith(MOCK_SERVER);
   });
 
-  it('does not throw when onServerUpdated is not provided (backwards compatible)', () => {
+  it('does not throw when onServerUpdated is not provided (backwards compatible)', async () => {
     renderHook(() =>
       useChannelEvents({
         channelId: CHANNEL_ID,
@@ -368,6 +390,7 @@ describe('useChannelEvents — onServerUpdated', () => {
         // onServerUpdated intentionally omitted
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -376,7 +399,7 @@ describe('useChannelEvents — onServerUpdated', () => {
     }).not.toThrow();
   });
 
-  it('registers a server:updated event listener', () => {
+  it('registers a server:updated event listener', async () => {
     renderHook(() =>
       useChannelEvents({
         channelId: CHANNEL_ID,
@@ -386,6 +409,7 @@ describe('useChannelEvents — onServerUpdated', () => {
         onServerUpdated: jest.fn(),
       }),
     );
+    await flushPromises();
 
     const addedTypes = (
       mockEventSourceInstance!.addEventListener.mock.calls as [string, unknown][]
@@ -393,7 +417,7 @@ describe('useChannelEvents — onServerUpdated', () => {
     expect(addedTypes).toContain('server:updated');
   });
 
-  it('removes the server:updated listener on unmount', () => {
+  it('removes the server:updated listener on unmount', async () => {
     const { unmount } = renderHook(() =>
       useChannelEvents({
         channelId: CHANNEL_ID,
@@ -403,6 +427,7 @@ describe('useChannelEvents — onServerUpdated', () => {
         onServerUpdated: jest.fn(),
       }),
     );
+    await flushPromises();
 
     unmount();
 
@@ -412,7 +437,7 @@ describe('useChannelEvents — onServerUpdated', () => {
     expect(removedTypes).toContain('server:updated');
   });
 
-  it('logs when the EventSource connection fails before opening', () => {
+  it('logs when the EventSource connection fails before opening', async () => {
     renderHook(() =>
       useChannelEvents({
         channelId: CHANNEL_ID,
@@ -421,6 +446,7 @@ describe('useChannelEvents — onServerUpdated', () => {
         onMessageDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateError();

--- a/harmony-frontend/src/__tests__/useServerEvents.test.tsx
+++ b/harmony-frontend/src/__tests__/useServerEvents.test.tsx
@@ -19,6 +19,8 @@ import type { User } from '../types/user';
 
 jest.mock('../lib/api-client', () => ({
   getAccessToken: jest.fn(() => 'mock-token'),
+  fetchSseTicket: jest.fn(() => Promise.resolve('mock-ticket')),
+  refreshAccessToken: jest.fn(() => Promise.resolve()),
 }));
 
 // ─── Mock EventSource ─────────────────────────────────────────────────────────
@@ -123,6 +125,14 @@ const MOCK_MESSAGE: Message = {
 
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
+/**
+ * The hooks use an async connect() that awaits fetchSseTicket before creating
+ * the EventSource. Even though the mock resolves immediately, the await still
+ * defers to the microtask queue. flushPromises drains it so the EventSource
+ * exists by the time assertions run.
+ */
+const flushPromises = () => act(async () => {});
+
 const originalEnv = process.env;
 
 beforeEach(() => {
@@ -140,7 +150,7 @@ afterEach(() => {
 // ─── Connection ───────────────────────────────────────────────────────────────
 
 describe('useServerEvents — connection', () => {
-  it('creates an EventSource with the correct server URL', () => {
+  it('creates an EventSource with the correct server URL', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -149,13 +159,14 @@ describe('useServerEvents — connection', () => {
         onChannelDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     expect(MockEventSource).toHaveBeenCalledWith(
-      `${API_URL}/api/events/server/${SERVER_ID}?token=mock-token`,
+      `${API_URL}/api/events/server/${SERVER_ID}?ticket=mock-ticket`,
     );
   });
 
-  it('does NOT create EventSource when enabled=false', () => {
+  it('does NOT create EventSource when enabled=false', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -165,11 +176,12 @@ describe('useServerEvents — connection', () => {
         enabled: false,
       }),
     );
+    await flushPromises();
 
     expect(MockEventSource).not.toHaveBeenCalled();
   });
 
-  it('closes the EventSource on unmount', () => {
+  it('closes the EventSource on unmount', async () => {
     const { unmount } = renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -178,13 +190,14 @@ describe('useServerEvents — connection', () => {
         onChannelDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     unmount();
 
     expect(mockEventSourceInstance?.close).toHaveBeenCalled();
   });
 
-  it('registers listeners for all eleven event types', () => {
+  it('registers listeners for all eleven event types', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -201,6 +214,7 @@ describe('useServerEvents — connection', () => {
         onServerUpdated: jest.fn(),
       }),
     );
+    await flushPromises();
 
     const addedTypes = (
       mockEventSourceInstance!.addEventListener.mock.calls as [string, unknown][]
@@ -223,7 +237,7 @@ describe('useServerEvents — connection', () => {
 // ─── Channel event handling ───────────────────────────────────────────────────
 
 describe('useServerEvents — channel events', () => {
-  it('calls onChannelCreated with parsed channel on channel:created event', () => {
+  it('calls onChannelCreated with parsed channel on channel:created event', async () => {
     const onChannelCreated = jest.fn();
 
     renderHook(() =>
@@ -234,6 +248,7 @@ describe('useServerEvents — channel events', () => {
         onChannelDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('channel:created', MOCK_CHANNEL);
@@ -243,7 +258,7 @@ describe('useServerEvents — channel events', () => {
     expect(onChannelCreated).toHaveBeenCalledWith(MOCK_CHANNEL);
   });
 
-  it('calls onChannelUpdated with parsed channel on channel:updated event', () => {
+  it('calls onChannelUpdated with parsed channel on channel:updated event', async () => {
     const onChannelUpdated = jest.fn();
 
     renderHook(() =>
@@ -254,6 +269,7 @@ describe('useServerEvents — channel events', () => {
         onChannelDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('channel:updated', {
@@ -266,7 +282,7 @@ describe('useServerEvents — channel events', () => {
     expect(onChannelUpdated).toHaveBeenCalledWith({ ...MOCK_CHANNEL, name: 'renamed' });
   });
 
-  it('calls onChannelDeleted with channelId on channel:deleted event', () => {
+  it('calls onChannelDeleted with channelId on channel:deleted event', async () => {
     const onChannelDeleted = jest.fn();
 
     renderHook(() =>
@@ -277,6 +293,7 @@ describe('useServerEvents — channel events', () => {
         onChannelDeleted,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('channel:deleted', { channelId: 'ch-001' });
@@ -290,7 +307,7 @@ describe('useServerEvents — channel events', () => {
 // ─── Member event handling ────────────────────────────────────────────────────
 
 describe('useServerEvents — member events', () => {
-  it('calls onMemberJoined with parsed User on member:joined event', () => {
+  it('calls onMemberJoined with parsed User on member:joined event', async () => {
     const onMemberJoined = jest.fn();
 
     renderHook(() =>
@@ -302,6 +319,7 @@ describe('useServerEvents — member events', () => {
         onMemberJoined,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('member:joined', MOCK_USER);
@@ -311,7 +329,7 @@ describe('useServerEvents — member events', () => {
     expect(onMemberJoined).toHaveBeenCalledWith(MOCK_USER);
   });
 
-  it('calls onMemberLeft with userId on member:left event', () => {
+  it('calls onMemberLeft with userId on member:left event', async () => {
     const onMemberLeft = jest.fn();
 
     renderHook(() =>
@@ -323,6 +341,7 @@ describe('useServerEvents — member events', () => {
         onMemberLeft,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('member:left', { userId: 'user-new' });
@@ -332,7 +351,7 @@ describe('useServerEvents — member events', () => {
     expect(onMemberLeft).toHaveBeenCalledWith('user-new');
   });
 
-  it('does not throw when onMemberJoined is not provided', () => {
+  it('does not throw when onMemberJoined is not provided', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -342,6 +361,7 @@ describe('useServerEvents — member events', () => {
         // onMemberJoined intentionally omitted
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -350,7 +370,7 @@ describe('useServerEvents — member events', () => {
     }).not.toThrow();
   });
 
-  it('does not throw when onMemberLeft is not provided', () => {
+  it('does not throw when onMemberLeft is not provided', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -360,6 +380,7 @@ describe('useServerEvents — member events', () => {
         // onMemberLeft intentionally omitted
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -368,7 +389,7 @@ describe('useServerEvents — member events', () => {
     }).not.toThrow();
   });
 
-  it('removes member:joined and member:left listeners on unmount', () => {
+  it('removes member:joined and member:left listeners on unmount', async () => {
     const { unmount } = renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -379,6 +400,7 @@ describe('useServerEvents — member events', () => {
         onMemberLeft: jest.fn(),
       }),
     );
+    await flushPromises();
 
     unmount();
 
@@ -390,7 +412,7 @@ describe('useServerEvents — member events', () => {
     expect(removedTypes).toContain('member:left');
   });
 
-  it('does not call onMemberJoined on malformed JSON', () => {
+  it('does not call onMemberJoined on malformed JSON', async () => {
     const onMemberJoined = jest.fn();
 
     renderHook(() =>
@@ -402,6 +424,7 @@ describe('useServerEvents — member events', () => {
         onMemberJoined,
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -430,7 +453,7 @@ describe('useServerEvents — member events', () => {
 // ─── Member status change handling ───────────────────────────────────────────
 
 describe('useServerEvents — member status change events', () => {
-  it('calls onMemberStatusChanged with id and status on member:statusChanged event', () => {
+  it('calls onMemberStatusChanged with id and status on member:statusChanged event', async () => {
     const onMemberStatusChanged = jest.fn();
 
     renderHook(() =>
@@ -442,6 +465,7 @@ describe('useServerEvents — member status change events', () => {
         onMemberStatusChanged,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('member:statusChanged', {
@@ -454,7 +478,7 @@ describe('useServerEvents — member status change events', () => {
     expect(onMemberStatusChanged).toHaveBeenCalledWith({ id: 'user-new', status: 'idle' });
   });
 
-  it('does not throw when onMemberStatusChanged is not provided', () => {
+  it('does not throw when onMemberStatusChanged is not provided', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -464,6 +488,7 @@ describe('useServerEvents — member status change events', () => {
         // onMemberStatusChanged intentionally omitted
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -475,7 +500,7 @@ describe('useServerEvents — member status change events', () => {
     }).not.toThrow();
   });
 
-  it('removes member:statusChanged listener on unmount', () => {
+  it('removes member:statusChanged listener on unmount', async () => {
     const { unmount } = renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -485,6 +510,7 @@ describe('useServerEvents — member status change events', () => {
         onMemberStatusChanged: jest.fn(),
       }),
     );
+    await flushPromises();
 
     unmount();
 
@@ -495,7 +521,7 @@ describe('useServerEvents — member status change events', () => {
     expect(removedTypes).toContain('member:statusChanged');
   });
 
-  it('does not call onMemberStatusChanged on malformed JSON', () => {
+  it('does not call onMemberStatusChanged on malformed JSON', async () => {
     const onMemberStatusChanged = jest.fn();
 
     renderHook(() =>
@@ -507,6 +533,7 @@ describe('useServerEvents — member status change events', () => {
         onMemberStatusChanged,
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -524,7 +551,7 @@ describe('useServerEvents — member status change events', () => {
 // ─── Visibility change event handling ────────────────────────────────────────
 
 describe('useServerEvents — channel:visibility-changed events', () => {
-  it('registers a listener for channel:visibility-changed', () => {
+  it('registers a listener for channel:visibility-changed', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -534,6 +561,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
         onChannelVisibilityChanged: jest.fn(),
       }),
     );
+    await flushPromises();
 
     const addedTypes = (
       mockEventSourceInstance!.addEventListener.mock.calls as [string, unknown][]
@@ -542,7 +570,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
     expect(addedTypes).toContain('channel:visibility-changed');
   });
 
-  it('calls onChannelVisibilityChanged with channel and oldVisibility on event', () => {
+  it('calls onChannelVisibilityChanged with channel and oldVisibility on event', async () => {
     const onChannelVisibilityChanged = jest.fn();
     const updatedChannel: Channel = { ...MOCK_CHANNEL, visibility: ChannelVisibility.PRIVATE };
 
@@ -555,6 +583,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
         onChannelVisibilityChanged,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('channel:visibility-changed', {
@@ -571,7 +600,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
     );
   });
 
-  it('does not throw when onChannelVisibilityChanged is not provided', () => {
+  it('does not throw when onChannelVisibilityChanged is not provided', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -581,6 +610,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
         // onChannelVisibilityChanged intentionally omitted
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -593,7 +623,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
     }).not.toThrow();
   });
 
-  it('removes channel:visibility-changed listener on unmount', () => {
+  it('removes channel:visibility-changed listener on unmount', async () => {
     const { unmount } = renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -603,6 +633,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
         onChannelVisibilityChanged: jest.fn(),
       }),
     );
+    await flushPromises();
 
     unmount();
 
@@ -613,7 +644,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
     expect(removedTypes).toContain('channel:visibility-changed');
   });
 
-  it('does not call onChannelVisibilityChanged on malformed JSON', () => {
+  it('does not call onChannelVisibilityChanged on malformed JSON', async () => {
     const onChannelVisibilityChanged = jest.fn();
 
     renderHook(() =>
@@ -625,6 +656,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
         onChannelVisibilityChanged,
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -638,7 +670,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
     expect(onChannelVisibilityChanged).not.toHaveBeenCalled();
   });
 
-  it('logs when the EventSource connection fails before opening', () => {
+  it('logs when the EventSource connection fails before opening', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -647,6 +679,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
         onChannelDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateError();
@@ -668,7 +701,7 @@ describe('useServerEvents — channel:visibility-changed events', () => {
 // ─── Message event handling ───────────────────────────────────────────────────
 
 describe('useServerEvents — message events', () => {
-  it('calls onMessageCreated with parsed message on message:created event', () => {
+  it('calls onMessageCreated with parsed message on message:created event', async () => {
     const onMessageCreated = jest.fn();
 
     renderHook(() =>
@@ -680,6 +713,7 @@ describe('useServerEvents — message events', () => {
         onMessageCreated,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('message:created', MOCK_MESSAGE);
@@ -689,7 +723,7 @@ describe('useServerEvents — message events', () => {
     expect(onMessageCreated).toHaveBeenCalledWith(MOCK_MESSAGE);
   });
 
-  it('calls onMessageEdited with parsed message on message:edited event', () => {
+  it('calls onMessageEdited with parsed message on message:edited event', async () => {
     const onMessageEdited = jest.fn();
 
     renderHook(() =>
@@ -701,6 +735,7 @@ describe('useServerEvents — message events', () => {
         onMessageEdited,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('message:edited', {
@@ -713,7 +748,7 @@ describe('useServerEvents — message events', () => {
     expect(onMessageEdited).toHaveBeenCalledWith({ ...MOCK_MESSAGE, content: 'edited content' });
   });
 
-  it('calls onMessageDeleted with messageId and channelId on message:deleted event', () => {
+  it('calls onMessageDeleted with messageId and channelId on message:deleted event', async () => {
     const onMessageDeleted = jest.fn();
 
     renderHook(() =>
@@ -725,6 +760,7 @@ describe('useServerEvents — message events', () => {
         onMessageDeleted,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('message:deleted', {
@@ -737,7 +773,7 @@ describe('useServerEvents — message events', () => {
     expect(onMessageDeleted).toHaveBeenCalledWith('msg-001', 'ch-001');
   });
 
-  it('does not throw when message callbacks are not provided', () => {
+  it('does not throw when message callbacks are not provided', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -746,6 +782,7 @@ describe('useServerEvents — message events', () => {
         onChannelDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -759,7 +796,7 @@ describe('useServerEvents — message events', () => {
     }).not.toThrow();
   });
 
-  it('removes message listeners on unmount', () => {
+  it('removes message listeners on unmount', async () => {
     const { unmount } = renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -771,6 +808,7 @@ describe('useServerEvents — message events', () => {
         onMessageDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     unmount();
 
@@ -783,7 +821,7 @@ describe('useServerEvents — message events', () => {
     expect(removedTypes).toContain('message:deleted');
   });
 
-  it('does not call onMessageCreated on malformed JSON', () => {
+  it('does not call onMessageCreated on malformed JSON', async () => {
     const onMessageCreated = jest.fn();
 
     renderHook(() =>
@@ -795,6 +833,7 @@ describe('useServerEvents — message events', () => {
         onMessageCreated,
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -812,7 +851,7 @@ describe('useServerEvents — message events', () => {
 // ─── server:updated event handling ───────────────────────────────────────────
 
 describe('useServerEvents — server:updated events', () => {
-  it('calls onServerUpdated with parsed server on server:updated event', () => {
+  it('calls onServerUpdated with parsed server on server:updated event', async () => {
     const onServerUpdated = jest.fn();
     const MOCK_SERVER = { id: SERVER_ID, name: 'Test Server', iconUrl: null, description: null };
 
@@ -825,6 +864,7 @@ describe('useServerEvents — server:updated events', () => {
         onServerUpdated,
       }),
     );
+    await flushPromises();
 
     act(() => {
       mockEventSourceInstance!.simulateEvent('server:updated', MOCK_SERVER);
@@ -834,7 +874,7 @@ describe('useServerEvents — server:updated events', () => {
     expect(onServerUpdated).toHaveBeenCalledWith(MOCK_SERVER);
   });
 
-  it('does not throw when onServerUpdated is not provided', () => {
+  it('does not throw when onServerUpdated is not provided', async () => {
     renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -843,6 +883,7 @@ describe('useServerEvents — server:updated events', () => {
         onChannelDeleted: jest.fn(),
       }),
     );
+    await flushPromises();
 
     expect(() => {
       act(() => {
@@ -854,7 +895,7 @@ describe('useServerEvents — server:updated events', () => {
     }).not.toThrow();
   });
 
-  it('removes server:updated listener on unmount', () => {
+  it('removes server:updated listener on unmount', async () => {
     const { unmount } = renderHook(() =>
       useServerEvents({
         serverId: SERVER_ID,
@@ -864,6 +905,7 @@ describe('useServerEvents — server:updated events', () => {
         onServerUpdated: jest.fn(),
       }),
     );
+    await flushPromises();
 
     unmount();
 

--- a/harmony-frontend/src/components/channel/NotificationBell.tsx
+++ b/harmony-frontend/src/components/channel/NotificationBell.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { apiClient } from '@/lib/api-client';
-import { getAccessToken } from '@/lib/api-client';
+import { getAccessToken, fetchSseTicket } from '@/lib/api-client';
 import { cn } from '@/lib/utils';
 
 interface Notification {
@@ -87,54 +87,65 @@ export function NotificationBell({ userId }: NotificationBellProps) {
     const token = getAccessToken();
     if (!token) return;
 
-    const apiBase =
-      process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
-    const url = `${apiBase}/api/events/user?token=${encodeURIComponent(token)}`;
-    const es = new EventSource(url);
-    eventSourceRef.current = es;
+    const apiBase = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+    let cancelled = false;
 
-    es.addEventListener('notification:mention', (e: MessageEvent) => {
+    (async () => {
+      let ticket: string;
       try {
-        const payload = JSON.parse(e.data) as {
-          id: string;
-          messageId: string;
-          channelId: string;
-          serverId: string;
-          authorId: string;
-          authorUsername: string;
-          timestamp: string;
-          read: boolean;
-        };
-        // Add an optimistic notification entry
-        const optimistic: Notification = {
-          id: payload.id,
-          type: 'mention',
-          messageId: payload.messageId,
-          channelId: payload.channelId,
-          serverId: payload.serverId,
-          read: false,
-          createdAt: payload.timestamp,
-          message: {
-            id: payload.messageId,
-            content: '',
-            isDeleted: false,
-            author: {
-              id: payload.authorId,
-              username: payload.authorUsername,
-              displayName: payload.authorUsername,
-              avatarUrl: null,
-            },
-          },
-        };
-        setNotifications((prev) => [optimistic, ...prev].slice(0, 50));
-        setUnreadCount((c) => c + 1);
+        ticket = await fetchSseTicket(apiBase, token);
       } catch {
-        // malformed payload — ignore
+        return; // abort silently — notification bell is non-critical
       }
-    });
+      if (cancelled) return;
+
+      const url = `${apiBase}/api/events/user?ticket=${encodeURIComponent(ticket)}`;
+      const es = new EventSource(url);
+      eventSourceRef.current = es;
+
+      es.addEventListener('notification:mention', (e: MessageEvent) => {
+        try {
+          const payload = JSON.parse(e.data) as {
+            id: string;
+            messageId: string;
+            channelId: string;
+            serverId: string;
+            authorId: string;
+            authorUsername: string;
+            timestamp: string;
+            read: boolean;
+          };
+          const optimistic: Notification = {
+            id: payload.id,
+            type: 'mention',
+            messageId: payload.messageId,
+            channelId: payload.channelId,
+            serverId: payload.serverId,
+            read: false,
+            createdAt: payload.timestamp,
+            message: {
+              id: payload.messageId,
+              content: '',
+              isDeleted: false,
+              author: {
+                id: payload.authorId,
+                username: payload.authorUsername,
+                displayName: payload.authorUsername,
+                avatarUrl: null,
+              },
+            },
+          };
+          setNotifications((prev) => [optimistic, ...prev].slice(0, 50));
+          setUnreadCount((c) => c + 1);
+        } catch {
+          // malformed payload — ignore
+        }
+      });
+    })();
 
     return () => {
-      es.close();
+      cancelled = true;
+      eventSourceRef.current?.close();
       eventSourceRef.current = null;
     };
   }, [userId]);

--- a/harmony-frontend/src/hooks/useChannelEvents.ts
+++ b/harmony-frontend/src/hooks/useChannelEvents.ts
@@ -19,7 +19,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { Message } from '@/types/message';
 import type { Server } from '@/types/server';
-import { getAccessToken, refreshAccessToken } from '@/lib/api-client';
+import { getAccessToken, refreshAccessToken, fetchSseTicket } from '@/lib/api-client';
 import { createFrontendLogger } from '@/lib/frontend-logger';
 import { getApiBaseUrl } from '@/lib/runtime-config';
 
@@ -80,134 +80,160 @@ export function useChannelEvents({
     const apiUrl = getApiBaseUrl();
     const token = getAccessToken();
     if (!token) return; // unauthenticated — don't attempt connection
-    const url = `${apiUrl}/api/events/channel/${channelId}?token=${encodeURIComponent(token)}`;
-    const es = new EventSource(url);
 
-    // ── Event handlers ──────────────────────────────────────────────────────
-
-    const handleCreated = (event: MessageEvent<string>) => {
-      try {
-        const msg = JSON.parse(event.data) as Message;
-        onCreatedRef.current(msg);
-      } catch (error) {
-        logger.warn('Dropped malformed channel SSE payload', {
-          feature: 'channel-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'message:created',
-          target: '/api/events/channel/[channelId]',
-          error,
-        });
-      }
-    };
-
-    const handleEdited = (event: MessageEvent<string>) => {
-      try {
-        const msg = JSON.parse(event.data) as Message;
-        onEditedRef.current(msg);
-      } catch (error) {
-        logger.warn('Dropped malformed channel SSE payload', {
-          feature: 'channel-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'message:edited',
-          target: '/api/events/channel/[channelId]',
-          error,
-        });
-      }
-    };
-
-    const handleDeleted = (event: MessageEvent<string>) => {
-      try {
-        const payload = JSON.parse(event.data) as { messageId: string };
-        onDeletedRef.current(payload.messageId);
-      } catch (error) {
-        logger.warn('Dropped malformed channel SSE payload', {
-          feature: 'channel-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'message:deleted',
-          target: '/api/events/channel/[channelId]',
-          error,
-        });
-      }
-    };
-
-    const handleServerUpdated = (event: MessageEvent<string>) => {
-      try {
-        const server = JSON.parse(event.data) as Server;
-        onServerUpdatedRef.current?.(server);
-      } catch (error) {
-        logger.warn('Dropped malformed channel SSE payload', {
-          feature: 'channel-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'server:updated',
-          target: '/api/events/channel/[channelId]',
-          error,
-        });
-      }
-    };
-
-    es.addEventListener('message:created', handleCreated);
-    es.addEventListener('message:edited', handleEdited);
-    es.addEventListener('message:deleted', handleDeleted);
-    es.addEventListener('server:updated', handleServerUpdated);
-
-    // Track whether the connection ever opened successfully.
-    // If onerror fires before onopen it's a permanent failure (4xx/5xx from the
-    // server or a network error before the stream started) — close immediately
-    // instead of letting EventSource retry with a stale/invalid token.
-    let everOpened = false;
+    let es: EventSource | null = null;
+    let cancelled = false;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    // Tracks registered handlers so cleanup can call removeEventListener.
+    const activeHandlers: Array<[string, (event: MessageEvent<string>) => void]> = [];
 
-    es.onopen = () => {
-      everOpened = true;
-      reconnectCountRef.current = 0; // reset budget on successful connection
-      setIsConnected(true);
-    };
-    es.onerror = () => {
-      setIsConnected(false);
-      logger.warn('Channel SSE connection failed', {
-        feature: 'channel-events',
-        event: everOpened ? 'stream_disconnected' : 'stream_failed',
-        source: 'sse',
-        target: '/api/events/channel/[channelId]',
-      });
-      if (!everOpened && reconnectCountRef.current === 0) {
-        // Never successfully opened on the first attempt — likely a 401/403. Stop retrying.
-        es.close();
+    const connect = async () => {
+      let ticket: string;
+      try {
+        ticket = await fetchSseTicket(apiUrl, token);
+      } catch (err) {
+        logger.warn('Failed to fetch SSE ticket; aborting channel connection', {
+          feature: 'channel-events',
+          event: 'ticket_fetch_failed',
+          source: 'sse',
+          target: '/api/events/ticket',
+          error: err,
+        });
         return;
       }
+      if (cancelled) return;
 
-      // The connection was previously healthy but dropped (e.g. network blip,
-      // server restart, or the access token expired and the backend rejected the
-      // EventSource auto-reconnect attempt). Stop the native retry loop (which
-      // would keep hammering the server with the same stale token) and
-      // proactively refresh the token before reconnecting.
-      es.close();
-      const attempt = reconnectCountRef.current;
-      if (attempt >= MAX_RECONNECT_ATTEMPTS) return; // give up after cap
+      const url = `${apiUrl}/api/events/channel/${channelId}?ticket=${encodeURIComponent(ticket)}`;
+      es = new EventSource(url);
 
-      reconnectCountRef.current += 1;
-      const delay = RECONNECT_DELAY_MS * reconnectCountRef.current;
-      reconnectTimer = setTimeout(() => {
-        // Attempt a silent token refresh so the next EventSource URL carries a
-        // valid token even when the user has been idle (no API calls to trigger
-        // the axios interceptor refresh).
-        refreshAccessToken().finally(() => {
-          setReconnectKey(k => k + 1);
+      // ── Event handlers ────────────────────────────────────────────────────
+
+      const handleCreated = (event: MessageEvent<string>) => {
+        try {
+          const msg = JSON.parse(event.data) as Message;
+          onCreatedRef.current(msg);
+        } catch (error) {
+          logger.warn('Dropped malformed channel SSE payload', {
+            feature: 'channel-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'message:created',
+            target: '/api/events/channel/[channelId]',
+            error,
+          });
+        }
+      };
+
+      const handleEdited = (event: MessageEvent<string>) => {
+        try {
+          const msg = JSON.parse(event.data) as Message;
+          onEditedRef.current(msg);
+        } catch (error) {
+          logger.warn('Dropped malformed channel SSE payload', {
+            feature: 'channel-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'message:edited',
+            target: '/api/events/channel/[channelId]',
+            error,
+          });
+        }
+      };
+
+      const handleDeleted = (event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as { messageId: string };
+          onDeletedRef.current(payload.messageId);
+        } catch (error) {
+          logger.warn('Dropped malformed channel SSE payload', {
+            feature: 'channel-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'message:deleted',
+            target: '/api/events/channel/[channelId]',
+            error,
+          });
+        }
+      };
+
+      const handleServerUpdated = (event: MessageEvent<string>) => {
+        try {
+          const server = JSON.parse(event.data) as Server;
+          onServerUpdatedRef.current?.(server);
+        } catch (error) {
+          logger.warn('Dropped malformed channel SSE payload', {
+            feature: 'channel-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'server:updated',
+            target: '/api/events/channel/[channelId]',
+            error,
+          });
+        }
+      };
+
+      es.addEventListener('message:created', handleCreated);
+      es.addEventListener('message:edited', handleEdited);
+      es.addEventListener('message:deleted', handleDeleted);
+      es.addEventListener('server:updated', handleServerUpdated);
+      activeHandlers.push(
+        ['message:created', handleCreated],
+        ['message:edited', handleEdited],
+        ['message:deleted', handleDeleted],
+        ['server:updated', handleServerUpdated],
+      );
+
+      // Track whether the connection ever opened successfully.
+      // If onerror fires before onopen it's a permanent failure (4xx/5xx from the
+      // server or a network error before the stream started) — close immediately
+      // instead of letting EventSource retry with a stale ticket.
+      let everOpened = false;
+
+      es.onopen = () => {
+        everOpened = true;
+        reconnectCountRef.current = 0; // reset budget on successful connection
+        setIsConnected(true);
+      };
+      es.onerror = () => {
+        setIsConnected(false);
+        logger.warn('Channel SSE connection failed', {
+          feature: 'channel-events',
+          event: everOpened ? 'stream_disconnected' : 'stream_failed',
+          source: 'sse',
+          target: '/api/events/channel/[channelId]',
         });
-      }, delay);
+        if (!everOpened && reconnectCountRef.current === 0) {
+          // Never successfully opened on the first attempt — likely a 401/403. Stop retrying.
+          es?.close();
+          return;
+        }
+
+        // The connection was previously healthy but dropped. Stop the native retry
+        // loop (which would reuse a consumed ticket) and proactively refresh the
+        // access token before reconnecting with a fresh ticket.
+        es?.close();
+        const attempt = reconnectCountRef.current;
+        if (attempt >= MAX_RECONNECT_ATTEMPTS) return; // give up after cap
+
+        reconnectCountRef.current += 1;
+        const delay = RECONNECT_DELAY_MS * reconnectCountRef.current;
+        reconnectTimer = setTimeout(() => {
+          refreshAccessToken().finally(() => {
+            setReconnectKey(k => k + 1);
+          });
+        }, delay);
+      };
     };
 
+    connect();
+
     return () => {
+      cancelled = true;
       if (reconnectTimer !== null) clearTimeout(reconnectTimer);
-      es.removeEventListener('message:created', handleCreated);
-      es.removeEventListener('message:edited', handleEdited);
-      es.removeEventListener('message:deleted', handleDeleted);
-      es.removeEventListener('server:updated', handleServerUpdated);
-      es.close();
+      if (es) {
+        activeHandlers.forEach(([type, handler]) => es!.removeEventListener(type, handler));
+        es.close();
+      }
       setIsConnected(false);
     };
   }, [channelId, enabled, reconnectKey]);

--- a/harmony-frontend/src/hooks/useServerEvents.ts
+++ b/harmony-frontend/src/hooks/useServerEvents.ts
@@ -39,7 +39,7 @@ import type { Channel, ChannelVisibility } from '@/types/channel';
 import type { Message } from '@/types/message';
 import type { User, UserStatus } from '@/types/user';
 import type { Server } from '@/types/server';
-import { getAccessToken, refreshAccessToken } from '@/lib/api-client';
+import { getAccessToken, refreshAccessToken, fetchSseTicket } from '@/lib/api-client';
 import { createFrontendLogger } from '@/lib/frontend-logger';
 import { getApiBaseUrl } from '@/lib/runtime-config';
 
@@ -134,12 +134,34 @@ export function useServerEvents({
     const token = getAccessToken();
     if (!token) return;
 
-    let url = `${apiUrl}/api/events/server/${serverId}?token=${encodeURIComponent(token)}`;
-    // On reconnect, pass the last seen event id so the server can replay missed messages.
-    if (reconnectKey > 0 && lastEventIdRef.current) {
-      url += `&lastEventId=${encodeURIComponent(lastEventIdRef.current)}`;
-    }
-    const es = new EventSource(url);
+    let es: EventSource | null = null;
+    let cancelled = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    // Tracks registered handlers so cleanup can call removeEventListener.
+    const activeHandlers: Array<[string, (event: MessageEvent<string>) => void]> = [];
+
+    const connect = async () => {
+      let ticket: string;
+      try {
+        ticket = await fetchSseTicket(apiUrl, token);
+      } catch (err) {
+        logger.warn('Failed to fetch SSE ticket; aborting server connection', {
+          feature: 'server-events',
+          event: 'ticket_fetch_failed',
+          source: 'sse',
+          target: '/api/events/ticket',
+          error: err,
+        });
+        return;
+      }
+      if (cancelled) return;
+
+      let url = `${apiUrl}/api/events/server/${serverId}?ticket=${encodeURIComponent(ticket)}`;
+      // On reconnect, pass the last seen event id so the server can replay missed messages.
+      if (reconnectKey > 0 && lastEventIdRef.current) {
+        url += `&lastEventId=${encodeURIComponent(lastEventIdRef.current)}`;
+      }
+      es = new EventSource(url);
 
     const handleCreated = (event: MessageEvent<string>) => {
       try {
@@ -321,67 +343,75 @@ export function useServerEvents({
       }
     };
 
-    es.addEventListener('channel:created', handleCreated);
-    es.addEventListener('channel:updated', handleUpdated);
-    es.addEventListener('channel:deleted', handleDeleted);
-    es.addEventListener('member:joined', handleMemberJoined);
-    es.addEventListener('member:left', handleMemberLeft);
-    es.addEventListener('member:statusChanged', handleMemberStatusChanged);
-    es.addEventListener('channel:visibility-changed', handleVisibilityChanged);
-    es.addEventListener('message:created', handleMessageCreated);
-    es.addEventListener('message:edited', handleMessageEdited);
-    es.addEventListener('message:deleted', handleMessageDeleted);
-    es.addEventListener('server:updated', handleServerUpdated);
+      es.addEventListener('channel:created', handleCreated);
+      es.addEventListener('channel:updated', handleUpdated);
+      es.addEventListener('channel:deleted', handleDeleted);
+      es.addEventListener('member:joined', handleMemberJoined);
+      es.addEventListener('member:left', handleMemberLeft);
+      es.addEventListener('member:statusChanged', handleMemberStatusChanged);
+      es.addEventListener('channel:visibility-changed', handleVisibilityChanged);
+      es.addEventListener('message:created', handleMessageCreated);
+      es.addEventListener('message:edited', handleMessageEdited);
+      es.addEventListener('message:deleted', handleMessageDeleted);
+      es.addEventListener('server:updated', handleServerUpdated);
+      activeHandlers.push(
+        ['channel:created', handleCreated],
+        ['channel:updated', handleUpdated],
+        ['channel:deleted', handleDeleted],
+        ['member:joined', handleMemberJoined],
+        ['member:left', handleMemberLeft],
+        ['member:statusChanged', handleMemberStatusChanged],
+        ['channel:visibility-changed', handleVisibilityChanged],
+        ['message:created', handleMessageCreated],
+        ['message:edited', handleMessageEdited],
+        ['message:deleted', handleMessageDeleted],
+        ['server:updated', handleServerUpdated],
+      );
 
-    let everOpened = false;
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+      let everOpened = false;
 
-    es.onopen = () => {
-      everOpened = true;
-      reconnectCountRef.current = 0; // reset budget on successful connection
-    };
-    es.onerror = () => {
-      logger.warn('Server SSE connection failed', {
-        feature: 'server-events',
-        event: everOpened ? 'stream_disconnected' : 'stream_failed',
-        source: 'sse',
-        target: '/api/events/server/[serverId]',
-      });
-      if (!everOpened && reconnectCountRef.current === 0) {
-        // Never successfully opened on the first attempt — likely 401/403. Stop retrying.
-        es.close();
-        return;
-      }
-
-      // Connection dropped after being healthy. Stop native retry (stale token)
-      // and schedule a reconnect with a proactive token refresh.
-      es.close();
-      const attempt = reconnectCountRef.current;
-      if (attempt >= MAX_RECONNECT_ATTEMPTS) return;
-
-      reconnectCountRef.current += 1;
-      const delay = RECONNECT_DELAY_MS * reconnectCountRef.current;
-      reconnectTimer = setTimeout(() => {
-        refreshAccessToken().finally(() => {
-          setReconnectKey(k => k + 1);
+      es.onopen = () => {
+        everOpened = true;
+        reconnectCountRef.current = 0; // reset budget on successful connection
+      };
+      es.onerror = () => {
+        logger.warn('Server SSE connection failed', {
+          feature: 'server-events',
+          event: everOpened ? 'stream_disconnected' : 'stream_failed',
+          source: 'sse',
+          target: '/api/events/server/[serverId]',
         });
-      }, delay);
+        if (!everOpened && reconnectCountRef.current === 0) {
+          // Never successfully opened on the first attempt — likely 401/403. Stop retrying.
+          es?.close();
+          return;
+        }
+
+        // Connection dropped after being healthy. Stop native retry (stale ticket)
+        // and schedule a reconnect with a proactive token refresh.
+        es?.close();
+        const attempt = reconnectCountRef.current;
+        if (attempt >= MAX_RECONNECT_ATTEMPTS) return;
+
+        reconnectCountRef.current += 1;
+        const delay = RECONNECT_DELAY_MS * reconnectCountRef.current;
+        reconnectTimer = setTimeout(() => {
+          refreshAccessToken().finally(() => {
+            setReconnectKey(k => k + 1);
+          });
+        }, delay);
+      };
     };
+
+    connect();
 
     return () => {
+      cancelled = true;
       if (reconnectTimer !== null) clearTimeout(reconnectTimer);
-      es.removeEventListener('channel:created', handleCreated);
-      es.removeEventListener('channel:updated', handleUpdated);
-      es.removeEventListener('channel:deleted', handleDeleted);
-      es.removeEventListener('member:joined', handleMemberJoined);
-      es.removeEventListener('member:left', handleMemberLeft);
-      es.removeEventListener('member:statusChanged', handleMemberStatusChanged);
-      es.removeEventListener('channel:visibility-changed', handleVisibilityChanged);
-      es.removeEventListener('message:created', handleMessageCreated);
-      es.removeEventListener('message:edited', handleMessageEdited);
-      es.removeEventListener('message:deleted', handleMessageDeleted);
-      es.removeEventListener('server:updated', handleServerUpdated);
-      es.close();
+      if (es) {
+        activeHandlers.forEach(([type, handler]) => es!.removeEventListener(type, handler));
+        es.close();
+      }
     };
   }, [serverId, enabled, reconnectKey]);
 }

--- a/harmony-frontend/src/lib/api-client.ts
+++ b/harmony-frontend/src/lib/api-client.ts
@@ -242,6 +242,21 @@ class ApiClient {
 export const apiClient = new ApiClient();
 
 /**
+ * Fetches a one-shot SSE ticket from the backend.
+ * The ticket must be passed as ?ticket=<nonce> when opening an EventSource.
+ * Throws if the request fails (caller should abort the SSE connection).
+ */
+export async function fetchSseTicket(apiBaseUrl: string, accessToken: string): Promise<string> {
+  const res = await fetch(`${apiBaseUrl}/api/events/ticket`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) throw new Error(`Failed to fetch SSE ticket: ${res.status}`);
+  const data = await res.json() as { ticket: string };
+  return data.ticket;
+}
+
+/**
  * Proactively refreshes the access token using the stored refresh token.
  * Safe to call from SSE hooks before reconnecting after a dropped connection.
  *

--- a/tests/integration/sse.test.ts
+++ b/tests/integration/sse.test.ts
@@ -10,18 +10,32 @@
 import { BACKEND_URL, LOCAL_SEEDS, localOnlyDescribe } from './env';
 import { login, register } from './helpers/auth';
 
+/** One-shot SSE nonce from POST /api/events/ticket (JWT cannot live in query strings). */
+async function getSseTicket(accessToken: string): Promise<string> {
+  const res = await fetch(`${BACKEND_URL}/api/events/ticket`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`SSE ticket issuance failed: HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as { ticket?: string };
+  if (!body.ticket) throw new Error('SSE ticket response missing ticket field');
+  return body.ticket;
+}
+
 // ─── Cloud-read-only smoke ────────────────────────────────────────────────────
 
 describe('SSE Smoke (cloud-read-only)', () => {
   // SSE-SMOKE-1: verify the SSE server endpoint responds with correct headers.
   // We can only test a known server ID in cloud mode if CLOUD_TEST_SERVER_ID is set.
-  test('SSE-SMOKE-1: SSE server endpoint returns correct response headers when token provided', async () => {
+  test('SSE-SMOKE-1: SSE server endpoint returns correct response headers when ticket provided', async () => {
     const serverId = process.env.CLOUD_TEST_SERVER_ID;
     const token = process.env.CLOUD_TEST_ACCESS_TOKEN;
 
     if (!serverId || !token) {
       // Without a known server ID and token, only verify the endpoint is mounted.
-      // Send a request without token to check it returns 401 (not 404).
+      // Send a request without ticket to check it returns 401 (not 404).
       const fakeServerId = '00000000-0000-0000-0000-000000000000';
       const res = await fetch(
         `${BACKEND_URL}/api/events/server/${fakeServerId}`,
@@ -38,8 +52,9 @@ describe('SSE Smoke (cloud-read-only)', () => {
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
     try {
+      const ticket = await getSseTicket(token);
       const res = await fetch(
-        `${BACKEND_URL}/api/events/server/${serverId}?token=${token}`,
+        `${BACKEND_URL}/api/events/server/${serverId}?ticket=${encodeURIComponent(ticket)}`,
         { signal: controller.signal },
       );
       clearTimeout(timeoutId);
@@ -86,8 +101,9 @@ localOnlyDescribe('SSE (local-only)', () => {
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
     try {
+      const ticket = await getSseTicket(accessToken);
       const res = await fetch(
-        `${BACKEND_URL}/api/events/channel/${channelId}?token=${accessToken}`,
+        `${BACKEND_URL}/api/events/channel/${channelId}?ticket=${encodeURIComponent(ticket)}`,
         { signal: controller.signal },
       );
       clearTimeout(timeoutId);
@@ -132,6 +148,7 @@ localOnlyDescribe('SSE (local-only)', () => {
       freshUsername,
       'TestPass123!',
     );
+    const freshTicket = await getSseTicket(freshToken);
 
     // Look up a channel from open-source-hub (not auto-joined on registration).
     const nonDefaultChannelRes = await fetch(
@@ -148,7 +165,7 @@ localOnlyDescribe('SSE (local-only)', () => {
 
     try {
       const res = await fetch(
-        `${BACKEND_URL}/api/events/channel/${nonDefaultChannelId}?token=${freshToken}`,
+        `${BACKEND_URL}/api/events/channel/${nonDefaultChannelId}?ticket=${encodeURIComponent(freshTicket)}`,
         { signal: controller.signal },
       );
       clearTimeout(timeoutId);
@@ -174,8 +191,9 @@ localOnlyDescribe('SSE (local-only)', () => {
 
     return new Promise<void>(async (resolve, reject) => {
       try {
+        const ticket = await getSseTicket(accessToken);
         const res = await fetch(
-          `${BACKEND_URL}/api/events/channel/${channelId}?token=${accessToken}`,
+          `${BACKEND_URL}/api/events/channel/${channelId}?ticket=${encodeURIComponent(ticket)}`,
           { signal: controller.signal },
         );
 
@@ -242,8 +260,9 @@ localOnlyDescribe('SSE (local-only)', () => {
 
     return new Promise<void>(async (resolve, reject) => {
       try {
+        const ticket = await getSseTicket(accessToken);
         const res = await fetch(
-          `${BACKEND_URL}/api/events/server/${serverId}?token=${accessToken}`,
+          `${BACKEND_URL}/api/events/server/${serverId}?ticket=${encodeURIComponent(ticket)}`,
           { signal: controller.signal },
         );
 
@@ -310,8 +329,9 @@ localOnlyDescribe('SSE (local-only)', () => {
 
     return new Promise<void>(async (resolve, reject) => {
       try {
+        const ticket = await getSseTicket(accessToken);
         const res = await fetch(
-          `${BACKEND_URL}/api/events/channel/${channelId}?token=${accessToken}`,
+          `${BACKEND_URL}/api/events/channel/${channelId}?ticket=${encodeURIComponent(ticket)}`,
           { signal: controller.signal },
         );
 


### PR DESCRIPTION
## Summary

Fixes all five HIGH severity security issues identified on the project board.

- **#425 — Dev admin backdoor too broad**: Guard tightened from `NODE_ENV !== 'production'` (active in test/staging) to `NODE_ENV === 'development' && ENABLE_DEV_ADMIN === 'true'`. Without the opt-in flag the backdoor is completely inert.
- **#426 — Hardcoded JWT secrets**: Removed `'dev-access-secret'` / `'dev-refresh-secret'` fallbacks and the `NODE_ENV !== 'test'` bypass. Server now throws at startup if either secret env var is missing.
- **#427 — Stack traces in non-dev error responses**: tRPC `errorFormatter` now requires `NODE_ENV === 'development'` **and** `EXPOSE_STACK=1` to include stack traces; all other environments get `undefined`.
- **#429 — Attachment URL SSRF**: `sendMessage` validates every attachment URL against the configured storage base (`R2_PUBLIC_URL` in production, `LOCAL_UPLOAD_BASE_URL` locally) and rejects anything that doesn't match.
- **#430 — JWT in SSE query params (log exposure)**: Replaced `?token=<jwt>` with a one-shot ticket system. Frontend calls `POST /api/events/ticket` (authenticated via Bearer header) to obtain a short-lived Redis nonce (60 s TTL); EventSource connects with `?ticket=<nonce>` which is immediately consumed on first use.

## Files changed

**Backend**
- `src/lib/admin.utils.ts` — ENABLE_DEV_ADMIN gate (#425)
- `src/services/auth.service.ts` — JWT secret enforcement + admin gate (#425, #426)
- `src/trpc/init.ts` — EXPOSE_STACK gate (#427)
- `src/trpc/routers/message.router.ts` — attachment URL validation (#429)
- `src/routes/events.router.ts` — SSE ticket endpoint + per-route nonce redemption (#430)
- `tests/admin.utils.test.ts` — full coverage for new ENABLE_DEV_ADMIN behavior
- `tests/auth.service.test.ts` — coverage for new guard conditions
- `tests/trpc.error-formatter.test.ts` — coverage for EXPOSE_STACK flag

**Frontend**
- `src/lib/api-client.ts` — `fetchSseTicket()` helper (#430)
- `src/hooks/useChannelEvents.ts` — async ticket fetch + `removeEventListener` in cleanup (#430)
- `src/hooks/useServerEvents.ts` — same (#430)
- `src/components/channel/NotificationBell.tsx` — same (#430)
- `src/__tests__/useChannelEvents.test.tsx` — async `flushPromises` pattern to handle async connect
- `src/__tests__/useServerEvents.test.tsx` — same

## Test plan

- [x] `tests/admin.utils.test.ts` — PASS (7 tests covering dev/prod/test env matrix)
- [x] `tests/auth.service.test.ts` — PASS (52 tests including new ENABLE_DEV_ADMIN and missing-secret tests)
- [x] `tests/trpc.error-formatter.test.ts` — PASS (3 tests covering production, dev+EXPOSE_STACK, dev without flag)
- [x] `src/__tests__/useChannelEvents.test.tsx` — PASS (15 tests, all now async-aware)
- [x] `src/__tests__/useServerEvents.test.tsx` — PASS (30 tests, all now async-aware)
- [x] All 397 frontend unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)