### PR TITLE
fix: real-time profile updates (closes #491)

### DIFF
--- a/harmony-backend/src/events/eventTypes.ts
+++ b/harmony-backend/src/events/eventTypes.ts
@@ -21,6 +21,7 @@ export const EventChannels = {
   CHANNEL_DELETED: 'harmony:CHANNEL_DELETED',
   SERVER_UPDATED: 'harmony:SERVER_UPDATED',
   USER_STATUS_CHANGED: 'harmony:USER_STATUS_CHANGED',
+  USER_PROFILE_UPDATED: 'harmony:USER_PROFILE_UPDATED',
   REACTION_ADDED: 'harmony:REACTION_ADDED',
   REACTION_REMOVED: 'harmony:REACTION_REMOVED',
   USER_MENTIONED: 'harmony:USER_MENTIONED',
@@ -135,6 +136,12 @@ export interface UserStatusChangedPayload {
   status: 'ONLINE' | 'IDLE' | 'DND' | 'OFFLINE';
 }
 
+export interface UserProfileUpdatedPayload {
+  userId: string;
+  serverId: string;
+  timestamp: string;
+}
+
 export interface ReactionAddedPayload {
   messageId: string;
   channelId: string;
@@ -179,6 +186,7 @@ export interface EventPayloadMap {
   [EventChannels.CHANNEL_DELETED]: ChannelDeletedPayload;
   [EventChannels.SERVER_UPDATED]: ServerUpdatedPayload;
   [EventChannels.USER_STATUS_CHANGED]: UserStatusChangedPayload;
+  [EventChannels.USER_PROFILE_UPDATED]: UserProfileUpdatedPayload;
   [EventChannels.REACTION_ADDED]: ReactionAddedPayload;
   [EventChannels.REACTION_REMOVED]: ReactionRemovedPayload;
   [EventChannels.USER_MENTIONED]: UserMentionedPayload;

--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -33,6 +33,7 @@ import type {
   ChannelDeletedPayload,
   ServerUpdatedPayload,
   UserStatusChangedPayload,
+  UserProfileUpdatedPayload,
   MemberJoinedPayload,
   MemberLeftPayload,
   VisibilityChangedPayload,
@@ -742,6 +743,41 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     },
   );
   subscriptions.push(statusChangedSubscription);
+
+  const profileUpdatedSubscription = eventBus.subscribe(
+    EventChannels.USER_PROFILE_UPDATED,
+    async (payload: UserProfileUpdatedPayload) => {
+      if (payload.serverId !== serverId) return;
+
+      try {
+        const user = await prisma.user.findUnique({
+          where: { id: payload.userId },
+          select: {
+            id: true,
+            username: true,
+            displayName: true,
+            avatarUrl: true,
+            publicProfile: true,
+          },
+        });
+        if (!user) return;
+
+        const isPublic = user.publicProfile;
+        writeEvent('member:profileUpdated', {
+          id: user.id,
+          username: isPublic ? user.username : 'Anonymous',
+          displayName: isPublic ? (user.displayName ?? undefined) : undefined,
+          avatarUrl: isPublic ? (user.avatarUrl ?? undefined) : undefined,
+        });
+      } catch (err) {
+        logger.warn(
+          { err, serverId, userId: payload.userId },
+          'Failed to hydrate SSE member:profileUpdated payload',
+        );
+      }
+    },
+  );
+  subscriptions.push(profileUpdatedSubscription);
 
   const memberJoinedSubscription = eventBus.subscribe(
     EventChannels.MEMBER_JOINED,

--- a/harmony-backend/src/services/user.service.ts
+++ b/harmony-backend/src/services/user.service.ts
@@ -64,18 +64,32 @@ export const userService = {
         ...(patch.status !== undefined && { status: patch.status }),
       });
 
-      // When status changes, publish one event per server the user belongs to so
-      // all connected members of those servers can update their member sidebar in real time.
-      // Status reflects presence only (not identity), so we publish for all servers
-      // regardless of the user's publicProfile setting.
-      if (patch.status !== undefined) {
+      const timestamp = new Date().toISOString();
+      const identityChanged =
+        patch.displayName !== undefined ||
+        patch.avatarUrl !== undefined ||
+        patch.publicProfile !== undefined;
+
+      // Fan out events per server. Fetch memberships once if either event type is needed.
+      if (patch.status !== undefined || identityChanged) {
         const memberships = await serverMemberRepository.findByUserIdSelect(userId);
         for (const { serverId } of memberships) {
-          void eventBus.publish(EventChannels.USER_STATUS_CHANGED, {
-            userId,
-            serverId,
-            status: patch.status,
-          });
+          if (patch.status !== undefined) {
+            void eventBus.publish(EventChannels.USER_STATUS_CHANGED, {
+              userId,
+              serverId,
+              status: patch.status,
+            });
+          }
+          if (identityChanged) {
+            // The SSE router hydrates displayName/avatarUrl from the DB so the
+            // publicProfile privacy gate is applied consistently (same as member:joined).
+            void eventBus.publish(EventChannels.USER_PROFILE_UPDATED, {
+              userId,
+              serverId,
+              timestamp,
+            });
+          }
         }
       }
 

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -346,6 +346,41 @@ export function HarmonyShell({
     [],
   );
 
+  const handleMemberProfileUpdated = useCallback(
+    ({
+      id,
+      username,
+      displayName,
+      avatarUrl,
+    }: {
+      id: string;
+      username: string;
+      displayName?: string;
+      avatarUrl?: string;
+    }) => {
+      setLocalMembers(prev =>
+        prev.map(m => (m.id === id ? { ...m, username, displayName, avatar: avatarUrl } : m)),
+      );
+      setLocalMessages(prev =>
+        prev.map(msg => {
+          if (msg.author.id !== id) return msg;
+          const updatedAuthor = { ...msg.author, username, displayName, avatarUrl };
+          const updatedMsg = { ...msg, author: updatedAuthor };
+          // Also patch the parentMessage author snapshot if this message is a reply
+          // authored by the same user.
+          if (msg.parentMessage?.author.id === id) {
+            updatedMsg.parentMessage = {
+              ...msg.parentMessage,
+              author: { ...msg.parentMessage.author, username, displayName, avatarUrl },
+            };
+          }
+          return updatedMsg;
+        }),
+      );
+    },
+    [],
+  );
+
   const authUserStatusKey = authUser ? `${authUser.id}:${authUser.status}:${authUser.role}` : null;
   const [prevAuthUserStatusKey, setPrevAuthUserStatusKey] = useState(authUserStatusKey);
   if (authUserStatusKey !== prevAuthUserStatusKey) {
@@ -412,6 +447,7 @@ export function HarmonyShell({
     onMemberJoined: handleMemberJoined,
     onMemberLeft: handleMemberLeft,
     onMemberStatusChanged: handleMemberStatusChanged,
+    onMemberProfileUpdated: handleMemberProfileUpdated,
     onChannelVisibilityChanged: handleChannelVisibilityChanged,
     // Message callbacks are disabled when the channel is locked (same guard as the
     // former useChannelEvents call) so locked guests don't accumulate stale state.

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -363,15 +363,16 @@ export function HarmonyShell({
       );
       setLocalMessages(prev =>
         prev.map(msg => {
-          if (msg.author.id !== id) return msg;
-          const updatedAuthor = { ...msg.author, username, displayName, avatarUrl };
-          const updatedMsg = { ...msg, author: updatedAuthor };
-          // Also patch the parentMessage author snapshot if this message is a reply
-          // authored by the same user.
-          if (msg.parentMessage?.author.id === id) {
+          const isMainAuthor = msg.author.id === id;
+          const isParentAuthor = msg.parentMessage?.author.id === id;
+          if (!isMainAuthor && !isParentAuthor) return msg;
+          const updatedMsg = isMainAuthor
+            ? { ...msg, author: { ...msg.author, username, displayName, avatarUrl } }
+            : { ...msg };
+          if (isParentAuthor) {
             updatedMsg.parentMessage = {
-              ...msg.parentMessage,
-              author: { ...msg.parentMessage.author, username, displayName, avatarUrl },
+              ...msg.parentMessage!,
+              author: { ...msg.parentMessage!.author, username, displayName, avatarUrl },
             };
           }
           return updatedMsg;

--- a/harmony-frontend/src/hooks/useServerEvents.ts
+++ b/harmony-frontend/src/hooks/useServerEvents.ts
@@ -24,6 +24,12 @@
  *     onMemberStatusChanged: ({ id, status }) => setMembers(prev =>
  *       prev.map(m => m.id === id ? { ...m, status } : m)
  *     ),
+ *     onMemberProfileUpdated: ({ id, username, displayName, avatarUrl }) => {
+ *       setMembers(prev => prev.map(m => m.id === id ? { ...m, username, displayName, avatarUrl } : m));
+ *       setMessages(prev => prev.map(msg =>
+ *         msg.author.id === id ? { ...msg, author: { ...msg.author, username, displayName, avatarUrl } } : msg
+ *       ));
+ *     },
  *     onChannelVisibilityChanged: (ch, oldVis) => { ... },
  *     onMessageCreated: (msg) => { if (msg.channelId === activeChannelId) append(msg); },
  *     onMessageEdited: (msg) => { if (msg.channelId === activeChannelId) update(msg); },
@@ -59,6 +65,13 @@ export interface UseServerEventsOptions {
   onMemberLeft?: (userId: string) => void;
   /** Called when a member's presence status changes (online/idle/offline). Optional. */
   onMemberStatusChanged?: (data: { id: string; status: UserStatus }) => void;
+  /** Called when a member's display name, avatar, or username changes. Optional. */
+  onMemberProfileUpdated?: (data: {
+    id: string;
+    username: string;
+    displayName?: string;
+    avatarUrl?: string;
+  }) => void;
   /**
    * Called when a channel's visibility changes. The updated channel object is
    * provided along with the previous visibility so callers can detect access
@@ -85,6 +98,7 @@ export function useServerEvents({
   onMemberJoined,
   onMemberLeft,
   onMemberStatusChanged,
+  onMemberProfileUpdated,
   onChannelVisibilityChanged,
   onMessageCreated,
   onMessageEdited,
@@ -107,6 +121,7 @@ export function useServerEvents({
   const onMemberJoinedRef = useRef(onMemberJoined);
   const onMemberLeftRef = useRef(onMemberLeft);
   const onMemberStatusChangedRef = useRef(onMemberStatusChanged);
+  const onMemberProfileUpdatedRef = useRef(onMemberProfileUpdated);
   const onVisibilityChangedRef = useRef(onChannelVisibilityChanged);
   const onMessageCreatedRef = useRef(onMessageCreated);
   const onMessageEditedRef = useRef(onMessageEdited);
@@ -120,6 +135,7 @@ export function useServerEvents({
     onMemberJoinedRef.current = onMemberJoined;
     onMemberLeftRef.current = onMemberLeft;
     onMemberStatusChangedRef.current = onMemberStatusChanged;
+    onMemberProfileUpdatedRef.current = onMemberProfileUpdated;
     onVisibilityChangedRef.current = onChannelVisibilityChanged;
     onMessageCreatedRef.current = onMessageCreated;
     onMessageEditedRef.current = onMessageEdited;
@@ -259,6 +275,27 @@ export function useServerEvents({
       }
     };
 
+    const handleMemberProfileUpdated = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as {
+          id: string;
+          username: string;
+          displayName?: string;
+          avatarUrl?: string;
+        };
+        onMemberProfileUpdatedRef.current?.(payload);
+      } catch (error) {
+        logger.warn('Dropped malformed server SSE payload', {
+          feature: 'server-events',
+          event: 'payload_parse_failed',
+          source: 'sse',
+          operation: 'member:profileUpdated',
+          target: '/api/events/server/[serverId]',
+          error,
+        });
+      }
+    };
+
     const handleVisibilityChanged = (event: MessageEvent<string>) => {
       try {
         // The backend sends the full updated channel object plus oldVisibility.
@@ -349,6 +386,7 @@ export function useServerEvents({
       es.addEventListener('member:joined', handleMemberJoined);
       es.addEventListener('member:left', handleMemberLeft);
       es.addEventListener('member:statusChanged', handleMemberStatusChanged);
+      es.addEventListener('member:profileUpdated', handleMemberProfileUpdated);
       es.addEventListener('channel:visibility-changed', handleVisibilityChanged);
       es.addEventListener('message:created', handleMessageCreated);
       es.addEventListener('message:edited', handleMessageEdited);
@@ -361,6 +399,7 @@ export function useServerEvents({
         ['member:joined', handleMemberJoined],
         ['member:left', handleMemberLeft],
         ['member:statusChanged', handleMemberStatusChanged],
+        ['member:profileUpdated', handleMemberProfileUpdated],
         ['channel:visibility-changed', handleVisibilityChanged],
         ['message:created', handleMessageCreated],
         ['message:edited', handleMessageEdited],


### PR DESCRIPTION
## Summary

Fixes #491 — display name, avatar, and `publicProfile` changes now propagate to all connected members in real time without requiring a page refresh.

- **Backend**: Added `USER_PROFILE_UPDATED` Redis pub/sub event channel and payload type. `user.service.ts` emits the event per server membership whenever `displayName`, `avatarUrl`, or `publicProfile` changes (status-only updates are not affected). The SSE router subscribes, hydrates from the DB to apply the `publicProfile` privacy gate (same pattern as `member:joined`), and emits a `member:profileUpdated` SSE event.
- **Frontend**: `useServerEvents` gains `onMemberProfileUpdated` option. `HarmonyShell` wires it to patch both `localMembers` (sidebar) and `localMessages` (message history + reply previews) so all in-flight UI updates immediately — no refresh needed.

## Test plan

- [ ] User A updates display name in settings → User B's sidebar and message history update immediately
- [ ] User A clears avatar → User B sees the fallback avatar immediately
- [ ] User A sets `publicProfile=false` → User B sees "Anonymous" / no avatar immediately
- [ ] Status-only update does NOT emit a `member:profileUpdated` event
- [ ] All backend user service tests pass (`npm test --testPathPattern=user.service`)
- [ ] All frontend tests pass (`cd harmony-frontend && npm test -- --watchAll=false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)