### PR TITLE
Show GIF send backend errors

### DIFF
--- a/harmony-frontend/src/__tests__/issue-238-message-input-aria-label.test.tsx
+++ b/harmony-frontend/src/__tests__/issue-238-message-input-aria-label.test.tsx
@@ -113,7 +113,7 @@ describe('Issue #238 — MessageInput: textarea aria-label accessibility', () =>
     await waitFor(() => {
       expect(mockSendMessageAction).toHaveBeenCalledTimes(1);
       expect(textarea).toHaveFocus();
-      expect(screen.getByRole('alert')).toHaveTextContent(/failed to send message/i);
+      expect(screen.getByRole('alert')).toHaveTextContent('network failure');
     });
   });
 });

--- a/harmony-frontend/src/components/channel/MessageInput.tsx
+++ b/harmony-frontend/src/components/channel/MessageInput.tsx
@@ -10,7 +10,7 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import dynamic from 'next/dynamic';
-import { cn } from '@/lib/utils';
+import { cn, getUserErrorMessage } from '@/lib/utils';
 import { sendMessageAction } from '@/app/actions/sendMessage';
 import { createReplyAction } from '@/app/actions/createReply';
 import { apiClient } from '@/lib/api-client';
@@ -296,8 +296,8 @@ export function MessageInput({
       setPendingAttachments([]);
       closeMentionDropdown();
       onMessageSent?.(msg);
-    } catch {
-      setSendError('Failed to send message. Please try again.');
+    } catch (err) {
+      setSendError(getUserErrorMessage(err, 'Failed to send message. Please try again.'));
     } finally {
       setIsSending(false);
     }


### PR DESCRIPTION
## Summary
- surface the actual backend/server-action error when sending a message fails
- replace the generic GIF send fallback in `MessageInput` with `getUserErrorMessage`
- make production GIF send failures diagnosable from the UI

## Test plan
- [x] `npm test -- --runInBand src/__tests__/issue-499-gif-picker.test.tsx src/__tests__/issue-498-emoji-picker.test.tsx`
- [x] `npm run lint -- src/components/channel/MessageInput.tsx`
- [x] `npm run build`