### PR TITLE
Improve tRPC error observability with safe structured logging

### DIFF
--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -20,7 +20,7 @@ import { presenceService } from './services/presence.service';
 
 const logger = createLogger({ component: 'app', instanceId });
 
-function buildSendMessageLogContext(input: unknown) {
+function buildTrpcInputLogContext(input: unknown) {
   if (!input || typeof input !== 'object') {
     return {};
   }
@@ -28,6 +28,8 @@ function buildSendMessageLogContext(input: unknown) {
   const obj = input as {
     serverId?: unknown;
     channelId?: unknown;
+    messageId?: unknown;
+    parentMessageId?: unknown;
     content?: unknown;
     attachments?: unknown;
   };
@@ -37,6 +39,9 @@ function buildSendMessageLogContext(input: unknown) {
   return {
     serverId: typeof obj.serverId === 'string' ? obj.serverId : undefined,
     channelId: typeof obj.channelId === 'string' ? obj.channelId : undefined,
+    messageId: typeof obj.messageId === 'string' ? obj.messageId : undefined,
+    parentMessageId: typeof obj.parentMessageId === 'string' ? obj.parentMessageId : undefined,
+    hasContent: typeof obj.content === 'string' ? obj.content.trim().length > 0 : undefined,
     contentLength: typeof obj.content === 'string' ? obj.content.length : undefined,
     attachmentCount: attachments.length,
     attachmentOrigins: attachments
@@ -51,6 +56,7 @@ function buildSendMessageLogContext(input: unknown) {
         }
       })
       .filter((origin): origin is string => origin !== null),
+    inputKeys: Object.keys(obj).sort(),
   };
 }
 
@@ -216,20 +222,9 @@ export function createApp(options: CreateAppOptions = {}) {
               path,
               trpcCode: error.code,
               errorMessage: error.message,
+              ...buildTrpcInputLogContext(input),
             },
             'tRPC request failed',
-          );
-        }
-
-        if (path === 'message.sendMessage' && error.code === 'BAD_REQUEST') {
-          logger.warn(
-            {
-              path,
-              trpcCode: error.code,
-              errorMessage: error.message,
-              ...buildSendMessageLogContext(input),
-            },
-            'message.sendMessage rejected with BAD_REQUEST',
           );
         }
 

--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -100,7 +100,6 @@ export interface CreateAppOptions {
 export function createApp(options: CreateAppOptions = {}) {
   presenceService.startSweeper();
 
-  const isE2E = process.env.NODE_ENV === 'e2e';
   const isProduction = process.env.NODE_ENV === 'production';
   // Each limiter calls makeStore() independently so it gets its own instance.
   const makeStore = (prefix: string): Store | undefined =>
@@ -224,13 +223,21 @@ export function createApp(options: CreateAppOptions = {}) {
               errorMessage: error.message,
               ...buildTrpcInputLogContext(input),
             },
-            'tRPC request failed',
+            'tRPC request failed with non-internal error',
           );
         }
 
         // Unexpected server errors include stack/cause via serializer.
         if (error.code === 'INTERNAL_SERVER_ERROR') {
-          logger.error({ err: error, path }, 'Unhandled tRPC error');
+          logger.error(
+            {
+              err: error,
+              path,
+              trpcCode: error.code,
+              errorMessage: error.message,
+            },
+            'tRPC request failed with INTERNAL_SERVER_ERROR',
+          );
         }
       },
     }),

--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -19,6 +19,8 @@ import { redis } from './db/redis';
 import { presenceService } from './services/presence.service';
 
 const logger = createLogger({ component: 'app', instanceId });
+const MAX_LOGGED_ATTACHMENT_ORIGINS = 5;
+const MAX_LOGGED_INPUT_KEYS = 20;
 
 function buildTrpcInputLogContext(input: unknown) {
   if (!input || typeof input !== 'object') {
@@ -35,6 +37,24 @@ function buildTrpcInputLogContext(input: unknown) {
   };
 
   const attachments = Array.isArray(obj.attachments) ? obj.attachments : [];
+  const attachmentOrigins = [
+    ...new Set(
+      attachments
+        .map((att) => {
+          if (!att || typeof att !== 'object') return null;
+          const url = (att as { url?: unknown }).url;
+          if (typeof url !== 'string') return null;
+          try {
+            return new URL(url).origin;
+          } catch {
+            return 'invalid-url';
+          }
+        })
+        .filter((origin): origin is string => origin !== null),
+    ),
+  ].slice(0, MAX_LOGGED_ATTACHMENT_ORIGINS);
+
+  const inputKeys = Object.keys(obj).sort().slice(0, MAX_LOGGED_INPUT_KEYS);
 
   return {
     serverId: typeof obj.serverId === 'string' ? obj.serverId : undefined,
@@ -44,19 +64,8 @@ function buildTrpcInputLogContext(input: unknown) {
     hasContent: typeof obj.content === 'string' ? obj.content.trim().length > 0 : undefined,
     contentLength: typeof obj.content === 'string' ? obj.content.length : undefined,
     attachmentCount: attachments.length,
-    attachmentOrigins: attachments
-      .map((att) => {
-        if (!att || typeof att !== 'object') return null;
-        const url = (att as { url?: unknown }).url;
-        if (typeof url !== 'string') return null;
-        try {
-          return new URL(url).origin;
-        } catch {
-          return 'invalid-url';
-        }
-      })
-      .filter((origin): origin is string => origin !== null),
-    inputKeys: Object.keys(obj).sort(),
+    attachmentOrigins,
+    inputKeys,
   };
 }
 

--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -210,6 +210,17 @@ export function createApp(options: CreateAppOptions = {}) {
       router: appRouter,
       createContext,
       onError({ error, path, input }) {
+        if (error.code !== 'INTERNAL_SERVER_ERROR') {
+          logger.warn(
+            {
+              path,
+              trpcCode: error.code,
+              errorMessage: error.message,
+            },
+            'tRPC request failed',
+          );
+        }
+
         if (path === 'message.sendMessage' && error.code === 'BAD_REQUEST') {
           logger.warn(
             {
@@ -222,7 +233,7 @@ export function createApp(options: CreateAppOptions = {}) {
           );
         }
 
-        // Only log unexpected server errors; auth/validation errors (4xx) are routine
+        // Unexpected server errors include stack/cause via serializer.
         if (error.code === 'INTERNAL_SERVER_ERROR') {
           logger.error({ err: error, path }, 'Unhandled tRPC error');
         }

--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -20,6 +20,40 @@ import { presenceService } from './services/presence.service';
 
 const logger = createLogger({ component: 'app', instanceId });
 
+function buildSendMessageLogContext(input: unknown) {
+  if (!input || typeof input !== 'object') {
+    return {};
+  }
+
+  const obj = input as {
+    serverId?: unknown;
+    channelId?: unknown;
+    content?: unknown;
+    attachments?: unknown;
+  };
+
+  const attachments = Array.isArray(obj.attachments) ? obj.attachments : [];
+
+  return {
+    serverId: typeof obj.serverId === 'string' ? obj.serverId : undefined,
+    channelId: typeof obj.channelId === 'string' ? obj.channelId : undefined,
+    contentLength: typeof obj.content === 'string' ? obj.content.length : undefined,
+    attachmentCount: attachments.length,
+    attachmentOrigins: attachments
+      .map((att) => {
+        if (!att || typeof att !== 'object') return null;
+        const url = (att as { url?: unknown }).url;
+        if (typeof url !== 'string') return null;
+        try {
+          return new URL(url).origin;
+        } catch {
+          return 'invalid-url';
+        }
+      })
+      .filter((origin): origin is string => origin !== null),
+  };
+}
+
 /**
  * Creates one Redis store per rate-limit route in production.
  * Each store gets a unique prefix so login/register/refresh counters don't
@@ -175,7 +209,19 @@ export function createApp(options: CreateAppOptions = {}) {
     createExpressMiddleware({
       router: appRouter,
       createContext,
-      onError({ error, path }) {
+      onError({ error, path, input }) {
+        if (path === 'message.sendMessage' && error.code === 'BAD_REQUEST') {
+          logger.warn(
+            {
+              path,
+              trpcCode: error.code,
+              errorMessage: error.message,
+              ...buildSendMessageLogContext(input),
+            },
+            'message.sendMessage rejected with BAD_REQUEST',
+          );
+        }
+
         // Only log unexpected server errors; auth/validation errors (4xx) are routine
         if (error.code === 'INTERNAL_SERVER_ERROR') {
           logger.error({ err: error, path }, 'Unhandled tRPC error');


### PR DESCRIPTION
## Summary
- log all non-internal tRPC errors as structured warnings in backend onError
- keep internal tRPC errors logged with full error object
- retain enhanced message.sendMessage BAD_REQUEST context (safe metadata only)

## Why
- make Railway Deploy Logs useful for diagnosing 4xx/validation/permission failures across all tRPC procedures
- preserve privacy by avoiding request content and full attachment URLs in logs

## Verification
- `cd harmony-backend && npm run lint`
- `cd harmony-backend && npm run build`
