### PR TITLE
Add GitHub issue templates for work items and bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,46 @@
+---
+name: Bug Report
+about: Report a reproducible defect with clear expected behavior and acceptance criteria
+title: "[Bug] "
+labels: [bug]
+assignees: []
+---
+
+## Summary
+<!-- Briefly describe the bug. -->
+
+## Impact
+<!-- Who is affected and how severe this is. -->
+
+## Environment
+- App version / commit:
+- Browser / OS:
+- Backend environment (local/staging/prod):
+
+## Current Behavior
+<!-- What is happening now. Include exact error text when possible. -->
+
+## Expected Behavior
+<!-- What should happen instead. -->
+
+## Steps To Reproduce
+1.
+2.
+3.
+
+## Evidence
+<!-- Screenshots, logs, network traces, console output, etc. -->
+
+## Suspected Scope
+<!-- Optional: likely files/components/services involved. -->
+
+## Acceptance Criteria
+- [ ] AC-1: Repro steps no longer produce the bug.
+- [ ] AC-2: A regression test covers the failing path.
+- [ ] AC-3: No related behavior regressions are introduced.
+
+## Validation Plan
+<!-- Exact commands/checks to prove the fix works. -->
+
+## Dependencies / Blockers
+<!-- Related issues/PRs, infra blockers, or required follow-ups. -->

--- a/.github/ISSUE_TEMPLATE/work-item.md
+++ b/.github/ISSUE_TEMPLATE/work-item.md
@@ -1,0 +1,41 @@
+---
+name: Work Item
+about: Create a scoped engineering issue with clear acceptance criteria
+title: "[Work Item] "
+labels: []
+assignees: []
+---
+
+## Summary
+<!-- One-paragraph description of the problem or request. -->
+
+## Context
+<!-- Why this matters now, who it affects, and any relevant links. -->
+
+## Current Behavior
+<!-- For bugs: what happens today. For features: what is missing today. -->
+
+## Expected Behavior
+<!-- What should happen after this issue is completed. -->
+
+## Steps To Reproduce (If Bug)
+1. 
+2. 
+3. 
+
+## Proposed Scope
+<!-- Concrete implementation scope. Keep this bounded. -->
+
+## Acceptance Criteria
+- [ ] AC-1:
+- [ ] AC-2:
+- [ ] AC-3:
+
+## Out Of Scope
+<!-- Explicitly list what is not part of this issue. -->
+
+## Validation Plan
+<!-- Commands/checks/evidence required before closing (tests, screenshots, logs, etc.). -->
+
+## Dependencies / Blockers
+<!-- Related issues, PRs, environments, or external blockers. -->


### PR DESCRIPTION
## Summary
- add a reusable work-item issue template with explicit context, scoped implementation, and checklist-based acceptance criteria
- add a dedicated bug-report template with repro, evidence, validation, and regression-test expectations

## Why
- standardizes new issues to match the repo's typical acceptance-criteria-first formatting
- improves issue clarity for implementation and PR review workflows

## Testing
- not applicable (documentation/template-only change)