### PR TITLE
feat: clickable mention notifications + channel/server context + #channel pills + self-mention highlight (#572)

### DIFF
--- a/harmony-backend/prisma/migrations/20260430000000_add_notification_channel_relation/migration.sql
+++ b/harmony-backend/prisma/migrations/20260430000000_add_notification_channel_relation/migration.sql
@@ -1,0 +1,3 @@
+-- AddForeignKey — wire notifications.channel_id → channels.id
+-- The column already exists; only the FK constraint was missing.
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_channel_id_fkey" FOREIGN KEY ("channel_id") REFERENCES "channels"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/harmony-backend/prisma/schema.prisma
+++ b/harmony-backend/prisma/schema.prisma
@@ -78,11 +78,11 @@ model User {
 
   messages                Message[]
   reactions               MessageReaction[]
-  visibilityAuditLog      VisibilityAuditLog[]      @relation("AuditActor")
+  visibilityAuditLog      VisibilityAuditLog[]     @relation("AuditActor")
   refreshTokens           RefreshToken[]
-  ownedServers            Server[]                  @relation("ServerOwner")
+  ownedServers            Server[]                 @relation("ServerOwner")
   serverMemberships       ServerMember[]
-  createdInvites          ServerInvite[]            @relation("InviteCreator")
+  createdInvites          ServerInvite[]           @relation("InviteCreator")
   mentions                MessageMention[]
   notifications           Notification[]
   pushSubscriptions       PushSubscription[]
@@ -92,12 +92,12 @@ model User {
 }
 
 model RefreshToken {
-  id         String    @id @default(uuid()) @db.Uuid
-  tokenHash  String    @unique @map("token_hash") @db.VarChar(64)
-  userId     String    @map("user_id") @db.Uuid
-  expiresAt  DateTime  @map("expires_at") @db.Timestamptz
-  revokedAt  DateTime? @map("revoked_at") @db.Timestamptz
-  createdAt  DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  id        String    @id @default(uuid()) @db.Uuid
+  tokenHash String    @unique @map("token_hash") @db.VarChar(64)
+  userId    String    @map("user_id") @db.Uuid
+  expiresAt DateTime  @map("expires_at") @db.Timestamptz
+  revokedAt DateTime? @map("revoked_at") @db.Timestamptz
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -116,9 +116,9 @@ model Server {
   ownerId     String   @map("owner_id") @db.Uuid
   createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
 
-  owner    User      @relation("ServerOwner", fields: [ownerId], references: [id])
-  channels Channel[]
-  members  ServerMember[]
+  owner                   User                     @relation("ServerOwner", fields: [ownerId], references: [id])
+  channels                Channel[]
+  members                 ServerMember[]
   invites                 ServerInvite[]
   notificationPreferences NotificationPreference[]
 
@@ -129,10 +129,10 @@ model Server {
 }
 
 model ServerMember {
-  userId    String   @map("user_id") @db.Uuid
-  serverId  String   @map("server_id") @db.Uuid
-  role      RoleType @default(MEMBER)
-  joinedAt  DateTime @default(now()) @map("joined_at") @db.Timestamptz
+  userId   String   @map("user_id") @db.Uuid
+  serverId String   @map("server_id") @db.Uuid
+  role     RoleType @default(MEMBER)
+  joinedAt DateTime @default(now()) @map("joined_at") @db.Timestamptz
 
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
   server Server @relation(fields: [serverId], references: [id], onDelete: Cascade)
@@ -155,11 +155,12 @@ model Channel {
   createdAt  DateTime          @default(now()) @map("created_at") @db.Timestamptz
   updatedAt  DateTime          @updatedAt @map("updated_at") @db.Timestamptz
 
-  server            Server              @relation(fields: [serverId], references: [id], onDelete: Cascade)
-  messages          Message[]
-  auditLog          VisibilityAuditLog[]
-  generatedMetaTags GeneratedMetaTags?
+  server                  Server                   @relation(fields: [serverId], references: [id], onDelete: Cascade)
+  messages                Message[]
+  auditLog                VisibilityAuditLog[]
+  generatedMetaTags       GeneratedMetaTags?
   notificationPreferences NotificationPreference[]
+  notifications           Notification[]
 
   // Composite unique — one slug per server
   @@unique([serverId, slug], map: "idx_channels_server_slug")
@@ -185,15 +186,15 @@ model Message {
   /// Denormalised count of non-deleted replies. Incremented on createReply; decremented when a reply is soft-deleted.
   replyCount      Int       @default(0) @map("reply_count")
 
-  channel     Channel          @relation(fields: [channelId], references: [id], onDelete: Cascade)
-  author      User             @relation(fields: [authorId], references: [id])
-  attachments Attachment[]
-  reactions   MessageReaction[]
+  channel       Channel           @relation(fields: [channelId], references: [id], onDelete: Cascade)
+  author        User              @relation(fields: [authorId], references: [id])
+  attachments   Attachment[]
+  reactions     MessageReaction[]
   /// The message this is a reply to (null for top-level messages).
-  parent      Message?         @relation("MessageReplies", fields: [parentMessageId], references: [id], onDelete: SetNull)
+  parent        Message?          @relation("MessageReplies", fields: [parentMessageId], references: [id], onDelete: SetNull)
   /// Direct replies to this message.
-  replies     Message[]        @relation("MessageReplies")
-  mentions    MessageMention[]
+  replies       Message[]         @relation("MessageReplies")
+  mentions      MessageMention[]
   notifications Notification[]
 
   // idx_messages_channel_time (non-partial) and
@@ -302,6 +303,7 @@ model Notification {
 
   user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
   message Message @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  channel Channel @relation(fields: [channelId], references: [id], onDelete: Cascade)
 
   /// Prevent duplicate mention notifications for the same user+message pair.
   @@unique([userId, type, messageId], map: "idx_notifications_unique")
@@ -311,28 +313,28 @@ model Notification {
 }
 
 model GeneratedMetaTags {
-  id                  String   @id @default(uuid()) @db.Uuid
-  channelId           String   @unique(map: "idx_meta_tags_channel") @map("channel_id") @db.Uuid
-  title               String   @db.VarChar(120)
-  description         String   @db.VarChar(320)
-  ogTitle             String   @map("og_title") @db.VarChar(120)
-  ogDescription       String   @map("og_description") @db.VarChar(320)
-  ogImage             String?  @map("og_image") @db.VarChar(500)
-  twitterCard         String   @map("twitter_card") @db.VarChar(20)
-  keywords            String   @db.Text
-  structuredData      Json     @map("structured_data")
-  contentHash         String   @map("content_hash") @db.VarChar(64)
-  needsRegeneration   Boolean  @default(false) @map("needs_regeneration")
-  generatedAt         DateTime @default(now()) @map("generated_at") @db.Timestamptz
-  schemaVersion       Int      @default(1) @map("schema_version")
+  id                String   @id @default(uuid()) @db.Uuid
+  channelId         String   @unique(map: "idx_meta_tags_channel") @map("channel_id") @db.Uuid
+  title             String   @db.VarChar(120)
+  description       String   @db.VarChar(320)
+  ogTitle           String   @map("og_title") @db.VarChar(120)
+  ogDescription     String   @map("og_description") @db.VarChar(320)
+  ogImage           String?  @map("og_image") @db.VarChar(500)
+  twitterCard       String   @map("twitter_card") @db.VarChar(20)
+  keywords          String   @db.Text
+  structuredData    Json     @map("structured_data")
+  contentHash       String   @map("content_hash") @db.VarChar(64)
+  needsRegeneration Boolean  @default(false) @map("needs_regeneration")
+  generatedAt       DateTime @default(now()) @map("generated_at") @db.Timestamptz
+  schemaVersion     Int      @default(1) @map("schema_version")
   /// Admin override title — takes precedence over generated title when present.
-  customTitle         String?  @map("custom_title") @db.VarChar(70)
+  customTitle       String?  @map("custom_title") @db.VarChar(70)
   /// Admin override description — takes precedence over generated description when present.
-  customDescription   String?  @map("custom_description") @db.VarChar(200)
+  customDescription String?  @map("custom_description") @db.VarChar(200)
   /// Admin override OG image URL — takes precedence over generated og_image when present.
-  customOgImage       String?  @map("custom_og_image") @db.VarChar(500)
-  createdAt           DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt           DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+  customOgImage     String?  @map("custom_og_image") @db.VarChar(500)
+  createdAt         DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt         DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
   channel Channel @relation(fields: [channelId], references: [id], onDelete: Cascade)
 

--- a/harmony-backend/src/services/notification.service.ts
+++ b/harmony-backend/src/services/notification.service.ts
@@ -9,6 +9,13 @@ const NOTIFICATION_INCLUDE = {
       author: { select: { id: true, username: true, displayName: true, avatarUrl: true } },
     },
   },
+  channel: {
+    select: {
+      slug: true,
+      name: true,
+      server: { select: { slug: true, name: true } },
+    },
+  },
 } as const;
 
 export const notificationService = {

--- a/harmony-frontend/src/components/channel/MessageList.tsx
+++ b/harmony-frontend/src/components/channel/MessageList.tsx
@@ -73,6 +73,12 @@ interface MessageListProps {
   serverId?: string;
   /** When true, shows the pin/unpin option on message hover. Grant to MODERATOR+. */
   canPin?: boolean;
+  /** Authenticated user's username — forwarded to MessageItem for self-mention highlight. */
+  currentUsername?: string;
+  /** Channels in the current server — forwarded for #channel pill resolution. */
+  channels?: { slug: string; name: string }[];
+  /** Current server slug — forwarded for #channel pill hrefs. */
+  serverSlug?: string;
   /** Called when the user clicks Reply on a message. */
   onReplyClick?: (message: Message) => void;
   /** Called when the user clicks pin/unpin on a message. */
@@ -84,6 +90,9 @@ export function MessageList({
   messages,
   serverId,
   canPin,
+  currentUsername,
+  channels,
+  serverSlug,
   onReplyClick,
   onPinToggle,
 }: MessageListProps) {
@@ -165,6 +174,9 @@ export function MessageList({
                   showHeader={mi === 0}
                   serverId={serverId}
                   canPin={canPin}
+                  currentUsername={currentUsername}
+                  channels={channels}
+                  serverSlug={serverSlug}
                   onReplyClick={onReplyClick}
                   onPinToggle={onPinToggle}
                 />

--- a/harmony-frontend/src/components/channel/NotificationBell.tsx
+++ b/harmony-frontend/src/components/channel/NotificationBell.tsx
@@ -106,43 +106,10 @@ export function NotificationBell({ userId }: NotificationBellProps) {
       const es = new EventSource(url);
       eventSourceRef.current = es;
 
-      es.addEventListener('notification:mention', (e: MessageEvent) => {
-        try {
-          const payload = JSON.parse(e.data) as {
-            id: string;
-            messageId: string;
-            channelId: string;
-            serverId: string;
-            authorId: string;
-            authorUsername: string;
-            timestamp: string;
-            read: boolean;
-          };
-          const optimistic: Notification = {
-            id: payload.id,
-            type: 'mention',
-            messageId: payload.messageId,
-            channelId: payload.channelId,
-            serverId: payload.serverId,
-            read: false,
-            createdAt: payload.timestamp,
-            message: {
-              id: payload.messageId,
-              content: '',
-              isDeleted: false,
-              author: {
-                id: payload.authorId,
-                username: payload.authorUsername,
-                displayName: payload.authorUsername,
-                avatarUrl: null,
-              },
-            },
-          };
-          setNotifications((prev) => [optimistic, ...prev].slice(0, 50));
-          setUnreadCount((c) => c + 1);
-        } catch {
-          // malformed payload — ignore
-        }
+      es.addEventListener('notification:mention', () => {
+        // Refetch the full list so channel/server slugs are populated for navigation.
+        setUnreadCount((c) => c + 1);
+        loadNotifications();
       });
     })();
 
@@ -257,9 +224,17 @@ export function NotificationBell({ userId }: NotificationBellProps) {
                 };
                 return (
                   <li key={n.id}>
-                    <button
-                      type='button'
+                    {/* Use div+role instead of <button> so the ✓ sibling <button> isn't nested inside interactive content (invalid HTML) */}
+                    <div
+                      role='button'
+                      tabIndex={0}
                       onClick={handleRowClick}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          handleRowClick();
+                        }
+                      }}
                       className={cn(
                         'flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-white/5',
                         !n.read && 'bg-indigo-500/10',
@@ -288,18 +263,16 @@ export function NotificationBell({ userId }: NotificationBellProps) {
                         </p>
                       </div>
                       {!n.read && (
-                        <span
+                        <button
+                          type='button'
                           onClick={(e) => { e.stopPropagation(); markAsRead(n.id); }}
-                          role='button'
-                          tabIndex={0}
-                          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); markAsRead(n.id); } }}
                           title='Mark as read'
                           className='mt-0.5 flex-shrink-0 text-[10px] text-indigo-400 hover:text-indigo-300 transition-colors'
                         >
                           ✓
-                        </span>
+                        </button>
                       )}
-                    </button>
+                    </div>
                   </li>
                 );
               })}

--- a/harmony-frontend/src/components/channel/NotificationBell.tsx
+++ b/harmony-frontend/src/components/channel/NotificationBell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api-client';
 import { getAccessToken, fetchSseTicket } from '@/lib/api-client';
 import { cn } from '@/lib/utils';
@@ -19,6 +20,7 @@ interface Notification {
     isDeleted: boolean;
     author: { id: string; username: string; displayName: string; avatarUrl: string | null };
   };
+  channel?: { slug: string; name: string; server: { slug: string; name: string } };
 }
 
 interface NotificationBellProps {
@@ -54,6 +56,7 @@ function formatRelativeTime(ts: string): string {
 }
 
 export function NotificationBell({ userId }: NotificationBellProps) {
+  const router = useRouter();
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
@@ -243,42 +246,63 @@ export function NotificationBell({ userId }: NotificationBellProps) {
               </li>
             )}
             {!isLoading &&
-              notifications.map((n) => (
-                <li
-                  key={n.id}
-                  className={cn(
-                    'flex items-start gap-3 px-4 py-3 transition-colors hover:bg-white/5',
-                    !n.read && 'bg-indigo-500/10',
-                  )}
-                >
-                  <div className='flex-1 min-w-0'>
-                    <p className='text-xs text-gray-300'>
-                      <span className='font-semibold text-white'>
-                        @{n.message.author.username}
-                      </span>{' '}
-                      mentioned you
-                    </p>
-                    {n.message.content && !n.message.isDeleted && (
-                      <p className='mt-0.5 truncate text-xs text-gray-400'>
-                        {n.message.content}
-                      </p>
-                    )}
-                    <p className='mt-0.5 text-[10px] text-gray-500'>
-                      {formatRelativeTime(n.createdAt)}
-                    </p>
-                  </div>
-                  {!n.read && (
+              notifications.map((n) => {
+                const serverSlug = n.channel?.server?.slug;
+                const channelSlug = n.channel?.slug;
+                const isNavigable = !!(serverSlug && channelSlug);
+                const handleRowClick = () => {
+                  if (!n.read) markAsRead(n.id);
+                  setIsOpen(false);
+                  if (isNavigable) router.push(`/c/${serverSlug}/${channelSlug}`);
+                };
+                return (
+                  <li key={n.id}>
                     <button
                       type='button'
-                      onClick={() => markAsRead(n.id)}
-                      title='Mark as read'
-                      className='mt-0.5 flex-shrink-0 text-[10px] text-indigo-400 hover:text-indigo-300 transition-colors'
+                      onClick={handleRowClick}
+                      className={cn(
+                        'flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-white/5',
+                        !n.read && 'bg-indigo-500/10',
+                        isNavigable ? 'cursor-pointer' : 'cursor-default',
+                      )}
                     >
-                      ✓
+                      <div className='flex-1 min-w-0'>
+                        <p className='text-xs text-gray-300'>
+                          <span className='font-semibold text-white'>
+                            @{n.message.author.username}
+                          </span>{' '}
+                          mentioned you
+                        </p>
+                        {n.channel && (
+                          <p className='mt-0.5 text-[10px] text-indigo-300'>
+                            in #{n.channel.name} · {n.channel.server.name}
+                          </p>
+                        )}
+                        {n.message.content && !n.message.isDeleted && (
+                          <p className='mt-0.5 truncate text-xs text-gray-400'>
+                            {n.message.content}
+                          </p>
+                        )}
+                        <p className='mt-0.5 text-[10px] text-gray-500'>
+                          {formatRelativeTime(n.createdAt)}
+                        </p>
+                      </div>
+                      {!n.read && (
+                        <span
+                          onClick={(e) => { e.stopPropagation(); markAsRead(n.id); }}
+                          role='button'
+                          tabIndex={0}
+                          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); markAsRead(n.id); } }}
+                          title='Mark as read'
+                          className='mt-0.5 flex-shrink-0 text-[10px] text-indigo-400 hover:text-indigo-300 transition-colors'
+                        >
+                          ✓
+                        </span>
+                      )}
                     </button>
-                  )}
-                </li>
-              ))}
+                  </li>
+                );
+              })}
           </ul>
         </div>
       )}

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -518,6 +518,9 @@ export function HarmonyShell({
                     messages={localMessages}
                     serverId={currentServer.id}
                     canPin={canPin}
+                    currentUsername={authUser?.username}
+                    channels={localChannels}
+                    serverSlug={currentServer.slug}
                     onReplyClick={handleReplyClick}
                     onPinToggle={handlePinToggle}
                   />

--- a/harmony-frontend/src/components/message/MentionText.tsx
+++ b/harmony-frontend/src/components/message/MentionText.tsx
@@ -29,8 +29,9 @@ export function MentionText({ content, currentUsername, channels, serverSlug }: 
   let lastIndex = 0;
   let key = 0;
 
-  // Single pass: match both @username and #channel-name tokens in source order.
-  const re = /(?:@([\w]{1,32})|#([\w-]{1,100}))/g;
+  // Single pass: match @username and #channel-name tokens only at start or after whitespace
+  // to avoid false positives in URL fragments (e.g. https://example.com/#section) or foo#bar.
+  const re = /(?<!\S)(?:@([\w]{1,32})|#([\w-]{1,100}))/g;
   let match: RegExpExecArray | null;
 
   while ((match = re.exec(content)) !== null) {

--- a/harmony-frontend/src/components/message/MentionText.tsx
+++ b/harmony-frontend/src/components/message/MentionText.tsx
@@ -1,55 +1,94 @@
 'use client';
 
 import React from 'react';
+import Link from 'next/link';
 
 export interface MentionTextProps {
   content: string;
   /** Current user's username — self-mentions get the accent highlight. */
   currentUsername?: string;
+  /** Channels in the current server — used to resolve #channel-name pills. */
+  channels?: { slug: string; name: string }[];
+  /** Current server slug — used to build href for #channel pills. */
+  serverSlug?: string;
 }
 
 /**
- * Renders message content with @username tokens styled as inline mention pills.
- * Self-mentions receive an accent background; other mentions are styled subtly.
- * Pass `currentUsername` from a parent component that already holds auth state.
+ * Renders message content with @username and #channel-name tokens styled as pills.
+ * Self-mentions get an accent background. #channel pills are clickable when the
+ * channel exists in the current server; otherwise they render non-navigable.
  */
-export function MentionText({ content, currentUsername }: MentionTextProps) {
-  if (!content.includes('@')) {
+export function MentionText({ content, currentUsername, channels, serverSlug }: MentionTextProps) {
+  if (!content.includes('@') && !content.includes('#')) {
     return <>{content}</>;
   }
 
+  const channelMap = new Map(channels?.map((c) => [c.slug.toLowerCase(), c]) ?? []);
+
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
-  let match: RegExpExecArray | null;
   let key = 0;
-  // Create a fresh regex per call so lastIndex state never bleeds between renders.
-  const re = /@([\w]{1,32})/g;
-  while ((match = re.exec(content)) !== null) {
-    const [full, username] = match;
-    const start = match.index;
 
+  // Single pass: match both @username and #channel-name tokens in source order.
+  const re = /(?:@([\w]{1,32})|#([\w-]{1,100}))/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(content)) !== null) {
+    const start = match.index;
     if (start > lastIndex) {
       parts.push(content.slice(lastIndex, start));
     }
 
-    const isSelf =
-      currentUsername && username.toLowerCase() === currentUsername.toLowerCase();
+    if (match[1] !== undefined) {
+      // @username pill
+      const username = match[1];
+      const isSelf =
+        !!currentUsername && username.toLowerCase() === currentUsername.toLowerCase();
+      parts.push(
+        <span
+          key={key++}
+          className={
+            isSelf
+              ? 'rounded px-0.5 font-semibold text-white bg-indigo-500/70 hover:bg-indigo-500 cursor-default'
+              : 'rounded px-0.5 font-semibold text-indigo-300 bg-indigo-500/20 hover:bg-indigo-500/40 cursor-default'
+          }
+          title={`@${username}`}
+        >
+          @{username}
+        </span>,
+      );
+    } else {
+      // #channel-name pill
+      const rawSlug = match[2];
+      const channel = channelMap.get(rawSlug.toLowerCase());
+      const pillClass =
+        'rounded px-0.5 font-semibold text-indigo-300 bg-indigo-500/20 hover:bg-indigo-500/40';
 
-    parts.push(
-      <span
-        key={key++}
-        className={
-          isSelf
-            ? 'rounded px-0.5 font-semibold text-white bg-indigo-500/70 hover:bg-indigo-500 cursor-default'
-            : 'rounded px-0.5 font-semibold text-indigo-300 bg-indigo-500/20 hover:bg-indigo-500/40 cursor-default'
-        }
-        title={`@${username}`}
-      >
-        {full}
-      </span>,
-    );
+      if (channel && serverSlug) {
+        parts.push(
+          <Link
+            key={key++}
+            href={`/c/${serverSlug}/${channel.slug}`}
+            className={`${pillClass} cursor-pointer`}
+            title={`#${channel.name}`}
+          >
+            #{rawSlug}
+          </Link>,
+        );
+      } else {
+        parts.push(
+          <span
+            key={key++}
+            className={`${pillClass} cursor-default`}
+            title={`#${rawSlug}`}
+          >
+            #{rawSlug}
+          </span>,
+        );
+      }
+    }
 
-    lastIndex = start + full.length;
+    lastIndex = match.index + match[0].length;
   }
 
   if (lastIndex < content.length) {

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -665,9 +665,10 @@ export function MessageItem({
   const isOwnMessage = !!user && user.id === message.author.id;
   const isMentioned =
     !!currentUsername &&
-    (localContent ?? message.content)
-      .toLowerCase()
-      .includes('@' + currentUsername.toLowerCase());
+    // Use suffix boundary (?!\w) so @ann doesn't match @announcements.
+    new RegExp(`@${currentUsername.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?!\\w)`, 'i').test(
+      localContent ?? message.content,
+    );
 
   const handleReactionAdd = useCallback(
     (emoji: string) => {

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -46,12 +46,27 @@ function getEmbedVideoUrl(url: string): string | null {
   }
 }
 
-function MessageContent({ content }: { content: string }) {
+function MessageContent({
+  content,
+  currentUsername,
+  channels,
+  serverSlug,
+}: {
+  content: string;
+  currentUsername?: string;
+  channels?: { slug: string; name: string }[];
+  serverSlug?: string;
+}) {
   const matches = [...content.matchAll(URL_PATTERN)];
   if (matches.length === 0) {
     return (
       <p className='whitespace-pre-line text-sm leading-relaxed text-[#dcddde]'>
-        <MentionText content={content} currentUsername={undefined} />
+        <MentionText
+          content={content}
+          currentUsername={currentUsername}
+          channels={channels}
+          serverSlug={serverSlug}
+        />
       </p>
     );
   }
@@ -82,7 +97,12 @@ function MessageContent({ content }: { content: string }) {
     <div className='mt-0.5'>
       {textContent && (
         <p className='whitespace-pre-line text-sm leading-relaxed text-[#dcddde]'>
-          <MentionText content={textContent} currentUsername={undefined} />
+          <MentionText
+            content={textContent}
+            currentUsername={currentUsername}
+            channels={channels}
+            serverSlug={serverSlug}
+          />
         </p>
       )}
       {videoEmbeds.length > 0 && (
@@ -579,6 +599,9 @@ export function MessageItem({
   showHeader = true,
   canPin,
   serverId,
+  currentUsername,
+  channels,
+  serverSlug,
   onReplyClick,
   onPinToggle,
 }: {
@@ -589,6 +612,12 @@ export function MessageItem({
   canPin?: boolean;
   /** Required for pin actions. Passed alongside canPin. */
   serverId?: string;
+  /** The authenticated user's username — used for self-mention detection and highlight. */
+  currentUsername?: string;
+  /** Channels in the current server — used to resolve #channel-name pills. */
+  channels?: { slug: string; name: string }[];
+  /** Current server slug — used for #channel pill hrefs. */
+  serverSlug?: string;
   /** Called when the user clicks Reply on this message. */
   onReplyClick?: (message: Message) => void;
   /** Called when the user triggers a pin/unpin action for this message. */
@@ -634,6 +663,11 @@ export function MessageItem({
   }
 
   const isOwnMessage = !!user && user.id === message.author.id;
+  const isMentioned =
+    !!currentUsername &&
+    (localContent ?? message.content)
+      .toLowerCase()
+      .includes('@' + currentUsername.toLowerCase());
 
   const handleReactionAdd = useCallback(
     (emoji: string) => {
@@ -901,7 +935,10 @@ export function MessageItem({
     return (
       <div
         data-message-id={message.id}
-        className='group relative flex flex-col px-4 py-0.5 hover:bg-white/[0.02]'
+        className={cn(
+          'group relative flex flex-col px-4 py-0.5 hover:bg-white/[0.02]',
+          isMentioned && 'border-l-2 border-yellow-400 bg-yellow-500/[0.06] hover:bg-yellow-500/[0.08]',
+        )}
       >
         {message.parentMessage && (
           <div className='ml-14 pt-1'>
@@ -921,7 +958,12 @@ export function MessageItem({
               editUi
             ) : (
               <div>
-                <MessageContent content={localContent ?? message.content} />
+                <MessageContent
+                  content={localContent ?? message.content}
+                  currentUsername={currentUsername}
+                  channels={channels}
+                  serverSlug={serverSlug}
+                />
                 {(message.editedAt || localContent !== undefined) && (
                   <span className='ml-1 text-[10px] text-gray-500'>(edited)</span>
                 )}
@@ -945,7 +987,10 @@ export function MessageItem({
   return (
     <div
       data-message-id={message.id}
-      className='group relative flex flex-col px-4 py-0.5 hover:bg-white/[0.02]'
+      className={cn(
+        'group relative flex flex-col px-4 py-0.5 hover:bg-white/[0.02]',
+        isMentioned && 'border-l-2 border-yellow-400 bg-yellow-500/[0.06] hover:bg-yellow-500/[0.08]',
+      )}
     >
       {message.parentMessage && (
         <div className='ml-14 pt-1'>
@@ -994,7 +1039,12 @@ export function MessageItem({
           {isEditing ? (
             editUi
           ) : (
-            <MessageContent content={localContent ?? message.content} />
+            <MessageContent
+              content={localContent ?? message.content}
+              currentUsername={currentUsername}
+              channels={channels}
+              serverSlug={serverSlug}
+            />
           )}
           <AttachmentList attachments={message.attachments} />
           <ReactionList


### PR DESCRIPTION
## Summary

Closes #572. Implements all four acceptance criteria for the mention/notification UX improvements.

### Changes

**Backend (`notification.service.ts`)**
- Enrich `NOTIFICATION_INCLUDE` to join `channel.slug`, `channel.name`, `channel.server.slug`, and `channel.server.name` so every notification API response carries the data needed for navigation.

**`NotificationBell.tsx`**
- Updated `Notification` interface to include `channel: { slug, name, server: { slug, name } }`.
- Each notification row is now a `<button>` that navigates to `/c/[serverSlug]/[channelSlug]`, marks the notification read, and closes the panel on click.
- A secondary line "in #channel-name · Server Name" is rendered below the mention text when channel data is available.
- The ✓ mark-as-read button uses `stopPropagation` so it doesn't trigger the row navigation.

**`MentionText.tsx`**
- Replaced the `@username`-only regex with a single-pass scanner that handles both `@username` and `#channel-name` tokens in source order.
- Accepts new optional props: `channels?: { slug, name }[]` and `serverSlug?: string`.
- `#channel-name` tokens render as `<Link>` pills when the slug exists in the current server's channel list; otherwise they render as non-navigable styled spans.

**`MessageItem.tsx`**
- Accepts new optional props: `currentUsername`, `channels`, `serverSlug`.
- Derives `isMentioned` once at render using `currentUsername`.
- Both return paths (compact and full-header) apply `border-l-2 border-yellow-400 bg-yellow-500/[0.06] hover:bg-yellow-500/[0.08]` when `isMentioned` is true.
- Threads all three new props through `MessageContent` → `MentionText`.

**`MessageList.tsx`**
- Accepts and forwards `currentUsername`, `channels`, `serverSlug` to `MessageItem`.

**`HarmonyShell.tsx`**
- Passes `authUser?.username`, `localChannels`, and `currentServer.slug` to `MessageList`.

## Test plan

- [x] All 432 frontend unit tests pass (`npm test` in `harmony-frontend`)
- [x] Backend TypeScript compiles cleanly (`npx tsc --noEmit` in `harmony-backend`)
- [ ] Manual: open a channel as a logged-in user, send a message mentioning yourself (`@yourname`) — row should show yellow highlight and left border
- [ ] Manual: send a message with `#some-channel` — pill should be rendered; clicking navigates to that channel if it exists in the current server
- [ ] Manual: trigger a mention notification; open the bell panel — entry should show "in #channel · Server"; clicking should navigate and close the panel
- [ ] Manual: unread mark-as-read ✓ button should work independently without triggering navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)