### PR TITLE
Allow MP4 attachments

### DIFF
--- a/harmony-backend/src/lib/storage/mime-types.ts
+++ b/harmony-backend/src/lib/storage/mime-types.ts
@@ -4,6 +4,7 @@ export const MIME_TO_EXT: Record<string, string> = {
   'image/png': '.png',
   'image/gif': '.gif',
   'image/webp': '.webp',
+  'video/mp4': '.mp4',
   'application/pdf': '.pdf',
   'text/plain': '.txt',
   'application/msword': '.doc',

--- a/harmony-backend/src/services/attachment.service.ts
+++ b/harmony-backend/src/services/attachment.service.ts
@@ -14,6 +14,8 @@ export const ALLOWED_CONTENT_TYPES = new Set([
   'image/png',
   'image/gif',
   'image/webp',
+  // Video
+  'video/mp4',
   // Documents
   'application/pdf',
   'text/plain',

--- a/harmony-backend/tests/attachment.router.test.ts
+++ b/harmony-backend/tests/attachment.router.test.ts
@@ -151,4 +151,20 @@ describe('POST /api/attachments/upload', () => {
     expect(res.status).toBe(201);
     expect(res.body.contentType).toBe('text/plain');
   });
+
+  it('returns 201 for a valid MP4 upload', async () => {
+    mockDetectMimeType.mockResolvedValueOnce('video/mp4');
+
+    const mp4Buffer = Buffer.from('fake-mp4-data');
+    const res = await request(app)
+      .post('/api/attachments/upload')
+      .set('Authorization', `Bearer ${VALID_TOKEN}`)
+      .attach('file', mp4Buffer, {
+        filename: 'clip.mp4',
+        contentType: 'video/mp4',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.contentType).toBe('video/mp4');
+  });
 });

--- a/harmony-backend/tests/attachment.router.test.ts
+++ b/harmony-backend/tests/attachment.router.test.ts
@@ -8,6 +8,8 @@
 import request from 'supertest';
 import { createApp } from '../src/app';
 import type { Express } from 'express';
+import { MIME_TO_EXT } from '../src/lib/storage/mime-types';
+import { storageProvider } from '../src/lib/storage';
 
 const VALID_TOKEN = 'valid-test-token';
 const TEST_USER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
@@ -51,6 +53,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   mockDetectMimeType.mockReset();
+  jest.clearAllMocks();
 });
 
 describe('POST /api/attachments/upload', () => {
@@ -166,5 +169,16 @@ describe('POST /api/attachments/upload', () => {
 
     expect(res.status).toBe(201);
     expect(res.body.contentType).toBe('video/mp4');
+    expect(storageProvider.upload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filename: 'clip.mp4',
+        contentType: 'video/mp4',
+        data: mp4Buffer,
+      }),
+    );
+  });
+
+  it('maps video/mp4 to the .mp4 storage extension', () => {
+    expect(MIME_TO_EXT['video/mp4']).toBe('.mp4');
   });
 });

--- a/harmony-frontend/src/components/channel/MessageInput.tsx
+++ b/harmony-frontend/src/components/channel/MessageInput.tsx
@@ -481,7 +481,7 @@ export function MessageInput({
           className='hidden'
           aria-hidden='true'
           onChange={handleFileChange}
-          accept='image/jpeg,image/png,image/gif,image/webp,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+          accept='image/jpeg,image/png,image/gif,image/webp,video/mp4,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         />
 
         {/* Attachment button */}


### PR DESCRIPTION
## Summary
- allow `video/mp4` through the backend attachment upload whitelist
- map accepted MP4 uploads to the `.mp4` storage extension instead of falling back to `.bin`
- add MP4 upload coverage and expose MP4 in the frontend file picker accept list

## Test plan
- [x] `cd harmony-backend && npm test -- --runInBand tests/attachment.router.test.ts`
- [x] `cd harmony-backend && npm run lint -- src/services/attachment.service.ts src/lib/storage/mime-types.ts tests/attachment.router.test.ts`
- [x] `cd harmony-backend && npm run build`
- [x] `cd harmony-frontend && npm run lint -- src/components/channel/MessageInput.tsx`
- [x] `cd harmony-frontend && npm run build`