### PR TITLE
fix: resolve search console canonical + structured data warnings

### DIFF
--- a/harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+++ b/harmony-frontend/src/__tests__/channel-page-metadata.test.ts
@@ -19,6 +19,11 @@ jest.mock('@/components/channel/GuestChannelView', () => ({
   GuestChannelView: () => null,
 }));
 
+const mockPermanentRedirect = jest.fn();
+jest.mock('next/navigation', () => ({
+  permanentRedirect: (...args: unknown[]) => mockPermanentRedirect(...args),
+}));
+
 import { renderToStaticMarkup } from 'react-dom/server';
 import GuestChannelPage, { generateMetadata } from '@/app/c/[serverSlug]/[channelSlug]/page';
 import {
@@ -102,6 +107,19 @@ describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
     expect(meta.alternates?.canonical).toBe('https://harmony.chat/c/harmony-hq/general');
   });
 
+  it('uses canonical slugs from API data for metadata canonical URL', async () => {
+    mockFetchPublicServer.mockResolvedValue(makeServer({ slug: 'harmony-hq-canonical' }));
+    mockFetchPublicChannel.mockResolvedValue({
+      channel: makeChannel(ChannelVisibility.PUBLIC_INDEXABLE, { slug: 'general-canonical' }),
+      isPrivate: false,
+    });
+
+    const meta = await generateMetadata(makeParams('Harmony-HQ', 'General'));
+    expect(meta.alternates?.canonical).toBe(
+      'https://harmony.chat/c/harmony-hq-canonical/general-canonical',
+    );
+  });
+
   it('includes Open Graph tags', async () => {
     const meta = await generateMetadata(makeParams());
     expect(meta).toMatchObject({
@@ -146,6 +164,17 @@ describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
       'url': 'https://harmony.chat/c/harmony-hq/general',
       'datePublished': '2026-01-01T00:00:00.000Z',
     });
+  });
+
+  it('redirects to canonical slugs when route params are non-canonical', async () => {
+    mockFetchPublicServer.mockResolvedValue(makeServer({ slug: 'harmony-hq-canonical' }));
+    mockFetchPublicChannel.mockResolvedValue({
+      channel: makeChannel(ChannelVisibility.PUBLIC_INDEXABLE, { slug: 'general-canonical' }),
+      isPrivate: false,
+    });
+
+    await GuestChannelPage(makeParams('Harmony-HQ', 'General'));
+    expect(mockPermanentRedirect).toHaveBeenCalledWith('/c/harmony-hq-canonical/general-canonical');
   });
 
   it('reuses persisted SEO metadata in JSON-LD when present', async () => {
@@ -214,7 +243,7 @@ describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
       author: {
         '@type': 'Organization',
         'name': 'admin',
-        'url': 'https://harmony.chat/c/admin/general',
+        'url': 'https://harmony.chat/c/harmony-hq/general',
       },
       name: 'general - admin | Harmony',
       headline: 'general - admin | Harmony',

--- a/harmony-frontend/src/__tests__/channel-page-metadata.test.ts
+++ b/harmony-frontend/src/__tests__/channel-page-metadata.test.ts
@@ -141,6 +141,7 @@ describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
       'author': {
         '@type': 'Organization',
         'name': 'Harmony HQ',
+        'url': 'https://harmony.chat/c/harmony-hq/general',
       },
       'url': 'https://harmony.chat/c/harmony-hq/general',
       'datePublished': '2026-01-01T00:00:00.000Z',
@@ -189,6 +190,7 @@ describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
       author: {
         '@type': 'Organization',
         'name': 'fallback-server',
+        'url': 'https://harmony.chat/c/fallback-server/general',
       },
     });
   });
@@ -212,6 +214,7 @@ describe('generateMetadata — PUBLIC_INDEXABLE channel', () => {
       author: {
         '@type': 'Organization',
         'name': 'admin',
+        'url': 'https://harmony.chat/c/admin/general',
       },
       name: 'general - admin | Harmony',
       headline: 'general - admin | Harmony',

--- a/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+++ b/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { permanentRedirect } from 'next/navigation';
 import { GuestChannelView } from '@/components/channel/GuestChannelView';
 import {
   fetchPublicServer,
@@ -10,6 +11,22 @@ import { getChannelUrl } from '@/lib/runtime-config';
 
 interface PageProps {
   params: Promise<{ serverSlug: string; channelSlug: string }>;
+}
+
+function getCanonicalSlugs(
+  serverSlug: string,
+  channelSlug: string,
+  server: Awaited<ReturnType<typeof fetchPublicServer>>,
+  channelResult: Awaited<ReturnType<typeof fetchPublicChannel>>,
+): { serverSlug: string; channelSlug: string } {
+  const canonicalServerSlug = server?.slug?.trim() || serverSlug;
+  const canonicalChannelSlug =
+    channelResult && !channelResult.isPrivate ? channelResult.channel.slug : channelSlug;
+
+  return {
+    serverSlug: canonicalServerSlug,
+    channelSlug: canonicalChannelSlug,
+  };
 }
 
 function sanitizeMetadataLabel(value: string): string {
@@ -67,7 +84,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     publicMetaTags,
   );
   const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
-  const canonicalUrl = getChannelUrl(serverSlug, channelSlug);
+  const canonicalSlugs = getCanonicalSlugs(serverSlug, channelSlug, server, channelResult);
+  const canonicalUrl = getChannelUrl(canonicalSlugs.serverSlug, canonicalSlugs.channelSlug);
 
   return {
     title,
@@ -107,7 +125,15 @@ export default async function GuestChannelPage({ params }: PageProps) {
     publicMetaTags,
   );
   const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
-  const canonicalUrl = getChannelUrl(serverSlug, channelSlug);
+  const canonicalSlugs = getCanonicalSlugs(serverSlug, channelSlug, server, channelResult);
+  const canonicalUrl = getChannelUrl(canonicalSlugs.serverSlug, canonicalSlugs.channelSlug);
+
+  if (
+    !channelResult?.isPrivate &&
+    (canonicalSlugs.serverSlug !== serverSlug || canonicalSlugs.channelSlug !== channelSlug)
+  ) {
+    permanentRedirect(`/c/${canonicalSlugs.serverSlug}/${canonicalSlugs.channelSlug}`);
+  }
 
   const jsonLd = isIndexable
     ? {

--- a/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
+++ b/harmony-frontend/src/app/c/[serverSlug]/[channelSlug]/page.tsx
@@ -107,6 +107,7 @@ export default async function GuestChannelPage({ params }: PageProps) {
     publicMetaTags,
   );
   const isIndexable = channel?.visibility === ChannelVisibility.PUBLIC_INDEXABLE;
+  const canonicalUrl = getChannelUrl(serverSlug, channelSlug);
 
   const jsonLd = isIndexable
     ? {
@@ -114,12 +115,13 @@ export default async function GuestChannelPage({ params }: PageProps) {
         '@type': 'DiscussionForumPosting',
         'name': title,
         'headline': title,
-        'url': getChannelUrl(serverSlug, channelSlug),
+        'url': canonicalUrl,
         'description': description,
         'text': description,
         'author': {
           '@type': 'Organization',
           'name': serverName,
+          'url': canonicalUrl,
         },
         ...(channel?.createdAt && { datePublished: channel.createdAt }),
       }


### PR DESCRIPTION
## Summary
- fix issue #584 by adding author.url to DiscussionForumPosting JSON-LD on public channel pages
- fix issue #585 by canonicalizing channel URLs from API slugs and redirecting non-canonical slug paths to one canonical route
- extend channel metadata tests to cover canonical URL normalization and redirect behavior

## Verification
- rtk npm test -- --runInBand src/__tests__/channel-page-metadata.test.ts
- rtk npx eslint src/app/c/[serverSlug]/[channelSlug]/page.tsx src/__tests__/channel-page-metadata.test.ts
- rtk npx tsc --noEmit (fails due to pre-existing unrelated errors in src/__tests__/gifsRoute.test.ts)

Closes #584
Closes #585