### PR TITLE
fix: derive unreadCount from notifications state + mark-as-read tests (#574)

### DIFF
--- a/harmony-backend/tests/notification.router.test.ts
+++ b/harmony-backend/tests/notification.router.test.ts
@@ -1,0 +1,204 @@
+/**
+ * notification.router.test.ts — Issue #574
+ *
+ * Integration-style tests for the tRPC notification endpoints using supertest.
+ * Prisma is mocked so no live database is required.
+ *
+ * Covers:
+ *   - notification.markAsRead   : persists the read flag for the authed user
+ *   - notification.markAllAsRead: persists read for all unread of the authed user
+ *   - Both endpoints reject unauthenticated requests
+ */
+
+// ─── Prisma mock ──────────────────────────────────────────────────────────────
+
+jest.mock('../src/db/prisma', () => ({
+  prisma: {
+    notification: {
+      findMany: jest.fn().mockResolvedValue([]),
+      count: jest.fn().mockResolvedValue(0),
+      updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+    notificationPreference: {
+      findMany: jest.fn().mockResolvedValue([]),
+      findFirst: jest.fn().mockResolvedValue(null),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    pushSubscription: {
+      upsert: jest.fn(),
+      deleteMany: jest.fn(),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    serverMember: {
+      findUnique: jest.fn().mockResolvedValue(null),
+    },
+  },
+}));
+
+// ─── Auth service mock ────────────────────────────────────────────────────────
+
+const AUTHED_USER_ID = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+jest.mock('../src/services/auth.service', () => ({
+  authService: {
+    verifyAccessToken: jest.fn((token: string) => {
+      if (token === 'valid-token') return { sub: AUTHED_USER_ID };
+      throw new Error('Invalid token');
+    }),
+  },
+}));
+
+jest.mock('../src/services/presence.service', () => ({
+  presenceService: { startSweeper: jest.fn() },
+}));
+
+jest.mock('../src/db/redis', () => ({
+  redis: { call: jest.fn(), quit: jest.fn() },
+}));
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+
+import request from 'supertest';
+import { createApp } from '../src/app';
+import { prisma } from '../src/db/prisma';
+
+const mockPrisma = prisma as unknown as {
+  notification: {
+    findMany: jest.Mock;
+    count: jest.Mock;
+    updateMany: jest.Mock;
+  };
+};
+
+const app = createApp();
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function authedPost(path: string, body?: object) {
+  return request(app)
+    .post(path)
+    .set('Authorization', 'Bearer valid-token')
+    .set('Origin', 'http://localhost:3000')
+    .send(body ?? {});
+}
+
+function authedGet(path: string) {
+  return request(app)
+    .get(path)
+    .set('Authorization', 'Bearer valid-token')
+    .set('Origin', 'http://localhost:3000');
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPrisma.notification.updateMany.mockResolvedValue({ count: 1 });
+  mockPrisma.notification.findMany.mockResolvedValue([]);
+  mockPrisma.notification.count.mockResolvedValue(0);
+});
+
+describe('POST /trpc/notification.markAsRead', () => {
+  const NOTIF_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+  it('returns 200 and calls updateMany with correct args for the authed user', async () => {
+    const res = await authedPost('/trpc/notification.markAsRead', {
+      notificationId: NOTIF_ID,
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith({
+      where: { id: NOTIF_ID, userId: AUTHED_USER_ID },
+      data: { read: true },
+    });
+  });
+
+  it('returns the batch payload in the tRPC result envelope', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await authedPost('/trpc/notification.markAsRead', {
+      notificationId: NOTIF_ID,
+    });
+
+    expect(res.body).toMatchObject({ result: { data: { count: 1 } } });
+  });
+
+  it('rejects requests without a valid token with UNAUTHORIZED', async () => {
+    const res = await request(app)
+      .post('/trpc/notification.markAsRead')
+      .set('Origin', 'http://localhost:3000')
+      .send({ notificationId: NOTIF_ID });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects requests with an invalid notificationId (not a UUID)', async () => {
+    const res = await authedPost('/trpc/notification.markAsRead', {
+      notificationId: 'not-a-uuid',
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockPrisma.notification.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /trpc/notification.markAllAsRead', () => {
+  it('returns 200 and calls updateMany scoped to userId and read:false', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 3 });
+
+    const res = await authedPost('/trpc/notification.markAllAsRead');
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith({
+      where: { userId: AUTHED_USER_ID, read: false },
+      data: { read: true },
+    });
+  });
+
+  it('returns the batch payload in the tRPC result envelope', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 3 });
+
+    const res = await authedPost('/trpc/notification.markAllAsRead');
+
+    expect(res.body).toMatchObject({ result: { data: { count: 3 } } });
+  });
+
+  it('rejects unauthenticated requests with UNAUTHORIZED', async () => {
+    const res = await request(app)
+      .post('/trpc/notification.markAllAsRead')
+      .set('Origin', 'http://localhost:3000')
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(mockPrisma.notification.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('returns count 0 when there are no unread notifications', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 0 });
+
+    const res = await authedPost('/trpc/notification.markAllAsRead');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ result: { data: { count: 0 } } });
+  });
+});
+
+describe('GET /trpc/notification.getUnreadCount', () => {
+  it('returns the unread count for the authed user', async () => {
+    mockPrisma.notification.count.mockResolvedValue(4);
+
+    const res = await authedGet('/trpc/notification.getUnreadCount');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ result: { data: 4 } });
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const res = await request(app)
+      .get('/trpc/notification.getUnreadCount')
+      .set('Origin', 'http://localhost:3000');
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/harmony-backend/tests/notification.service.test.ts
+++ b/harmony-backend/tests/notification.service.test.ts
@@ -1,0 +1,124 @@
+/**
+ * notification.service.test.ts — Issue #574
+ *
+ * Verifies that markAsRead and markAllAsRead correctly persist read-state
+ * changes in the database.
+ *
+ * Uses a mocked Prisma client so the suite runs without a live database.
+ */
+
+// ─── Prisma mock ──────────────────────────────────────────────────────────────
+
+jest.mock('../src/db/prisma', () => ({
+  prisma: {
+    notification: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '../src/db/prisma';
+import { notificationService } from '../src/services/notification.service';
+
+const mockPrisma = prisma as unknown as {
+  notification: {
+    findMany: jest.Mock;
+    count: jest.Mock;
+    updateMany: jest.Mock;
+  };
+};
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const USER_ID = '00000000-0000-0000-0000-000000000001';
+const NOTIF_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('notificationService.markAsRead', () => {
+  it('calls updateMany with the correct notificationId and userId', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 1 });
+
+    await notificationService.markAsRead(NOTIF_ID, USER_ID);
+
+    expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith({
+      where: { id: NOTIF_ID, userId: USER_ID },
+      data: { read: true },
+    });
+  });
+
+  it('returns the batch payload from updateMany', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await notificationService.markAsRead(NOTIF_ID, USER_ID);
+
+    expect(result).toEqual({ count: 1 });
+  });
+
+  it('returns count 0 when no matching notification is found', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await notificationService.markAsRead(NOTIF_ID, USER_ID);
+
+    expect(result).toEqual({ count: 0 });
+  });
+
+  it('does not update notifications belonging to a different user', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 0 });
+
+    await notificationService.markAsRead(NOTIF_ID, 'other-user-id');
+
+    // The where clause must include the userId guard
+    expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ userId: 'other-user-id' }) }),
+    );
+  });
+});
+
+describe('notificationService.markAllAsRead', () => {
+  it('calls updateMany scoped to the userId and only unread notifications', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 3 });
+
+    await notificationService.markAllAsRead(USER_ID);
+
+    expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith({
+      where: { userId: USER_ID, read: false },
+      data: { read: true },
+    });
+  });
+
+  it('returns the batch payload from updateMany', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 5 });
+
+    const result = await notificationService.markAllAsRead(USER_ID);
+
+    expect(result).toEqual({ count: 5 });
+  });
+
+  it('returns count 0 when there are no unread notifications', async () => {
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await notificationService.markAllAsRead(USER_ID);
+
+    expect(result).toEqual({ count: 0 });
+  });
+});
+
+describe('notificationService.getUnreadCount', () => {
+  it('counts only unread notifications for the given user', async () => {
+    mockPrisma.notification.count.mockResolvedValue(2);
+
+    const count = await notificationService.getUnreadCount(USER_ID);
+
+    expect(count).toBe(2);
+    expect(mockPrisma.notification.count).toHaveBeenCalledWith({
+      where: { userId: USER_ID, read: false },
+    });
+  });
+});

--- a/harmony-frontend/src/__tests__/NotificationBell.test.tsx
+++ b/harmony-frontend/src/__tests__/NotificationBell.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * NotificationBell.test.tsx — Issue #574
+ *
+ * Covers:
+ *   - Single mark-as-read: clicking ✓ calls the correct mutation and marks the
+ *     notification as read in the UI.
+ *   - Bulk mark-as-read: clicking "Mark all as read" calls the correct mutation
+ *     and marks every notification as read in the UI.
+ *   - Unread badge/count reflects changes for both flows.
+ *   - Silent mutation failure leaves the UI unchanged (no crash, no phantom read).
+ */
+
+// ─── Module-level mock variables ─────────────────────────────────────────────
+
+const mockTrpcQuery = jest.fn();
+const mockTrpcMutation = jest.fn();
+
+// ─── Jest module mocks ────────────────────────────────────────────────────────
+
+jest.mock('@/lib/api-client', () => ({
+  apiClient: {
+    trpcQuery: (...args: unknown[]) => mockTrpcQuery(...args),
+    trpcMutation: (...args: unknown[]) => mockTrpcMutation(...args),
+  },
+  getAccessToken: () => null,
+  fetchSseTicket: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { NotificationBell } from '@/components/channel/NotificationBell';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const USER_ID = '00000000-0000-0000-0000-000000000001';
+
+const makeNotification = (id: string, read: boolean) => ({
+  id,
+  type: 'mention',
+  messageId: `msg-${id}`,
+  channelId: 'channel-1',
+  serverId: 'server-1',
+  read,
+  createdAt: new Date().toISOString(),
+  message: {
+    id: `msg-${id}`,
+    content: `Hello @user from ${id}`,
+    isDeleted: false,
+    author: { id: 'author-1', username: 'alice', displayName: 'Alice', avatarUrl: null },
+  },
+});
+
+const unread1 = makeNotification('notif-1111-1111-1111-111111111111', false);
+const unread2 = makeNotification('notif-2222-2222-2222-222222222222', false);
+const alreadyRead = makeNotification('notif-3333-3333-3333-333333333333', true);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function renderOpenBell(notifications = [unread1, unread2, alreadyRead]) {
+  mockTrpcQuery.mockResolvedValueOnce(notifications);
+  const utils = render(<NotificationBell userId={USER_ID} />);
+
+  // Wait for the async load to complete
+  await waitFor(() => expect(mockTrpcQuery).toHaveBeenCalledWith('notification.getNotifications'));
+
+  // Open the panel
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
+  });
+
+  return utils;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('NotificationBell — mark-as-read flows (Issue #574)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTrpcMutation.mockResolvedValue({ count: 1 });
+  });
+
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  it('shows the unread badge with correct count on initial load', async () => {
+    await renderOpenBell();
+    const badge = screen.getByText('2');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('hides the unread badge when all notifications are read', async () => {
+    await renderOpenBell([alreadyRead]);
+    expect(screen.queryByText(/^\d+$/)).not.toBeInTheDocument();
+  });
+
+  it('renders "Mark all as read" button only when there are unread notifications', async () => {
+    await renderOpenBell();
+    expect(screen.getByRole('button', { name: /mark all as read/i })).toBeInTheDocument();
+  });
+
+  it('does not render "Mark all as read" when all are already read', async () => {
+    await renderOpenBell([alreadyRead]);
+    expect(screen.queryByRole('button', { name: /mark all as read/i })).not.toBeInTheDocument();
+  });
+
+  // ── Single mark-as-read ───────────────────────────────────────────────────
+
+  it('calls markAsRead mutation with the correct notificationId', async () => {
+    await renderOpenBell();
+
+    const [firstCheckmark] = screen.getAllByTitle('Mark as read');
+    await act(async () => {
+      fireEvent.click(firstCheckmark);
+    });
+
+    await waitFor(() =>
+      expect(mockTrpcMutation).toHaveBeenCalledWith('notification.markAsRead', {
+        notificationId: unread1.id,
+      }),
+    );
+  });
+
+  it('removes the unread highlight and ✓ button after marking a single notification read', async () => {
+    await renderOpenBell();
+
+    const checkmarks = screen.getAllByTitle('Mark as read');
+    await act(async () => {
+      fireEvent.click(checkmarks[0]);
+    });
+
+    await waitFor(() => {
+      // The first ✓ button should be gone (notification is now read)
+      expect(screen.getAllByTitle('Mark as read')).toHaveLength(1);
+    });
+  });
+
+  it('decrements the unread badge count by 1 after single mark-as-read', async () => {
+    await renderOpenBell();
+    expect(screen.getByText('2')).toBeInTheDocument();
+
+    const [firstCheckmark] = screen.getAllByTitle('Mark as read');
+    await act(async () => {
+      fireEvent.click(firstCheckmark);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument();
+    });
+  });
+
+  it('leaves the notification unread when the markAsRead mutation fails', async () => {
+    mockTrpcMutation.mockRejectedValue(new Error('Network error'));
+    await renderOpenBell();
+
+    const [firstCheckmark] = screen.getAllByTitle('Mark as read');
+    await act(async () => {
+      fireEvent.click(firstCheckmark);
+    });
+
+    // Badge and ✓ buttons should be unchanged
+    await waitFor(() => {
+      expect(screen.getAllByTitle('Mark as read')).toHaveLength(2);
+    });
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  // ── Bulk mark-all-as-read ─────────────────────────────────────────────────
+
+  it('calls markAllAsRead mutation when "Mark all as read" is clicked', async () => {
+    await renderOpenBell();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /mark all as read/i }));
+    });
+
+    await waitFor(() =>
+      expect(mockTrpcMutation).toHaveBeenCalledWith('notification.markAllAsRead'),
+    );
+  });
+
+  it('removes all unread indicators after bulk mark-as-read', async () => {
+    await renderOpenBell();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /mark all as read/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTitle('Mark as read')).not.toBeInTheDocument();
+    });
+  });
+
+  it('resets the unread badge to zero after bulk mark-as-read', async () => {
+    await renderOpenBell();
+    expect(screen.getByText('2')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /mark all as read/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('2')).not.toBeInTheDocument();
+      expect(screen.queryByText('1')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides "Mark all as read" button after all notifications are marked read', async () => {
+    await renderOpenBell();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /mark all as read/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /mark all as read/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('leaves all notifications unread when the markAllAsRead mutation fails', async () => {
+    mockTrpcMutation.mockRejectedValue(new Error('Network error'));
+    await renderOpenBell();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /mark all as read/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTitle('Mark as read')).toHaveLength(2);
+    });
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+});

--- a/harmony-frontend/src/components/channel/NotificationBell.tsx
+++ b/harmony-frontend/src/components/channel/NotificationBell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { apiClient } from '@/lib/api-client';
 import { getAccessToken, fetchSseTicket } from '@/lib/api-client';
 import { cn } from '@/lib/utils';
@@ -55,8 +55,8 @@ function formatRelativeTime(ts: string): string {
 
 export function NotificationBell({ userId }: NotificationBellProps) {
   const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [unreadCount, setUnreadCount] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
+  const unreadCount = useMemo(() => notifications.filter((n) => !n.read).length, [notifications]);
   const [isLoading, setIsLoading] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -67,7 +67,6 @@ export function NotificationBell({ userId }: NotificationBellProps) {
     try {
       const data = await apiClient.trpcQuery<Notification[]>('notification.getNotifications');
       setNotifications(data ?? []);
-      setUnreadCount((data ?? []).filter((n) => !n.read).length);
     } catch {
       // ignore — network errors shouldn't crash the bell
     } finally {
@@ -136,7 +135,6 @@ export function NotificationBell({ userId }: NotificationBellProps) {
             },
           };
           setNotifications((prev) => [optimistic, ...prev].slice(0, 50));
-          setUnreadCount((c) => c + 1);
         } catch {
           // malformed payload — ignore
         }
@@ -172,9 +170,8 @@ export function NotificationBell({ userId }: NotificationBellProps) {
       setNotifications((prev) =>
         prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
       );
-      setUnreadCount((c) => Math.max(0, c - 1));
     } catch {
-      // ignore
+      // ignore — non-critical, badge will self-correct on next load
     }
   };
 
@@ -182,9 +179,8 @@ export function NotificationBell({ userId }: NotificationBellProps) {
     try {
       await apiClient.trpcMutation('notification.markAllAsRead');
       setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
-      setUnreadCount(0);
     } catch {
-      // ignore
+      // ignore — non-critical, badge will self-correct on next load
     }
   };
 


### PR DESCRIPTION
## Summary

- Removes the separate `unreadCount` state from `NotificationBell` and derives it via `useMemo` from the `notifications` array, eliminating any possible drift between the two
- Adds 31 automated tests (13 frontend + 18 backend) covering both single-read and bulk-read flows per the acceptance criteria

## Root Cause

`unreadCount` was maintained as an independent `useState` variable updated in sync with the `notifications` array in four separate call sites (`loadNotifications`, `markAsRead`, `markAllAsRead`, and the SSE optimistic path). Any one of these updating the array without also updating the counter (or vice-versa) would produce a stale badge. Using `useMemo` over the array makes the badge a pure function of the data — impossible to drift.

## Test plan

- [x] `harmony-frontend/src/__tests__/NotificationBell.test.tsx` — 13 tests: single-read mutation args, UI unread indicator removal, badge decrement, bulk-read mutation, badge reset, silent failure leaves state unchanged
- [x] `harmony-backend/tests/notification.service.test.ts` — 8 tests: `markAsRead` / `markAllAsRead` Prisma `updateMany` where-clause correctness, correct batch payload return, count 0 on no-op
- [x] `harmony-backend/tests/notification.router.test.ts` — 10 tests: authenticated requests succeed, unauthenticated rejected 401, invalid UUID rejected 400, correct tRPC result envelope
- [x] Full test suites pass — 908 backend tests, 445 frontend tests, zero regressions

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)