### PR TITLE
fix: include attachments in public channel message API responses

### DIFF
--- a/harmony-backend/src/routes/public.router.ts
+++ b/harmony-backend/src/routes/public.router.ts
@@ -62,6 +62,9 @@ export function createPublicRouter(store?: Store) {
             createdAt: true,
             editedAt: true,
             author: { select: { id: true, username: true } },
+            attachments: {
+              select: { id: true, url: true, filename: true, contentType: true, sizeBytes: true },
+            },
           },
         });
 
@@ -111,6 +114,9 @@ export function createPublicRouter(store?: Store) {
             createdAt: true,
             editedAt: true,
             author: { select: { id: true, username: true } },
+            attachments: {
+              select: { id: true, url: true, filename: true, contentType: true, sizeBytes: true },
+            },
           },
         });
 


### PR DESCRIPTION
## Summary

- Guest users viewing public channels could not see images/file attachments because the two public REST endpoints (`GET /api/public/channels/:channelId/messages` and `GET /api/public/channels/:channelId/messages/:messageId`) omitted the `attachments` relation from the Prisma `select`
- Added `attachments: { select: { id, url, filename, contentType, sizeBytes } }` to both selects in `harmony-backend/src/routes/public.router.ts`
- The frontend `messageService.toFrontendMessage` already maps this shape correctly, so no frontend changes are needed

Closes #588

## Test plan

- [ ] Seed the local DB (`npm run db:seed:mock`), upload an image to a public channel as an authenticated user, then open the channel while logged out — image should render
- [ ] All 890 backend unit tests pass (`npm test` in `harmony-backend`)
- [ ] No frontend test changes required (frontend mapping logic was already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)