### PR TITLE
fix: re-anchor scroll to bottom when media loads in message list

### DIFF
--- a/harmony-frontend/src/components/channel/MessageList.tsx
+++ b/harmony-frontend/src/components/channel/MessageList.tsx
@@ -121,6 +121,10 @@ export function MessageList({
   }, []);
 
   useLayoutEffect(() => {
+    // Nothing to scroll to yet — don't mark as mounted so that the first
+    // real messages get the instant-scroll path instead of smooth scroll.
+    if (messages.length === 0) return;
+
     if (!hasMountedRef.current) {
       // Initial load: jump instantly so the user starts at the bottom
       hasMountedRef.current = true;

--- a/harmony-frontend/src/components/channel/MessageList.tsx
+++ b/harmony-frontend/src/components/channel/MessageList.tsx
@@ -102,6 +102,15 @@ export function MessageList({
     isNearBottomRef.current = distanceFromBottom <= 100;
   }, []);
 
+  // Called by MessageItem when an image or video finishes loading. If the user
+  // was at (or near) the bottom when the media started loading, the newly
+  // expanded content will have shifted the visible area up — re-anchor to bottom.
+  const handleMediaLoad = useCallback(() => {
+    if (!isNearBottomRef.current) return;
+    const el = scrollContainerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, []);
+
   useLayoutEffect(() => {
     if (!hasMountedRef.current) {
       // Initial load: jump instantly so the user starts at the bottom
@@ -167,6 +176,7 @@ export function MessageList({
                   canPin={canPin}
                   onReplyClick={onReplyClick}
                   onPinToggle={onPinToggle}
+                  onMediaLoad={handleMediaLoad}
                 />
               ))}
             </div>

--- a/harmony-frontend/src/components/channel/MessageList.tsx
+++ b/harmony-frontend/src/components/channel/MessageList.tsx
@@ -7,7 +7,7 @@
 
 'use client';
 
-import { useRef, useLayoutEffect, useCallback, useMemo } from 'react';
+import { useRef, useLayoutEffect, useCallback, useEffect, useMemo } from 'react';
 import { MessageItem } from '@/components/message/MessageItem';
 import { formatDate } from '@/lib/utils';
 import { ChannelVisibility } from '@/types';
@@ -89,6 +89,7 @@ export function MessageList({
 }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   // #c7: only auto-scroll when user is already near the bottom
   const isNearBottomRef = useRef(true);
   // Track whether the initial mount scroll has happened so we jump instantly
@@ -102,13 +103,21 @@ export function MessageList({
     isNearBottomRef.current = distanceFromBottom <= 100;
   }, []);
 
-  // Called by MessageItem when an image or video finishes loading. If the user
-  // was at (or near) the bottom when the media started loading, the newly
-  // expanded content will have shifted the visible area up — re-anchor to bottom.
-  const handleMediaLoad = useCallback(() => {
-    if (!isNearBottomRef.current) return;
-    const el = scrollContainerRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+  // When any message content grows in height (images, videos, embeds loading),
+  // re-anchor the scroll position to the bottom if the user was already there.
+  // ResizeObserver is used instead of onLoad handlers so that ALL sources of
+  // height change are covered (attachments, inline video embeds, avatars, etc.).
+  useEffect(() => {
+    const scrollEl = scrollContainerRef.current;
+    const contentEl = contentRef.current;
+    if (!scrollEl || !contentEl) return;
+    const observer = new ResizeObserver(() => {
+      if (isNearBottomRef.current) {
+        scrollEl.scrollTop = scrollEl.scrollHeight;
+      }
+    });
+    observer.observe(contentEl);
+    return () => observer.disconnect();
   }, []);
 
   useLayoutEffect(() => {
@@ -159,7 +168,7 @@ export function MessageList({
       </div>
 
       {/* Message groups with date separators */}
-      <div className='space-y-4'>
+      <div ref={contentRef} className='space-y-4'>
         {groups.map((group, gi) => {
           const prevGroup = groups[gi - 1];
           const showDateSeparator =
@@ -176,7 +185,6 @@ export function MessageList({
                   canPin={canPin}
                   onReplyClick={onReplyClick}
                   onPinToggle={onPinToggle}
-                  onMediaLoad={handleMediaLoad}
                 />
               ))}
             </div>

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -116,13 +116,7 @@ const EmojiPickerPopover = dynamic(
 
 // ─── AttachmentList ───────────────────────────────────────────────────────────
 
-function AttachmentList({
-  attachments,
-  onMediaLoad,
-}: {
-  attachments: Message['attachments'];
-  onMediaLoad?: () => void;
-}) {
+function AttachmentList({ attachments }: { attachments: Message['attachments'] }) {
   if (!attachments || attachments.length === 0) return null;
   return (
     <div className='mt-1.5 flex flex-col gap-2'>
@@ -139,12 +133,7 @@ function AttachmentList({
               className='inline-block max-w-sm'
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={a.url}
-                alt={a.filename}
-                className='max-h-64 rounded-md object-contain'
-                onLoad={onMediaLoad}
-              />
+              <img src={a.url} alt={a.filename} className='max-h-64 rounded-md object-contain' />
             </a>
           );
         }
@@ -160,7 +149,6 @@ function AttachmentList({
               preload='metadata'
               className='max-h-80 max-w-md rounded-md bg-black'
               aria-label={a.filename || 'Embedded attachment video'}
-              onLoadedMetadata={onMediaLoad}
             />
           );
         }
@@ -603,7 +591,6 @@ export function MessageItem({
   serverId,
   onReplyClick,
   onPinToggle,
-  onMediaLoad,
 }: {
   message: Message;
   /** Set to false for grouped follow-up messages from the same author. Hides the avatar and author line. */
@@ -616,8 +603,6 @@ export function MessageItem({
   onReplyClick?: (message: Message) => void;
   /** Called when the user triggers a pin/unpin action for this message. */
   onPinToggle?: (messageId: string, pinned: boolean) => void;
-  /** Called when an image or video attachment finishes loading, so the scroll container can re-anchor to the bottom. */
-  onMediaLoad?: () => void;
 }) {
   const { user, isAuthenticated } = useAuth();
   const { showToast } = useToast();
@@ -979,7 +964,7 @@ export function MessageItem({
                 )}
               </div>
             )}
-            <AttachmentList attachments={message.attachments} onMediaLoad={onMediaLoad} />
+            <AttachmentList attachments={message.attachments} />
             <ReactionList
               reactions={localReactions}
               messageId={message.id}

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -116,7 +116,13 @@ const EmojiPickerPopover = dynamic(
 
 // ─── AttachmentList ───────────────────────────────────────────────────────────
 
-function AttachmentList({ attachments }: { attachments: Message['attachments'] }) {
+function AttachmentList({
+  attachments,
+  onMediaLoad,
+}: {
+  attachments: Message['attachments'];
+  onMediaLoad?: () => void;
+}) {
   if (!attachments || attachments.length === 0) return null;
   return (
     <div className='mt-1.5 flex flex-col gap-2'>
@@ -133,7 +139,12 @@ function AttachmentList({ attachments }: { attachments: Message['attachments'] }
               className='inline-block max-w-sm'
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={a.url} alt={a.filename} className='max-h-64 rounded-md object-contain' />
+              <img
+                src={a.url}
+                alt={a.filename}
+                className='max-h-64 rounded-md object-contain'
+                onLoad={onMediaLoad}
+              />
             </a>
           );
         }
@@ -149,6 +160,7 @@ function AttachmentList({ attachments }: { attachments: Message['attachments'] }
               preload='metadata'
               className='max-h-80 max-w-md rounded-md bg-black'
               aria-label={a.filename || 'Embedded attachment video'}
+              onLoadedMetadata={onMediaLoad}
             />
           );
         }
@@ -591,6 +603,7 @@ export function MessageItem({
   serverId,
   onReplyClick,
   onPinToggle,
+  onMediaLoad,
 }: {
   message: Message;
   /** Set to false for grouped follow-up messages from the same author. Hides the avatar and author line. */
@@ -603,6 +616,8 @@ export function MessageItem({
   onReplyClick?: (message: Message) => void;
   /** Called when the user triggers a pin/unpin action for this message. */
   onPinToggle?: (messageId: string, pinned: boolean) => void;
+  /** Called when an image or video attachment finishes loading, so the scroll container can re-anchor to the bottom. */
+  onMediaLoad?: () => void;
 }) {
   const { user, isAuthenticated } = useAuth();
   const { showToast } = useToast();
@@ -964,7 +979,7 @@ export function MessageItem({
                 )}
               </div>
             )}
-            <AttachmentList attachments={message.attachments} />
+            <AttachmentList attachments={message.attachments} onMediaLoad={onMediaLoad} />
             <ReactionList
               reactions={localReactions}
               messageId={message.id}


### PR DESCRIPTION
## Summary

- Adds a `ResizeObserver` on the message content wrapper that re-anchors `scrollTop` to the true bottom whenever content grows in height (images, inline video embeds, avatars — any source) and the user was already at the bottom
- Fixes a race condition where the component could mount with `messages = []`, mark itself as "mounted," then use **smooth scroll** when messages arrived; mid-animation scroll events would set `isNearBottomRef = false`, causing the `ResizeObserver` to skip re-anchoring when images loaded

## Root cause

When the API response is slow the component renders with an empty message list first. The previous code set `hasMountedRef = true` on that empty render, so when real messages arrived it fell through to the smooth-scroll path — a long animation from position 0 to the bottom. While animating, scroll events reported `distanceFromBottom > 100`, flipping `isNearBottomRef = false`. Images that loaded mid-animation were then ignored by the ResizeObserver.

## Test plan

- [ ] Open a channel with image/video attachments and verify the view stays pinned to the bottom as media loads
- [ ] Refresh the page many times and confirm the initial view is always at the bottom
- [ ] Verify that scrolling up and then receiving a new message does NOT auto-scroll (existing behavior preserved)
- [ ] Verify smooth scroll still works when a new message arrives while already at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)