### PR TITLE
Allow trusted Pixabay GIF attachments

### DIFF
--- a/harmony-backend/src/trpc/routers/message.router.ts
+++ b/harmony-backend/src/trpc/routers/message.router.ts
@@ -3,23 +3,28 @@ import { TRPCError } from '@trpc/server';
 import { router, withPermission } from '../init';
 import { messageService } from '../../services/message.service';
 
+const TRUSTED_EXTERNAL_ATTACHMENT_BASES = ['https://cdn.pixabay.com'];
+
 /**
- * Returns the base URL that all attachment URLs must start with.
- * Computed from STORAGE_PROVIDER and the corresponding base URL env var.
- * Returns null when the base URL is not configured (skips validation).
+ * Returns the allowed attachment base URLs:
+ * - project-owned upload host
+ * - explicitly trusted external CDN origins used by rich media pickers
  */
-function getAllowedAttachmentBase(): string | null {
+function getAllowedAttachmentBases(): string[] {
+  const bases = [...TRUSTED_EXTERNAL_ATTACHMENT_BASES];
   if (process.env.STORAGE_PROVIDER === 's3') {
-    return process.env.R2_PUBLIC_URL ?? null;
+    if (process.env.R2_PUBLIC_URL) bases.unshift(process.env.R2_PUBLIC_URL);
+    return bases;
   }
-  return process.env.LOCAL_UPLOAD_BASE_URL ?? 'http://localhost:4000';
+  bases.unshift(process.env.LOCAL_UPLOAD_BASE_URL ?? 'http://localhost:4000');
+  return bases;
 }
 
 /**
  * Reject prefix-stripping tricks (e.g. https://allowed.example.com.evil/...) by
  * comparing URL origins and, when the allowlist has a path, requiring a path prefix.
  */
-function isAllowedAttachmentUrl(attUrl: string, allowedBase: string): boolean {
+function isAllowedAttachmentUrlForBase(attUrl: string, allowedBase: string): boolean {
   let allowed: URL;
   let candidate: URL;
   try {
@@ -37,6 +42,10 @@ function isAllowedAttachmentUrl(attUrl: string, allowedBase: string): boolean {
   }
   const p = candidate.pathname;
   return p === basePath || p.startsWith(`${basePath}/`);
+}
+
+export function isAllowedAttachmentUrl(attUrl: string, allowedBases: string[]): boolean {
+  return allowedBases.some((allowedBase) => isAllowedAttachmentUrlForBase(attUrl, allowedBase));
 }
 
 // sizeBytes is accepted as a plain number (JSON-safe).
@@ -83,12 +92,10 @@ export const messageRouter = router({
     )
     .mutation(({ input, ctx }) => {
       if (input.attachments?.length) {
-        const allowedBase = getAllowedAttachmentBase();
-        if (allowedBase) {
-          for (const att of input.attachments) {
-            if (!isAllowedAttachmentUrl(att.url, allowedBase)) {
-              throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid attachment URL' });
-            }
+        const allowedBases = getAllowedAttachmentBases();
+        for (const att of input.attachments) {
+          if (!isAllowedAttachmentUrl(att.url, allowedBases)) {
+            throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid attachment URL' });
           }
         }
       }

--- a/harmony-backend/tests/message.router.attachments.test.ts
+++ b/harmony-backend/tests/message.router.attachments.test.ts
@@ -1,0 +1,101 @@
+import { TRPCError } from '@trpc/server';
+
+const mockRequirePermission = jest.fn();
+const mockSendMessage = jest.fn();
+
+jest.mock('../src/services/permission.service', () => ({
+  permissionService: {
+    requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+  },
+}));
+
+jest.mock('../src/services/message.service', () => ({
+  messageService: {
+    sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+  },
+}));
+
+import { createCallerFactory, type TRPCContext } from '../src/trpc/init';
+import { messageRouter } from '../src/trpc/routers/message.router';
+
+const createCaller = createCallerFactory(messageRouter);
+
+function callerAs(userId: string | null) {
+  const ctx: TRPCContext = { userId, ip: '127.0.0.1', userAgent: 'jest' };
+  return createCaller(ctx);
+}
+
+const VALID_INPUT = {
+  serverId: '01cca9d4-77e6-40e3-a94b-9e3a73b8cdc8',
+  channelId: '65029c74-f956-4512-86d9-4e0555d760ae',
+  content: '',
+  attachments: [
+    {
+      filename: '347325_tiny.mp4',
+      url: 'https://cdn.pixabay.com/video/2026/04/17/347325_tiny.mp4',
+      contentType: 'video/mp4',
+      sizeBytes: 12345,
+    },
+  ],
+};
+
+describe('messageRouter.sendMessage attachment URL validation', () => {
+  const originalStorageProvider = process.env.STORAGE_PROVIDER;
+  const originalR2PublicUrl = process.env.R2_PUBLIC_URL;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STORAGE_PROVIDER = 's3';
+    process.env.R2_PUBLIC_URL = 'https://uploads.harmony.example';
+    mockRequirePermission.mockResolvedValue(undefined);
+    mockSendMessage.mockResolvedValue({ id: 'msg-1' });
+  });
+
+  afterAll(() => {
+    process.env.STORAGE_PROVIDER = originalStorageProvider;
+    process.env.R2_PUBLIC_URL = originalR2PublicUrl;
+  });
+
+  it('accepts trusted Pixabay CDN URLs for GIF picker video attachments', async () => {
+    await expect(callerAs('user-1').sendMessage(VALID_INPUT)).resolves.toEqual({ id: 'msg-1' });
+    expect(mockSendMessage).toHaveBeenCalledWith({
+      serverId: VALID_INPUT.serverId,
+      channelId: VALID_INPUT.channelId,
+      authorId: 'user-1',
+      content: '',
+      attachments: VALID_INPUT.attachments,
+    });
+  });
+
+  it('rejects lookalike Pixabay origins that only share the prefix text', async () => {
+    await expect(
+      callerAs('user-1').sendMessage({
+        ...VALID_INPUT,
+        attachments: [
+          {
+            ...VALID_INPUT.attachments[0],
+            url: 'https://cdn.pixabay.com.evil.example/video/2026/04/17/347325_tiny.mp4',
+          },
+        ],
+      }),
+    ).rejects.toMatchObject<Partial<TRPCError>>({
+      code: 'BAD_REQUEST',
+      message: 'Invalid attachment URL',
+    });
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('still accepts project-owned uploaded attachments', async () => {
+    await expect(
+      callerAs('user-1').sendMessage({
+        ...VALID_INPUT,
+        attachments: [
+          {
+            ...VALID_INPUT.attachments[0],
+            url: 'https://uploads.harmony.example/4d4dbfce-1f1f-4ffa-9d24-e23f8f3e723b.mp4',
+          },
+        ],
+      }),
+    ).resolves.toEqual({ id: 'msg-1' });
+  });
+});


### PR DESCRIPTION
## Summary
- allow trusted Pixabay CDN video URLs through `message.sendMessage` attachment validation
- keep the project-owned upload allowlist intact and still reject lookalike prefix-spoofed origins
- add focused router tests covering accepted Pixabay URLs, rejected lookalikes, and existing project-owned attachment URLs

## Test plan
- [x] `cd harmony-backend && npm test -- --runInBand tests/message.router.attachments.test.ts`
- [x] `cd harmony-backend && npm run lint -- src/trpc/routers/message.router.ts tests/message.router.attachments.test.ts`
- [x] `cd harmony-backend && npm run build`