### PR TITLE
fix(#590): auto-hyperlink URLs in messages

### DIFF
--- a/harmony-frontend/src/__tests__/issue-590-url-hyperlinks.test.tsx
+++ b/harmony-frontend/src/__tests__/issue-590-url-hyperlinks.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * issue-590-url-hyperlinks.test.tsx
+ *
+ * Regression test for issue #590: URLs in messages must be rendered as
+ * clickable hyperlinks opening in a new tab, not as plain text.
+ */
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MessageItem } from '@/components/message/MessageItem';
+import type { Message } from '@/types';
+
+const mockUseAuth = jest.fn();
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ showToast: jest.fn() }),
+}));
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/c/test-server/general',
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const baseMessage: Message = {
+  id: 'msg-link-1',
+  channelId: 'channel-1',
+  authorId: 'user-1',
+  author: { id: 'user-1', username: 'alice', displayName: 'Alice' },
+  content: '',
+  timestamp: '2026-04-30T00:00:00.000Z',
+  attachments: [],
+};
+
+describe('Issue #590 — URL hyperlinks in messages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: 'user-2' } });
+  });
+
+  it('AC-1: renders a standalone URL as a clickable anchor', () => {
+    render(<MessageItem message={{ ...baseMessage, content: 'https://example.com' }} />);
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('AC-2: link opens in a new tab', () => {
+    render(<MessageItem message={{ ...baseMessage, content: 'https://example.com' }} />);
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('renders a URL inline alongside surrounding text', () => {
+    render(
+      <MessageItem
+        message={{ ...baseMessage, content: 'Check this out: https://google.com and let me know' }}
+      />,
+    );
+    const link = screen.getByRole('link', { name: 'https://google.com' });
+    expect(link).toBeInTheDocument();
+    expect(screen.getByText(/Check this out:/)).toBeInTheDocument();
+    expect(screen.getByText(/and let me know/)).toBeInTheDocument();
+  });
+
+  it('does not render a plain-text URL as an anchor (no URL in content)', () => {
+    render(<MessageItem message={{ ...baseMessage, content: 'hello world' }} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('embeds video URLs without also creating a hyperlink', () => {
+    const mp4 = 'https://example.com/video.mp4';
+    render(<MessageItem message={{ ...baseMessage, content: mp4 }} />);
+    // Video embed should be present
+    const video = document.querySelector('video');
+    expect(video).not.toBeNull();
+    // The video URL should NOT also appear as an <a> link
+    expect(screen.queryByRole('link', { name: mp4 })).not.toBeInTheDocument();
+  });
+});

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -46,6 +46,8 @@ function getEmbedVideoUrl(url: string): string | null {
   }
 }
 
+type ContentPart = { kind: 'text'; value: string } | { kind: 'link'; url: string };
+
 function MessageContent({ content, currentUsername }: { content: string; currentUsername?: string }) {
   const matches = [...content.matchAll(URL_PATTERN)];
   if (matches.length === 0) {
@@ -56,7 +58,7 @@ function MessageContent({ content, currentUsername }: { content: string; current
     );
   }
 
-  const textSegments: string[] = [];
+  const parts: ContentPart[] = [];
   const videoEmbeds: string[] = [];
   let lastIndex = 0;
 
@@ -65,28 +67,49 @@ function MessageContent({ content, currentUsername }: { content: string; current
     const index = match.index ?? 0;
     const embedUrl = getEmbedVideoUrl(url);
 
-    textSegments.push(content.slice(lastIndex, index));
-    if (!embedUrl) {
-      textSegments.push(url);
-    } else {
+    if (index > lastIndex) {
+      parts.push({ kind: 'text', value: content.slice(lastIndex, index) });
+    }
+
+    if (embedUrl) {
       videoEmbeds.push(embedUrl);
+    } else {
+      parts.push({ kind: 'link', url });
     }
 
     lastIndex = index + url.length;
   }
 
-  textSegments.push(content.slice(lastIndex));
-  const textContent = textSegments.join('').trim();
+  if (lastIndex < content.length) {
+    parts.push({ kind: 'text', value: content.slice(lastIndex) });
+  }
+
+  const hasInlineContent = parts.length > 0;
 
   return (
     <div className='mt-0.5'>
-      {textContent && (
+      {hasInlineContent && (
         <p className='whitespace-pre-line text-sm leading-relaxed text-[#dcddde]'>
-          <MentionText content={textContent} currentUsername={currentUsername} />
+          {parts.map((part, i) => {
+            if (part.kind === 'link') {
+              return (
+                <a
+                  key={i}
+                  href={part.url}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-blue-400 underline hover:text-blue-300'
+                >
+                  {part.url}
+                </a>
+              );
+            }
+            return <MentionText key={i} content={part.value} currentUsername={currentUsername} />;
+          })}
         </p>
       )}
       {videoEmbeds.length > 0 && (
-        <div className={`${textContent ? 'mt-2' : ''} flex flex-col gap-2`}>
+        <div className={`${hasInlineContent ? 'mt-2' : ''} flex flex-col gap-2`}>
           {videoEmbeds.map(url => (
             <video
               key={url}


### PR DESCRIPTION
## Summary
- URLs in message content are now rendered as clickable `<a>` tags that open in a new tab (`target="_blank" rel="noopener noreferrer"`)
- Video URLs (`.mp4`, `.webm`, etc.) continue to be embedded as inline video players as before
- Surrounding text and `@mention` highlighting are preserved when URLs appear inline

## Changes
- `MessageItem.tsx`: Replaced the `textSegments` join approach in `MessageContent` with an ordered `ContentPart[]` array (`text` | `link`), rendered inline so hyperlinks appear exactly where the URL was in the original message
- Added regression test `issue-590-url-hyperlinks.test.tsx` covering: standalone URL as anchor, `target="_blank"` attribute, inline URL with surrounding text, no anchor for plain text, and video URLs not duplicated as links

## Test plan
- [ ] Run `npm test` in `harmony-frontend` — all tests pass
- [ ] Log in, navigate to any channel, send a message containing a URL (e.g. `https://example.com`) — it should render as a clickable blue underlined link
- [ ] Send a message containing only a `.mp4` URL — it should still embed as a video, not show a link
- [ ] Send a message with a URL inline: `Check https://example.com out` — link appears inline with surrounding text

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)