### PR TITLE
feat(#573): add @everyone and @here broadcast mention behavior

### DIFF
--- a/harmony-backend/src/services/mention.service.ts
+++ b/harmony-backend/src/services/mention.service.ts
@@ -1,19 +1,42 @@
+import { UserStatus } from '@prisma/client';
+import type { Prisma } from '@prisma/client';
 import { prisma } from '../db/prisma';
 import { eventBus, EventChannels } from '../events/eventBus';
 import { createLogger } from '../lib/logger';
 
 const logger = createLogger({ component: 'mention-service' });
 
+/** Broadcast mention tokens that target a group rather than a specific user. */
+export const BROADCAST_MENTIONS = ['everyone', 'here'] as const;
+export type BroadcastMention = (typeof BROADCAST_MENTIONS)[number];
+
 /**
  * Parse @username tokens from message content and return unique lowercase usernames.
+ * Broadcast tokens (@everyone, @here) are excluded — they are handled separately.
  * A fresh RegExp is created per call so `lastIndex` state never bleeds between calls.
  */
 export function extractMentionedUsernames(content: string): string[] {
   const names = new Set<string>();
+  const broadcastSet = new Set<string>(BROADCAST_MENTIONS);
   for (const m of content.matchAll(/@([a-zA-Z0-9_-]{1,32})/g)) {
-    names.add(m[1].toLowerCase());
+    const name = m[1].toLowerCase();
+    if (!broadcastSet.has(name)) {
+      names.add(name);
+    }
   }
   return [...names];
+}
+
+/**
+ * Detect which broadcast mention tokens (@everyone, @here) appear in content.
+ * Returns at most one entry per token type regardless of repetition.
+ */
+export function extractBroadcastMentions(content: string): BroadcastMention[] {
+  const found = new Set<BroadcastMention>();
+  for (const m of content.matchAll(/@(everyone|here)/gi)) {
+    found.add(m[1].toLowerCase() as BroadcastMention);
+  }
+  return [...found];
 }
 
 /**
@@ -115,5 +138,101 @@ export async function processMentions(params: {
     }
   } catch (err) {
     logger.warn({ err, messageId, serverId }, 'Failed to process mentions');
+  }
+}
+
+/**
+ * Fan out notifications for @everyone and @here broadcast mentions.
+ *
+ * - @everyone: all server members who are not the author.
+ * - @here:     only server members whose status is ONLINE or IDLE at send time.
+ *
+ * If both tokens appear in the same message, each eligible user receives at
+ * most one notification (de-duplicated by the unique constraint on Notification).
+ *
+ * Best-effort: failures are logged but never thrown.
+ */
+export async function processBroadcastMentions(params: {
+  messageId: string;
+  channelId: string;
+  serverId: string;
+  authorId: string;
+  authorUsername: string;
+  content: string;
+}): Promise<void> {
+  const { messageId, channelId, serverId, authorId, authorUsername, content } = params;
+
+  const broadcastTokens = extractBroadcastMentions(content);
+  if (broadcastTokens.length === 0) return;
+
+  const hasEveryone = broadcastTokens.includes('everyone');
+
+  try {
+    // Build the status filter: @here → ONLINE/IDLE, @everyone → any status.
+    const statusFilter: Prisma.ServerMemberWhereInput = hasEveryone
+      ? {}
+      : { user: { status: { in: [UserStatus.ONLINE, UserStatus.IDLE] } } };
+
+    const members = await prisma.serverMember.findMany({
+      where: {
+        serverId,
+        userId: { not: authorId },
+        ...statusFilter,
+      },
+      select: { userId: true },
+    });
+
+    if (members.length === 0) return;
+
+    const now = new Date();
+
+    await prisma.messageMention.createMany({
+      data: members.map((m) => ({ messageId, userId: m.userId })),
+      skipDuplicates: true,
+    });
+
+    await prisma.notification.createMany({
+      data: members.map((m) => ({
+        userId: m.userId,
+        type: hasEveryone ? 'mention_everyone' : 'mention_here',
+        messageId,
+        channelId,
+        serverId,
+        createdAt: now,
+      })),
+      skipDuplicates: true,
+    });
+
+    const inserted = await prisma.notification.findMany({
+      where: {
+        userId: { in: members.map((m) => m.userId) },
+        type: { in: ['mention_everyone', 'mention_here'] },
+        messageId,
+        createdAt: now,
+      },
+      select: { id: true, userId: true },
+    });
+
+    for (const notif of inserted) {
+      eventBus
+        .publish(EventChannels.USER_MENTIONED, {
+          notificationId: notif.id,
+          userId: notif.userId,
+          messageId,
+          channelId,
+          serverId,
+          authorId,
+          authorUsername,
+          timestamp: now.toISOString(),
+        })
+        .catch((err) =>
+          logger.warn(
+            { err, userId: notif.userId, messageId },
+            'Failed to publish broadcast USER_MENTIONED',
+          ),
+        );
+    }
+  } catch (err) {
+    logger.warn({ err, messageId, serverId }, 'Failed to process broadcast mentions');
   }
 }

--- a/harmony-backend/src/services/mention.service.ts
+++ b/harmony-backend/src/services/mention.service.ts
@@ -33,7 +33,7 @@ export function extractMentionedUsernames(content: string): string[] {
  */
 export function extractBroadcastMentions(content: string): BroadcastMention[] {
   const found = new Set<BroadcastMention>();
-  for (const m of content.matchAll(/@(everyone|here)/gi)) {
+  for (const m of content.matchAll(/@(everyone|here)\b/gi)) {
     found.add(m[1].toLowerCase() as BroadcastMention);
   }
   return [...found];

--- a/harmony-backend/src/services/message.service.ts
+++ b/harmony-backend/src/services/message.service.ts
@@ -6,7 +6,7 @@ import { permissionService } from './permission.service';
 import { eventBus, EventChannels } from '../events/eventBus';
 import { channelRepository } from '../repositories/channel.repository';
 import { messageRepository } from '../repositories/message.repository';
-import { processMentions } from './mention.service';
+import { processMentions, processBroadcastMentions } from './mention.service';
 import { pushNotificationService } from './pushNotification.service';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -217,6 +217,16 @@ export const messageService = {
     }).catch((err) =>
       logger.warn({ err, messageId: message.id }, 'processMentions failed on sendMessage'),
     );
+    processBroadcastMentions({
+      messageId: message.id,
+      channelId,
+      serverId,
+      authorId,
+      authorUsername,
+      content,
+    }).catch((err) =>
+      logger.warn({ err, messageId: message.id }, 'processBroadcastMentions failed on sendMessage'),
+    );
 
     // Dispatch push notifications fire-and-forget
     (async () => {
@@ -296,6 +306,16 @@ export const messageService = {
       content,
     }).catch((err) =>
       logger.warn({ err, messageId }, 'processMentions failed on editMessage'),
+    );
+    processBroadcastMentions({
+      messageId,
+      channelId: message.channelId,
+      serverId,
+      authorId,
+      authorUsername: updated.author.username,
+      content,
+    }).catch((err) =>
+      logger.warn({ err, messageId }, 'processBroadcastMentions failed on editMessage'),
     );
 
     return updated;
@@ -542,6 +562,16 @@ export const messageService = {
       content,
     }).catch((err) =>
       logger.warn({ err, messageId: reply.id }, 'processMentions failed on createReply'),
+    );
+    processBroadcastMentions({
+      messageId: reply.id,
+      channelId,
+      serverId,
+      authorId,
+      authorUsername: reply.author.username,
+      content,
+    }).catch((err) =>
+      logger.warn({ err, messageId: reply.id }, 'processBroadcastMentions failed on createReply'),
     );
 
     return reply;

--- a/harmony-backend/tests/mention.service.test.ts
+++ b/harmony-backend/tests/mention.service.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import { extractMentionedUsernames, extractBroadcastMentions, processMentions } from '../src/services/mention.service';
+import { extractMentionedUsernames, extractBroadcastMentions, processMentions, processBroadcastMentions } from '../src/services/mention.service';
 
 const prisma = new PrismaClient();
 
@@ -261,5 +261,125 @@ describe('processMentions', () => {
 
     const notifCount = await prisma.notification.count({ where: { messageId } });
     expect(notifCount).toBe(0);
+  });
+});
+
+// ── processBroadcastMentions ──────────────────────────────────────────────────
+
+describe('processBroadcastMentions', () => {
+  const ts2 = Date.now() + 1;
+
+  let bcastAuthorId: string;
+  let onlineUserId: string;
+  let idleUserId: string;
+  let offlineUserId: string;
+  let bcastServerId: string;
+  let bcastChannelId: string;
+  let bcastMessageId: string;
+
+  beforeAll(async () => {
+    const author = await prisma.user.create({
+      data: { email: `bc-author-${ts2}@test.com`, username: `bc_author_${ts2}`, passwordHash: 'x', displayName: 'BcAuthor' },
+    });
+    bcastAuthorId = author.id;
+
+    const online = await prisma.user.create({
+      data: { email: `bc-online-${ts2}@test.com`, username: `bc_online_${ts2}`, passwordHash: 'x', displayName: 'Online', status: 'ONLINE' },
+    });
+    onlineUserId = online.id;
+
+    const idle = await prisma.user.create({
+      data: { email: `bc-idle-${ts2}@test.com`, username: `bc_idle_${ts2}`, passwordHash: 'x', displayName: 'Idle', status: 'IDLE' },
+    });
+    idleUserId = idle.id;
+
+    const offline = await prisma.user.create({
+      data: { email: `bc-offline-${ts2}@test.com`, username: `bc_offline_${ts2}`, passwordHash: 'x', displayName: 'Offline', status: 'OFFLINE' },
+    });
+    offlineUserId = offline.id;
+
+    const server = await prisma.server.create({
+      data: { name: `Broadcast Test Server ${ts2}`, slug: `bc-test-${ts2}`, ownerId: bcastAuthorId },
+    });
+    bcastServerId = server.id;
+
+    await prisma.serverMember.createMany({
+      data: [
+        { userId: bcastAuthorId, serverId: bcastServerId, role: 'OWNER' },
+        { userId: onlineUserId, serverId: bcastServerId, role: 'MEMBER' },
+        { userId: idleUserId, serverId: bcastServerId, role: 'MEMBER' },
+        { userId: offlineUserId, serverId: bcastServerId, role: 'MEMBER' },
+      ],
+    });
+
+    const channel = await prisma.channel.create({
+      data: { serverId: bcastServerId, name: 'general', slug: 'general' },
+    });
+    bcastChannelId = channel.id;
+
+    const message = await prisma.message.create({
+      data: { channelId: bcastChannelId, authorId: bcastAuthorId, content: 'placeholder' },
+    });
+    bcastMessageId = message.id;
+  });
+
+  afterAll(async () => {
+    await prisma.notification.deleteMany({ where: { messageId: bcastMessageId } });
+    await prisma.messageMention.deleteMany({ where: { messageId: bcastMessageId } });
+    await prisma.message.delete({ where: { id: bcastMessageId } });
+    await prisma.serverMember.deleteMany({ where: { serverId: bcastServerId } });
+    await prisma.channel.delete({ where: { id: bcastChannelId } });
+    await prisma.server.delete({ where: { id: bcastServerId } });
+    await prisma.user.deleteMany({ where: { id: { in: [bcastAuthorId, onlineUserId, idleUserId, offlineUserId] } } });
+  });
+
+  beforeEach(async () => {
+    await prisma.notification.deleteMany({ where: { messageId: bcastMessageId } });
+    await prisma.messageMention.deleteMany({ where: { messageId: bcastMessageId } });
+  });
+
+  const baseParams = () => ({
+    messageId: bcastMessageId,
+    channelId: bcastChannelId,
+    serverId: bcastServerId,
+    authorId: bcastAuthorId,
+    authorUsername: `bc_author_${ts2}`,
+    content: '',
+  });
+
+  it('@everyone notifies all members (online, idle, and offline), excluding the author', async () => {
+    await processBroadcastMentions({ ...baseParams(), content: '@everyone listen up' });
+
+    const notifiedIds = (await prisma.notification.findMany({ where: { messageId: bcastMessageId } })).map((n) => n.userId);
+    expect(notifiedIds).toContain(onlineUserId);
+    expect(notifiedIds).toContain(idleUserId);
+    expect(notifiedIds).toContain(offlineUserId);
+    expect(notifiedIds).not.toContain(bcastAuthorId);
+  });
+
+  it('@here notifies only ONLINE and IDLE members, not OFFLINE, and not the author', async () => {
+    await processBroadcastMentions({ ...baseParams(), content: '@here check this out' });
+
+    const notifiedIds = (await prisma.notification.findMany({ where: { messageId: bcastMessageId } })).map((n) => n.userId);
+    expect(notifiedIds).toContain(onlineUserId);
+    expect(notifiedIds).toContain(idleUserId);
+    expect(notifiedIds).not.toContain(offlineUserId);
+    expect(notifiedIds).not.toContain(bcastAuthorId);
+  });
+
+  it('when @everyone and @here both appear, each eligible user receives at most one notification', async () => {
+    await processBroadcastMentions({ ...baseParams(), content: '@everyone and @here please read' });
+
+    const allNotified = await prisma.notification.findMany({ where: { messageId: bcastMessageId } });
+    const userIds = allNotified.map((n) => n.userId);
+
+    // No duplicate notifications for any single user
+    const uniqueUserIds = new Set(userIds);
+    expect(userIds.length).toBe(uniqueUserIds.size);
+
+    // @everyone takes precedence — all non-author members notified
+    expect(uniqueUserIds).toContain(onlineUserId);
+    expect(uniqueUserIds).toContain(idleUserId);
+    expect(uniqueUserIds).toContain(offlineUserId);
   });
 });

--- a/harmony-backend/tests/mention.service.test.ts
+++ b/harmony-backend/tests/mention.service.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import { extractMentionedUsernames, processMentions } from '../src/services/mention.service';
+import { extractMentionedUsernames, extractBroadcastMentions, processMentions } from '../src/services/mention.service';
 
 const prisma = new PrismaClient();
 
@@ -138,6 +138,43 @@ describe('extractMentionedUsernames', () => {
   it('handles content starting mid-word after @', () => {
     // Email-style addresses should not be over-matched beyond the word boundary
     expect(extractMentionedUsernames('email@domain.com')).toEqual(['domain']);
+  });
+});
+
+// ── extractBroadcastMentions ──────────────────────────────────────────────────
+
+describe('extractBroadcastMentions', () => {
+  it('detects @everyone', () => {
+    expect(extractBroadcastMentions('hey @everyone listen up')).toEqual(['everyone']);
+  });
+
+  it('detects @here', () => {
+    expect(extractBroadcastMentions('ping @here please')).toEqual(['here']);
+  });
+
+  it('detects both tokens when both appear', () => {
+    const result = extractBroadcastMentions('@everyone and @here');
+    expect(result.sort()).toEqual(['everyone', 'here']);
+  });
+
+  it('deduplicates repeated tokens', () => {
+    expect(extractBroadcastMentions('@everyone @everyone')).toEqual(['everyone']);
+  });
+
+  it('is case-insensitive', () => {
+    expect(extractBroadcastMentions('@EVERYONE @HERE')).toEqual(expect.arrayContaining(['everyone', 'here']));
+  });
+
+  it('does NOT match @hereford (substring false positive)', () => {
+    expect(extractBroadcastMentions('ask @hereford about it')).toEqual([]);
+  });
+
+  it('does NOT match @everyone123 (trailing alphanumeric)', () => {
+    expect(extractBroadcastMentions('@everyone123 is not a broadcast')).toEqual([]);
+  });
+
+  it('returns empty array when no broadcast tokens present', () => {
+    expect(extractBroadcastMentions('hello @alice')).toEqual([]);
   });
 });
 

--- a/harmony-frontend/src/components/message/MentionText.tsx
+++ b/harmony-frontend/src/components/message/MentionText.tsx
@@ -8,9 +8,13 @@ export interface MentionTextProps {
   currentUsername?: string;
 }
 
+const BROADCAST_MENTIONS = new Set(['everyone', 'here']);
+
 /**
  * Renders message content with @username tokens styled as inline mention pills.
- * Self-mentions receive an accent background; other mentions are styled subtly.
+ * - @everyone / @here get a distinct amber highlight with a tooltip.
+ * - Self-mentions receive an accent (indigo) background.
+ * - Other @username mentions are styled subtly.
  * Pass `currentUsername` from a parent component that already holds auth state.
  */
 export function MentionText({ content, currentUsername }: MentionTextProps) {
@@ -32,18 +36,27 @@ export function MentionText({ content, currentUsername }: MentionTextProps) {
       parts.push(content.slice(lastIndex, start));
     }
 
-    const isSelf =
-      currentUsername && username.toLowerCase() === currentUsername.toLowerCase();
+    const lowerName = username.toLowerCase();
+    const isBroadcast = BROADCAST_MENTIONS.has(lowerName);
+    const isSelf = !isBroadcast && currentUsername && lowerName === currentUsername.toLowerCase();
+
+    const tooltip = isBroadcast
+      ? lowerName === 'everyone'
+        ? 'Notifies all members of this channel'
+        : 'Notifies online members of this channel'
+      : `@${username}`;
 
     parts.push(
       <span
         key={key++}
         className={
-          isSelf
-            ? 'rounded px-0.5 font-semibold text-white bg-indigo-500/70 hover:bg-indigo-500 cursor-default'
-            : 'rounded px-0.5 font-semibold text-indigo-300 bg-indigo-500/20 hover:bg-indigo-500/40 cursor-default'
+          isBroadcast
+            ? 'rounded px-0.5 font-semibold text-amber-200 bg-amber-500/30 hover:bg-amber-500/50 cursor-default'
+            : isSelf
+              ? 'rounded px-0.5 font-semibold text-white bg-indigo-500/70 hover:bg-indigo-500 cursor-default'
+              : 'rounded px-0.5 font-semibold text-indigo-300 bg-indigo-500/20 hover:bg-indigo-500/40 cursor-default'
         }
-        title={`@${username}`}
+        title={tooltip}
       >
         {full}
       </span>,

--- a/harmony-frontend/src/components/message/MentionText.tsx
+++ b/harmony-frontend/src/components/message/MentionText.tsx
@@ -12,8 +12,8 @@ const BROADCAST_MENTIONS = new Set(['everyone', 'here']);
 
 /**
  * Renders message content with @username tokens styled as inline mention pills.
- * - @everyone / @here get a distinct amber highlight with a tooltip.
- * - Self-mentions receive an accent (indigo) background.
+ * - @everyone / @here share the same indigo styling as regular mentions, with tooltips.
+ * - Self-mentions receive a stronger indigo background.
  * - Other @username mentions are styled subtly.
  * Pass `currentUsername` from a parent component that already holds auth state.
  */
@@ -51,7 +51,7 @@ export function MentionText({ content, currentUsername }: MentionTextProps) {
         key={key++}
         className={
           isBroadcast
-            ? 'rounded px-0.5 font-semibold text-amber-200 bg-amber-500/30 hover:bg-amber-500/50 cursor-default'
+            ? 'rounded px-0.5 font-semibold text-indigo-300 bg-indigo-500/20 hover:bg-indigo-500/40 cursor-default'
             : isSelf
               ? 'rounded px-0.5 font-semibold text-white bg-indigo-500/70 hover:bg-indigo-500 cursor-default'
               : 'rounded px-0.5 font-semibold text-indigo-300 bg-indigo-500/20 hover:bg-indigo-500/40 cursor-default'

--- a/harmony-frontend/src/components/message/MessageItem.tsx
+++ b/harmony-frontend/src/components/message/MessageItem.tsx
@@ -653,7 +653,9 @@ export function MessageItem({
     const re = /@([a-zA-Z0-9_-]{1,32})/g;
     let m;
     while ((m = re.exec(displayedContent)) !== null) {
-      if (m[1].toLowerCase() === currentUsername.toLowerCase()) return true;
+      const name = m[1].toLowerCase();
+      if (name === currentUsername.toLowerCase()) return true;
+      if (name === 'everyone' || name === 'here') return true;
     }
     return false;
   })();


### PR DESCRIPTION
## Summary
- `@everyone` in a message notifies all server members (excluding the author), regardless of online status
- `@here` notifies only members who are currently ONLINE or IDLE at send time
- Both tokens highlight the message row yellow and render with the same indigo pill styling as regular `@username` mentions
- If both tokens appear in one message, each eligible user receives at most one notification (deduped by unique constraint)

## Changes

**Backend**
- `mention.service.ts`: Added `extractBroadcastMentions()` to detect `@everyone`/`@here` tokens, and `processBroadcastMentions()` which fans out notifications to all or online-only server members. Broadcast tokens are excluded from regular username parsing to prevent double-notifications.
- `message.service.ts`: Wired `processBroadcastMentions()` into `sendMessage`, `editMessage`, and `createReply` (fire-and-forget, best-effort, same pattern as existing `processMentions`)

**Frontend**
- `MentionText.tsx`: `@everyone` and `@here` render with the same `text-indigo-300 bg-indigo-500/20` pill styling as regular mentions, with tooltips describing which members will be notified
- `MessageItem.tsx`: `isMentioned` row-highlight logic extended to return `true` when the message contains `@everyone` or `@here`, so the message row gets the yellow highlight just like a direct mention

## Test plan
- [ ] Run `npm test` in `harmony-frontend` — all tests pass
- [ ] Run existing `mention.service.test.ts` in `harmony-backend` — all 11 tests pass
- [ ] Send a message with `@everyone` — all channel members (except author) receive a notification; message row highlights yellow for recipients
- [ ] Send a message with `@here` — only ONLINE/IDLE members are notified
- [ ] Send a message with both tokens — no duplicate notifications per user
- [ ] Verify existing `@username` mentions still work without regression

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)