### PR TITLE
fix: vertically center message input text to align with icon buttons

### DIFF
--- a/harmony-frontend/src/components/channel/MessageInput.tsx
+++ b/harmony-frontend/src/components/channel/MessageInput.tsx
@@ -470,7 +470,7 @@ export function MessageInput({
 
       <div
         className={cn(
-          'flex items-end gap-1 rounded-lg bg-[#40444b] px-2 py-2',
+          'flex items-center gap-1 rounded-lg bg-[#40444b] px-2 py-2',
           isAtLimit && 'ring-1 ring-red-500/60',
         )}
       >


### PR DESCRIPTION
## Summary

- Fixes #564 — placeholder and typed text in the message input were top-aligned inside the textarea while the attachment (+) and emoji/GIF buttons were vertically centered, causing visible misalignment
- Changed `items-end` to `items-center` on the outer flex container in `MessageInput.tsx` so all three elements (attachment button, textarea, right-side controls) share the same vertical midpoint

## Root Cause

`items-end` bottom-aligned the textarea with the surrounding icon buttons. Since textarea content renders from the top of its box, the text sat above the buttons' visual center.

## Test Plan

- [ ] Open a channel and confirm placeholder text is vertically centered with the + and emoji/GIF buttons
- [ ] Type a single-line message and confirm typed text aligns with the icons
- [ ] Type a multi-line message and confirm buttons remain reasonably positioned
- [ ] Verify no regressions in message sending, emoji picker, GIF button, or attachment flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)