### PR TITLE
fix(#565): default #general to PUBLIC_NO_INDEX on private server creation

### DIFF
--- a/harmony-backend/src/services/channel.service.ts
+++ b/harmony-backend/src/services/channel.service.ts
@@ -221,7 +221,7 @@ export const channelService = {
       name: 'general',
       slug: 'general',
       type: ChannelType.TEXT,
-      visibility: isPublic ? ChannelVisibility.PUBLIC_INDEXABLE : ChannelVisibility.PRIVATE,
+      visibility: isPublic ? ChannelVisibility.PUBLIC_INDEXABLE : ChannelVisibility.PUBLIC_NO_INDEX,
       position: 0,
     }, tx);
   },

--- a/harmony-backend/tests/channel.service.test.ts
+++ b/harmony-backend/tests/channel.service.test.ts
@@ -565,7 +565,7 @@ describe('channelService.createDefaultChannel', () => {
     await prisma.server.delete({ where: { id: defaultChannelServerId } }).catch(() => {});
   });
 
-  it('CS-26: delegates to createChannel with the correct fixed arguments', async () => {
+  it('CS-26: delegates to createChannel with PUBLIC_NO_INDEX visibility when isPublic=false', async () => {
     const spy = jest.spyOn(channelService, 'createChannel');
 
     const result = await channelService.createDefaultChannel(defaultChannelServerId);
@@ -575,11 +575,12 @@ describe('channelService.createDefaultChannel', () => {
       name: 'general',
       slug: 'general',
       type: 'TEXT',
-      visibility: 'PRIVATE',
+      visibility: 'PUBLIC_NO_INDEX',
       position: 0,
     }, undefined);
     expect(result.name).toBe('general');
     expect(result.slug).toBe('general');
+    expect(result.visibility).toBe('PUBLIC_NO_INDEX');
 
     spy.mockRestore();
   });


### PR DESCRIPTION
## Summary

Fixes #565.

- `createDefaultChannel` was setting `#general` to `PRIVATE` for private servers, blocking newly joined members from seeing any channel content
- Changed the fallback visibility from `PRIVATE` → `PUBLIC_NO_INDEX` so all server members can read `#general` immediately after joining, while the channel remains non-indexable by search engines
- Updated test CS-26 to assert the new `PUBLIC_NO_INDEX` behavior

## Test plan

- [ ] Create a private server — confirm `#general` is created with `PUBLIC_NO_INDEX` visibility
- [ ] Add a non-admin member to that server — confirm they can open and read `#general` without admin action
- [ ] Confirm `#general` does not appear in the public sitemap / does not emit `index,follow` metadata
- [ ] Confirm existing public servers still create `#general` as `PUBLIC_INDEXABLE`
- [ ] Backend unit tests pass: `channel.service.test.ts` CS-26 and CS-26b

🤖 Generated with [Claude Code](https://claude.com/claude-code)