### PR TITLE
fix: send no body instead of null for no-input tRPC mutations

### DIFF
--- a/harmony-frontend/src/lib/api-client.ts
+++ b/harmony-frontend/src/lib/api-client.ts
@@ -234,7 +234,7 @@ class ApiClient {
 
   /** Call a tRPC mutation procedure (POST). Returns the unwrapped data. */
   async trpcMutation<T>(procedure: string, input?: unknown): Promise<T> {
-    const res = await this.client.post<TrpcResponse<T>>(`/trpc/${procedure}`, input ?? null);
+    const res = await this.client.post<TrpcResponse<T>>(`/trpc/${procedure}`, input);
     return res.data.result.data;
   }
 }


### PR DESCRIPTION
## Summary

Closes #574 (root cause — the badge-counter fix in #591 was incomplete).

- `trpcMutation` was passing `input ?? null` to Axios. When called with no input argument (i.e. `notification.markAllAsRead`), Axios serialized this to the JSON literal `null`, which the tRPC v11 HTTP adapter rejects with **HTTP 500** before even running auth middleware.
- The 500 was silently caught by the `catch {}` block in `markAllAsRead`, so no state update happened and the button appeared to do nothing.
- Removing the `?? null` fallback lets Axios omit the request body entirely when `input` is `undefined`, which tRPC handles correctly for void/no-input procedures.

## Root-cause evidence

```
# null body → 500 (broken)
curl -X POST .../trpc/notification.markAllAsRead -d 'null' -H 'Authorization: Bearer invalid'
→ HTTP 500 {"error":"Internal server error"}

# no body → 401 (correct — auth middleware runs)
curl -X POST .../trpc/notification.markAllAsRead -H 'Authorization: Bearer invalid'
→ HTTP 401 {"error":{"message":"UNAUTHORIZED",...}}

# {} body → 401 (also correct)
curl -X POST .../trpc/notification.markAllAsRead -d '{}' -H 'Authorization: Bearer invalid'
→ HTTP 401 {"error":{"message":"UNAUTHORIZED",...}}
```

## Why #591 didn't fully fix it

PR #591 fixed the `unreadCount` badge-counter drift (useMemo) and added tests, but the tests mock `trpcMutation` so they never exercise the real wire format. The actual HTTP call to `markAllAsRead` has been silently returning 500 since the endpoint was introduced.

## Test plan

- [x] All 457 frontend tests pass
- [x] `markAsRead` still returns the expected args (unchanged path)
- [x] All other `trpcMutation` callers pass input objects — they are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)