### PR TITLE
feat: delete text/voice channels (admin/owner)

### DIFF
--- a/harmony-backend/src/repositories/channel.repository.ts
+++ b/harmony-backend/src/repositories/channel.repository.ts
@@ -1,4 +1,4 @@
-import { ChannelVisibility, Prisma } from '@prisma/client';
+import { ChannelType, ChannelVisibility, Prisma } from '@prisma/client';
 import { prisma } from '../db/prisma';
 
 type Client = Prisma.TransactionClient | typeof prisma;
@@ -51,5 +51,9 @@ export const channelRepository = {
 
   delete(id: string, client: Client = prisma) {
     return client.channel.delete({ where: { id } });
+  },
+
+  countByServerIdAndType(serverId: string, type: ChannelType, client: Client = prisma) {
+    return client.channel.count({ where: { serverId, type } });
   },
 };

--- a/harmony-backend/src/services/channel.service.ts
+++ b/harmony-backend/src/services/channel.service.ts
@@ -172,6 +172,19 @@ export const channelService = {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Channel not found in this server' });
     }
 
+    if (channel.type === ChannelType.TEXT) {
+      const textChannelCount = await channelRepository.countByServerIdAndType(
+        serverId,
+        ChannelType.TEXT,
+      );
+      if (textChannelCount <= 1) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Cannot delete the last text channel in a server',
+        });
+      }
+    }
+
     await channelRepository.delete(channelId);
 
     // Write-through: invalidate all caches for deleted channel (best-effort)

--- a/harmony-backend/src/services/channel.service.ts
+++ b/harmony-backend/src/services/channel.service.ts
@@ -185,7 +185,7 @@ export const channelService = {
       }
     }
 
-    await channelRepository.delete(channelId);
+    const deleted = await channelRepository.delete(channelId);
 
     // Write-through: invalidate all caches for deleted channel (best-effort)
     cacheService
@@ -226,6 +226,8 @@ export const channelService = {
           'Failed to publish channel deleted event',
         ),
       );
+
+    return deleted;
   },
 
   async createDefaultChannel(serverId: string, isPublic = false, tx?: Prisma.TransactionClient) {

--- a/harmony-backend/tests/channel.service.events.test.ts
+++ b/harmony-backend/tests/channel.service.events.test.ts
@@ -28,6 +28,7 @@ const mockChannelCreate = jest.fn();
 const mockChannelUpdate = jest.fn();
 const mockChannelDelete = jest.fn();
 const mockChannelFindUnique = jest.fn();
+const mockChannelCount = jest.fn();
 const mockServerFindUnique = jest.fn();
 
 jest.mock('../src/db/prisma', () => ({
@@ -37,6 +38,7 @@ jest.mock('../src/db/prisma', () => ({
       update: mockChannelUpdate,
       delete: mockChannelDelete,
       findUnique: mockChannelFindUnique,
+      count: mockChannelCount,
     },
     server: {
       findUnique: mockServerFindUnique,
@@ -87,6 +89,7 @@ beforeEach(() => {
   mockChannelCreate.mockResolvedValue(MOCK_CHANNEL);
   mockChannelUpdate.mockResolvedValue({ ...MOCK_CHANNEL, name: 'renamed' });
   mockChannelDelete.mockResolvedValue(MOCK_CHANNEL);
+  mockChannelCount.mockResolvedValue(2); // >1 text channel by default so deletes succeed
 });
 
 // ─── createChannel publishes CHANNEL_CREATED ──────────────────────────────────

--- a/harmony-backend/tests/channel.service.test.ts
+++ b/harmony-backend/tests/channel.service.test.ts
@@ -480,7 +480,13 @@ describe('channelService.deleteChannel', () => {
   it('CS-21: deletes channel and fires all three cache operations + event', async () => {
     const result = await channelService.deleteChannel(deleteChannelId, serverId);
 
-    expect(result).toBeUndefined();
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: deleteChannelId,
+        serverId,
+        slug: `to-delete-${ts}`,
+      }),
+    );
 
     // Verify the channel is actually gone from the DB
     const gone = await prisma.channel.findUnique({ where: { id: deleteChannelId } });
@@ -534,9 +540,13 @@ describe('channelService.deleteChannel', () => {
     mockCacheInvalidatePattern.mockRejectedValue(new Error('invalidatePattern error'));
     mockPublish.mockRejectedValue(new Error('event bus error'));
 
-    await expect(
-      channelService.deleteChannel(ch.id, serverId),
-    ).resolves.toBeUndefined();
+    await expect(channelService.deleteChannel(ch.id, serverId)).resolves.toEqual(
+      expect.objectContaining({
+        id: ch.id,
+        serverId,
+        slug: `cs25-delete-${ts}`,
+      }),
+    );
   });
 });
 

--- a/harmony-frontend/src/__tests__/ChannelSidebar.server-menu.test.tsx
+++ b/harmony-frontend/src/__tests__/ChannelSidebar.server-menu.test.tsx
@@ -67,6 +67,14 @@ const baseChannel = {
   createdAt: new Date().toISOString(),
 };
 
+const voiceChannel = {
+  ...baseChannel,
+  id: '33333333-3333-4333-8333-333333333333',
+  name: 'Voice',
+  slug: 'voice',
+  type: ChannelType.VOICE,
+};
+
 const baseUser: User = {
   id: 'member-1',
   username: 'member',
@@ -75,11 +83,18 @@ const baseUser: User = {
   isSystemAdmin: false,
 };
 
-function renderSidebar(userOverrides: Partial<typeof baseUser> = {}, isAuthenticated = true) {
+function renderSidebar(
+  userOverrides: Partial<typeof baseUser> = {},
+  isAuthenticated = true,
+  options: {
+    channels?: (typeof baseChannel)[];
+    onCreateChannel?: (defaultType: ChannelType) => void;
+  } = {},
+) {
   return render(
     <ChannelSidebar
       server={baseServer}
-      channels={[baseChannel]}
+      channels={options.channels ?? [baseChannel]}
       currentChannelId={baseChannel.id}
       currentUser={{ ...baseUser, ...userOverrides }}
       isOpen
@@ -87,6 +102,7 @@ function renderSidebar(userOverrides: Partial<typeof baseUser> = {}, isAuthentic
       isAuthenticated={isAuthenticated}
       serverId={baseServer.id}
       members={[]}
+      onCreateChannel={options.onCreateChannel}
     />,
   );
 }
@@ -104,12 +120,43 @@ describe('ChannelSidebar server menu', () => {
     expect(screen.getByRole('menuitem', { name: /server settings/i })).toBeInTheDocument();
   });
 
+  it('shows channel management entrypoints for server admin users', () => {
+    const onCreateChannel = jest.fn();
+    renderSidebar({ role: 'admin' }, true, {
+      channels: [baseChannel, voiceChannel],
+      onCreateChannel,
+    });
+
+    expect(screen.getByRole('button', { name: /add text channel/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add voice channel/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /settings for general/i })).toHaveAttribute(
+      'href',
+      '/settings/meee/general',
+    );
+    expect(screen.getByRole('link', { name: /settings for voice/i })).toHaveAttribute(
+      'href',
+      '/settings/meee/voice',
+    );
+  });
+
   it('hides server settings for non-admin users', () => {
     renderSidebar();
 
     fireEvent.click(screen.getByRole('button', { name: /open server menu/i }));
 
     expect(screen.queryByRole('menuitem', { name: /server settings/i })).not.toBeInTheDocument();
+  });
+
+  it('hides channel management entrypoints for non-admin users', () => {
+    renderSidebar({}, true, {
+      channels: [baseChannel, voiceChannel],
+      onCreateChannel: jest.fn(),
+    });
+
+    expect(screen.queryByRole('button', { name: /add text channel/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add voice channel/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /settings for general/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /settings for voice/i })).not.toBeInTheDocument();
   });
 
   it('shows leave flow and redirects after successful leave', async () => {

--- a/harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/actions.ts
+++ b/harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/actions.ts
@@ -8,7 +8,8 @@
  */
 
 import { revalidatePath } from 'next/cache';
-import { updateChannel, getChannel, getAuditLog } from '@/services/channelService';
+import { redirect } from 'next/navigation';
+import { updateChannel, getChannel, getAuditLog, deleteChannel } from '@/services/channelService';
 import { getServer } from '@/services/serverService';
 import type { Channel } from '@/types';
 import type { AuditLogPage } from '@/services/channelService';
@@ -119,6 +120,28 @@ export async function triggerSeoRegeneration(
 ): Promise<MetaTagJobAccepted> {
   const channel = await resolveChannelForSeo(serverSlug, channelSlug);
   return triggerMetaTagRegeneration(channel.id);
+}
+
+/**
+ * Server action: delete a channel. Resolves IDs from route slugs (don't trust raw IDs from
+ * the client), then redirects to the server home after deletion.
+ * Auth enforced by the backend `channel.deleteChannel` procedure (requires channel:delete).
+ */
+export async function deleteChannelAction(
+  serverSlug: string,
+  channelSlug: string,
+): Promise<void> {
+  const channel = await getChannel(serverSlug, channelSlug);
+  if (!channel) throw new Error('Channel not found');
+
+  const server = await getServer(serverSlug);
+  if (!server) throw new Error('Server not found');
+
+  await deleteChannel(channel.id, server.id);
+
+  revalidatePath(`/channels/${serverSlug}`, 'layout');
+  revalidatePath(`/settings/${serverSlug}`, 'layout');
+  redirect(`/channels/${serverSlug}`);
 }
 
 export async function fetchSeoRegenerationStatus(

--- a/harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/actions.ts
+++ b/harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/actions.ts
@@ -127,10 +127,7 @@ export async function triggerSeoRegeneration(
  * the client), then redirects to the server home after deletion.
  * Auth enforced by the backend `channel.deleteChannel` procedure (requires channel:delete).
  */
-export async function deleteChannelAction(
-  serverSlug: string,
-  channelSlug: string,
-): Promise<void> {
+export async function deleteChannelAction(serverSlug: string, channelSlug: string): Promise<void> {
   const channel = await getChannel(serverSlug, channelSlug);
   if (!channel) throw new Error('Channel not found');
 
@@ -140,6 +137,7 @@ export async function deleteChannelAction(
   await deleteChannel(channel.id, server.id);
 
   revalidatePath(`/channels/${serverSlug}`, 'layout');
+  revalidatePath(`/c/${serverSlug}`, 'layout');
   revalidatePath(`/settings/${serverSlug}`, 'layout');
   redirect(`/channels/${serverSlug}`);
 }

--- a/harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/page.tsx
+++ b/harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/page.tsx
@@ -1,7 +1,8 @@
 import { notFound } from 'next/navigation';
-import { getChannel } from '@/services/channelService';
+import { getChannel, getChannels } from '@/services/channelService';
 import { ChannelSettingsPage } from '@/components/settings/ChannelSettingsPage';
 import { requireServerSettingsAccess } from '@/app/settings/[serverSlug]/settings-access';
+import { ChannelType } from '@/types';
 
 interface PageProps {
   params: Promise<{ serverSlug: string; channelSlug: string }>;
@@ -14,5 +15,16 @@ export default async function SettingsPage({ params }: PageProps) {
   const channel = await getChannel(serverSlug, channelSlug);
   if (!channel) notFound();
 
-  return <ChannelSettingsPage channel={channel} serverSlug={serverSlug} canManageSeo />;
+  const allChannels = await getChannels(channel.serverId);
+  const textChannelCount = allChannels.filter(c => c.type === ChannelType.TEXT).length;
+  const isLastTextChannel = channel.type === ChannelType.TEXT && textChannelCount <= 1;
+
+  return (
+    <ChannelSettingsPage
+      channel={channel}
+      serverSlug={serverSlug}
+      canManageSeo
+      isLastTextChannel={isLastTextChannel}
+    />
+  );
 }

--- a/harmony-frontend/src/components/channel/ChannelSidebar.tsx
+++ b/harmony-frontend/src/components/channel/ChannelSidebar.tsx
@@ -196,8 +196,6 @@ export function ChannelSidebar({
   // Precompute userId → User map to avoid O(members × participants) lookups on every render.
   const memberMap = useMemo(() => new Map(members?.map(m => [m.id, m]) ?? []), [members]);
 
-  const isAdmin =
-    isAuthenticated && (currentUser.isSystemAdmin || currentUser.id === server.ownerId);
   const hasServerSettingsAccess =
     isAuthenticated &&
     (currentUser.isSystemAdmin ||
@@ -336,7 +334,9 @@ export function ChannelSidebar({
                 isCollapsed={textCollapsed}
                 onToggle={() => setTextCollapsed(v => !v)}
                 onAdd={
-                  isAdmin && onCreateChannel ? () => onCreateChannel(ChannelType.TEXT) : undefined
+                  hasServerSettingsAccess && onCreateChannel
+                    ? () => onCreateChannel(ChannelType.TEXT)
+                    : undefined
                 }
                 addLabel='Add text channel'
               />
@@ -378,7 +378,7 @@ export function ChannelSidebar({
                               </span>
                             )}
                           </Link>
-                          {isAdmin && (
+                          {hasServerSettingsAccess && (
                             <Link
                               href={`/settings/${server.slug}/${channel.slug}`}
                               title='Channel settings'
@@ -416,7 +416,9 @@ export function ChannelSidebar({
                 isCollapsed={voiceCollapsed}
                 onToggle={() => setVoiceCollapsed(v => !v)}
                 onAdd={
-                  isAdmin && onCreateChannel ? () => onCreateChannel(ChannelType.VOICE) : undefined
+                  hasServerSettingsAccess && onCreateChannel
+                    ? () => onCreateChannel(ChannelType.VOICE)
+                    : undefined
                 }
                 addLabel='Add voice channel'
               />
@@ -450,7 +452,7 @@ export function ChannelSidebar({
                           <ChannelIcon type={channel.type} />
                           <span className='flex-1 truncate text-left'>{channel.name}</span>
                         </button>
-                        {isAdmin && (
+                        {hasServerSettingsAccess && (
                           <Link
                             href={`/settings/${server.slug}/${channel.slug}`}
                             title='Channel settings'

--- a/harmony-frontend/src/components/channel/ChannelSidebar.tsx
+++ b/harmony-frontend/src/components/channel/ChannelSidebar.tsx
@@ -389,24 +389,49 @@ export function ChannelSidebar({
                 <ul className='list-none'>
                   {voiceChannels.map(channel => (
                     <li key={channel.id}>
-                      <button
-                        type='button'
-                        disabled={!isAuthenticated || joining}
-                        aria-disabled={!isAuthenticated || joining}
-                        onClick={() => {
-                          if (joinChannel) void joinChannel(channel.id, serverId, channel.name);
-                        }}
-                        className={cn(
-                          'group flex w-full items-center gap-1.5 rounded px-2 py-1 text-sm transition-colors',
-                          connectedChannelId === channel.id
-                            ? cn(BG_ACTIVE, 'text-white')
-                            : 'text-gray-400 hover:bg-[#393c43] hover:text-gray-200',
-                          !isAuthenticated && 'cursor-default opacity-60',
+                      <div className='group flex items-center gap-1.5 rounded px-2 py-1 text-sm transition-colors hover:bg-[#393c43]'>
+                        <button
+                          type='button'
+                          disabled={!isAuthenticated || joining}
+                          aria-disabled={!isAuthenticated || joining}
+                          onClick={() => {
+                            if (joinChannel) void joinChannel(channel.id, serverId, channel.name);
+                          }}
+                          className={cn(
+                            'flex flex-1 min-w-0 items-center gap-1.5',
+                            connectedChannelId === channel.id
+                              ? 'text-white'
+                              : 'text-gray-400 group-hover:text-gray-200',
+                            !isAuthenticated && 'cursor-default opacity-60',
+                          )}
+                        >
+                          <ChannelIcon type={channel.type} />
+                          <span className='flex-1 truncate text-left'>{channel.name}</span>
+                        </button>
+                        {isAdmin && (
+                          <Link
+                            href={`/settings/${server.slug}/${channel.slug}`}
+                            title='Channel settings'
+                            aria-label={`Settings for ${channel.name}`}
+                            className='flex-shrink-0 rounded p-0.5 text-gray-500 opacity-0 transition-opacity group-hover:opacity-100 hover:text-gray-200'
+                            onClick={e => e.stopPropagation()}
+                          >
+                            <svg
+                              className='h-3.5 w-3.5'
+                              viewBox='0 0 20 20'
+                              fill='currentColor'
+                              aria-hidden='true'
+                              focusable='false'
+                            >
+                              <path
+                                fillRule='evenodd'
+                                d='M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z'
+                                clipRule='evenodd'
+                              />
+                            </svg>
+                          </Link>
                         )}
-                      >
-                        <ChannelIcon type={channel.type} />
-                        <span className='flex-1 truncate text-left'>{channel.name}</span>
-                      </button>
+                      </div>
                       {/* Participant list for this voice channel — from all-channels map */}
                       {(() => {
                         const channelParticipants = allChannelParticipants[channel.id] ?? [];

--- a/harmony-frontend/src/components/channel/ChannelSidebar.tsx
+++ b/harmony-frontend/src/components/channel/ChannelSidebar.tsx
@@ -344,9 +344,7 @@ export function ChannelSidebar({
                     const badge = VISIBILITY_BADGE[channel.visibility];
                     return (
                       <li key={channel.id}>
-                        <Link
-                          href={`${basePath}/${server.slug}/${channel.slug}`}
-                          aria-current={isActive ? 'page' : undefined}
+                        <div
                           className={cn(
                             'group flex items-center gap-1.5 rounded px-2 py-1 text-sm transition-colors',
                             isActive
@@ -354,18 +352,46 @@ export function ChannelSidebar({
                               : 'text-gray-400 hover:bg-[#393c43] hover:text-gray-200',
                           )}
                         >
-                          <ChannelIcon type={channel.type} />
-                          <span className='flex-1 truncate'>{channel.name}</span>
-                          {badge && (
-                            <span
-                              className='text-xs opacity-60'
-                              role='img'
-                              aria-label={VISIBILITY_LABEL[channel.visibility]}
+                          <Link
+                            href={`${basePath}/${server.slug}/${channel.slug}`}
+                            aria-current={isActive ? 'page' : undefined}
+                            className='flex flex-1 min-w-0 items-center gap-1.5'
+                          >
+                            <ChannelIcon type={channel.type} />
+                            <span className='flex-1 truncate'>{channel.name}</span>
+                            {badge && (
+                              <span
+                                className='text-xs opacity-60'
+                                role='img'
+                                aria-label={VISIBILITY_LABEL[channel.visibility]}
+                              >
+                                {badge}
+                              </span>
+                            )}
+                          </Link>
+                          {isAdmin && (
+                            <Link
+                              href={`/settings/${server.slug}/${channel.slug}`}
+                              title='Channel settings'
+                              aria-label={`Settings for ${channel.name}`}
+                              className='flex-shrink-0 rounded p-0.5 text-gray-500 opacity-0 transition-opacity group-hover:opacity-100 hover:text-gray-200'
                             >
-                              {badge}
-                            </span>
+                              <svg
+                                className='h-3.5 w-3.5'
+                                viewBox='0 0 20 20'
+                                fill='currentColor'
+                                aria-hidden='true'
+                                focusable='false'
+                              >
+                                <path
+                                  fillRule='evenodd'
+                                  d='M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z'
+                                  clipRule='evenodd'
+                                />
+                              </svg>
+                            </Link>
                           )}
-                        </Link>
+                        </div>
                       </li>
                     );
                   })}

--- a/harmony-frontend/src/components/channel/ChannelSidebar.tsx
+++ b/harmony-frontend/src/components/channel/ChannelSidebar.tsx
@@ -415,7 +415,14 @@ export function ChannelSidebar({
                 <ul className='list-none'>
                   {voiceChannels.map(channel => (
                     <li key={channel.id}>
-                      <div className='group flex items-center gap-1.5 rounded px-2 py-1 text-sm transition-colors hover:bg-[#393c43]'>
+                      <div
+                        className={cn(
+                          'group flex items-center gap-1.5 rounded px-2 py-1 text-sm transition-colors',
+                          connectedChannelId === channel.id
+                            ? cn(BG_ACTIVE, 'hover:bg-[#3d4148]')
+                            : 'hover:bg-[#393c43]',
+                        )}
+                      >
                         <button
                           type='button'
                           disabled={!isAuthenticated || joining}

--- a/harmony-frontend/src/components/settings/ChannelSettingsPage.tsx
+++ b/harmony-frontend/src/components/settings/ChannelSettingsPage.tsx
@@ -12,6 +12,7 @@ import { cn, getUserErrorMessage } from '@/lib/utils';
 import {
   saveChannelSettings,
   fetchAuditLog,
+  deleteChannelAction,
 } from '@/app/settings/[serverSlug]/[channelSlug]/actions';
 import { VisibilityToggle } from '@/components/channel/VisibilityToggle';
 import { SeoPreviewSection } from '@/components/settings/SeoPreviewSection';
@@ -108,14 +109,15 @@ function ChannelNotificationsSection({ channel, serverId }: { channel: Channel; 
   );
 }
 
-type Section = 'overview' | 'permissions' | 'visibility' | 'seo' | 'notifications';
+type Section = 'overview' | 'permissions' | 'visibility' | 'seo' | 'notifications' | 'danger';
 
-const SECTIONS: { id: Section; label: string }[] = [
+const SECTIONS: { id: Section; label: string; danger?: boolean }[] = [
   { id: 'overview', label: 'Overview' },
   { id: 'permissions', label: 'Permissions' },
   { id: 'visibility', label: 'Visibility' },
   { id: 'seo', label: 'SEO Preview' },
   { id: 'notifications', label: 'Notifications' },
+  { id: 'danger', label: 'Delete Channel', danger: true },
 ];
 
 // ─── Overview section ─────────────────────────────────────────────────────────
@@ -608,7 +610,71 @@ function VisibilitySection({
   );
 }
 
-// ─── Loading spinner ──────────────────────────────────────────────────────────
+// ─── Danger zone section ──────────────────────────────────────────────────────
+
+function DangerZoneSection({ channel, serverSlug }: { channel: Channel; serverSlug: string }) {
+  const [confirmText, setConfirmText] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const nameMatches = confirmText === channel.name;
+
+  async function handleDelete() {
+    if (!nameMatches || deleting) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteChannelAction(serverSlug, channel.slug);
+    } catch (err) {
+      setError(getUserErrorMessage(err, 'Failed to delete channel.'));
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <div className='max-w-lg space-y-6'>
+      <h2 className='text-xl font-semibold text-white'>Delete Channel</h2>
+      <div className='rounded border border-red-500/40 bg-red-950/20 p-5 space-y-4'>
+        <p className='text-sm text-gray-300'>
+          Deleting <span className='font-semibold text-white'>#{channel.name}</span> is permanent
+          and cannot be undone. All messages and settings for this channel will be lost.
+        </p>
+        <div>
+          <label
+            htmlFor='confirm-channel-name'
+            className='mb-1.5 block text-xs font-semibold uppercase tracking-wide text-gray-400'
+          >
+            Type the channel name to confirm
+          </label>
+          <input
+            id='confirm-channel-name'
+            type='text'
+            value={confirmText}
+            onChange={e => setConfirmText(e.target.value)}
+            placeholder={channel.name}
+            disabled={deleting}
+            className={cn(
+              'w-full rounded px-3 py-2 text-sm text-white placeholder-gray-600 outline-none',
+              'focus:ring-2 focus:ring-red-500 disabled:opacity-50',
+              BG.input,
+            )}
+          />
+        </div>
+        {error && <p className='text-xs text-red-400'>{error}</p>}
+        <button
+          type='button'
+          onClick={handleDelete}
+          disabled={!nameMatches || deleting}
+          className='rounded px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors'
+        >
+          {deleting ? 'Deleting…' : 'Delete Channel'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
 
 export interface ChannelSettingsPageProps {
   channel: Channel;
@@ -673,7 +739,7 @@ export function ChannelSettingsPage({
 
         {/* Nav items */}
         <nav aria-label='Settings sections'>
-          {SECTIONS.map(({ id, label }) => (
+          {SECTIONS.map(({ id, label, danger }) => (
             <button
               key={id}
               type='button'
@@ -684,9 +750,13 @@ export function ChannelSettingsPage({
               aria-current={activeSection === id ? 'page' : undefined}
               className={cn(
                 'w-full cursor-pointer rounded px-2 py-1.5 text-left text-sm transition-colors',
-                activeSection === id
-                  ? cn(BG.active, 'font-medium text-white')
-                  : 'text-gray-400 hover:bg-[#393c43] hover:text-gray-200',
+                danger
+                  ? activeSection === id
+                    ? cn(BG.active, 'font-medium text-red-400')
+                    : 'text-red-400/80 hover:bg-[#393c43] hover:text-red-400'
+                  : activeSection === id
+                    ? cn(BG.active, 'font-medium text-white')
+                    : 'text-gray-400 hover:bg-[#393c43] hover:text-gray-200',
               )}
             >
               {label}
@@ -762,6 +832,9 @@ export function ChannelSettingsPage({
           )}
           {activeSection === 'notifications' && (
             <ChannelNotificationsSection channel={channel} serverId={channel.serverId} />
+          )}
+          {activeSection === 'danger' && (
+            <DangerZoneSection channel={channel} serverSlug={serverSlug} />
           )}
         </div>
       </main>

--- a/harmony-frontend/src/components/settings/ChannelSettingsPage.tsx
+++ b/harmony-frontend/src/components/settings/ChannelSettingsPage.tsx
@@ -612,12 +612,21 @@ function VisibilitySection({
 
 // ─── Danger zone section ──────────────────────────────────────────────────────
 
-function DangerZoneSection({ channel, serverSlug }: { channel: Channel; serverSlug: string }) {
+function DangerZoneSection({
+  channel,
+  serverSlug,
+  isLastTextChannel,
+}: {
+  channel: Channel;
+  serverSlug: string;
+  isLastTextChannel: boolean;
+}) {
   const [confirmText, setConfirmText] = useState('');
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const nameMatches = confirmText === channel.name;
+  const blocked = isLastTextChannel;
 
   async function handleDelete() {
     if (!nameMatches || deleting) return;
@@ -635,40 +644,50 @@ function DangerZoneSection({ channel, serverSlug }: { channel: Channel; serverSl
     <div className='max-w-lg space-y-6'>
       <h2 className='text-xl font-semibold text-white'>Delete Channel</h2>
       <div className='rounded border border-red-500/40 bg-red-950/20 p-5 space-y-4'>
-        <p className='text-sm text-gray-300'>
-          Deleting <span className='font-semibold text-white'>#{channel.name}</span> is permanent
-          and cannot be undone. All messages and settings for this channel will be lost.
-        </p>
-        <div>
-          <label
-            htmlFor='confirm-channel-name'
-            className='mb-1.5 block text-xs font-semibold uppercase tracking-wide text-gray-400'
-          >
-            Type the channel name to confirm
-          </label>
-          <input
-            id='confirm-channel-name'
-            type='text'
-            value={confirmText}
-            onChange={e => setConfirmText(e.target.value)}
-            placeholder={channel.name}
-            disabled={deleting}
-            className={cn(
-              'w-full rounded px-3 py-2 text-sm text-white placeholder-gray-600 outline-none',
-              'focus:ring-2 focus:ring-red-500 disabled:opacity-50',
-              BG.input,
-            )}
-          />
-        </div>
-        {error && <p className='text-xs text-red-400'>{error}</p>}
-        <button
-          type='button'
-          onClick={handleDelete}
-          disabled={!nameMatches || deleting}
-          className='rounded px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors'
-        >
-          {deleting ? 'Deleting…' : 'Delete Channel'}
-        </button>
+        {blocked ? (
+          <p className='text-sm text-gray-300'>
+            <span className='font-semibold text-white'>#{channel.name}</span> cannot be deleted
+            because it is the only text channel in this server. Create another text channel first.
+          </p>
+        ) : (
+          <>
+            <p className='text-sm text-gray-300'>
+              Deleting <span className='font-semibold text-white'>#{channel.name}</span> is
+              permanent and cannot be undone. All messages and settings for this channel will be
+              lost.
+            </p>
+            <div>
+              <label
+                htmlFor='confirm-channel-name'
+                className='mb-1.5 block text-xs font-semibold uppercase tracking-wide text-gray-400'
+              >
+                Type the channel name to confirm
+              </label>
+              <input
+                id='confirm-channel-name'
+                type='text'
+                value={confirmText}
+                onChange={e => setConfirmText(e.target.value)}
+                placeholder={channel.name}
+                disabled={deleting}
+                className={cn(
+                  'w-full rounded px-3 py-2 text-sm text-white placeholder-gray-600 outline-none',
+                  'focus:ring-2 focus:ring-red-500 disabled:opacity-50',
+                  BG.input,
+                )}
+              />
+            </div>
+            {error && <p className='text-xs text-red-400'>{error}</p>}
+            <button
+              type='button'
+              onClick={handleDelete}
+              disabled={!nameMatches || deleting}
+              className='rounded px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors'
+            >
+              {deleting ? 'Deleting…' : 'Delete Channel'}
+            </button>
+          </>
+        )}
       </div>
     </div>
   );
@@ -681,6 +700,7 @@ export interface ChannelSettingsPageProps {
   serverSlug: string;
   serverOwnerId?: string;
   canManageSeo?: boolean;
+  isLastTextChannel?: boolean;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -690,6 +710,7 @@ export function ChannelSettingsPage({
   serverSlug,
   serverOwnerId: _serverOwnerId,
   canManageSeo = true,
+  isLastTextChannel = false,
 }: ChannelSettingsPageProps) {
   const router = useRouter();
   const [activeSection, setActiveSection] = useState<Section>('overview');
@@ -834,7 +855,11 @@ export function ChannelSettingsPage({
             <ChannelNotificationsSection channel={channel} serverId={channel.serverId} />
           )}
           {activeSection === 'danger' && (
-            <DangerZoneSection channel={channel} serverSlug={serverSlug} />
+            <DangerZoneSection
+              channel={channel}
+              serverSlug={serverSlug}
+              isLastTextChannel={isLastTextChannel}
+            />
           )}
         </div>
       </main>

--- a/harmony-frontend/src/components/settings/ChannelSettingsPage.tsx
+++ b/harmony-frontend/src/components/settings/ChannelSettingsPage.tsx
@@ -879,7 +879,7 @@ export function ChannelSettingsPage({
           {effectiveSection === 'notifications' && (
             <ChannelNotificationsSection channel={channel} serverId={channel.serverId} />
           )}
-          {activeSection === 'danger' && (
+          {effectiveSection === 'danger' && (
             <DangerZoneSection
               channel={channel}
               serverSlug={serverSlug}

--- a/harmony-frontend/src/lib/api-client.ts
+++ b/harmony-frontend/src/lib/api-client.ts
@@ -234,7 +234,7 @@ class ApiClient {
 
   /** Call a tRPC mutation procedure (POST). Returns the unwrapped data. */
   async trpcMutation<T>(procedure: string, input?: unknown): Promise<T> {
-    const res = await this.client.post<TrpcResponse<T>>(`/trpc/${procedure}`, input);
+    const res = await this.client.post<TrpcResponse<T>>(`/trpc/${procedure}`, input ?? null);
     return res.data.result.data;
   }
 }
@@ -252,7 +252,7 @@ export async function fetchSseTicket(apiBaseUrl: string, accessToken: string): P
     headers: { Authorization: `Bearer ${accessToken}` },
   });
   if (!res.ok) throw new Error(`Failed to fetch SSE ticket: ${res.status}`);
-  const data = await res.json() as { ticket: string };
+  const data = (await res.json()) as { ticket: string };
   return data.ticket;
 }
 


### PR DESCRIPTION
## Summary

- Adds a **settings gear icon** to both text and voice channel sidebar rows (admins/owners only, hover-revealed), giving all channel types a direct path to their settings page
- Adds a **Delete Channel** section to the channel settings page for both text and voice channels
- Enforces a guard preventing deletion of the last text channel in a server (backend + frontend)
- Fixes a tRPC void-return bug that caused a spurious error after successful deletion

## What changed

### Backend (`harmony-backend`)

- **`src/repositories/channel.repository.ts`** — new `countByServerIdAndType` method used to count text channels before deletion
- **`src/services/channel.service.ts`** — `deleteChannel` now:
  - Rejects with `BAD_REQUEST` if the channel is a TEXT channel and it's the last one in the server
  - Returns the deleted channel record instead of `void`, so tRPC serializes a proper `result.data` field (fixes "response missing result.data" error on success)
- **`tests/channel.service.events.test.ts`** — updated Prisma mock to include `count`, defaulting to 2 so existing event-publishing tests continue to pass

### Frontend (`harmony-frontend`)

- **`src/components/channel/ChannelSidebar.tsx`** — both text and voice channel rows now show a hover-revealed settings gear icon (admin/owner only) linking to `/settings/[serverSlug]/[channelSlug]`
- **`src/app/settings/[serverSlug]/[channelSlug]/page.tsx`** — fetches the full channel list at page load and derives `isLastTextChannel` to pass down
- **`src/app/settings/[serverSlug]/[channelSlug]/actions.ts`** — new `deleteChannelAction` server action: resolves channel/server from URL slugs (defense-in-depth), calls the service, invalidates caches, then redirects to the server home
- **`src/components/settings/ChannelSettingsPage.tsx`** — new **Delete Channel** sidebar section (styled in red) with:
  - A confirmation input requiring the user to type the exact channel name before the button activates
  - A blocked state (no confirmation form, explanatory message) when the channel is the only text channel — voice channels are always deletable

## Reviewer notes

- Voice channels previously had no route to their settings page because they render as join-buttons rather than navigation links. The gear icon resolves this without changing the join interaction. Text channels get the same treatment for consistency
- The backend guard is the authoritative enforcement point for the last-text-channel rule; the frontend disabled state is a UX convenience only
- The `trpcMutate` helper throws when `result.data` is `undefined` — returning the deleted record from the service is consistent with how `deleteServer` is already handled elsewhere in the codebase
- The two pre-existing test failures (`metaTagUpdate.integration`, `cache.middleware`) are unrelated to this change and were failing on `main` before this branch