### PR TITLE
fix: preserve voice connection across text channel switches

### DIFF
--- a/harmony-frontend/src/__tests__/private-channel-pane-lock.test.tsx
+++ b/harmony-frontend/src/__tests__/private-channel-pane-lock.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { HarmonyShell } from '@/components/layout/HarmonyShell';
 import { ChannelType, ChannelVisibility } from '@/types';
@@ -6,6 +6,8 @@ import type { Channel, Message, Server, User } from '@/types';
 
 const mockUseAuth = jest.fn();
 const mockUseServerEvents = jest.fn();
+const mockSetVoiceChannelIds = jest.fn();
+const mockUseVoiceOptional = jest.fn();
 
 jest.mock('@/hooks/useAuth', () => ({
   useAuth: () => mockUseAuth(),
@@ -17,6 +19,7 @@ jest.mock('next/navigation', () => ({
 
 jest.mock('@/contexts/VoiceContext', () => ({
   VoiceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useVoiceOptional: () => mockUseVoiceOptional(),
 }));
 
 jest.mock('@/hooks/useServerEvents', () => ({
@@ -166,6 +169,9 @@ beforeAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockUseVoiceOptional.mockReturnValue({
+    setVoiceChannelIds: mockSetVoiceChannelIds,
+  });
   mockUseAuth.mockReturnValue({
     user: null,
     isAuthenticated: false,
@@ -209,5 +215,34 @@ describe('Issue #338 — private channel denial keeps the shell mounted', () => 
         onMessageDeleted: undefined,
       }),
     );
+  });
+
+  it('publishes live voice channel ids after channel events update local channels', async () => {
+    renderShell();
+
+    await waitFor(() => {
+      expect(mockSetVoiceChannelIds).toHaveBeenLastCalledWith([]);
+    });
+
+    const voiceChannel: Channel = {
+      id: 'voice-1',
+      name: 'Standup',
+      slug: 'standup',
+      serverId: server.id,
+      type: ChannelType.VOICE,
+      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+      position: 1,
+      createdAt: '2026-04-16T12:00:00.000Z',
+    };
+
+    act(() => {
+      const latestServerEventsOptions =
+        mockUseServerEvents.mock.calls[mockUseServerEvents.mock.calls.length - 1][0];
+      latestServerEventsOptions.onChannelCreated(voiceChannel);
+    });
+
+    await waitFor(() => {
+      expect(mockSetVoiceChannelIds).toHaveBeenLastCalledWith(['voice-1']);
+    });
   });
 });

--- a/harmony-frontend/src/app/channels/[serverSlug]/layout.tsx
+++ b/harmony-frontend/src/app/channels/[serverSlug]/layout.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from 'react';
+import { getServers } from '@/services/serverService';
+import { getChannels } from '@/services/channelService';
+import { getSessionUser } from '@/lib/trpc-client';
+import { VoiceProvider } from '@/contexts/VoiceContext';
+import { ChannelType } from '@/types/channel';
+
+interface ServerLayoutProps {
+  children: ReactNode;
+  params: Promise<{ serverSlug: string }>;
+}
+
+/**
+ * Layout: Server voice scope
+ *
+ * Wraps VoiceProvider at the [serverSlug] segment so it persists across
+ * text-channel navigations within the same server. Without this layout,
+ * VoiceProvider lived inside HarmonyShell (rendered by the page), which
+ * caused it to unmount and disconnect the Twilio room on every channel switch.
+ *
+ * Next.js App Router preserves layouts across child navigations, so the
+ * provider only remounts when the user switches to a different server.
+ */
+export default async function ServerVoiceLayout({ children, params }: ServerLayoutProps) {
+  const { serverSlug } = await params;
+
+  let serverId: string | undefined;
+  let voiceChannelIds: string[] = [];
+  let currentUserId: string | undefined;
+
+  try {
+    const [servers, sessionUser] = await Promise.all([getServers(), getSessionUser()]);
+    const server = servers.find(s => s.slug === serverSlug);
+    if (server) {
+      serverId = server.id;
+      const channels = await getChannels(server.id);
+      voiceChannelIds = channels.filter(c => c.type === ChannelType.VOICE).map(c => c.id);
+    }
+    currentUserId = sessionUser?.id;
+  } catch {
+    // Data fetch failed — render children without voice context.
+    // VoiceProvider is skipped; HarmonyShell's voice UI will be inert.
+  }
+
+  if (!serverId) {
+    return <>{children}</>;
+  }
+
+  return (
+    <VoiceProvider serverId={serverId} voiceChannelIds={voiceChannelIds} currentUserId={currentUserId}>
+      {children}
+    </VoiceProvider>
+  );
+}

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -25,6 +25,7 @@ import { useServerListSync } from '@/hooks/useServerListSync';
 import { ChannelType, ChannelVisibility, UserStatus } from '@/types';
 import { useRouter } from 'next/navigation';
 import { CreateServerModal } from '@/components/server-rail/CreateServerModal';
+import { useVoiceOptional } from '@/contexts/VoiceContext';
 import type { Server, Channel, Message, User } from '@/types';
 
 // ─── Discord colour tokens ────────────────────────────────────────────────────
@@ -119,6 +120,7 @@ export function HarmonyShell({
   }
   // Local channels state so newly created channels appear immediately in the sidebar.
   const [localChannels, setLocalChannels] = useState<Channel[]>(channels);
+  const voice = useVoiceOptional();
   // Map of serverId → default channel slug — used by BrowseServersModal for "Open" navigation.
   // Mirrors the same derivation in ServerRail so both always agree on the default channel.
   const defaultChannelByServerId = useMemo(() => {
@@ -140,6 +142,15 @@ export function HarmonyShell({
     setPrevChannelsProp(channels);
     setLocalChannels(channels);
   }
+  const localVoiceChannelIds = useMemo(
+    () => localChannels.filter(c => c.type === ChannelType.VOICE).map(c => c.id),
+    [localChannels],
+  );
+  const localVoiceChannelIdsKey = localVoiceChannelIds.join(',');
+  const setVoiceChannelIds = voice?.setVoiceChannelIds;
+  useEffect(() => {
+    setVoiceChannelIds?.(localVoiceChannelIds);
+  }, [setVoiceChannelIds, localVoiceChannelIds, localVoiceChannelIdsKey]);
   // Local members state so join/leave/status events update the sidebar without reload.
   const [localMembers, setLocalMembers] = useState<User[]>(members);
   // Reset when the members prop changes (server navigation or SSR revalidation).
@@ -310,7 +321,10 @@ export function HarmonyShell({
           }
           return {
             ...m,
-            reactions: [...(m.reactions ?? []), { emoji: data.emoji, count: 1, userIds: [data.userId] }],
+            reactions: [
+              ...(m.reactions ?? []),
+              { emoji: data.emoji, count: 1, userIds: [data.userId] },
+            ],
           };
         }),
       );
@@ -328,13 +342,18 @@ export function HarmonyShell({
           if (!existing) return m;
           // Guard against duplicate SSE delivery
           if (!existing.userIds.includes(data.userId)) return m;
-          const updated = existing.count <= 1
-            ? (m.reactions ?? []).filter(r => r.emoji !== data.emoji)
-            : m.reactions!.map(r =>
-                r.emoji === data.emoji
-                  ? { ...r, count: r.count - 1, userIds: r.userIds.filter(id => id !== data.userId) }
-                  : r,
-              );
+          const updated =
+            existing.count <= 1
+              ? (m.reactions ?? []).filter(r => r.emoji !== data.emoji)
+              : m.reactions!.map(r =>
+                  r.emoji === data.emoji
+                    ? {
+                        ...r,
+                        count: r.count - 1,
+                        userIds: r.userIds.filter(id => id !== data.userId),
+                      }
+                    : r,
+                );
           return { ...m, reactions: updated };
         }),
       );
@@ -524,178 +543,178 @@ export function HarmonyShell({
 
   return (
     <div className='flex h-screen overflow-hidden bg-[#202225] font-sans'>
-        {/* Skip-to-content: visually hidden, appears on keyboard focus (WCAG 2.4.1) */}
-        <a
-          href='#main-content'
-          className='sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:z-50 focus-visible:m-2 focus-visible:rounded focus-visible:bg-[#5865f2] focus-visible:px-4 focus-visible:py-2 focus-visible:text-sm focus-visible:font-semibold focus-visible:text-white focus-visible:outline-none'
-        >
-          Skip to content
-        </a>
+      {/* Skip-to-content: visually hidden, appears on keyboard focus (WCAG 2.4.1) */}
+      <a
+        href='#main-content'
+        className='sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:z-50 focus-visible:m-2 focus-visible:rounded focus-visible:bg-[#5865f2] focus-visible:px-4 focus-visible:py-2 focus-visible:text-sm focus-visible:font-semibold focus-visible:text-white focus-visible:outline-none'
+      >
+        Skip to content
+      </a>
 
-        {/* 1. Server rail — uses allChannels (full set) to derive default slug per server */}
-        <ServerRail
-          servers={localServers}
-          allChannels={allChannels}
-          currentServerId={currentServer.id}
-          basePath={basePath}
-          isMobileVisible={isMenuOpen}
-          onBrowseServers={() => setIsBrowseServersOpen(true)}
-          onAddServer={
-            isAuthLoading
-              ? undefined
-              : () => {
-                  if (!isAuthenticated) {
-                    router.push('/auth/login');
-                    return;
-                  }
-                  setIsCreateServerOpen(true);
+      {/* 1. Server rail — uses allChannels (full set) to derive default slug per server */}
+      <ServerRail
+        servers={localServers}
+        allChannels={allChannels}
+        currentServerId={currentServer.id}
+        basePath={basePath}
+        isMobileVisible={isMenuOpen}
+        onBrowseServers={() => setIsBrowseServersOpen(true)}
+        onAddServer={
+          isAuthLoading
+            ? undefined
+            : () => {
+                if (!isAuthenticated) {
+                  router.push('/auth/login');
+                  return;
                 }
-          }
+                setIsCreateServerOpen(true);
+              }
+        }
+      />
+
+      {/* 2. Channel sidebar — mobile overlay when isMenuOpen, always visible on desktop */}
+      <ChannelSidebar
+        server={currentServer}
+        channels={localChannels}
+        currentChannelId={currentChannel.id}
+        currentUser={currentUser}
+        isOpen={isMenuOpen}
+        onClose={() => setIsMenuOpen(false)}
+        basePath={basePath}
+        isAuthenticated={isAuthenticated}
+        serverId={currentServer.id}
+        members={members}
+        onCreateChannel={defaultType => {
+          setCreateChannelDefaultType(defaultType);
+          setIsCreateChannelOpen(true);
+        }}
+      />
+
+      {/* 3. Main column */}
+      <main
+        id='main-content'
+        className='flex flex-1 flex-col overflow-hidden'
+        aria-label={`${currentChannel.name} channel`}
+        tabIndex={-1}
+      >
+        <TopBar
+          channel={currentChannel}
+          serverSlug={currentServer.slug}
+          isAdmin={checkIsAdmin(currentServer.ownerId)}
+          isMembersOpen={isMembersOpen}
+          onMembersToggle={() => setIsMembersOpen(!isMembersOpen)}
+          onSearchOpen={isChannelLocked ? undefined : () => setIsSearchOpen(true)}
+          onPinsOpen={isChannelLocked ? undefined : () => setIsPinsOpen(v => !v)}
+          disableMessageActions={isChannelLocked}
+          isMenuOpen={isMenuOpen}
+          onMenuToggle={() => setIsMenuOpen(v => !v)}
+          userId={authUser?.id}
         />
 
-        {/* 2. Channel sidebar — mobile overlay when isMenuOpen, always visible on desktop */}
-        <ChannelSidebar
-          server={currentServer}
-          channels={localChannels}
-          currentChannelId={currentChannel.id}
-          currentUser={currentUser}
-          isOpen={isMenuOpen}
-          onClose={() => setIsMenuOpen(false)}
-          basePath={basePath}
-          isAuthenticated={isAuthenticated}
-          serverId={currentServer.id}
-          members={members}
-          onCreateChannel={defaultType => {
-            setCreateChannelDefaultType(defaultType);
-            setIsCreateChannelOpen(true);
+        <div className='flex flex-1 overflow-hidden'>
+          <div className={cn('flex flex-1 flex-col overflow-hidden', BG.primary)}>
+            {lockedMessagePane ? (
+              lockedMessagePane
+            ) : (
+              <>
+                <MessageList
+                  key={currentChannel.id}
+                  channel={currentChannel}
+                  messages={localMessages}
+                  serverId={currentServer.id}
+                  canPin={canPin}
+                  onReplyClick={handleReplyClick}
+                  onPinToggle={handlePinToggle}
+                />
+                <MessageInput
+                  channelId={currentChannel.id}
+                  channelName={currentChannel.name}
+                  serverId={currentServer.id}
+                  isReadOnly={currentUser.role === 'guest'}
+                  onMessageSent={handleMessageSent}
+                  replyingTo={replyingTo}
+                  onCancelReply={handleCancelReply}
+                />
+                {!isAuthLoading && !isAuthenticated && (
+                  <GuestPromoBanner
+                    serverName={currentServer.name}
+                    memberCount={currentServer.memberCount ?? members.length}
+                  />
+                )}
+              </>
+            )}
+          </div>
+          {!isChannelLocked && (
+            <PinnedMessagesPanel
+              channelId={currentChannel.id}
+              serverId={currentServer.id}
+              channelName={currentChannel.name}
+              isOpen={isPinsOpen}
+              refreshKey={pinsRefreshKey}
+              onClose={() => setIsPinsOpen(false)}
+            />
+          )}
+          <MembersSidebar
+            members={localMembers}
+            isOpen={isMembersOpen}
+            onClose={() => setIsMembersOpen(false)}
+          />
+        </div>
+      </main>
+
+      <CreateServerModal
+        isOpen={isCreateServerOpen}
+        onClose={() => setIsCreateServerOpen(false)}
+        onCreated={handleServerCreated}
+      />
+
+      <BrowseServersModal
+        isOpen={isBrowseServersOpen}
+        onClose={() => setIsBrowseServersOpen(false)}
+        joinedServerIds={new Set(localServers.map(s => s.id))}
+        defaultChannelByServerId={defaultChannelByServerId}
+        basePath={basePath}
+        onJoined={notifyServerJoined}
+      />
+
+      {!isChannelLocked && (
+        <SearchModal
+          messages={localMessages}
+          channelName={currentChannel.name}
+          isOpen={isSearchOpen}
+          onClose={() => setIsSearchOpen(false)}
+          onResultSelect={message => {
+            const el = document.querySelector(`[data-message-id="${message.id}"]`);
+            if (!el) return;
+            el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            el.classList.remove('message-highlight-flash');
+            // Force a reflow so re-selecting the same message re-triggers the animation.
+            void (el as HTMLElement).offsetWidth;
+            el.classList.add('message-highlight-flash');
           }}
         />
+      )}
 
-        {/* 3. Main column */}
-        <main
-          id='main-content'
-          className='flex flex-1 flex-col overflow-hidden'
-          aria-label={`${currentChannel.name} channel`}
-          tabIndex={-1}
-        >
-          <TopBar
-            channel={currentChannel}
-            serverSlug={currentServer.slug}
-            isAdmin={checkIsAdmin(currentServer.ownerId)}
-            isMembersOpen={isMembersOpen}
-            onMembersToggle={() => setIsMembersOpen(!isMembersOpen)}
-            onSearchOpen={isChannelLocked ? undefined : () => setIsSearchOpen(true)}
-            onPinsOpen={isChannelLocked ? undefined : () => setIsPinsOpen(v => !v)}
-            disableMessageActions={isChannelLocked}
-            isMenuOpen={isMenuOpen}
-            onMenuToggle={() => setIsMenuOpen(v => !v)}
-            userId={authUser?.id}
-          />
-
-          <div className='flex flex-1 overflow-hidden'>
-            <div className={cn('flex flex-1 flex-col overflow-hidden', BG.primary)}>
-              {lockedMessagePane ? (
-                lockedMessagePane
-              ) : (
-                <>
-                  <MessageList
-                    key={currentChannel.id}
-                    channel={currentChannel}
-                    messages={localMessages}
-                    serverId={currentServer.id}
-                    canPin={canPin}
-                    onReplyClick={handleReplyClick}
-                    onPinToggle={handlePinToggle}
-                  />
-                  <MessageInput
-                    channelId={currentChannel.id}
-                    channelName={currentChannel.name}
-                    serverId={currentServer.id}
-                    isReadOnly={currentUser.role === 'guest'}
-                    onMessageSent={handleMessageSent}
-                    replyingTo={replyingTo}
-                    onCancelReply={handleCancelReply}
-                  />
-                  {!isAuthLoading && !isAuthenticated && (
-                    <GuestPromoBanner
-                      serverName={currentServer.name}
-                      memberCount={currentServer.memberCount ?? members.length}
-                    />
-                  )}
-                </>
-              )}
-            </div>
-            {!isChannelLocked && (
-              <PinnedMessagesPanel
-                channelId={currentChannel.id}
-                serverId={currentServer.id}
-                channelName={currentChannel.name}
-                isOpen={isPinsOpen}
-                refreshKey={pinsRefreshKey}
-                onClose={() => setIsPinsOpen(false)}
-              />
-            )}
-            <MembersSidebar
-              members={localMembers}
-              isOpen={isMembersOpen}
-              onClose={() => setIsMembersOpen(false)}
-            />
-          </div>
-        </main>
-
-        <CreateServerModal
-          isOpen={isCreateServerOpen}
-          onClose={() => setIsCreateServerOpen(false)}
-          onCreated={handleServerCreated}
+      {isCreateChannelOpen && (
+        <CreateChannelModal
+          serverId={currentServer.id}
+          serverSlug={currentServer.slug}
+          existingChannels={localChannels}
+          defaultType={createChannelDefaultType}
+          onCreated={newChannel =>
+            setLocalChannels(prev => {
+              // Insert before voice channels so text/announcement channels stay grouped correctly.
+              const insertIdx =
+                newChannel.type === ChannelType.VOICE
+                  ? prev.length
+                  : prev.findIndex(c => c.type === ChannelType.VOICE);
+              const at = insertIdx === -1 ? prev.length : insertIdx;
+              return [...prev.slice(0, at), newChannel, ...prev.slice(at)];
+            })
+          }
+          onClose={() => setIsCreateChannelOpen(false)}
         />
-
-        <BrowseServersModal
-          isOpen={isBrowseServersOpen}
-          onClose={() => setIsBrowseServersOpen(false)}
-          joinedServerIds={new Set(localServers.map(s => s.id))}
-          defaultChannelByServerId={defaultChannelByServerId}
-          basePath={basePath}
-          onJoined={notifyServerJoined}
-        />
-
-        {!isChannelLocked && (
-          <SearchModal
-            messages={localMessages}
-            channelName={currentChannel.name}
-            isOpen={isSearchOpen}
-            onClose={() => setIsSearchOpen(false)}
-            onResultSelect={message => {
-              const el = document.querySelector(`[data-message-id="${message.id}"]`);
-              if (!el) return;
-              el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-              el.classList.remove('message-highlight-flash');
-              // Force a reflow so re-selecting the same message re-triggers the animation.
-              void (el as HTMLElement).offsetWidth;
-              el.classList.add('message-highlight-flash');
-            }}
-          />
-        )}
-
-        {isCreateChannelOpen && (
-          <CreateChannelModal
-            serverId={currentServer.id}
-            serverSlug={currentServer.slug}
-            existingChannels={localChannels}
-            defaultType={createChannelDefaultType}
-            onCreated={newChannel =>
-              setLocalChannels(prev => {
-                // Insert before voice channels so text/announcement channels stay grouped correctly.
-                const insertIdx =
-                  newChannel.type === ChannelType.VOICE
-                    ? prev.length
-                    : prev.findIndex(c => c.type === ChannelType.VOICE);
-                const at = insertIdx === -1 ? prev.length : insertIdx;
-                return [...prev.slice(0, at), newChannel, ...prev.slice(at)];
-              })
-            }
-            onClose={() => setIsCreateChannelOpen(false)}
-          />
-        )}
+      )}
     </div>
   );
 }

--- a/harmony-frontend/src/components/layout/HarmonyShell.tsx
+++ b/harmony-frontend/src/components/layout/HarmonyShell.tsx
@@ -19,7 +19,6 @@ import { ServerRail } from '@/components/server-rail/ServerRail';
 import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
 import { CreateChannelModal } from '@/components/channel/CreateChannelModal';
 import { useAuth } from '@/hooks/useAuth';
-import { VoiceProvider } from '@/contexts/VoiceContext';
 import { BrowseServersModal } from '@/components/server-rail/BrowseServersModal';
 import { useServerEvents } from '@/hooks/useServerEvents';
 import { useServerListSync } from '@/hooks/useServerListSync';
@@ -133,11 +132,6 @@ export function HarmonyShell({
     return map;
   }, [allChannels]);
 
-  // Stable list of voice channel IDs for VoiceProvider — recomputed only when channels change.
-  const voiceChannelIds = useMemo(
-    () => localChannels.filter(c => c.type === ChannelType.VOICE).map(c => c.id),
-    [localChannels],
-  );
   // Track the channels prop reference so localChannels resets whenever the server
   // passes a fresh array (server navigation or revalidatePath refresh) — same
   // render-time derivation pattern used above for localMessages/prevChannelId.
@@ -529,8 +523,7 @@ export function HarmonyShell({
   }, [isChannelLocked]);
 
   return (
-    <VoiceProvider serverId={currentServer.id} voiceChannelIds={voiceChannelIds} currentUserId={authUser?.id}>
-      <div className='flex h-screen overflow-hidden bg-[#202225] font-sans'>
+    <div className='flex h-screen overflow-hidden bg-[#202225] font-sans'>
         {/* Skip-to-content: visually hidden, appears on keyboard focus (WCAG 2.4.1) */}
         <a
           href='#main-content'
@@ -703,7 +696,6 @@ export function HarmonyShell({
             onClose={() => setIsCreateChannelOpen(false)}
           />
         )}
-      </div>
-    </VoiceProvider>
+    </div>
   );
 }

--- a/harmony-frontend/src/contexts/VoiceContext.tsx
+++ b/harmony-frontend/src/contexts/VoiceContext.tsx
@@ -72,6 +72,8 @@ export interface VoiceContextValue {
   leaveChannel: () => Promise<void>;
   setMuted: (muted: boolean) => Promise<void>;
   setDeafened: (deafened: boolean) => Promise<void>;
+  /** Updates the server's live voice channel set after channel create/delete events. */
+  setVoiceChannelIds: (channelIds: string[]) => void;
 }
 
 // ─── Context ─────────────────────────────────────────────────────────────────
@@ -109,9 +111,15 @@ interface VoiceProviderProps {
   currentUserId?: string;
 }
 
-export function VoiceProvider({ children, serverId, voiceChannelIds, currentUserId }: VoiceProviderProps) {
+export function VoiceProvider({
+  children,
+  serverId,
+  voiceChannelIds,
+  currentUserId,
+}: VoiceProviderProps) {
   const { showToast } = useToast();
 
+  const [liveVoiceChannelIds, setLiveVoiceChannelIds] = useState<string[]>(voiceChannelIds);
   const [connectedChannelId, setConnectedChannelId] = useState<string | null>(null);
   const [connectedChannelName, setConnectedChannelName] = useState<string | null>(null);
   const [participants, setParticipants] = useState<VoiceParticipant[]>([]);
@@ -147,16 +155,36 @@ export function VoiceProvider({ children, serverId, voiceChannelIds, currentUser
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const remoteAudioTracksRef = useRef<Map<string, any[]>>(new Map());
 
+  const setVoiceChannelIds = useCallback((channelIds: string[]) => {
+    setLiveVoiceChannelIds(prev => {
+      const nextKey = channelIds.join(',');
+      return prev.join(',') === nextKey ? prev : channelIds;
+    });
+  }, []);
+
   // ── Fetch participant lists for all voice channels on mount / server change ──
   // This populates the sidebar before the user has joined any channel.
   // Stable string key so text-channel mutations don't trigger a re-fetch here.
-  // voiceChannelIds itself changes reference on every setLocalChannels call in HarmonyShell,
+  // liveVoiceChannelIds itself changes reference on every setLocalChannels call in HarmonyShell,
   // but the IDs only change when a voice channel is actually added or removed.
-  const voiceChannelIdsKey = voiceChannelIds.join(',');
+  const voiceChannelIdsKey = liveVoiceChannelIds.join(',');
 
   useEffect(() => {
-    if (!serverId || !voiceChannelIdsKey) return;
-    const ids = voiceChannelIdsKey.split(',');
+    setLiveVoiceChannelIds(voiceChannelIds);
+  }, [serverId, voiceChannelIds]);
+
+  useEffect(() => {
+    if (!serverId) return;
+    const ids = voiceChannelIdsKey ? voiceChannelIdsKey.split(',') : [];
+    const idSet = new Set(ids);
+    setChannelParticipants(prev => {
+      const next: Record<string, VoiceParticipant[]> = {};
+      for (const [channelId, participants] of Object.entries(prev)) {
+        if (idSet.has(channelId)) next[channelId] = participants;
+      }
+      return Object.keys(next).length === Object.keys(prev).length ? prev : next;
+    });
+    if (ids.length === 0) return;
     void Promise.all(
       ids.map(channelId =>
         apiClient
@@ -520,7 +548,7 @@ export function VoiceProvider({ children, serverId, voiceChannelIds, currentUser
         setJoining(false);
       }
     },
-    [leaveChannel, resetVoiceState, showToast],
+    [currentUserId, leaveChannel, resetVoiceState, showToast],
   );
 
   const setMuted = useCallback(async (muted: boolean) => {
@@ -733,6 +761,7 @@ export function VoiceProvider({ children, serverId, voiceChannelIds, currentUser
         leaveChannel,
         setMuted,
         setDeafened,
+        setVoiceChannelIds,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

- Related issue: #122
- `VoiceProvider` was rendered inside `HarmonyShell`, a page-level component that unmounts on every channel navigation. This caused the Twilio room to disconnect and a `voice.leave` to fire whenever the user switched text channels.
- Added `harmony-frontend/src/app/channels/[serverSlug]/layout.tsx` — a server layout that wraps `VoiceProvider` at the `[serverSlug]` segment. Next.js App Router preserves layouts across child navigations, so the provider now stays mounted for the entire server session and only remounts when the user switches servers (which correctly disconnects the voice session).
- `HarmonyShell` now publishes its live voice-channel ID set into `VoiceProvider`, so voice-channel create/delete events refresh participant state without remounting the provider.
- Removed `VoiceProvider`, its import, and the original `voiceChannelIds` useMemo from `HarmonyShell`.

## Test plan

- [ ] Join a voice channel, then click through several text channels — voice connection should remain active throughout
- [ ] Switch to a different server — voice connection should disconnect (expected, voice is server-scoped)
- [x] Confirm frontend unit tests pass (`npm test -- --runInBand` in `harmony-frontend`)
- [x] Confirm no new TypeScript or lint errors introduced (`npm run lint`, `npm run build` in `harmony-frontend`; `npm run build` in `harmony-backend`)
- [ ] Full backend Jest suite: attempted after `prisma generate`; blocked locally by missing `DATABASE_URL` and Redis `NOAUTH` in this worktree. Targeted `tests/voice.service.test.ts` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
