### PR TITLE
[codex] Fix SEO preview fallback for public channels

### DIFF
--- a/harmony-backend/src/routes/admin.metaTag.router.ts
+++ b/harmony-backend/src/routes/admin.metaTag.router.ts
@@ -143,7 +143,12 @@ adminMetaTagRouter.get(
       const record = await metaTagRepository.findByChannelId(channelId);
 
       if (!record) {
-        res.status(404).json({ error: 'Meta tags not found for this channel' });
+        logger.warn(
+          { channelId, operation: 'adminSeoPreviewFallback' },
+          'Admin SEO preview missing persisted meta tags; generating fallback preview',
+        );
+        const fallbackPreview = await metaTagService.getFallbackMetaTagsForPreview(channelId);
+        res.json(fallbackPreview);
         return;
       }
 

--- a/harmony-backend/src/routes/admin.metaTag.router.ts
+++ b/harmony-backend/src/routes/admin.metaTag.router.ts
@@ -21,11 +21,13 @@ import { prisma } from '../db/prisma';
 import { redis } from '../db/redis';
 import { createLogger } from '../lib/logger';
 import { auditLogService } from '../services/auditLog.service';
+import { cacheService, sanitizeKeySegment } from '../services/cache.service';
 import type { MetaTagPreview } from '../services/metaTag/types';
 
 const logger = createLogger({ component: 'admin-meta-tag-router' });
 
 const BASE_URL = process.env.BASE_URL ?? 'https://harmony.chat';
+const FALLBACK_PREVIEW_TTL_SECONDS = 60;
 
 // ─── Validation schemas ───────────────────────────────────────────────────────
 
@@ -41,6 +43,10 @@ const IDEMPOTENCY_TTL_SECONDS = 60;
 
 function idempotencyKey(channelId: string, key: string): string {
   return `meta-tag:idempotency:${channelId}:${key}`;
+}
+
+function fallbackPreviewCacheKey(channelId: string): string {
+  return `meta-tag:admin-preview-fallback:${sanitizeKeySegment(channelId)}`;
 }
 
 // ─── Admin authorization middleware ──────────────────────────────────────────
@@ -123,6 +129,30 @@ function buildPreview(
   };
 }
 
+async function getCachedFallbackPreview(channelId: string): Promise<MetaTagPreview> {
+  const cacheKey = fallbackPreviewCacheKey(channelId);
+
+  try {
+    const entry = await cacheService.get<MetaTagPreview>(cacheKey);
+    if (entry && !cacheService.isStale(entry, FALLBACK_PREVIEW_TTL_SECONDS)) {
+      return entry.data;
+    }
+  } catch (err) {
+    logger.warn(
+      { err, channelId, cacheKey },
+      'Failed to read admin SEO fallback preview cache; generating directly',
+    );
+  }
+
+  const fallbackPreview = await metaTagService.getFallbackMetaTagsForPreview(channelId);
+  cacheService
+    .set(cacheKey, fallbackPreview, { ttl: FALLBACK_PREVIEW_TTL_SECONDS })
+    .catch((err) =>
+      logger.warn({ err, channelId, cacheKey }, 'Failed to cache admin SEO fallback preview'),
+    );
+  return fallbackPreview;
+}
+
 // ─── Router ───────────────────────────────────────────────────────────────────
 
 export const adminMetaTagRouter = Router();
@@ -147,7 +177,7 @@ adminMetaTagRouter.get(
           { channelId, operation: 'adminSeoPreviewFallback' },
           'Admin SEO preview missing persisted meta tags; generating fallback preview',
         );
-        const fallbackPreview = await metaTagService.getFallbackMetaTagsForPreview(channelId);
+        const fallbackPreview = await getCachedFallbackPreview(channelId);
         res.json(fallbackPreview);
         return;
       }

--- a/harmony-backend/src/routes/admin.metaTag.router.ts
+++ b/harmony-backend/src/routes/admin.metaTag.router.ts
@@ -21,13 +21,12 @@ import { prisma } from '../db/prisma';
 import { redis } from '../db/redis';
 import { createLogger } from '../lib/logger';
 import { auditLogService } from '../services/auditLog.service';
-import { cacheService, sanitizeKeySegment } from '../services/cache.service';
+import { cacheService, CacheKeys, CacheTTL } from '../services/cache.service';
 import type { MetaTagPreview } from '../services/metaTag/types';
 
 const logger = createLogger({ component: 'admin-meta-tag-router' });
 
 const BASE_URL = process.env.BASE_URL ?? 'https://harmony.chat';
-const FALLBACK_PREVIEW_TTL_SECONDS = 60;
 
 // ─── Validation schemas ───────────────────────────────────────────────────────
 
@@ -43,10 +42,6 @@ const IDEMPOTENCY_TTL_SECONDS = 60;
 
 function idempotencyKey(channelId: string, key: string): string {
   return `meta-tag:idempotency:${channelId}:${key}`;
-}
-
-function fallbackPreviewCacheKey(channelId: string): string {
-  return `meta-tag:admin-preview-fallback:${sanitizeKeySegment(channelId)}`;
 }
 
 // ─── Admin authorization middleware ──────────────────────────────────────────
@@ -130,11 +125,11 @@ function buildPreview(
 }
 
 async function getCachedFallbackPreview(channelId: string): Promise<MetaTagPreview> {
-  const cacheKey = fallbackPreviewCacheKey(channelId);
+  const cacheKey = CacheKeys.metaChannelAdminPreviewFallback(channelId);
 
   try {
     const entry = await cacheService.get<MetaTagPreview>(cacheKey);
-    if (entry && !cacheService.isStale(entry, FALLBACK_PREVIEW_TTL_SECONDS)) {
+    if (entry && !cacheService.isStale(entry, CacheTTL.metaChannelAdminPreviewFallback)) {
       return entry.data;
     }
   } catch (err) {
@@ -146,7 +141,7 @@ async function getCachedFallbackPreview(channelId: string): Promise<MetaTagPrevi
 
   const fallbackPreview = await metaTagService.getFallbackMetaTagsForPreview(channelId);
   cacheService
-    .set(cacheKey, fallbackPreview, { ttl: FALLBACK_PREVIEW_TTL_SECONDS })
+    .set(cacheKey, fallbackPreview, { ttl: CacheTTL.metaChannelAdminPreviewFallback })
     .catch((err) =>
       logger.warn({ err, channelId, cacheKey }, 'Failed to cache admin SEO fallback preview'),
     );

--- a/harmony-backend/src/services/cache.service.ts
+++ b/harmony-backend/src/services/cache.service.ts
@@ -29,6 +29,8 @@ export const CacheKeys = {
     `channel:msgs:${sanitizeKeySegment(id)}:page:${page}`,
   serverInfo: (id: string) => `server:${sanitizeKeySegment(id)}:info`,
   metaChannel: (id: string) => `meta:channel:${sanitizeKeySegment(id)}`,
+  metaChannelAdminPreviewFallback: (id: string) =>
+    `meta:channel:${sanitizeKeySegment(id)}:admin-preview-fallback`,
   analysisChannel: (id: string) => `analysis:channel:${sanitizeKeySegment(id)}`,
 } as const;
 
@@ -37,6 +39,7 @@ export const CacheTTL = {
   channelVisibility: 3600, // 1 hour
   channelMessages: 60, // 1 minute
   serverInfo: 300, // 5 minutes
+  metaChannelAdminPreviewFallback: 300, // 5 minutes
 } as const;
 
 export const cacheService = {

--- a/harmony-backend/tests/admin.metaTag.router.test.ts
+++ b/harmony-backend/tests/admin.metaTag.router.test.ts
@@ -202,10 +202,19 @@ describe('GET /api/admin/channels/:channelId/meta-tags', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns 404 when meta tags record does not exist', async () => {
+  it('returns an ephemeral fallback preview when meta tags record does not exist', async () => {
     mockMetaTagRepo.findByChannelId.mockResolvedValue(null);
     const res = await request(app).get(url).set('Authorization', `Bearer ${VALID_TOKEN}`);
-    expect(res.status).toBe(404);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      isFallbackPreview: true,
+      isCustom: false,
+      customTitle: null,
+      customDescription: null,
+      customOgImage: null,
+    });
+    expect(res.body.searchPreview.url).toContain('/c/test-server/general');
   });
 
   it('returns 200 with MetaTagPreview on success', async () => {
@@ -615,7 +624,10 @@ describe('processRegenerationJob terminal states (AC-5)', () => {
     expect(parsed.startedAt).not.toBeNull();
     expect(parsed.completedAt).not.toBeNull();
     expect(parsed.errorCode).toBeNull();
-    expect(mockMetaTagRepo.saveGeneratedFields).toHaveBeenCalledWith(CHANNEL_ID, expect.any(Object));
+    expect(mockMetaTagRepo.saveGeneratedFields).toHaveBeenCalledWith(
+      CHANNEL_ID,
+      expect.any(Object),
+    );
   });
 
   it('transitions job to processing before succeeding', async () => {
@@ -628,7 +640,9 @@ describe('processRegenerationJob terminal states (AC-5)', () => {
       try {
         const parsed = JSON.parse(value) as MetaTagJobStatus;
         if (parsed.jobId === JOB_ID) states.push(parsed.status);
-      } catch { /* not a job record */ }
+      } catch {
+        /* not a job record */
+      }
       return origSet(key, value);
     });
 

--- a/harmony-backend/tests/admin.metaTag.router.test.ts
+++ b/harmony-backend/tests/admin.metaTag.router.test.ts
@@ -217,6 +217,17 @@ describe('GET /api/admin/channels/:channelId/meta-tags', () => {
     expect(res.body.searchPreview.url).toContain('/c/test-server/general');
   });
 
+  it('caches the ephemeral fallback preview briefly to avoid repeated regeneration work', async () => {
+    mockMetaTagRepo.findByChannelId.mockResolvedValue(null);
+
+    const first = await request(app).get(url).set('Authorization', `Bearer ${VALID_TOKEN}`);
+    const second = await request(app).get(url).set('Authorization', `Bearer ${VALID_TOKEN}`);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(mockPrisma.message.findMany).toHaveBeenCalledTimes(1);
+  });
+
   it('returns 200 with MetaTagPreview on success', async () => {
     mockMetaTagRepo.findByChannelId.mockResolvedValue(META_TAG_RECORD);
     const res = await request(app).get(url).set('Authorization', `Bearer ${VALID_TOKEN}`);

--- a/harmony-backend/tests/cache.service.test.ts
+++ b/harmony-backend/tests/cache.service.test.ts
@@ -6,7 +6,13 @@
  * Requires REDIS_URL pointing at a running Redis instance.
  */
 
-import { cacheService, CacheKeys, CacheTTL, CacheEntry, sanitizeKeySegment } from '../src/services/cache.service';
+import {
+  cacheService,
+  CacheKeys,
+  CacheTTL,
+  CacheEntry,
+  sanitizeKeySegment,
+} from '../src/services/cache.service';
 import { redis } from '../src/db/redis';
 
 beforeAll(async () => {
@@ -37,6 +43,12 @@ describe('CacheKeys', () => {
   it('generates correct server info key', () => {
     expect(CacheKeys.serverInfo('srv-1')).toBe('server:srv-1:info');
   });
+
+  it('generates correct admin meta tag fallback preview key', () => {
+    expect(CacheKeys.metaChannelAdminPreviewFallback('abc-123')).toBe(
+      'meta:channel:abc-123:admin-preview-fallback',
+    );
+  });
 });
 
 // ─── Key sanitization ───────────────────────────────────────────────────────
@@ -56,6 +68,9 @@ describe('sanitizeKeySegment', () => {
   it('produces safe cache keys via CacheKeys helpers', () => {
     expect(CacheKeys.channelVisibility('*')).toBe('channel::visibility');
     expect(CacheKeys.channelMessages('a]b[c', 1)).toBe('channel:msgs:abc:page:1');
+    expect(CacheKeys.metaChannelAdminPreviewFallback('a]b[c')).toBe(
+      'meta:channel:abc:admin-preview-fallback',
+    );
   });
 });
 
@@ -66,6 +81,7 @@ describe('CacheTTL', () => {
     expect(CacheTTL.channelVisibility).toBe(3600);
     expect(CacheTTL.channelMessages).toBe(60);
     expect(CacheTTL.serverInfo).toBe(300);
+    expect(CacheTTL.metaChannelAdminPreviewFallback).toBe(300);
   });
 });
 
@@ -182,7 +198,9 @@ describe('cacheService.getOrRevalidate', () => {
     await redis.set('test:swr-stale', JSON.stringify(staleEntry), 'EX', 300);
 
     let resolveRevalidation: (v: unknown) => void;
-    const revalidationDone = new Promise((r) => { resolveRevalidation = r; });
+    const revalidationDone = new Promise((r) => {
+      resolveRevalidation = r;
+    });
 
     const fetcher = jest.fn().mockImplementation(() => {
       return new Promise((resolve) => {

--- a/harmony-frontend/src/__tests__/SeoPreviewSection.test.tsx
+++ b/harmony-frontend/src/__tests__/SeoPreviewSection.test.tsx
@@ -66,6 +66,21 @@ describe('SeoPreviewSection', () => {
     expect(screen.queryByRole('button', { name: /save overrides/i })).not.toBeInTheDocument();
   });
 
+  it('shows a safe retry fallback when preview loading fails', async () => {
+    mockFetchSeoPreview.mockRejectedValue(
+      new Error(
+        'An error occurred in the Server Components render. The specific message is omitted in production builds.',
+      ),
+    );
+
+    render(<SeoPreviewSection serverSlug='demo' channelSlug='general' canManageSeo />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'SEO preview is temporarily unavailable. Please try again in a few minutes.',
+    );
+    expect(screen.queryByText(/specific message is omitted/i)).not.toBeInTheDocument();
+  });
+
   it('shows inline validation and submits valid overrides', async () => {
     mockSaveSeoOverrides.mockResolvedValue(
       buildPreview({

--- a/harmony-frontend/src/__tests__/SeoPreviewSection.test.tsx
+++ b/harmony-frontend/src/__tests__/SeoPreviewSection.test.tsx
@@ -7,6 +7,7 @@ import {
   saveSeoOverrides,
   triggerSeoRegeneration,
 } from '@/app/settings/[serverSlug]/[channelSlug]/actions';
+import { SEO_PREVIEW_LOAD_ERROR } from '@/lib/seoConstants';
 
 jest.mock('@/app/settings/[serverSlug]/[channelSlug]/actions', () => ({
   fetchSeoPreview: jest.fn(),
@@ -75,9 +76,7 @@ describe('SeoPreviewSection', () => {
 
     render(<SeoPreviewSection serverSlug='demo' channelSlug='general' canManageSeo />);
 
-    expect(await screen.findByRole('alert')).toHaveTextContent(
-      'SEO preview is temporarily unavailable. Please try again in a few minutes.',
-    );
+    expect(await screen.findByRole('alert')).toHaveTextContent(SEO_PREVIEW_LOAD_ERROR);
     expect(screen.queryByText(/specific message is omitted/i)).not.toBeInTheDocument();
   });
 

--- a/harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/actions.ts
+++ b/harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/actions.ts
@@ -19,6 +19,7 @@ import {
 } from '@/services/channelService';
 import { getServer, getServerMembersWithRole } from '@/services/serverService';
 import { createFrontendLogger } from '@/lib/frontend-logger';
+import { SEO_PREVIEW_LOAD_ERROR } from '@/lib/seoConstants';
 import type { ServerMemberInfo } from '@/types';
 import type { Channel } from '@/types';
 import { ChannelVisibility } from '@/types';
@@ -121,7 +122,7 @@ export async function fetchSeoPreview(
       operation: 'fetchSeoPreview',
       route: `/settings/${serverSlug}/${channelSlug}`,
     });
-    throw new Error('SEO preview is temporarily unavailable. Please try again in a few minutes.');
+    throw new Error(SEO_PREVIEW_LOAD_ERROR);
   }
 }
 

--- a/harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/actions.ts
+++ b/harmony-frontend/src/app/settings/[serverSlug]/[channelSlug]/actions.ts
@@ -18,6 +18,7 @@ import {
   type ChannelMemberEntry,
 } from '@/services/channelService';
 import { getServer, getServerMembersWithRole } from '@/services/serverService';
+import { createFrontendLogger } from '@/lib/frontend-logger';
 import type { ServerMemberInfo } from '@/types';
 import type { Channel } from '@/types';
 import { ChannelVisibility } from '@/types';
@@ -31,6 +32,11 @@ import {
   type MetaTagJobStatus,
   type MetaTagPreview,
 } from '@/services/metaTagAdminService';
+
+const seoPreviewLogger = createFrontendLogger({
+  component: 'seo-preview-actions',
+  feature: 'seo-preview',
+});
 
 export async function saveChannelSettings(
   serverSlug: string,
@@ -107,7 +113,16 @@ export async function fetchSeoPreview(
   channelSlug: string,
 ): Promise<MetaTagPreview> {
   const channel = await resolveChannelForSeo(serverSlug, channelSlug);
-  return getMetaTagPreview(channel.id);
+  try {
+    return await getMetaTagPreview(channel.id);
+  } catch (err) {
+    seoPreviewLogger.error('SEO preview fetch failed', {
+      error: err,
+      operation: 'fetchSeoPreview',
+      route: `/settings/${serverSlug}/${channelSlug}`,
+    });
+    throw new Error('SEO preview is temporarily unavailable. Please try again in a few minutes.');
+  }
 }
 
 export async function saveSeoOverrides(

--- a/harmony-frontend/src/components/settings/SeoPreviewSection.tsx
+++ b/harmony-frontend/src/components/settings/SeoPreviewSection.tsx
@@ -13,6 +13,8 @@ import type { MetaTagJobStatus, MetaTagPreview } from '@/services/metaTagAdminSe
 const TITLE_MAX = 70;
 const DESCRIPTION_MAX = 200;
 const OG_IMAGE_MAX = 500;
+const SEO_PREVIEW_LOAD_ERROR =
+  'SEO preview is temporarily unavailable. Please try again in a few minutes.';
 
 function buildValidationError(value: string, max: number, label: string): string | null {
   if (value.length <= max) return null;
@@ -86,9 +88,9 @@ export function SeoPreviewSection({
         setCustomTitle(nextPreview.customTitle ?? '');
         setCustomDescription(nextPreview.customDescription ?? '');
         setCustomOgImage(nextPreview.customOgImage ?? '');
-      } catch (err) {
+      } catch {
         if (cancelled) return;
-        setError(getUserErrorMessage(err, 'Failed to load SEO preview.'));
+        setError(SEO_PREVIEW_LOAD_ERROR);
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/harmony-frontend/src/components/settings/SeoPreviewSection.tsx
+++ b/harmony-frontend/src/components/settings/SeoPreviewSection.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { getUserErrorMessage, cn } from '@/lib/utils';
+import { SEO_PREVIEW_LOAD_ERROR } from '@/lib/seoConstants';
 import {
   fetchSeoPreview,
   fetchSeoRegenerationStatus,
@@ -13,8 +14,6 @@ import type { MetaTagJobStatus, MetaTagPreview } from '@/services/metaTagAdminSe
 const TITLE_MAX = 70;
 const DESCRIPTION_MAX = 200;
 const OG_IMAGE_MAX = 500;
-const SEO_PREVIEW_LOAD_ERROR =
-  'SEO preview is temporarily unavailable. Please try again in a few minutes.';
 
 function buildValidationError(value: string, max: number, label: string): string | null {
   if (value.length <= max) return null;

--- a/harmony-frontend/src/lib/seoConstants.ts
+++ b/harmony-frontend/src/lib/seoConstants.ts
@@ -1,0 +1,2 @@
+export const SEO_PREVIEW_LOAD_ERROR =
+  'SEO preview is temporarily unavailable. Please try again in a few minutes.';


### PR DESCRIPTION
## Summary

Fixes the Channel Settings SEO Preview failure for public indexed channels that do not yet have persisted generated meta tags.

## Root Cause

The admin SEO Preview endpoint returned 404 when a valid public indexed channel had no generated meta tags row. The settings server action treated that as a hard failure, and the client could surface production server-component error text instead of a controlled preview or fallback state.

## Changes

- Return an ephemeral fallback preview from the admin SEO Preview endpoint when the persisted meta tag row is missing.
- Log a non-PII backend warning for the fallback path.
- Log frontend server-action failures with sanitized metadata and rethrow a generic retry message.
- Render a fixed user-safe retry message for initial SEO Preview load failures.
- Add backend and frontend regressions for the fallback preview and safe-error UI.

## Verification

- harmony-backend: npm test -- admin.metaTag.router.test.ts --runInBand
- harmony-frontend: npm test -- SeoPreviewSection.test.tsx --runInBand
- harmony-backend: npx tsc --noEmit
- harmony-backend: npm run lint
- harmony-frontend: npm run lint

Note: harmony-frontend npx tsc --noEmit is currently blocked by pre-existing unrelated casts in src/__tests__/gifsRoute.test.ts.

Fixes #569
