### PR TITLE
[codex] Fix cloud integration public fixture failures

### DIFF
--- a/harmony-backend/src/routes/public.router.ts
+++ b/harmony-backend/src/routes/public.router.ts
@@ -11,6 +11,36 @@ import { inviteService } from '../services/invite.service';
 
 const logger = createLogger({ component: 'public-router' });
 
+const PUBLIC_ATTACHMENT_SELECT = {
+  id: true,
+  url: true,
+  filename: true,
+  contentType: true,
+} as const;
+
+type PublicMessageRecord = {
+  attachments?: Array<{
+    id: string;
+    url: string;
+    filename: string;
+    contentType: string;
+  }>;
+};
+
+function toJsonSafePublicMessage<T extends PublicMessageRecord>(message: T) {
+  const { attachments = [], ...rest } = message;
+
+  return {
+    ...rest,
+    attachments: attachments.map((attachment) => ({
+      id: attachment.id,
+      url: attachment.url,
+      filename: attachment.filename,
+      contentType: attachment.contentType,
+    })),
+  };
+}
+
 /**
  * Factory so createApp() can inject a rate-limit store (e.g. a mock in tests
  * or a RedisStore in production) without requiring a real Redis connection in
@@ -63,13 +93,13 @@ export function createPublicRouter(store?: Store) {
             editedAt: true,
             author: { select: { id: true, username: true } },
             attachments: {
-              select: { id: true, url: true, filename: true, contentType: true, sizeBytes: true },
+              select: PUBLIC_ATTACHMENT_SELECT,
             },
           },
         });
 
         res.set('Cache-Control', `public, max-age=${CacheTTL.channelMessages}`);
-        res.json({ messages, page, pageSize });
+        res.json({ messages: messages.map(toJsonSafePublicMessage), page, pageSize });
       } catch (err) {
         logger.error({ err, channelId: req.params.channelId }, 'Public messages route failed');
         if (!res.headersSent) {
@@ -115,7 +145,7 @@ export function createPublicRouter(store?: Store) {
             editedAt: true,
             author: { select: { id: true, username: true } },
             attachments: {
-              select: { id: true, url: true, filename: true, contentType: true, sizeBytes: true },
+              select: PUBLIC_ATTACHMENT_SELECT,
             },
           },
         });
@@ -126,7 +156,7 @@ export function createPublicRouter(store?: Store) {
         }
 
         res.set('Cache-Control', `public, max-age=${CacheTTL.channelMessages}`);
-        res.json(message);
+        res.json(toJsonSafePublicMessage(message));
       } catch (err) {
         logger.error(
           { err, channelId: req.params.channelId, messageId: req.params.messageId },
@@ -247,7 +277,9 @@ export function createPublicRouter(store?: Store) {
         const channels = await prisma.channel.findMany({
           where: {
             serverId: server.id,
-            visibility: { in: [ChannelVisibility.PUBLIC_INDEXABLE, ChannelVisibility.PUBLIC_NO_INDEX] },
+            visibility: {
+              in: [ChannelVisibility.PUBLIC_INDEXABLE, ChannelVisibility.PUBLIC_NO_INDEX],
+            },
           },
           orderBy: { position: 'asc' },
           select: { id: true, name: true, slug: true, type: true, topic: true },

--- a/harmony-backend/tests/public.router.test.ts
+++ b/harmony-backend/tests/public.router.test.ts
@@ -115,6 +115,19 @@ const MESSAGE = {
   author: { id: 'usr-0000-0000-0000-000000000001', username: 'alice' },
 };
 
+const MESSAGE_WITH_ATTACHMENT = {
+  ...MESSAGE,
+  attachments: [
+    {
+      id: 'att-0000-0000-0000-000000000001',
+      url: 'https://cdn.example.test/file.png',
+      filename: 'file.png',
+      contentType: 'image/png',
+      sizeBytes: BigInt(1234),
+    },
+  ],
+};
+
 // ─── Test setup ───────────────────────────────────────────────────────────────
 
 let app: ReturnType<typeof createApp>;
@@ -193,8 +206,20 @@ describe('GET /api/public/servers/:serverSlug/channels', () => {
   it('returns 200 with PUBLIC_INDEXABLE and PUBLIC_NO_INDEX channels', async () => {
     mockPrisma.server.findUnique.mockResolvedValue({ id: SERVER.id });
     mockPrisma.channel.findMany.mockResolvedValue([
-      { id: CHANNEL.id, name: CHANNEL.name, slug: CHANNEL.slug, type: CHANNEL.type, topic: CHANNEL.topic },
-      { id: NO_INDEX_CHANNEL.id, name: NO_INDEX_CHANNEL.name, slug: NO_INDEX_CHANNEL.slug, type: NO_INDEX_CHANNEL.type, topic: null },
+      {
+        id: CHANNEL.id,
+        name: CHANNEL.name,
+        slug: CHANNEL.slug,
+        type: CHANNEL.type,
+        topic: CHANNEL.topic,
+      },
+      {
+        id: NO_INDEX_CHANNEL.id,
+        name: NO_INDEX_CHANNEL.name,
+        slug: NO_INDEX_CHANNEL.slug,
+        type: NO_INDEX_CHANNEL.type,
+        topic: null,
+      },
     ]);
 
     const res = await request(app).get(`/api/public/servers/${SERVER.slug}/channels`);
@@ -203,12 +228,19 @@ describe('GET /api/public/servers/:serverSlug/channels', () => {
     expect(res.body).toHaveProperty('channels');
     expect(res.body.channels).toHaveLength(2);
     expect(res.body.channels[0]).toMatchObject({ id: CHANNEL.id, name: CHANNEL.name });
-    expect(res.body.channels[1]).toMatchObject({ id: NO_INDEX_CHANNEL.id, name: NO_INDEX_CHANNEL.name });
+    expect(res.body.channels[1]).toMatchObject({
+      id: NO_INDEX_CHANNEL.id,
+      name: NO_INDEX_CHANNEL.name,
+    });
     expect(res.body.channels[0]).not.toHaveProperty('visibility');
     expect(res.body.channels[1]).not.toHaveProperty('visibility');
     expect(mockPrisma.channel.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ visibility: { in: [ChannelVisibility.PUBLIC_INDEXABLE, ChannelVisibility.PUBLIC_NO_INDEX] } }),
+        where: expect.objectContaining({
+          visibility: {
+            in: [ChannelVisibility.PUBLIC_INDEXABLE, ChannelVisibility.PUBLIC_NO_INDEX],
+          },
+        }),
       }),
     );
   });
@@ -263,6 +295,27 @@ describe('GET /api/public/channels/:channelId/messages', () => {
     expect(res.body.messages[0]).toMatchObject({ id: MESSAGE.id, content: MESSAGE.content });
     expect(res.body).toHaveProperty('page', 1);
     expect(res.body).toHaveProperty('pageSize', 50);
+  });
+
+  it('returns JSON-safe attachment fields for public paginated messages', async () => {
+    mockPrisma.channel.findUnique.mockResolvedValue({
+      id: CHANNEL.id,
+      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+    });
+    mockPrisma.message.findMany.mockResolvedValue([MESSAGE_WITH_ATTACHMENT]);
+
+    const res = await request(app).get(`/api/public/channels/${CHANNEL.id}/messages?page=2`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.messages[0].attachments).toEqual([
+      {
+        id: 'att-0000-0000-0000-000000000001',
+        url: 'https://cdn.example.test/file.png',
+        filename: 'file.png',
+        contentType: 'image/png',
+      },
+    ]);
+    expect(res.body.messages[0].attachments[0]).not.toHaveProperty('sizeBytes');
   });
 
   it('PR-2: returns correct page and passes skip/take to Prisma when ?page=3', async () => {
@@ -358,6 +411,27 @@ describe('GET /api/public/channels/:channelId/messages/:messageId', () => {
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ id: MESSAGE.id, content: MESSAGE.content });
     expect(res.body.author).toMatchObject({ username: 'alice' });
+  });
+
+  it('returns JSON-safe attachment fields for a public single-message response', async () => {
+    mockPrisma.channel.findUnique.mockResolvedValue({
+      id: CHANNEL.id,
+      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+    });
+    mockPrisma.message.findFirst.mockResolvedValue(MESSAGE_WITH_ATTACHMENT);
+
+    const res = await request(app).get(`/api/public/channels/${CHANNEL.id}/messages/${MESSAGE.id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.attachments).toEqual([
+      {
+        id: 'att-0000-0000-0000-000000000001',
+        url: 'https://cdn.example.test/file.png',
+        filename: 'file.png',
+        contentType: 'image/png',
+      },
+    ]);
+    expect(res.body.attachments[0]).not.toHaveProperty('sizeBytes');
   });
 
   it('returns 404 when the channel is PRIVATE', async () => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -18,6 +18,12 @@ Shared knowledge base for the Harmony team. Add an entry whenever a mistake is c
 
 <!-- Most recent entries at the top -->
 
+**Date:** 2026-05-03
+**Caught by:** [Human: user]
+**Related Issue:** #592
+**Mistake / Situation:** I started issue work from an existing shared checkout instead of immediately isolating the issue branch in a per-issue worktree while other workers were active.
+**Rule / Fix:** When the user says other workers are making disjoint Harmony issue branches, create or switch into the requested isolated per-issue worktree before any branch-changing or editing command, and leave the original checkout untouched.
+
 **Date:** 2026-04-28  
 **Caught by:** [Human: user]  
 **Related Issue:** N/A  

--- a/tests/integration/env.test.ts
+++ b/tests/integration/env.test.ts
@@ -24,6 +24,11 @@ describe('getCloudFixture cache behavior', () => {
       )
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ channels: [{ slug: 'general' }] }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'general', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
       );
     global.fetch = fetchMock;
 
@@ -43,7 +48,7 @@ describe('getCloudFixture cache behavior', () => {
       publicChannelTargets: [{ serverSlug: 'harmony-hq', channelSlug: 'general' }],
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   test('reuses an in-flight discovery promise for concurrent callers', async () => {
@@ -58,6 +63,11 @@ describe('getCloudFixture cache behavior', () => {
       )
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ channels: [{ slug: 'general' }] }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'general', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
       );
     global.fetch = fetchMock;
 
@@ -91,7 +101,7 @@ describe('getCloudFixture cache behavior', () => {
       },
     ]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   test('discovers up to 3 channels and populates publicChannels', async () => {
@@ -112,6 +122,21 @@ describe('getCloudFixture cache behavior', () => {
           }),
           { status: 200 },
         ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'general', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'announcements', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'dev-updates', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
       );
     global.fetch = fetchMock;
 
@@ -131,7 +156,67 @@ describe('getCloudFixture cache behavior', () => {
       ],
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  test('skips PUBLIC_NO_INDEX channels when choosing JSON-LD cloud fixture targets', async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: 'server-1', slug: 'harmony-hq' }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            channels: [
+              { slug: 'introductions' },
+              { slug: 'general' },
+              { slug: 'announcements' },
+              { slug: 'dev-updates' },
+            ],
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'introductions', visibility: 'PUBLIC_NO_INDEX' }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'general', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'announcements', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'dev-updates', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
+      );
+    global.fetch = fetchMock;
+
+    const { getCloudFixture } = await loadCloudEnvModule();
+
+    const fixture = await getCloudFixture();
+
+    expect(fixture).toEqual({
+      serverId: 'server-1',
+      serverSlug: 'harmony-hq',
+      publicChannel: 'general',
+      publicChannels: ['general', 'announcements', 'dev-updates'],
+      publicChannelTargets: [
+        { serverSlug: 'harmony-hq', channelSlug: 'general' },
+        { serverSlug: 'harmony-hq', channelSlug: 'announcements' },
+        { serverSlug: 'harmony-hq', channelSlug: 'dev-updates' },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
   });
 
   test('collects crawler targets across multiple servers while keeping the primary fixture on the richest server', async () => {
@@ -155,12 +240,27 @@ describe('getCloudFixture cache behavior', () => {
         ),
       )
       .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'one', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
             channels: [{ slug: 'two' }, { slug: 'three' }],
           }),
           { status: 200 },
         ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'two', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ slug: 'three', visibility: 'PUBLIC_INDEXABLE' }), {
+          status: 200,
+        }),
       );
     global.fetch = fetchMock;
 

--- a/tests/integration/env.ts
+++ b/tests/integration/env.ts
@@ -122,6 +122,7 @@ async function resolveIndexableChannelsForServer(
 ): Promise<string[]> {
   const publicChannels: string[] = [];
 
+  // Sequential fetch: stop as soon as we have 3 PUBLIC_INDEXABLE channels.
   for (const candidate of channelCandidates) {
     if (!candidate.slug) continue;
 

--- a/tests/integration/env.ts
+++ b/tests/integration/env.ts
@@ -116,6 +116,33 @@ type DiscoveredServerFixture = {
 
 let cloudFixturePromise: Promise<CloudFixture> | null = null;
 
+async function resolveIndexableChannelsForServer(
+  serverSlug: string,
+  channelCandidates: Array<{ slug?: string }>,
+): Promise<string[]> {
+  const publicChannels: string[] = [];
+
+  for (const candidate of channelCandidates) {
+    if (!candidate.slug) continue;
+
+    const channelRes = await fetch(
+      `${BACKEND_URL}/api/public/servers/${serverSlug}/channels/${candidate.slug}`,
+    );
+    if (!channelRes.ok) continue;
+
+    const channel = (await channelRes.json()) as {
+      slug?: string;
+      visibility?: string;
+    };
+    if (channel.visibility !== 'PUBLIC_INDEXABLE') continue;
+
+    publicChannels.push(channel.slug ?? candidate.slug);
+    if (publicChannels.length >= 3) break;
+  }
+
+  return publicChannels;
+}
+
 async function resolveCloudFixtureFromPublicApi(): Promise<CloudFixture> {
   const serversRes = await fetch(`${BACKEND_URL}/api/public/servers`);
   if (!serversRes.ok) {
@@ -139,10 +166,10 @@ async function resolveCloudFixtureFromPublicApi(): Promise<CloudFixture> {
     const channelsBody = (await channelsRes.json()) as {
       channels?: Array<{ slug?: string }>;
     };
-    const publicChannels = (channelsBody.channels ?? [])
-      .filter((ch): ch is { slug: string } => typeof ch.slug === 'string' && ch.slug.length > 0)
-      .slice(0, 3)
-      .map((ch) => ch.slug);
+    const publicChannels = await resolveIndexableChannelsForServer(
+      server.slug,
+      channelsBody.channels ?? [],
+    );
     if (!publicChannels.length) continue;
 
     discoveredFixtures.push({
@@ -183,7 +210,7 @@ async function resolveCloudFixtureFromPublicApi(): Promise<CloudFixture> {
   }
 
   throw new Error(
-    'Cloud fixture discovery failed: no public server/channel pair is available at the configured BACKEND_URL',
+    'Cloud fixture discovery failed: no PUBLIC_INDEXABLE public server/channel pair is available at the configured BACKEND_URL',
   );
 }
 


### PR DESCRIPTION
## Summary

- Fix cloud fixture discovery so JSON-LD assertions only target `PUBLIC_INDEXABLE` channels.
- Stop public message responses from selecting or emitting attachment `sizeBytes` BigInts.
- Add regressions for both the cloud fixture selection and JSON-safe public message serialization.

## Root Cause

Issue #592 was opened by the cloud integration failure tracker after GPC-2 selected a guest-accessible channel that was not guaranteed to be `PUBLIC_INDEXABLE`, so the page correctly omitted JSON-LD. While verifying the same cloud subset, GPC-5 also exposed that public message pages with attachments can return HTTP 500 because Express cannot JSON-serialize Prisma BigInt attachment sizes.

Closes #592.

## Checks

- `npm test -- --runTestsByPath env.test.ts` in `tests/integration`
- `npm test -- --runTestsByPath tests/public.router.test.ts` in `harmony-backend`
- `npm run build` in `harmony-backend`
- `npm run lint` in `harmony-backend` (passes with two existing warnings in unrelated tests)
- Live cloud subset against the issue URLs: JSON-LD assertions pass with this fixture fix; deployed GPC-5 remains red until this backend fix is deployed.
