### PR TITLE
feat: add guest message search for public channels

### DIFF
--- a/harmony-backend/src/routes/public.router.ts
+++ b/harmony-backend/src/routes/public.router.ts
@@ -10,6 +10,35 @@ import { metaTagService } from '../services/metaTag/metaTagService';
 import { inviteService } from '../services/invite.service';
 
 const logger = createLogger({ component: 'public-router' });
+const DEFAULT_SEARCH_LIMIT = 20;
+const MAX_SEARCH_LIMIT = 50;
+const MAX_SEARCH_QUERY_LENGTH = 120;
+
+function parseSearchQuery(value: unknown): string {
+  const raw = Array.isArray(value) ? value[0] : value;
+  return typeof raw === 'string' ? raw.trim().slice(0, MAX_SEARCH_QUERY_LENGTH) : '';
+}
+
+function parseSearchLimit(value: unknown): number {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const parsed = typeof raw === 'string' ? Number(raw) : Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_SEARCH_LIMIT;
+  return Math.min(MAX_SEARCH_LIMIT, Math.max(1, Math.floor(parsed)));
+}
+
+function buildSearchContext(content: string, query: string): string {
+  const normalizedContent = content.toLowerCase();
+  const normalizedQuery = query.toLowerCase();
+  const matchIndex = normalizedContent.indexOf(normalizedQuery);
+  if (matchIndex === -1) return content.length > 180 ? `${content.slice(0, 177)}...` : content;
+
+  const radius = 70;
+  const start = Math.max(0, matchIndex - radius);
+  const end = Math.min(content.length, matchIndex + query.length + radius);
+  const prefix = start > 0 ? '...' : '';
+  const suffix = end < content.length ? '...' : '';
+  return `${prefix}${content.slice(start, end)}${suffix}`;
+}
 
 /**
  * Factory so createApp() can inject a rate-limit store (e.g. a mock in tests
@@ -78,6 +107,65 @@ export function createPublicRouter(store?: Store) {
       }
     },
   );
+
+  /**
+   * GET /api/public/channels/:channelId/messages/search?q=<keyword>
+   * Searches non-deleted messages within a single guest-accessible public channel.
+   */
+  router.get('/channels/:channelId/messages/search', async (req: Request, res: Response) => {
+    try {
+      const { channelId } = req.params;
+      const query = parseSearchQuery(req.query.q);
+      const limit = parseSearchLimit(req.query.limit);
+
+      if (!query) {
+        res.status(400).json({ error: 'Search query is required' });
+        return;
+      }
+
+      const channel = await prisma.channel.findUnique({
+        where: { id: channelId },
+        select: { id: true, visibility: true },
+      });
+
+      if (!channel || channel.visibility === ChannelVisibility.PRIVATE) {
+        res.status(404).json({ error: 'Channel not found' });
+        return;
+      }
+
+      const messages = await prisma.message.findMany({
+        where: {
+          channelId,
+          isDeleted: false,
+          content: { contains: query, mode: 'insensitive' },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+          editedAt: true,
+          author: { select: { id: true, username: true } },
+        },
+      });
+
+      res.set('Cache-Control', 'no-store');
+      res.json({
+        results: messages.map((message) => ({
+          ...message,
+          context: buildSearchContext(message.content, query),
+        })),
+        query,
+        limit,
+      });
+    } catch (err) {
+      logger.error({ err, channelId: req.params.channelId }, 'Public message search route failed');
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  });
 
   /**
    * GET /api/public/channels/:channelId/messages/:messageId
@@ -247,7 +335,9 @@ export function createPublicRouter(store?: Store) {
         const channels = await prisma.channel.findMany({
           where: {
             serverId: server.id,
-            visibility: { in: [ChannelVisibility.PUBLIC_INDEXABLE, ChannelVisibility.PUBLIC_NO_INDEX] },
+            visibility: {
+              in: [ChannelVisibility.PUBLIC_INDEXABLE, ChannelVisibility.PUBLIC_NO_INDEX],
+            },
           },
           orderBy: { position: 'asc' },
           select: { id: true, name: true, slug: true, type: true, topic: true },

--- a/harmony-backend/src/routes/public.router.ts
+++ b/harmony-backend/src/routes/public.router.ts
@@ -21,7 +21,7 @@ function parseSearchQuery(value: unknown): string {
 
 function parseSearchLimit(value: unknown): number {
   const raw = Array.isArray(value) ? value[0] : value;
-  const parsed = typeof raw === 'string' ? Number(raw) : Number(raw);
+  const parsed = Number(raw);
   if (!Number.isFinite(parsed)) return DEFAULT_SEARCH_LIMIT;
   return Math.min(MAX_SEARCH_LIMIT, Math.max(1, Math.floor(parsed)));
 }
@@ -128,6 +128,7 @@ export function createPublicRouter(store?: Store) {
         select: { id: true, visibility: true },
       });
 
+      // PUBLIC_NO_INDEX controls crawler indexing only; guests can still read and search it.
       if (!channel || channel.visibility === ChannelVisibility.PRIVATE) {
         res.status(404).json({ error: 'Channel not found' });
         return;

--- a/harmony-backend/tests/public.router.test.ts
+++ b/harmony-backend/tests/public.router.test.ts
@@ -5,6 +5,7 @@
  *   GET /api/public/servers/:serverSlug
  *   GET /api/public/servers/:serverSlug/channels
  *   GET /api/public/channels/:channelId/messages
+ *   GET /api/public/channels/:channelId/messages/search
  *   GET /api/public/channels/:channelId/messages/:messageId
  *
  * Prisma and cacheService are mocked so no running database or Redis is required.
@@ -193,8 +194,20 @@ describe('GET /api/public/servers/:serverSlug/channels', () => {
   it('returns 200 with PUBLIC_INDEXABLE and PUBLIC_NO_INDEX channels', async () => {
     mockPrisma.server.findUnique.mockResolvedValue({ id: SERVER.id });
     mockPrisma.channel.findMany.mockResolvedValue([
-      { id: CHANNEL.id, name: CHANNEL.name, slug: CHANNEL.slug, type: CHANNEL.type, topic: CHANNEL.topic },
-      { id: NO_INDEX_CHANNEL.id, name: NO_INDEX_CHANNEL.name, slug: NO_INDEX_CHANNEL.slug, type: NO_INDEX_CHANNEL.type, topic: null },
+      {
+        id: CHANNEL.id,
+        name: CHANNEL.name,
+        slug: CHANNEL.slug,
+        type: CHANNEL.type,
+        topic: CHANNEL.topic,
+      },
+      {
+        id: NO_INDEX_CHANNEL.id,
+        name: NO_INDEX_CHANNEL.name,
+        slug: NO_INDEX_CHANNEL.slug,
+        type: NO_INDEX_CHANNEL.type,
+        topic: null,
+      },
     ]);
 
     const res = await request(app).get(`/api/public/servers/${SERVER.slug}/channels`);
@@ -203,12 +216,19 @@ describe('GET /api/public/servers/:serverSlug/channels', () => {
     expect(res.body).toHaveProperty('channels');
     expect(res.body.channels).toHaveLength(2);
     expect(res.body.channels[0]).toMatchObject({ id: CHANNEL.id, name: CHANNEL.name });
-    expect(res.body.channels[1]).toMatchObject({ id: NO_INDEX_CHANNEL.id, name: NO_INDEX_CHANNEL.name });
+    expect(res.body.channels[1]).toMatchObject({
+      id: NO_INDEX_CHANNEL.id,
+      name: NO_INDEX_CHANNEL.name,
+    });
     expect(res.body.channels[0]).not.toHaveProperty('visibility');
     expect(res.body.channels[1]).not.toHaveProperty('visibility');
     expect(mockPrisma.channel.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ visibility: { in: [ChannelVisibility.PUBLIC_INDEXABLE, ChannelVisibility.PUBLIC_NO_INDEX] } }),
+        where: expect.objectContaining({
+          visibility: {
+            in: [ChannelVisibility.PUBLIC_INDEXABLE, ChannelVisibility.PUBLIC_NO_INDEX],
+          },
+        }),
       }),
     );
   });
@@ -479,6 +499,73 @@ describe('GET /api/public/channels/:channelId/messages — additional', () => {
 
     expect(res.status).toBe(500);
     expect(res.body).toHaveProperty('error', 'Internal server error');
+  });
+});
+
+// ─── GET /api/public/channels/:channelId/messages/search ────────────────────
+
+describe('GET /api/public/channels/:channelId/messages/search', () => {
+  it('returns case-insensitive matches scoped to the current public channel', async () => {
+    const matchingMessage = {
+      ...MESSAGE,
+      content: 'We shipped the Guest Search sidebar today.',
+    };
+    mockPrisma.channel.findUnique.mockResolvedValue({
+      id: CHANNEL.id,
+      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+    });
+    mockPrisma.message.findMany.mockResolvedValue([matchingMessage]);
+
+    const res = await request(app).get(
+      `/api/public/channels/${CHANNEL.id}/messages/search?q=guest%20search`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      results: [
+        expect.objectContaining({
+          id: matchingMessage.id,
+          content: matchingMessage.content,
+          context: 'We shipped the Guest Search sidebar today.',
+          author: matchingMessage.author,
+        }),
+      ],
+      query: 'guest search',
+      limit: 20,
+    });
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          channelId: CHANNEL.id,
+          isDeleted: false,
+          content: { contains: 'guest search', mode: 'insensitive' },
+        },
+      }),
+    );
+  });
+
+  it('returns 400 for an empty keyword', async () => {
+    const res = await request(app).get(`/api/public/channels/${CHANNEL.id}/messages/search?q=`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error', 'Search query is required');
+    expect(mockPrisma.channel.findUnique).not.toHaveBeenCalled();
+    expect(mockPrisma.message.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 and does not search messages when the channel is private', async () => {
+    mockPrisma.channel.findUnique.mockResolvedValue({
+      id: CHANNEL.id,
+      visibility: ChannelVisibility.PRIVATE,
+    });
+
+    const res = await request(app).get(
+      `/api/public/channels/${CHANNEL.id}/messages/search?q=secret`,
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error', 'Channel not found');
+    expect(mockPrisma.message.findMany).not.toHaveBeenCalled();
   });
 });
 

--- a/harmony-backend/tests/public.router.test.ts
+++ b/harmony-backend/tests/public.router.test.ts
@@ -1093,4 +1093,23 @@ describe('Rate limiting on publicRouter', () => {
       nowSpy.mockRestore();
     }
   });
+
+  it('returns 429 after exhausting the limit on guest message search', async () => {
+    mockPrisma.channel.findUnique.mockResolvedValue({
+      id: CHANNEL.id,
+      visibility: ChannelVisibility.PUBLIC_INDEXABLE,
+    });
+    mockPrisma.message.findMany.mockResolvedValue([]);
+
+    for (let i = 0; i < 100; i++) {
+      await request(app).get(`/api/public/channels/${CHANNEL.id}/messages/search?q=guest`);
+    }
+
+    const res = await request(app).get(
+      `/api/public/channels/${CHANNEL.id}/messages/search?q=guest`,
+    );
+
+    expect(res.status).toBe(429);
+    expect(res.body).toHaveProperty('error');
+  });
 });

--- a/harmony-frontend/src/__tests__/GuestMessageSearch.test.tsx
+++ b/harmony-frontend/src/__tests__/GuestMessageSearch.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GuestMessageSearch } from '@/components/channel/GuestMessageSearch';
+import { searchPublicChannelMessages } from '@/services/publicMessageSearchService';
+
+jest.mock('@/services/publicMessageSearchService', () => ({
+  searchPublicChannelMessages: jest.fn(),
+}));
+
+const mockSearchPublicChannelMessages = searchPublicChannelMessages as jest.MockedFunction<
+  typeof searchPublicChannelMessages
+>;
+
+describe('GuestMessageSearch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens guest search and displays author, timestamp, and context for matching messages', async () => {
+    mockSearchPublicChannelMessages.mockResolvedValue({
+      query: 'launch',
+      limit: 20,
+      results: [
+        {
+          id: 'msg-1',
+          content: 'We are ready to launch guest search.',
+          context: 'We are ready to launch guest search.',
+          createdAt: '2026-05-01T12:00:00.000Z',
+          editedAt: null,
+          author: { id: 'user-1', username: 'alice' },
+        },
+      ],
+    });
+
+    render(<GuestMessageSearch channelId='channel-1' channelName='general' />);
+
+    await userEvent.click(screen.getByRole('button', { name: /search messages/i }));
+    await userEvent.type(screen.getByPlaceholderText('Search messages in #general'), 'launch');
+
+    await waitFor(() =>
+      expect(mockSearchPublicChannelMessages).toHaveBeenCalledWith('channel-1', 'launch'),
+    );
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('We are ready to launch guest search.')).toBeInTheDocument();
+    expect(screen.getByText(/May 1, 2026/)).toBeInTheDocument();
+  });
+});

--- a/harmony-frontend/src/__tests__/publicMessageSearchService.test.ts
+++ b/harmony-frontend/src/__tests__/publicMessageSearchService.test.ts
@@ -1,0 +1,76 @@
+import {
+  searchPublicChannelMessages,
+  type PublicMessageSearchResponse,
+} from '@/services/publicMessageSearchService';
+
+const mockFetch = jest.fn();
+
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function makeResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe('publicMessageSearchService', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  it('searches the current public channel with URL-encoded channel and query values', async () => {
+    const payload: PublicMessageSearchResponse = {
+      query: 'Guest Search',
+      limit: 20,
+      results: [
+        {
+          id: 'msg-1',
+          content: 'Guest Search is available now',
+          context: 'Guest Search is available now',
+          createdAt: '2026-05-01T12:00:00.000Z',
+          editedAt: null,
+          author: { id: 'user-1', username: 'alice' },
+        },
+      ],
+    };
+    mockFetch.mockResolvedValue(makeResponse(payload));
+
+    await expect(
+      searchPublicChannelMessages('channel/with space', 'Guest Search'),
+    ).resolves.toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:4000/api/public/channels/channel%2Fwith%20space/messages/search?q=Guest%20Search',
+      { cache: 'no-store' },
+    );
+  });
+
+  it('returns an empty result without calling fetch for blank queries', async () => {
+    await expect(searchPublicChannelMessages('channel-1', '   ')).resolves.toEqual({
+      query: '',
+      limit: 20,
+      results: [],
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty result when the backend rejects or the request fails', async () => {
+    mockFetch.mockResolvedValueOnce(makeResponse({}, { ok: false, status: 404 }));
+
+    await expect(searchPublicChannelMessages('channel-1', 'missing')).resolves.toEqual({
+      query: 'missing',
+      limit: 20,
+      results: [],
+    });
+
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(searchPublicChannelMessages('channel-1', 'offline')).resolves.toEqual({
+      query: 'offline',
+      limit: 20,
+      results: [],
+    });
+  });
+});

--- a/harmony-frontend/src/components/channel/GuestChannelView.tsx
+++ b/harmony-frontend/src/components/channel/GuestChannelView.tsx
@@ -21,6 +21,7 @@ import { MessageList } from '@/components/channel/MessageList';
 import { GuestPromoBanner } from '@/components/channel/GuestPromoBanner';
 import { GuestHeader } from '@/components/channel/GuestHeader';
 import { PrivateChannelLockedPane } from '@/components/channel/PrivateChannelLockedPane';
+import { GuestMessageSearch } from '@/components/channel/GuestMessageSearch';
 import type { Channel } from '@/types';
 
 // ─── Channel Header ───────────────────────────────────────────────────────────
@@ -46,6 +47,7 @@ function ChannelHeader({ channel }: { channel: Channel }) {
           <p className='truncate text-sm text-gray-400'>{channel.topic}</p>
         </>
       )}
+      <GuestMessageSearch channelId={channel.id} channelName={channel.name} />
     </div>
   );
 }
@@ -93,10 +95,7 @@ export async function GuestChannelView({ serverSlug, channelSlug }: GuestChannel
         {isMember && <AuthRedirect to={`/channels/${serverSlug}/${channelSlug}`} />}
         <GuestHeader server={server} />
         <div className='flex flex-1 overflow-hidden'>
-          <ServerSidebar
-            serverInfo={server}
-            publicChannels={publicChannels}
-          />
+          <ServerSidebar serverInfo={server} publicChannels={publicChannels} />
           <PrivateChannelLockedPane mode='guest' />
         </div>
       </div>

--- a/harmony-frontend/src/components/channel/GuestMessageSearch.tsx
+++ b/harmony-frontend/src/components/channel/GuestMessageSearch.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  searchPublicChannelMessages,
+  type PublicMessageSearchResult,
+} from '@/services/publicMessageSearchService';
+
+interface GuestMessageSearchProps {
+  channelId: string;
+  channelName: string;
+}
+
+function formatSearchTimestamp(value: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+function SearchResultItem({ result }: { result: PublicMessageSearchResult }) {
+  return (
+    <li className='rounded-md px-3 py-2 text-left hover:bg-white/5'>
+      <div className='flex flex-wrap items-baseline gap-x-2 gap-y-0.5'>
+        <span className='text-sm font-semibold text-white'>{result.author.username}</span>
+        <time className='text-xs text-gray-400' dateTime={result.createdAt}>
+          {formatSearchTimestamp(result.createdAt)}
+        </time>
+      </div>
+      <p className='mt-1 line-clamp-3 text-sm leading-5 text-gray-300'>{result.context}</p>
+    </li>
+  );
+}
+
+export function GuestMessageSearch({ channelId, channelName }: GuestMessageSearchProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<PublicMessageSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const openSearch = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const closeSearch = useCallback(() => {
+    setIsOpen(false);
+    setQuery('');
+    setResults([]);
+    setIsLoading(false);
+    setHasSearched(false);
+  }, []);
+
+  const handleQueryChange = useCallback((nextQuery: string) => {
+    setQuery(nextQuery);
+    if (!nextQuery.trim()) {
+      setResults([]);
+      setIsLoading(false);
+      setHasSearched(false);
+      return;
+    }
+    setIsLoading(true);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        if (isOpen) closeSearch();
+        else openSearch();
+      }
+      if (event.key === 'Escape') closeSearch();
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [closeSearch, isOpen, openSearch]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const focusTimer = window.setTimeout(() => inputRef.current?.focus(), 0);
+    return () => window.clearTimeout(focusTimer);
+  }, [isOpen]);
+
+  useEffect(() => {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) return;
+
+    let cancelled = false;
+    const searchTimer = window.setTimeout(async () => {
+      const response = await searchPublicChannelMessages(channelId, trimmedQuery);
+      if (cancelled) return;
+      setResults(response.results);
+      setIsLoading(false);
+      setHasSearched(true);
+    }, 250);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(searchTimer);
+    };
+  }, [channelId, query]);
+
+  return (
+    <>
+      <button
+        type='button'
+        onClick={openSearch}
+        className='ml-auto inline-flex h-8 shrink-0 items-center gap-2 rounded-md border border-white/10 bg-[#40444b] px-3 text-xs font-medium text-gray-200 transition-colors hover:bg-[#4b5058] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#5865f2]'
+        aria-label='Search messages'
+      >
+        <svg
+          className='h-4 w-4'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth={2}
+          aria-hidden='true'
+        >
+          <circle cx='11' cy='11' r='8' />
+          <path d='m21 21-4.35-4.35' />
+        </svg>
+        <span className='hidden sm:inline'>Search</span>
+      </button>
+
+      {isOpen && (
+        <div
+          className='fixed inset-0 z-50 flex items-start justify-center bg-black/60 px-4 pt-20'
+          role='dialog'
+          aria-modal='true'
+          aria-label='Search public channel messages'
+          onClick={closeSearch}
+        >
+          <div
+            className='w-full max-w-xl overflow-hidden rounded-lg border border-white/10 bg-[#2f3136] shadow-2xl'
+            onClick={event => event.stopPropagation()}
+          >
+            <div className='flex items-center gap-3 border-b border-black/20 px-4 py-3'>
+              <svg
+                className='h-5 w-5 shrink-0 text-gray-400'
+                viewBox='0 0 24 24'
+                fill='none'
+                stroke='currentColor'
+                strokeWidth={2}
+                aria-hidden='true'
+              >
+                <circle cx='11' cy='11' r='8' />
+                <path d='m21 21-4.35-4.35' />
+              </svg>
+              <input
+                ref={inputRef}
+                type='search'
+                value={query}
+                onChange={event => handleQueryChange(event.target.value)}
+                placeholder={`Search messages in #${channelName}`}
+                className='min-w-0 flex-1 bg-transparent text-sm text-white placeholder:text-gray-400 focus:outline-none'
+              />
+              <button
+                type='button'
+                onClick={closeSearch}
+                aria-label='Close search'
+                className='rounded p-1 text-gray-400 hover:bg-white/10 hover:text-white'
+              >
+                <svg
+                  className='h-4 w-4'
+                  viewBox='0 0 24 24'
+                  fill='none'
+                  stroke='currentColor'
+                  strokeWidth={2}
+                  aria-hidden='true'
+                >
+                  <path d='M18 6 6 18M6 6l12 12' />
+                </svg>
+              </button>
+            </div>
+
+            <div className='max-h-96 overflow-y-auto p-2'>
+              {!query.trim() && (
+                <p className='px-3 py-6 text-center text-sm text-gray-400'>
+                  Type a keyword to search this channel.
+                </p>
+              )}
+              {isLoading && (
+                <p className='px-3 py-6 text-center text-sm text-gray-400'>Searching...</p>
+              )}
+              {!isLoading && hasSearched && results.length === 0 && (
+                <p className='px-3 py-6 text-center text-sm text-gray-400'>No messages found.</p>
+              )}
+              {!isLoading && results.length > 0 && (
+                <ul className='space-y-1' aria-label='Search results'>
+                  {results.map(result => (
+                    <SearchResultItem key={result.id} result={result} />
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/harmony-frontend/src/components/channel/GuestMessageSearch.tsx
+++ b/harmony-frontend/src/components/channel/GuestMessageSearch.tsx
@@ -60,7 +60,6 @@ export function GuestMessageSearch({ channelId, channelName }: GuestMessageSearc
       setHasSearched(false);
       return;
     }
-    setIsLoading(true);
   }, []);
 
   useEffect(() => {
@@ -89,6 +88,7 @@ export function GuestMessageSearch({ channelId, channelName }: GuestMessageSearc
 
     let cancelled = false;
     const searchTimer = window.setTimeout(async () => {
+      setIsLoading(true);
       const response = await searchPublicChannelMessages(channelId, trimmedQuery);
       if (cancelled) return;
       setResults(response.results);

--- a/harmony-frontend/src/services/publicMessageSearchService.ts
+++ b/harmony-frontend/src/services/publicMessageSearchService.ts
@@ -1,0 +1,41 @@
+import { API_CONFIG } from '@/lib/constants';
+
+export interface PublicMessageSearchResult {
+  id: string;
+  content: string;
+  context: string;
+  createdAt: string;
+  editedAt?: string | null;
+  author: { id: string; username: string };
+}
+
+export interface PublicMessageSearchResponse {
+  results: PublicMessageSearchResult[];
+  query: string;
+  limit: number;
+}
+
+const EMPTY_LIMIT = 20;
+
+function emptySearchResult(query: string): PublicMessageSearchResponse {
+  return { results: [], query, limit: EMPTY_LIMIT };
+}
+
+export async function searchPublicChannelMessages(
+  channelId: string,
+  query: string,
+): Promise<PublicMessageSearchResponse> {
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery) return emptySearchResult('');
+
+  try {
+    const res = await fetch(
+      `${API_CONFIG.BASE_URL}/api/public/channels/${encodeURIComponent(channelId)}/messages/search?q=${encodeURIComponent(trimmedQuery)}`,
+      { cache: 'no-store' },
+    );
+    if (!res.ok) return emptySearchResult(trimmedQuery);
+    return (await res.json()) as PublicMessageSearchResponse;
+  } catch {
+    return emptySearchResult(trimmedQuery);
+  }
+}


### PR DESCRIPTION
## Summary
- add a guest-accessible public channel message search endpoint scoped to the current channel
- add guest search UI in public channel headers with author, timestamp, and context results
- add focused backend and frontend regression coverage

Closes #486

## Verification
- npm --prefix harmony-backend test -- public.router.test.ts --runInBand
- npm --prefix harmony-backend run lint
- npm --prefix harmony-backend run build
- npm --prefix harmony-frontend test -- publicMessageSearchService.test.ts GuestMessageSearch.test.tsx --runInBand
- npm --prefix harmony-frontend test -- --runInBand
- npm --prefix harmony-frontend run lint
- npm --prefix harmony-frontend run build

## Notes
- Full backend test suite was attempted but local DB/Redis-dependent tests require DATABASE_URL and Redis auth; the issue-relevant backend public router suite passed.
- Full frontend tsc --noEmit still reports unrelated existing errors in src/__tests__/gifsRoute.test.ts; next build TypeScript passed.