### PR TITLE
fix: harden username validation

### DIFF
--- a/harmony-backend/src/routes/auth.router.ts
+++ b/harmony-backend/src/routes/auth.router.ts
@@ -28,8 +28,9 @@ const registerSchema = z.object({
     .string()
     .min(3, { message: 'Username must be at least 3 characters' })
     .max(32, { message: 'Username must be at most 32 characters' })
-    .regex(/^[a-zA-Z0-9_-]+$/, {
-      message: 'Username may only contain letters, numbers, underscores, and hyphens',
+    .regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/, {
+      message:
+        'Username must start with a letter or number and may only contain letters, numbers, underscores, and hyphens',
     }),
   passwordSalt: passwordSaltSchema,
   passwordVerifier: passwordVerifierSchema,

--- a/harmony-backend/tests/auth.test.ts
+++ b/harmony-backend/tests/auth.test.ts
@@ -146,6 +146,29 @@ describe('POST /api/auth/register', () => {
     expect(res.body.error).toBe('Validation failed');
   });
 
+  it.each(['--admin', '_admin', '__system'])(
+    'rejects username %s because usernames must start with a letter or number',
+    async (username) => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.create.mockResolvedValue({ ...mockUser, username });
+      mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
+
+      const res = await request(app)
+        .post('/api/auth/register')
+        .set('Origin', 'http://localhost:3000')
+        .send({
+          email: `${username.replace(/[^a-zA-Z0-9]/g, '')}@example.com`,
+          username,
+          passwordSalt: PASSWORD_SALT,
+          passwordVerifier: derivePasswordVerifier('password123'),
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation failed');
+      expect(mockPrisma.user.create).not.toHaveBeenCalled();
+    },
+  );
+
   it('returns 409 when email is already in use', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(mockUser);
 

--- a/harmony-backend/tests/auth.test.ts
+++ b/harmony-backend/tests/auth.test.ts
@@ -149,10 +149,6 @@ describe('POST /api/auth/register', () => {
   it.each(['--admin', '_admin', '__system'])(
     'rejects username %s because usernames must start with a letter or number',
     async (username) => {
-      mockPrisma.user.findUnique.mockResolvedValue(null);
-      mockPrisma.user.create.mockResolvedValue({ ...mockUser, username });
-      mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
-
       const res = await request(app)
         .post('/api/auth/register')
         .set('Origin', 'http://localhost:3000')
@@ -168,6 +164,35 @@ describe('POST /api/auth/register', () => {
       expect(mockPrisma.user.create).not.toHaveBeenCalled();
     },
   );
+
+  it('accepts usernames that start with a number', async () => {
+    const numericUsernameUser = { ...mockUser, username: '0validname' };
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+    mockPrisma.user.create.mockResolvedValue(numericUsernameUser);
+    mockPrisma.refreshToken.create.mockResolvedValue({
+      ...mockRefreshToken,
+      userId: numericUsernameUser.id,
+    });
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({
+        email: '0validname@example.com',
+        username: numericUsernameUser.username,
+        passwordSalt: PASSWORD_SALT,
+        passwordVerifier: derivePasswordVerifier('password123'),
+      });
+
+    expect(res.status).toBe(201);
+    expect(typeof res.body.accessToken).toBe('string');
+    expect(typeof res.body.refreshToken).toBe('string');
+    expect(mockPrisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ username: numericUsernameUser.username }),
+      }),
+    );
+  });
 
   it('returns 409 when email is already in use', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(mockUser);


### PR DESCRIPTION
## Summary
- Require registration usernames to start with a letter or number while preserving the existing 3-32 character length and allowed follow-up characters.
- Add route-level regression coverage for leading hyphen/underscore impersonation-style usernames.

Closes #441

## Verification
- `npm --prefix harmony-backend test -- auth.test.ts` (red before fix, green after)
- `npm --prefix harmony-backend run lint` (passes with existing warnings only)
- `npm --prefix harmony-backend run build`
- `npm --prefix harmony-frontend run lint` (passes with existing warnings only)
- `npm --prefix harmony-frontend test -- --runInBand`
- `npm --prefix harmony-frontend run build`

## Notes
- Issue #441 is assigned to `acabrera04`.
- Full backend suite was attempted, but the only visible long-running Jest process belonged to another worker's `/private/tmp/harmony-issue-480` worktree and was not interrupted.