### PR TITLE
Require proxy hop config in production

### DIFF
--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -153,15 +153,14 @@ export function createApp(options: CreateAppOptions = {}) {
   // clients spoof XFF and poison rate-limit buckets. Set to `1` on Railway.
   const trustProxyHopsEnv = process.env.TRUST_PROXY_HOPS;
   if (trustProxyHopsEnv !== undefined && trustProxyHopsEnv.trim() === '') {
-    throw new Error(
-      `Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected a non-negative integer.`,
-    );
+    throw new Error(`Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected an integer.`);
   }
   const trustProxyHops = trustProxyHopsEnv === undefined ? 0 : Number(trustProxyHopsEnv);
   if (!Number.isInteger(trustProxyHops) || trustProxyHops < 0) {
-    throw new Error(
-      `Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected a non-negative integer.`,
-    );
+    throw new Error(`Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected an integer.`);
+  }
+  if (isProduction && trustProxyHops < 1) {
+    throw new Error('TRUST_PROXY_HOPS must be set to a positive integer in production.');
   }
   if (trustProxyHops > 0) {
     app.set('trust proxy', trustProxyHops);

--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -153,11 +153,11 @@ export function createApp(options: CreateAppOptions = {}) {
   // clients spoof XFF and poison rate-limit buckets. Set to `1` on Railway.
   const trustProxyHopsEnv = process.env.TRUST_PROXY_HOPS;
   if (trustProxyHopsEnv !== undefined && trustProxyHopsEnv.trim() === '') {
-    throw new Error(`Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected an integer.`);
+    throw new Error(`Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected a non-negative integer.`);
   }
   const trustProxyHops = trustProxyHopsEnv === undefined ? 0 : Number(trustProxyHopsEnv);
   if (!Number.isInteger(trustProxyHops) || trustProxyHops < 0) {
-    throw new Error(`Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected an integer.`);
+    throw new Error(`Invalid TRUST_PROXY_HOPS value "${trustProxyHopsEnv}". Expected a non-negative integer.`);
   }
   if (isProduction && trustProxyHops < 1) {
     throw new Error('TRUST_PROXY_HOPS must be set to a positive integer in production.');

--- a/harmony-backend/tests/app.rate-limit.test.ts
+++ b/harmony-backend/tests/app.rate-limit.test.ts
@@ -41,6 +41,22 @@ function createStoreFactory(): { factory: () => Store; incrementCalls: string[] 
 }
 
 describe('auth rate limiters — store delegation (Issue #318)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalTrustProxyHops = process.env.TRUST_PROXY_HOPS;
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    if (originalTrustProxyHops === undefined) {
+      delete process.env.TRUST_PROXY_HOPS;
+    } else {
+      process.env.TRUST_PROXY_HOPS = originalTrustProxyHops;
+    }
+  });
+
   it('calls increment() on the injected store for POST /api/auth/login', async () => {
     const { factory, incrementCalls } = createStoreFactory();
     const app = createApp({ rateLimitStore: factory });
@@ -82,21 +98,50 @@ describe('auth rate limiters — store delegation (Issue #318)', () => {
   });
 
   it('does not lock out local development after 10 login attempts', async () => {
-    const previousEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
 
-    try {
-      const app = createApp();
-      let lastStatus = 0;
+    const app = createApp();
+    let lastStatus = 0;
 
-      for (let attempt = 0; attempt < 11; attempt += 1) {
-        const res = await request(app).post('/api/auth/login').send({});
-        lastStatus = res.status;
-      }
-
-      expect(lastStatus).not.toBe(429);
-    } finally {
-      process.env.NODE_ENV = previousEnv;
+    for (let attempt = 0; attempt < 11; attempt += 1) {
+      const res = await request(app).post('/api/auth/login').send({});
+      lastStatus = res.status;
     }
+
+    expect(lastStatus).not.toBe(429);
+  });
+
+  it('throws in production when TRUST_PROXY_HOPS is unset', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.TRUST_PROXY_HOPS;
+
+    expect(() => createApp({ rateLimitStore: createStoreFactory().factory })).toThrow(
+      'TRUST_PROXY_HOPS must be set to a positive integer in production.',
+    );
+  });
+
+  it('throws in production when TRUST_PROXY_HOPS is zero', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.TRUST_PROXY_HOPS = '0';
+
+    expect(() => createApp({ rateLimitStore: createStoreFactory().factory })).toThrow(
+      'TRUST_PROXY_HOPS must be set to a positive integer in production.',
+    );
+  });
+
+  it('sets trust proxy in production when TRUST_PROXY_HOPS is positive', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.TRUST_PROXY_HOPS = '1';
+
+    const app = createApp({ rateLimitStore: createStoreFactory().factory });
+
+    expect(app.get('trust proxy')).toBe(1);
+  });
+
+  it('allows local development without TRUST_PROXY_HOPS', () => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.TRUST_PROXY_HOPS;
+
+    expect(() => createApp()).not.toThrow();
   });
 });

--- a/harmony-backend/tests/trpc.error-formatter.test.ts
+++ b/harmony-backend/tests/trpc.error-formatter.test.ts
@@ -13,6 +13,7 @@
  */
 
 import request from 'supertest';
+import type { Store, IncrementResponse, ClientRateLimitInfo, Options } from 'express-rate-limit';
 import { createApp } from '../src/app';
 
 // ─── Mock Prisma ──────────────────────────────────────────────────────────────
@@ -31,20 +32,43 @@ jest.mock('../src/db/prisma', () => ({
 
 const AUTHED_ENDPOINT = '/trpc/user.getCurrentUser';
 
+function createNoopRateLimitStore(): Store {
+  return {
+    init(_options: Options) {},
+    async increment(_key: string): Promise<IncrementResponse> {
+      return { totalHits: 1, resetTime: new Date(Date.now() + 15 * 60 * 1000) };
+    },
+    async decrement(_key: string): Promise<void> {},
+    async resetKey(_key: string): Promise<void> {},
+    async get(_key: string): Promise<ClientRateLimitInfo | undefined> {
+      return { totalHits: 1, resetTime: new Date(Date.now() + 15 * 60 * 1000) };
+    },
+  };
+}
+
 describe('tRPC errorFormatter — stack trace suppression', () => {
   const originalEnv = process.env.NODE_ENV;
+  const originalTrustProxyHops = process.env.TRUST_PROXY_HOPS;
 
   afterEach(() => {
-    process.env.NODE_ENV = originalEnv;
+    if (originalEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalEnv;
+    }
+    if (originalTrustProxyHops === undefined) {
+      delete process.env.TRUST_PROXY_HOPS;
+    } else {
+      process.env.TRUST_PROXY_HOPS = originalTrustProxyHops;
+    }
   });
 
   it('omits stack trace when NODE_ENV is production', async () => {
     process.env.NODE_ENV = 'production';
-    const app = createApp();
+    process.env.TRUST_PROXY_HOPS = '1';
+    const app = createApp({ rateLimitStore: createNoopRateLimitStore });
 
-    const res = await request(app)
-      .get(AUTHED_ENDPOINT)
-      .set('Accept', 'application/json');
+    const res = await request(app).get(AUTHED_ENDPOINT).set('Accept', 'application/json');
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBeDefined();
@@ -54,12 +78,10 @@ describe('tRPC errorFormatter — stack trace suppression', () => {
   it('includes stack trace when NODE_ENV is development and EXPOSE_STACK=1', async () => {
     process.env.NODE_ENV = 'development';
     process.env.EXPOSE_STACK = '1';
-    const app = createApp();
+    const app = createApp({ rateLimitStore: createNoopRateLimitStore });
 
     try {
-      const res = await request(app)
-        .get(AUTHED_ENDPOINT)
-        .set('Accept', 'application/json');
+      const res = await request(app).get(AUTHED_ENDPOINT).set('Accept', 'application/json');
 
       expect(res.status).toBe(401);
       expect(res.body.error).toBeDefined();
@@ -72,11 +94,9 @@ describe('tRPC errorFormatter — stack trace suppression', () => {
   it('omits stack trace when NODE_ENV is development but EXPOSE_STACK is unset', async () => {
     process.env.NODE_ENV = 'development';
     delete process.env.EXPOSE_STACK;
-    const app = createApp();
+    const app = createApp({ rateLimitStore: createNoopRateLimitStore });
 
-    const res = await request(app)
-      .get(AUTHED_ENDPOINT)
-      .set('Accept', 'application/json');
+    const res = await request(app).get(AUTHED_ENDPOINT).set('Accept', 'application/json');
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBeDefined();


### PR DESCRIPTION
## Summary
- Require a positive TRUST_PROXY_HOPS value when the backend starts in production
- Add regression coverage for unset, zero, and valid production proxy hop config
- Keep production-mode tRPC error formatter tests isolated from Redis-backed rate limiter stores

## Verification
- npm --prefix harmony-backend test -- --runTestsByPath tests/app.rate-limit.test.ts tests/trpc.error-formatter.test.ts --runInBand
- npm --prefix harmony-backend run lint (passes with existing warnings in unrelated tests/channelMember.test.ts and tests/events.router.sse-server-updated.test.ts)
- npm --prefix harmony-backend run build
- npm --prefix harmony-frontend test -- --runInBand

Full backend suite note: npm --prefix harmony-backend test -- --runInBand is blocked in this local environment by missing DATABASE_URL and Redis NOAUTH; the issue-related targeted backend tests pass.

Closes #440