### PR TITLE
Harden session cookie SameSite policy

### DIFF
--- a/harmony-frontend/src/__tests__/session-actions.test.ts
+++ b/harmony-frontend/src/__tests__/session-actions.test.ts
@@ -10,6 +10,10 @@ import { AUTH_COOKIE_NAME } from '@/lib/auth-constants';
 const mockCookies = cookies as jest.MockedFunction<typeof cookies>;
 
 describe('session actions', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('sets the auth session cookie with SameSite=Strict', async () => {
     const set = jest.fn();
     mockCookies.mockResolvedValue({
@@ -25,5 +29,37 @@ describe('session actions', () => {
       path: '/',
       maxAge: 7 * 24 * 60 * 60,
     });
+  });
+
+  it('sets the auth session cookie as secure in production', async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: 'production',
+      writable: true,
+      configurable: true,
+    });
+
+    const set = jest.fn();
+    mockCookies.mockResolvedValue({
+      set,
+    } as unknown as Awaited<ReturnType<typeof cookies>>);
+
+    try {
+      await setSessionCookie('access-token');
+
+      expect(set).toHaveBeenCalledWith(
+        AUTH_COOKIE_NAME,
+        'access-token',
+        expect.objectContaining({
+          secure: true,
+        }),
+      );
+    } finally {
+      Object.defineProperty(process.env, 'NODE_ENV', {
+        value: originalNodeEnv,
+        writable: true,
+        configurable: true,
+      });
+    }
   });
 });

--- a/harmony-frontend/src/__tests__/session-actions.test.ts
+++ b/harmony-frontend/src/__tests__/session-actions.test.ts
@@ -1,0 +1,29 @@
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+import { cookies } from 'next/headers';
+
+import { setSessionCookie } from '@/app/actions/session';
+import { AUTH_COOKIE_NAME } from '@/lib/auth-constants';
+
+const mockCookies = cookies as jest.MockedFunction<typeof cookies>;
+
+describe('session actions', () => {
+  it('sets the auth session cookie with SameSite=Strict', async () => {
+    const set = jest.fn();
+    mockCookies.mockResolvedValue({
+      set,
+    } as unknown as Awaited<ReturnType<typeof cookies>>);
+
+    await setSessionCookie('access-token');
+
+    expect(set).toHaveBeenCalledWith(AUTH_COOKIE_NAME, 'access-token', {
+      httpOnly: true,
+      secure: false,
+      sameSite: 'strict',
+      path: '/',
+      maxAge: 7 * 24 * 60 * 60,
+    });
+  });
+});

--- a/harmony-frontend/src/app/actions/session.ts
+++ b/harmony-frontend/src/app/actions/session.ts
@@ -9,7 +9,7 @@ import { AUTH_COOKIE_NAME } from '@/lib/auth-constants';
 const MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
 
 /**
- * Sets the auth session cookie (httpOnly, SameSite=Lax).
+ * Sets the auth session cookie (httpOnly, SameSite=Strict).
  *
  * Stores the raw JWT access token so that server-side tRPC calls
  * (in trpc-client.ts) can forward it as a Bearer token to the backend.
@@ -21,7 +21,7 @@ export async function setSessionCookie(accessToken: string): Promise<void> {
   cookieStore.set(AUTH_COOKIE_NAME, accessToken, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
+    sameSite: 'strict',
     path: '/',
     maxAge: MAX_AGE_SECONDS,
   });


### PR DESCRIPTION
## Summary
- Change the frontend auth session cookie from SameSite=Lax to SameSite=Strict.
- Add a focused regression test that asserts the server action writes the cookie with SameSite=Strict.

Closes #439

## Verification
- harmony-frontend: npm test -- --runTestsByPath src/__tests__/session-actions.test.ts
- harmony-frontend: npm run lint (warnings only: existing no-img/exhaustive-deps warnings)
- harmony-frontend: npm test -- --runInBand
- harmony-frontend: npm run build
- harmony-backend: npm run lint (warnings only: existing unused-var warnings)
- harmony-backend: npm run build
- harmony-backend: DATABASE_URL=postgresql://harmony:harmony@localhost:55432/harmony_e2e REDIS_URL=redis://:e2esecret@localhost:56379 npm test -- --runInBand --forceExit