### PR TITLE
Fix SSE membership revalidation

### DIFF
--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -147,6 +147,7 @@ type BufferedSseState = {
   ready: boolean;
   pendingFrames: string[];
   heartbeat: ReturnType<typeof setInterval> | null;
+  authorizationRevalidation: ReturnType<typeof setInterval> | null;
 };
 
 function formatEvent(eventType: string, data: unknown, id?: string): string {
@@ -160,6 +161,7 @@ function createBufferedSseState(): BufferedSseState {
     ready: false,
     pendingFrames: [],
     heartbeat: null,
+    authorizationRevalidation: null,
   };
 }
 
@@ -170,10 +172,97 @@ function cleanupSseConnection(state: BufferedSseState, subscriptions: EventSubsc
     clearInterval(state.heartbeat);
     state.heartbeat = null;
   }
+  if (state.authorizationRevalidation) {
+    clearInterval(state.authorizationRevalidation);
+    state.authorizationRevalidation = null;
+  }
   state.pendingFrames.length = 0;
   for (const subscription of subscriptions) {
     subscription.unsubscribe();
   }
+}
+
+function closeSseForRevokedAccess(
+  res: Response,
+  state: BufferedSseState,
+  subscriptions: EventSubscription[],
+): void {
+  if (state.closed) return;
+  cleanupSseConnection(state, subscriptions);
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+  res.status(403).json({ error: 'SSE authorization revoked' });
+}
+
+async function isServerMember(userId: string, serverId: string): Promise<boolean> {
+  const membership = await prisma.serverMember.findFirst({
+    where: { userId, serverId },
+    select: { userId: true },
+  });
+  return Boolean(membership);
+}
+
+async function canAccessChannelStream(
+  userId: string,
+  channelId: string,
+  serverId: string,
+): Promise<boolean> {
+  const membership = await prisma.serverMember.findFirst({
+    where: { userId, serverId },
+    select: { role: true },
+  });
+  if (!membership) return false;
+
+  const channel = await prisma.channel.findUnique({
+    where: { id: channelId },
+    select: { serverId: true, visibility: true },
+  });
+  if (!channel || channel.serverId !== serverId) return false;
+  if (channel.visibility !== 'PRIVATE') return true;
+  if (membership.role === 'OWNER' || membership.role === 'ADMIN') return true;
+
+  const channelMembership = await prisma.channelMember.findUnique({
+    where: { userId_channelId: { userId, channelId } },
+    select: { userId: true },
+  });
+  return Boolean(channelMembership);
+}
+
+function startAuthorizationRevalidation(
+  res: Response,
+  state: BufferedSseState,
+  subscriptions: EventSubscription[],
+  isStillAuthorized: () => Promise<boolean>,
+  logContext: Record<string, string>,
+): void {
+  let revalidationInFlight = false;
+  const configuredIntervalMs = Number(process.env.SSE_MEMBERSHIP_REVALIDATION_INTERVAL_MS);
+  const intervalMs =
+    Number.isFinite(configuredIntervalMs) && configuredIntervalMs > 0
+      ? configuredIntervalMs
+      : 30_000;
+
+  state.authorizationRevalidation = setInterval(async () => {
+    if (state.closed || revalidationInFlight) return;
+    revalidationInFlight = true;
+    try {
+      const authorized = await isStillAuthorized();
+      if (!authorized) {
+        closeSseForRevokedAccess(res, state, subscriptions);
+      }
+    } catch (err) {
+      logger.warn(
+        { err, ...logContext },
+        'SSE membership revalidation failed; keeping stream open',
+      );
+    } finally {
+      revalidationInFlight = false;
+    }
+  }, intervalMs);
+
+  state.authorizationRevalidation.unref?.();
 }
 
 function createBufferedEventWriter(
@@ -276,18 +365,14 @@ eventsRouter.get('/channel/:channelId', async (req: Request, res: Response) => {
   // ── Authorisation — verify user is a member of the channel's server ───────
   const channel = await prisma.channel.findUnique({
     where: { id: channelId },
-    select: { serverId: true },
+    select: { serverId: true, visibility: true },
   });
   if (!channel) {
     res.status(404).json({ error: 'Channel not found' });
     return;
   }
 
-  const membership = await prisma.serverMember.findFirst({
-    where: { userId, serverId: channel.serverId },
-    select: { userId: true },
-  });
-  if (!membership) {
+  if (!(await canAccessChannelStream(userId, channelId, channel.serverId))) {
     res.status(403).json({ error: 'You are not a member of this server' });
     return;
   }
@@ -438,6 +523,23 @@ eventsRouter.get('/channel/:channelId', async (req: Request, res: Response) => {
     reactionRemovedSubscription,
   ];
 
+  const memberLeftSubscription = eventBus.subscribe(
+    EventChannels.MEMBER_LEFT,
+    (payload: MemberLeftPayload) => {
+      if (payload.serverId !== channel.serverId || payload.userId !== userId) return;
+      closeSseForRevokedAccess(res, sseState, channelSubscriptions);
+    },
+  );
+  channelSubscriptions.push(memberLeftSubscription);
+
+  startAuthorizationRevalidation(
+    res,
+    sseState,
+    channelSubscriptions,
+    () => canAccessChannelStream(userId, channelId, channel.serverId),
+    { route: 'channel-events', channelId, serverId: channel.serverId, userId },
+  );
+
   // ── Replay messages missed during reconnect gap ──────────────────────────
   const replayFrames = lastEventId
     ? async (): Promise<string[]> => {
@@ -550,11 +652,7 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     return;
   }
 
-  const membership = await prisma.serverMember.findFirst({
-    where: { userId, serverId },
-    select: { userId: true },
-  });
-  if (!membership) {
+  if (!(await isServerMember(userId, serverId))) {
     res.status(403).json({ error: 'You are not a member of this server' });
     return;
   }
@@ -851,10 +949,22 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     EventChannels.MEMBER_LEFT,
     (payload: MemberLeftPayload) => {
       if (payload.serverId !== serverId) return;
+      if (payload.userId === userId) {
+        closeSseForRevokedAccess(res, sseState, subscriptions);
+        return;
+      }
       writeEvent('member:left', { userId: payload.userId });
     },
   );
   subscriptions.push(memberLeftSubscription);
+
+  startAuthorizationRevalidation(
+    res,
+    sseState,
+    subscriptions,
+    () => isServerMember(userId, serverId),
+    { route: 'server-events', serverId, userId },
+  );
 
   const visibilityChangedSubscription = eventBus.subscribe(
     EventChannels.VISIBILITY_CHANGED,
@@ -954,7 +1064,14 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
       }
     : undefined;
 
-  await finalizeSseSetup(req, res, sseState, subscriptions, { route: 'server-events', serverId }, serverReplayFrames);
+  await finalizeSseSetup(
+    req,
+    res,
+    sseState,
+    subscriptions,
+    { route: 'server-events', serverId },
+    serverReplayFrames,
+  );
 });
 
 // ─── User-scoped notification SSE route ──────────────────────────────────────
@@ -998,5 +1115,8 @@ eventsRouter.get('/user', async (req: Request, res: Response) => {
     },
   );
 
-  await finalizeSseSetup(req, res, sseState, [mentionSubscription], { route: 'user-events', userId });
+  await finalizeSseSetup(req, res, sseState, [mentionSubscription], {
+    route: 'user-events',
+    userId,
+  });
 });

--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -166,7 +166,6 @@ function createBufferedSseState(): BufferedSseState {
 }
 
 function cleanupSseConnection(state: BufferedSseState, subscriptions: EventSubscription[]): void {
-  if (state.closed) return;
   state.closed = true;
   if (state.heartbeat) {
     clearInterval(state.heartbeat);
@@ -180,6 +179,7 @@ function cleanupSseConnection(state: BufferedSseState, subscriptions: EventSubsc
   for (const subscription of subscriptions) {
     subscription.unsubscribe();
   }
+  subscriptions.length = 0;
 }
 
 function closeSseForRevokedAccess(
@@ -188,6 +188,7 @@ function closeSseForRevokedAccess(
   subscriptions: EventSubscription[],
 ): void {
   if (state.closed) return;
+  state.closed = true;
   cleanupSseConnection(state, subscriptions);
   if (res.headersSent) {
     res.end();
@@ -209,16 +210,18 @@ async function canAccessChannelStream(
   channelId: string,
   serverId: string,
 ): Promise<boolean> {
-  const membership = await prisma.serverMember.findFirst({
-    where: { userId, serverId },
-    select: { role: true },
-  });
+  const [membership, channel] = await Promise.all([
+    prisma.serverMember.findFirst({
+      where: { userId, serverId },
+      select: { role: true },
+    }),
+    prisma.channel.findUnique({
+      where: { id: channelId },
+      select: { serverId: true, visibility: true },
+    }),
+  ]);
   if (!membership) return false;
 
-  const channel = await prisma.channel.findUnique({
-    where: { id: channelId },
-    select: { serverId: true, visibility: true },
-  });
   if (!channel || channel.serverId !== serverId) return false;
   if (channel.visibility !== 'PRIVATE') return true;
   if (membership.role === 'OWNER' || membership.role === 'ADMIN') return true;

--- a/harmony-backend/tests/events.router.server.test.ts
+++ b/harmony-backend/tests/events.router.server.test.ts
@@ -160,6 +160,10 @@ beforeEach(() => {
   });
 });
 
+afterEach(() => {
+  delete process.env.SSE_MEMBERSHIP_REVALIDATION_INTERVAL_MS;
+});
+
 // ─── SSE headers ──────────────────────────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — SSE headers', () => {
@@ -627,7 +631,6 @@ describe('GET /api/events/server/:serverId — membership revocation', () => {
     });
 
     expect(prisma.serverMember.findFirst).toHaveBeenCalledTimes(2);
-    delete process.env.SSE_MEMBERSHIP_REVALIDATION_INTERVAL_MS;
   });
 });
 

--- a/harmony-backend/tests/events.router.server.test.ts
+++ b/harmony-backend/tests/events.router.server.test.ts
@@ -324,15 +324,12 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     const chunks: string[] = [];
     let response: http.IncomingMessage | null = null;
     await new Promise<void>((resolve, reject) => {
-      const req = http.get(
-        { hostname: 'localhost', port, path: sseUrl },
-        (res) => {
-          response = res;
-          responseStarted.resolve();
-          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
-          res.on('error', reject);
-        },
-      );
+      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
+        response = res;
+        responseStarted.resolve();
+        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+        res.on('error', reject);
+      });
 
       req.on('error', reject);
 
@@ -462,14 +459,11 @@ describe('GET /api/events/server/:serverId — Last-Event-ID replay', () => {
     const chunks: string[] = [];
     const responseStarted = createDeferred<void>();
     await new Promise<void>((resolve, reject) => {
-      const req = http.get(
-        { hostname: 'localhost', port, path: sseUrlWithReplay },
-        (res) => {
-          responseStarted.resolve();
-          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
-          res.on('error', reject);
-        },
-      );
+      const req = http.get({ hostname: 'localhost', port, path: sseUrlWithReplay }, (res) => {
+        responseStarted.resolve();
+        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+        res.on('error', reject);
+      });
       req.on('error', reject);
 
       setTimeout(async () => {
@@ -558,6 +552,82 @@ describe('GET /api/events/server/:serverId — authorisation', () => {
       `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
     );
     expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /api/events/server/:serverId — membership revocation', () => {
+  const sseUrl = `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`;
+
+  it('closes the stream instead of forwarding member:left when the connected user is removed', async () => {
+    let memberLeftHandler: ((payload: unknown) => void) | null = null;
+    const unsubscribes: jest.Mock[] = [];
+
+    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => void) => {
+      if (channel === 'harmony:MEMBER_LEFT') {
+        memberLeftHandler = handler;
+      }
+      const unsubscribe = jest.fn();
+      unsubscribes.push(unsubscribe);
+      return { unsubscribe, ready: Promise.resolve() };
+    });
+
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad server address');
+    const port = addr.port;
+
+    const chunks: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
+        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+        res.on('close', resolve);
+        res.on('error', reject);
+
+        setTimeout(() => {
+          if (!memberLeftHandler) {
+            reject(new Error('MEMBER_LEFT handler was not registered'));
+            return;
+          }
+          memberLeftHandler({
+            userId: 'test-user-id',
+            serverId: VALID_SERVER_ID,
+            reason: 'KICKED',
+            timestamp: new Date().toISOString(),
+          });
+        }, 50);
+      });
+      req.on('error', reject);
+    });
+
+    expect(chunks.join('')).not.toContain('event: member:left');
+    expect(unsubscribes.length).toBeGreaterThan(0);
+    expect(unsubscribes.every((unsubscribe) => unsubscribe.mock.calls.length === 1)).toBe(true);
+  });
+
+  it('periodically revalidates membership and closes when server access is revoked', async () => {
+    process.env.SSE_MEMBERSHIP_REVALIDATION_INTERVAL_MS = '20';
+    (prisma.serverMember.findFirst as jest.Mock)
+      .mockResolvedValueOnce({ userId: 'test-user-id' })
+      .mockResolvedValueOnce(null);
+
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad server address');
+    const port = addr.port;
+
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
+        res.on('data', () => {});
+        res.on('close', resolve);
+        res.on('error', reject);
+      });
+      req.on('error', reject);
+      req.setTimeout(1_000, () => {
+        req.destroy();
+        reject(new Error('SSE stream did not close after membership revalidation'));
+      });
+    });
+
+    expect(prisma.serverMember.findFirst).toHaveBeenCalledTimes(2);
+    delete process.env.SSE_MEMBERSHIP_REVALIDATION_INTERVAL_MS;
   });
 });
 

--- a/harmony-backend/tests/events.router.test.ts
+++ b/harmony-backend/tests/events.router.test.ts
@@ -31,6 +31,7 @@ jest.mock('../src/events/eventBus', () => ({
     MESSAGE_CREATED: 'harmony:MESSAGE_CREATED',
     MESSAGE_EDITED: 'harmony:MESSAGE_EDITED',
     MESSAGE_DELETED: 'harmony:MESSAGE_DELETED',
+    MEMBER_LEFT: 'harmony:MEMBER_LEFT',
   },
 }));
 
@@ -49,6 +50,7 @@ jest.mock('../src/db/prisma', () => ({
     message: { findUnique: jest.fn(), findMany: jest.fn(), create: jest.fn(), update: jest.fn() },
     channel: { findUnique: jest.fn() },
     serverMember: { findFirst: jest.fn() },
+    channelMember: { findUnique: jest.fn() },
   },
 }));
 
@@ -142,7 +144,11 @@ beforeEach(() => {
   mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
   // Default prisma mocks for auth path through SSE endpoint
   (prisma.channel.findUnique as jest.Mock).mockResolvedValue({ serverId: 'test-server-id' });
-  (prisma.serverMember.findFirst as jest.Mock).mockResolvedValue({ userId: 'test-user-id' });
+  (prisma.serverMember.findFirst as jest.Mock).mockResolvedValue({
+    userId: 'test-user-id',
+    role: 'MEMBER',
+  });
+  (prisma.channelMember.findUnique as jest.Mock).mockResolvedValue(null);
   (prisma.message.findMany as jest.Mock).mockResolvedValue([]);
 });
 
@@ -289,6 +295,87 @@ describe('GET /api/events/channel/:channelId — subscription readiness', () => 
     const body = chunks.join('');
     expect(body).toContain('event: message:created');
     expect(body).toContain('hello from the setup window');
+  });
+});
+
+describe('GET /api/events/channel/:channelId — membership revocation', () => {
+  const VALID_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440001';
+  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?ticket=${SSE_TEST_TICKET}`;
+
+  it('closes the stream when the connected user is removed from the server', async () => {
+    let memberLeftHandler: ((payload: unknown) => void) | null = null;
+    const unsubscribes: jest.Mock[] = [];
+
+    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => void) => {
+      if (channel === 'harmony:MEMBER_LEFT') {
+        memberLeftHandler = handler;
+      }
+      const unsubscribe = jest.fn();
+      unsubscribes.push(unsubscribe);
+      return { unsubscribe, ready: Promise.resolve() };
+    });
+
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad server address');
+    const port = addr.port;
+
+    const chunks: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
+        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+        res.on('close', resolve);
+        res.on('error', reject);
+
+        setTimeout(() => {
+          if (!memberLeftHandler) {
+            reject(new Error('MEMBER_LEFT handler was not registered'));
+            return;
+          }
+          memberLeftHandler({
+            userId: 'test-user-id',
+            serverId: 'test-server-id',
+            reason: 'KICKED',
+            timestamp: new Date().toISOString(),
+          });
+        }, 50);
+      });
+      req.on('error', reject);
+    });
+
+    expect(chunks.join('')).not.toContain('event: member:left');
+    expect(unsubscribes.length).toBeGreaterThan(0);
+    expect(unsubscribes.every((unsubscribe) => unsubscribe.mock.calls.length === 1)).toBe(true);
+  });
+
+  it('periodically revalidates access and closes when private-channel membership is revoked', async () => {
+    process.env.SSE_MEMBERSHIP_REVALIDATION_INTERVAL_MS = '20';
+    (prisma.channel.findUnique as jest.Mock).mockResolvedValue({
+      serverId: 'test-server-id',
+      visibility: 'PRIVATE',
+    });
+    (prisma.channelMember.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ userId: 'test-user-id' })
+      .mockResolvedValueOnce(null);
+
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad server address');
+    const port = addr.port;
+
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
+        res.on('data', () => {});
+        res.on('close', resolve);
+        res.on('error', reject);
+      });
+      req.on('error', reject);
+      req.setTimeout(1_000, () => {
+        req.destroy();
+        reject(new Error('SSE stream did not close after membership revalidation'));
+      });
+    });
+
+    expect(prisma.channelMember.findUnique).toHaveBeenCalledTimes(2);
+    delete process.env.SSE_MEMBERSHIP_REVALIDATION_INTERVAL_MS;
   });
 });
 

--- a/harmony-backend/tests/events.router.test.ts
+++ b/harmony-backend/tests/events.router.test.ts
@@ -152,6 +152,10 @@ beforeEach(() => {
   (prisma.message.findMany as jest.Mock).mockResolvedValue([]);
 });
 
+afterEach(() => {
+  delete process.env.SSE_MEMBERSHIP_REVALIDATION_INTERVAL_MS;
+});
+
 // ─── SSE headers ──────────────────────────────────────────────────────────────
 
 describe('GET /api/events/channel/:channelId — SSE headers', () => {
@@ -375,7 +379,6 @@ describe('GET /api/events/channel/:channelId — membership revocation', () => {
     });
 
     expect(prisma.channelMember.findUnique).toHaveBeenCalledTimes(2);
-    delete process.env.SSE_MEMBERSHIP_REVALIDATION_INTERVAL_MS;
   });
 });
 


### PR DESCRIPTION
## Summary
- close server/channel SSE streams immediately when the connected user is removed from the server
- add periodic SSE authorization revalidation for server streams and private channel membership changes
- add regression coverage for connected-then-revoked SSE access

Closes #480

## Verification
- npm --prefix harmony-backend test -- events.router.test.ts events.router.server.test.ts --runInBand
- npm --prefix harmony-backend test -- events.router.member.test.ts events.router.visibility.test.ts --runInBand
- npm --prefix harmony-backend run lint
- npm --prefix harmony-backend run build
- npm --prefix harmony-frontend run lint
- npm --prefix harmony-frontend test -- --runInBand
- npm --prefix harmony-frontend run build

Note: full backend Jest was attempted but hung without output in this isolated worktree and was stopped; focused SSE suites passed.