### PR TITLE
Limit public auth validation error details

### DIFF
--- a/harmony-backend/src/routes/auth.router.ts
+++ b/harmony-backend/src/routes/auth.router.ts
@@ -74,6 +74,7 @@ function publicValidationError(error: z.ZodError): {
   return {
     error: 'Validation failed',
     fields: error.errors.map((issue) => ({
+      // Empty field names represent root-level validation errors with no Zod path.
       field: issue.path.map(String).join('.'),
       message: issue.message,
     })),

--- a/harmony-backend/src/routes/auth.router.ts
+++ b/harmony-backend/src/routes/auth.router.ts
@@ -67,13 +67,26 @@ function trpcCodeToHttp(code: TRPCError['code']): number {
   }
 }
 
+function publicValidationError(error: z.ZodError): {
+  error: 'Validation failed';
+  fields: Array<{ field: string; message: string }>;
+} {
+  return {
+    error: 'Validation failed',
+    fields: error.errors.map((issue) => ({
+      field: issue.path.map(String).join('.'),
+      message: issue.message,
+    })),
+  };
+}
+
 function handleError(res: Response, err: unknown): void {
   if (err instanceof TRPCError) {
     res.status(trpcCodeToHttp(err.code)).json({ error: err.message });
     return;
   }
   if (err instanceof z.ZodError) {
-    res.status(400).json({ error: 'Validation failed', details: err.errors });
+    res.status(400).json(publicValidationError(err));
     return;
   }
   logger.error({ err }, 'Auth route failed');
@@ -97,7 +110,7 @@ authRouter.post('/register/challenge', (_req: Request, res: Response) => {
 authRouter.post('/register', async (req: Request, res: Response) => {
   const parsed = registerSchema.safeParse(req.body);
   if (!parsed.success) {
-    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+    res.status(400).json(publicValidationError(parsed.error));
     return;
   }
 
@@ -117,7 +130,7 @@ authRouter.post('/register', async (req: Request, res: Response) => {
 authRouter.post('/login/challenge', async (req: Request, res: Response) => {
   const parsed = challengeSchema.safeParse(req.body);
   if (!parsed.success) {
-    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+    res.status(400).json(publicValidationError(parsed.error));
     return;
   }
 
@@ -137,7 +150,7 @@ authRouter.post('/login/challenge', async (req: Request, res: Response) => {
 authRouter.post('/login', async (req: Request, res: Response) => {
   const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) {
-    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+    res.status(400).json(publicValidationError(parsed.error));
     return;
   }
 
@@ -157,7 +170,7 @@ authRouter.post('/login', async (req: Request, res: Response) => {
 authRouter.post('/logout', async (req: Request, res: Response) => {
   const parsed = logoutSchema.safeParse(req.body);
   if (!parsed.success) {
-    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+    res.status(400).json(publicValidationError(parsed.error));
     return;
   }
 
@@ -176,7 +189,7 @@ authRouter.post('/logout', async (req: Request, res: Response) => {
 authRouter.post('/refresh', async (req: Request, res: Response) => {
   const parsed = refreshSchema.safeParse(req.body);
   if (!parsed.success) {
-    res.status(400).json({ error: 'Validation failed', details: parsed.error.errors });
+    res.status(400).json(publicValidationError(parsed.error));
     return;
   }
 

--- a/harmony-backend/tests/auth.test.ts
+++ b/harmony-backend/tests/auth.test.ts
@@ -146,6 +146,26 @@ describe('POST /api/auth/register', () => {
     expect(res.body.error).toBe('Validation failed');
   });
 
+  it('returns sanitized validation fields without raw Zod issue details', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Origin', 'http://localhost:3000')
+      .send({ email: 'bad-email', username: 'a' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: 'Validation failed',
+      fields: expect.arrayContaining([
+        { field: 'email', message: 'Please enter a valid email address' },
+        { field: 'username', message: 'Username must be at least 3 characters' },
+      ]),
+    });
+    expect(res.body).not.toHaveProperty('details');
+    for (const fieldError of res.body.fields) {
+      expect(Object.keys(fieldError).sort()).toEqual(['field', 'message']);
+    }
+  });
+
   it('returns 409 when email is already in use', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(mockUser);
 
@@ -296,6 +316,25 @@ describe('POST /api/auth/login', () => {
       .send({ email: 'not-an-email' });
 
     expect(res.status).toBe(400);
+  });
+
+  it('returns sanitized validation fields without raw Zod issue details', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .set('Origin', 'http://localhost:3000')
+      .send({ email: 'not-an-email' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: 'Validation failed',
+      fields: expect.arrayContaining([
+        { field: 'email', message: 'Please enter a valid email address' },
+      ]),
+    });
+    expect(res.body).not.toHaveProperty('details');
+    for (const fieldError of res.body.fields) {
+      expect(Object.keys(fieldError).sort()).toEqual(['field', 'message']);
+    }
   });
 });
 

--- a/harmony-frontend/src/__tests__/utils.test.ts
+++ b/harmony-frontend/src/__tests__/utils.test.ts
@@ -94,6 +94,25 @@ describe('utils', () => {
   });
 
   describe('getUserErrorMessage', () => {
+    it('joins auth validation field messages from Axios errors', () => {
+      const err = {
+        isAxiosError: true,
+        response: {
+          data: {
+            error: 'Validation failed',
+            fields: [
+              { field: 'email', message: 'Please enter a valid email address' },
+              { field: '', message: 'Request body is invalid' },
+            ],
+          },
+        },
+      } as AxiosError;
+
+      expect(getUserErrorMessage(err)).toBe(
+        'Please enter a valid email address. Request body is invalid',
+      );
+    });
+
     it('joins validation detail messages from Axios errors', () => {
       const err = {
         isAxiosError: true,

--- a/harmony-frontend/src/lib/utils.ts
+++ b/harmony-frontend/src/lib/utils.ts
@@ -92,7 +92,12 @@ export function getUserErrorMessage(
   if (isAxiosError(err)) {
     const data = err.response?.data;
     if (data) {
-      // Validation errors: { error: "Validation failed", details: [{ message: "..." }] }
+      // Auth validation errors: { error: "Validation failed", fields: [{ field, message }] }
+      if (Array.isArray(data.fields) && data.fields.length > 0) {
+        const messages = data.fields.map((f: { message?: string }) => f.message).filter(Boolean);
+        if (messages.length > 0) return messages.join('. ');
+      }
+      // Legacy validation errors: { error: "Validation failed", details: [{ message: "..." }] }
       if (Array.isArray(data.details) && data.details.length > 0) {
         const messages = data.details.map((d: { message?: string }) => d.message).filter(Boolean);
         if (messages.length > 0) return messages.join('. ');


### PR DESCRIPTION
## Summary

- Replace raw Zod issue-tree responses in the auth router with sanitized `{ field, message }` validation fields.
- Add register/login regression tests that assert public auth validation responses do not expose raw Zod `details`.

## Verification

- `npm --prefix harmony-backend test -- auth.test.ts`
- `npm --prefix harmony-backend run lint` (passes with pre-existing warnings only)
- `npm --prefix harmony-backend run build`
- `npm --prefix harmony-frontend run lint` (passes with pre-existing warnings only)
- `npm --prefix harmony-frontend test -- --runInBand`
- `npm --prefix harmony-frontend run build`

Note: full `npm --prefix harmony-backend test -- --runInBand` could not complete in this fresh worktree because unrelated DB/Redis-backed suites require local `DATABASE_URL` and Redis auth configuration.

Closes #438