### PR TITLE
Fix stale system admin cache

### DIFF
--- a/harmony-backend/src/lib/admin.utils.ts
+++ b/harmony-backend/src/lib/admin.utils.ts
@@ -18,9 +18,6 @@ export const RESERVED_EMAILS = new Set<string>([ADMIN_EMAIL]);
 /** Lowercase usernames that must not be claimable via public registration. */
 export const RESERVED_USERNAMES = new Set<string>(['admin']);
 
-/** Cached admin user ID to avoid repeated DB lookups. */
-let _adminUserId: string | null = null;
-
 function isDevAdminEnabled(): boolean {
   return process.env.NODE_ENV === 'development' && process.env.ENABLE_DEV_ADMIN === 'true';
 }
@@ -28,18 +25,12 @@ function isDevAdminEnabled(): boolean {
 /**
  * Returns true if the given userId belongs to the system admin account.
  * Only active when NODE_ENV=development AND ENABLE_DEV_ADMIN=true.
- * Caches the result after the first positive lookup.
  */
 export async function isSystemAdmin(userId: string): Promise<boolean> {
   if (!isDevAdminEnabled()) return false;
-  if (_adminUserId === userId) return true;
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: { email: true },
   });
-  if (user?.email === ADMIN_EMAIL) {
-    _adminUserId = userId;
-    return true;
-  }
-  return false;
+  return user?.email === ADMIN_EMAIL;
 }

--- a/harmony-backend/tests/admin.utils.test.ts
+++ b/harmony-backend/tests/admin.utils.test.ts
@@ -5,7 +5,12 @@
  * matches ADMIN_EMAIL cannot escalate privileges in production.
  */
 
-import { isSystemAdmin, ADMIN_EMAIL, RESERVED_EMAILS, RESERVED_USERNAMES } from '../src/lib/admin.utils';
+import {
+  isSystemAdmin,
+  ADMIN_EMAIL,
+  RESERVED_EMAILS,
+  RESERVED_USERNAMES,
+} from '../src/lib/admin.utils';
 
 const ADMIN_USER_ID = '00000000-0000-0000-0000-000000000099';
 
@@ -84,6 +89,18 @@ describe('isSystemAdmin — ENABLE_DEV_ADMIN guard (issue #425)', () => {
     const result = await isSystemAdmin('attacker-id');
 
     expect(result).toBe(false);
+  });
+
+  it('rechecks the database so a deleted admin row does not stay authorized', async () => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'development', writable: true });
+    process.env.ENABLE_DEV_ADMIN = 'true';
+    mockPrisma.user.findUnique
+      .mockResolvedValueOnce({ email: ADMIN_EMAIL })
+      .mockResolvedValueOnce(null);
+
+    await expect(isSystemAdmin(ADMIN_USER_ID)).resolves.toBe(true);
+    await expect(isSystemAdmin(ADMIN_USER_ID)).resolves.toBe(false);
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Summary
- remove the module-scope positive admin ID cache from isSystemAdmin
- add regression coverage proving a deleted admin row no longer stays authorized

## Verification
- npm test -- --runTestsByPath tests/admin.utils.test.ts --runInBand
- npm run lint (passes with two unrelated existing warnings)
- npm run build (passes after allowing Prisma cache writes)
- attempted full npm test -- --runInBand; sandboxed run hit listen EPERM on Supertest, approved run hung silently and was stopped for this worktree

Closes #435