### PR TITLE
Fix SSE auth ticket exposure

### DIFF
--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -3,18 +3,19 @@
  *
  * POST /api/events/ticket
  *   Requires Authorization: Bearer <accessToken>.
- *   Returns a one-shot nonce stored in Redis for 60 s.
+ *   Requires { stream: "channel" | "server" | "user" }.
+ *   Sets a stream-scoped, short-lived, HTTP-only, one-shot ticket cookie stored in Redis for 60 s.
  *
- * GET /api/events/channel/:channelId?ticket=<nonce>
- * GET /api/events/server/:serverId?ticket=<nonce>
- * GET /api/events/user?ticket=<nonce>
+ * GET /api/events/channel/:channelId
+ * GET /api/events/server/:serverId
+ * GET /api/events/user
  *
  * Streams real-time events using Server-Sent Events.
  *
  * Auth: EventSource cannot send custom headers, so a short-lived one-shot ticket
- * is used instead of passing the JWT directly in the query string. The frontend
- * calls POST /api/events/ticket first, then opens the EventSource with ?ticket=<nonce>.
- * The nonce is consumed immediately on first use, preventing replay.
+ * cookie is used instead of passing the JWT or ticket in the query string. The
+ * frontend calls POST /api/events/ticket first, then opens EventSource with
+ * credentials enabled. The nonce is consumed immediately on first use, preventing replay.
  */
 
 import crypto from 'crypto';
@@ -61,9 +62,68 @@ function isValidUUID(id: string): boolean {
 // ─── SSE ticket helpers ───────────────────────────────────────────────────────
 
 const TICKET_TTL_SECONDS = 60;
+const SSE_TICKET_COOKIE_NAMES = {
+  channel: 'harmony_sse_ticket_channel',
+  server: 'harmony_sse_ticket_server',
+  user: 'harmony_sse_ticket_user',
+} as const;
+
+type SseTicketStream = keyof typeof SSE_TICKET_COOKIE_NAMES;
+
+function isSseTicketStream(value: unknown): value is SseTicketStream {
+  return value === 'channel' || value === 'server' || value === 'user';
+}
 
 function ticketKey(nonce: string): string {
   return `sse:ticket:${nonce}`;
+}
+
+function serializeSseTicketCookie(
+  stream: SseTicketStream,
+  value: string,
+  maxAgeSeconds: number,
+): string {
+  const secure = process.env.NODE_ENV === 'production';
+  const attributes = [
+    `${SSE_TICKET_COOKIE_NAMES[stream]}=${encodeURIComponent(value)}`,
+    'Path=/api/events',
+    'HttpOnly',
+    `Max-Age=${maxAgeSeconds}`,
+    secure ? 'SameSite=None' : 'SameSite=Lax',
+  ];
+  if (secure) attributes.push('Secure');
+  return attributes.join('; ');
+}
+
+function readCookie(req: Request, name: string): string | null {
+  const cookieHeader = req.headers.cookie;
+  if (!cookieHeader) return null;
+
+  for (const pair of cookieHeader.split(';')) {
+    const separatorIndex = pair.indexOf('=');
+    if (separatorIndex === -1) continue;
+    const key = pair.slice(0, separatorIndex).trim();
+    if (key !== name) continue;
+    try {
+      return decodeURIComponent(pair.slice(separatorIndex + 1).trim());
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+async function redeemSseTicketFromCookie(
+  req: Request,
+  res: Response,
+  stream: SseTicketStream,
+): Promise<string | null> {
+  const ticket = readCookie(req, SSE_TICKET_COOKIE_NAMES[stream]);
+  if (!ticket) return null;
+
+  res.setHeader('Set-Cookie', serializeSseTicketCookie(stream, '', 0));
+  return redeemTicket(ticket);
 }
 
 /**
@@ -94,11 +154,16 @@ async function redeemTicket(nonce: string): Promise<string | null> {
  * POST /api/events/ticket
  *
  * Requires Authorization: Bearer <accessToken>.
- * Returns { ticket: <nonce> } — the nonce must be passed as ?ticket=<nonce>
- * when opening an SSE connection. The nonce is valid for 60 seconds and can
- * only be used once.
+ * Requires { stream: "channel" | "server" | "user" }. Sets a stream-scoped
+ * HTTP-only ticket cookie for the next SSE connection. The nonce is valid for
+ * 60 seconds and can only be used once.
  */
 eventsRouter.post('/ticket', async (req: Request, res: Response) => {
+  if (!isSseTicketStream(req.body?.stream)) {
+    res.status(400).json({ error: 'Invalid stream type' });
+    return;
+  }
+
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) {
     res.status(401).json({ error: 'Missing or invalid Authorization header' });
@@ -116,7 +181,8 @@ eventsRouter.post('/ticket', async (req: Request, res: Response) => {
 
   const nonce = crypto.randomUUID();
   await redis.set(ticketKey(nonce), userId, 'EX', TICKET_TTL_SECONDS);
-  res.json({ ticket: nonce });
+  res.setHeader('Set-Cookie', serializeSseTicketCookie(req.body.stream, nonce, TICKET_TTL_SECONDS));
+  res.json({ ok: true });
 });
 
 // ─── Prisma select shape (matches frontend Message type) ──────────────────────
@@ -260,16 +326,10 @@ eventsRouter.get('/channel/:channelId', async (req: Request, res: Response) => {
     return;
   }
 
-  // ── Auth — one-shot ticket exchanged via POST /api/events/ticket ─────────
-  const ticket = typeof req.query.ticket === 'string' ? req.query.ticket : null;
-  if (!ticket) {
-    res.status(401).json({ error: 'Missing ticket query parameter' });
-    return;
-  }
-
-  const userId = await redeemTicket(ticket);
+  // ── Auth — one-shot ticket cookie exchanged via POST /api/events/ticket ───
+  const userId = await redeemSseTicketFromCookie(req, res, 'channel');
   if (!userId) {
-    res.status(401).json({ error: 'Invalid or expired SSE ticket' });
+    res.status(401).json({ error: 'Missing, invalid, or expired SSE ticket' });
     return;
   }
 
@@ -508,14 +568,14 @@ const CHANNEL_SSE_SELECT = {
 // ─── Server-scoped SSE route — channel list updates ───────────────────────────
 
 /**
- * GET /api/events/server/:serverId?ticket=<nonce>
+ * GET /api/events/server/:serverId
  *
  * Streams real-time server events to authenticated, authorised clients using
  * Server-Sent Events. Scoped to a server so all members see the same sidebar,
  * member, message, and server updates regardless of which channel they are viewing.
  *
  * Auth: one-shot ticket pattern — call POST /api/events/ticket first, then
- * pass the returned nonce as ?ticket=<nonce>.
+ * open EventSource with credentials so the ticket cookie is sent.
  *
  * Authorisation: user must be a member of the server.
  */
@@ -527,16 +587,10 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     return;
   }
 
-  // ── Auth — one-shot ticket ────────────────────────────────────────────────
-  const ticket = typeof req.query.ticket === 'string' ? req.query.ticket : null;
-  if (!ticket) {
-    res.status(401).json({ error: 'Missing ticket query parameter' });
-    return;
-  }
-
-  const userId = await redeemTicket(ticket);
+  // ── Auth — one-shot ticket cookie ─────────────────────────────────────────
+  const userId = await redeemSseTicketFromCookie(req, res, 'server');
   if (!userId) {
-    res.status(401).json({ error: 'Invalid or expired SSE ticket' });
+    res.status(401).json({ error: 'Missing, invalid, or expired SSE ticket' });
     return;
   }
 
@@ -954,27 +1008,28 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
       }
     : undefined;
 
-  await finalizeSseSetup(req, res, sseState, subscriptions, { route: 'server-events', serverId }, serverReplayFrames);
+  await finalizeSseSetup(
+    req,
+    res,
+    sseState,
+    subscriptions,
+    { route: 'server-events', serverId },
+    serverReplayFrames,
+  );
 });
 
 // ─── User-scoped notification SSE route ──────────────────────────────────────
 
 /**
- * GET /api/events/user?ticket=<nonce>
+ * GET /api/events/user
  *
  * Streams real-time mention notifications to the authenticated user.
  * Each connected client only receives events addressed to their own userId.
  */
 eventsRouter.get('/user', async (req: Request, res: Response) => {
-  const ticket = typeof req.query.ticket === 'string' ? req.query.ticket : null;
-  if (!ticket) {
-    res.status(401).json({ error: 'Missing ticket query parameter' });
-    return;
-  }
-
-  const userId = await redeemTicket(ticket);
+  const userId = await redeemSseTicketFromCookie(req, res, 'user');
   if (!userId) {
-    res.status(401).json({ error: 'Invalid or expired SSE ticket' });
+    res.status(401).json({ error: 'Missing, invalid, or expired SSE ticket' });
     return;
   }
 
@@ -998,5 +1053,8 @@ eventsRouter.get('/user', async (req: Request, res: Response) => {
     },
   );
 
-  await finalizeSseSetup(req, res, sseState, [mentionSubscription], { route: 'user-events', userId });
+  await finalizeSseSetup(req, res, sseState, [mentionSubscription], {
+    route: 'user-events',
+    userId,
+  });
 });

--- a/harmony-backend/tests/events.router.member.test.ts
+++ b/harmony-backend/tests/events.router.member.test.ts
@@ -12,7 +12,7 @@ import { createApp } from '../src/app';
 import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
 import { redis } from '../src/db/redis';
-import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
+import { seedSseTestTicket, SSE_TEST_TICKET_COOKIE } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 
 const VALID_SERVER_ID = '550e8400-e29b-41d4-a716-446655440002';
@@ -97,19 +97,22 @@ function sseGet(
     if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
     const port = addr.port;
 
-    const req = http.get({ hostname: 'localhost', port, path }, (res) => {
-      const headers = res.headers as Record<string, string | string[] | undefined>;
-      const statusCode = res.statusCode ?? 0;
-      res.on('data', () => {});
-      const timer = setTimeout(() => {
-        res.destroy();
-        resolve({ statusCode, headers });
-      }, timeoutMs);
-      res.on('close', () => {
-        clearTimeout(timer);
-        resolve({ statusCode, headers });
-      });
-    });
+    const req = http.get(
+      { hostname: 'localhost', port, path, headers: { Cookie: SSE_TEST_TICKET_COOKIE } },
+      (res) => {
+        const headers = res.headers as Record<string, string | string[] | undefined>;
+        const statusCode = res.statusCode ?? 0;
+        res.on('data', () => {});
+        const timer = setTimeout(() => {
+          res.destroy();
+          resolve({ statusCode, headers });
+        }, timeoutMs);
+        res.on('close', () => {
+          clearTimeout(timer);
+          resolve({ statusCode, headers });
+        });
+      },
+    );
 
     req.on('error', reject);
     req.setTimeout(timeoutMs + 500, () => {
@@ -156,7 +159,7 @@ beforeEach(() => {
 // ─── Member event subscriptions ───────────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — member event subscriptions', () => {
-  const sseUrl = (id: string) => `/api/events/server/${id}?ticket=${SSE_TEST_TICKET}`;
+  const sseUrl = (id: string) => `/api/events/server/${id}`;
 
   it('subscribes to MEMBER_JOINED and MEMBER_LEFT event channels', async () => {
     await sseGet(httpServer, sseUrl(VALID_SERVER_ID));
@@ -184,12 +187,14 @@ describe('GET /api/events/server/:serverId — member:joined event', () => {
     // Capture the MEMBER_JOINED subscriber so we can invoke it directly
     let memberJoinedHandler: ((payload: unknown) => Promise<void>) | null = null;
 
-    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => Promise<void>) => {
-      if (channel === 'harmony:MEMBER_JOINED') {
-        memberJoinedHandler = handler;
-      }
-      return { unsubscribe: jest.fn(), ready: Promise.resolve() };
-    });
+    mockSubscribe.mockImplementation(
+      (channel: string, handler: (payload: unknown) => Promise<void>) => {
+        if (channel === 'harmony:MEMBER_JOINED') {
+          memberJoinedHandler = handler;
+        }
+        return { unsubscribe: jest.fn(), ready: Promise.resolve() };
+      },
+    );
 
     // Open the SSE connection (captures subscribers)
     const addr = httpServer.address();
@@ -199,7 +204,12 @@ describe('GET /api/events/server/:serverId — member:joined event', () => {
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
+        {
+          hostname: 'localhost',
+          port,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
+        },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -249,12 +259,14 @@ describe('GET /api/events/server/:serverId — member:joined event', () => {
 
     let memberJoinedHandler: ((payload: unknown) => Promise<void>) | null = null;
 
-    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => Promise<void>) => {
-      if (channel === 'harmony:MEMBER_JOINED') {
-        memberJoinedHandler = handler;
-      }
-      return { unsubscribe: jest.fn(), ready: Promise.resolve() };
-    });
+    mockSubscribe.mockImplementation(
+      (channel: string, handler: (payload: unknown) => Promise<void>) => {
+        if (channel === 'harmony:MEMBER_JOINED') {
+          memberJoinedHandler = handler;
+        }
+        return { unsubscribe: jest.fn(), ready: Promise.resolve() };
+      },
+    );
 
     const addr = httpServer.address();
     if (!addr || typeof addr === 'string') throw new Error('Bad address');
@@ -263,7 +275,12 @@ describe('GET /api/events/server/:serverId — member:joined event', () => {
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
+        {
+          hostname: 'localhost',
+          port,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
+        },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -302,12 +319,14 @@ describe('GET /api/events/server/:serverId — member:joined event', () => {
   it('does not emit member:joined for a different server', async () => {
     let memberJoinedHandler: ((payload: unknown) => Promise<void>) | null = null;
 
-    mockSubscribe.mockImplementation((channel: string, handler: (payload: unknown) => Promise<void>) => {
-      if (channel === 'harmony:MEMBER_JOINED') {
-        memberJoinedHandler = handler;
-      }
-      return { unsubscribe: jest.fn(), ready: Promise.resolve() };
-    });
+    mockSubscribe.mockImplementation(
+      (channel: string, handler: (payload: unknown) => Promise<void>) => {
+        if (channel === 'harmony:MEMBER_JOINED') {
+          memberJoinedHandler = handler;
+        }
+        return { unsubscribe: jest.fn(), ready: Promise.resolve() };
+      },
+    );
 
     const addr = httpServer.address();
     if (!addr || typeof addr === 'string') throw new Error('Bad address');
@@ -316,7 +335,12 @@ describe('GET /api/events/server/:serverId — member:joined event', () => {
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
+        {
+          hostname: 'localhost',
+          port,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
+        },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -368,7 +392,12 @@ describe('GET /api/events/server/:serverId — member:left event', () => {
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
+        {
+          hostname: 'localhost',
+          port,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
+        },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -416,7 +445,12 @@ describe('GET /api/events/server/:serverId — member:left event', () => {
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
+        {
+          hostname: 'localhost',
+          port,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
+        },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 

--- a/harmony-backend/tests/events.router.server.test.ts
+++ b/harmony-backend/tests/events.router.server.test.ts
@@ -12,7 +12,7 @@ import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
 import { redis } from '../src/db/redis';
 import { createDeferred, waitFor } from './helpers/async';
-import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
+import { seedSseTestTicket, SSE_TEST_TICKET_COOKIE } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 import type { ChannelCreatedPayload, MessageCreatedPayload } from '../src/events/eventTypes';
 
@@ -99,19 +99,22 @@ function sseGet(
     if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
     const port = addr.port;
 
-    const req = http.get({ hostname: 'localhost', port, path }, (res) => {
-      const headers = res.headers as Record<string, string | string[] | undefined>;
-      const statusCode = res.statusCode ?? 0;
-      res.on('data', () => {});
-      const timer = setTimeout(() => {
-        res.destroy();
-        resolve({ statusCode, headers });
-      }, timeoutMs);
-      res.on('close', () => {
-        clearTimeout(timer);
-        resolve({ statusCode, headers });
-      });
-    });
+    const req = http.get(
+      { hostname: 'localhost', port, path, headers: { Cookie: SSE_TEST_TICKET_COOKIE } },
+      (res) => {
+        const headers = res.headers as Record<string, string | string[] | undefined>;
+        const statusCode = res.statusCode ?? 0;
+        res.on('data', () => {});
+        const timer = setTimeout(() => {
+          res.destroy();
+          resolve({ statusCode, headers });
+        }, timeoutMs);
+        res.on('close', () => {
+          clearTimeout(timer);
+          resolve({ statusCode, headers });
+        });
+      },
+    );
 
     req.on('error', reject);
     req.setTimeout(timeoutMs + 500, () => {
@@ -163,7 +166,7 @@ beforeEach(() => {
 // ─── SSE headers ──────────────────────────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — SSE headers', () => {
-  const sseUrl = (id: string) => `/api/events/server/${id}?ticket=${SSE_TEST_TICKET}`;
+  const sseUrl = (id: string) => `/api/events/server/${id}`;
 
   it('sets Content-Type: text/event-stream', async () => {
     const { headers } = await sseGet(server, sseUrl(VALID_SERVER_ID));
@@ -196,7 +199,7 @@ describe('GET /api/events/server/:serverId — SSE headers', () => {
 });
 
 describe('GET /api/events/server/:serverId — subscription readiness', () => {
-  const sseUrl = `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`;
+  const sseUrl = `/api/events/server/${VALID_SERVER_ID}`;
 
   it('waits for all server-scoped subscriptions before flushing SSE headers', async () => {
     const ready = createDeferred<void>();
@@ -210,10 +213,13 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     const port = addr.port;
 
     let headersReceived = false;
-    const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
-      headersReceived = true;
-      res.resume();
-    });
+    const req = http.get(
+      { hostname: 'localhost', port, path: sseUrl, headers: { Cookie: SSE_TEST_TICKET_COOKIE } },
+      (res) => {
+        headersReceived = true;
+        res.resume();
+      },
+    );
 
     await new Promise((resolve) => setTimeout(resolve, 75));
     expect(headersReceived).toBe(false);
@@ -248,12 +254,15 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     const chunks: string[] = [];
     let response: http.IncomingMessage | null = null;
     await new Promise<void>((resolve, reject) => {
-      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
-        response = res;
-        responseStarted.resolve();
-        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
-        res.on('error', reject);
-      });
+      const req = http.get(
+        { hostname: 'localhost', port, path: sseUrl, headers: { Cookie: SSE_TEST_TICKET_COOKIE } },
+        (res) => {
+          response = res;
+          responseStarted.resolve();
+          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+          res.on('error', reject);
+        },
+      );
 
       req.on('error', reject);
 
@@ -325,7 +334,7 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     let response: http.IncomingMessage | null = null;
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: sseUrl },
+        { hostname: 'localhost', port, path: sseUrl, headers: { Cookie: SSE_TEST_TICKET_COOKIE } },
         (res) => {
           response = res;
           responseStarted.resolve();
@@ -372,7 +381,7 @@ describe('GET /api/events/server/:serverId — Last-Event-ID replay', () => {
   const REPLAY_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440020';
   const REPLAY_MESSAGE_ID = '550e8400-e29b-41d4-a716-446655440021';
   const lastEventId = '2026-04-19T09:59:00.000Z';
-  const sseUrlWithReplay = `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}&lastEventId=${encodeURIComponent(lastEventId)}`;
+  const sseUrlWithReplay = `/api/events/server/${VALID_SERVER_ID}?lastEventId=${encodeURIComponent(lastEventId)}`;
 
   it('replays message:created events missed during the reconnect gap', async () => {
     (prisma.channel.findMany as jest.Mock).mockResolvedValue([{ id: REPLAY_CHANNEL_ID }]);
@@ -396,15 +405,23 @@ describe('GET /api/events/server/:serverId — Last-Event-ID replay', () => {
 
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
-      const req = http.get({ hostname: 'localhost', port, path: sseUrlWithReplay }, (res) => {
-        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
-        res.on('error', reject);
-        setTimeout(() => {
-          res.destroy();
-          req.destroy();
-          resolve();
-        }, 150);
-      });
+      const req = http.get(
+        {
+          hostname: 'localhost',
+          port,
+          path: sseUrlWithReplay,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
+        },
+        (res) => {
+          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+          res.on('error', reject);
+          setTimeout(() => {
+            res.destroy();
+            req.destroy();
+            resolve();
+          }, 150);
+        },
+      );
       req.on('error', reject);
     });
 
@@ -463,7 +480,12 @@ describe('GET /api/events/server/:serverId — Last-Event-ID replay', () => {
     const responseStarted = createDeferred<void>();
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: sseUrlWithReplay },
+        {
+          hostname: 'localhost',
+          port,
+          path: sseUrlWithReplay,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
+        },
         (res) => {
           responseStarted.resolve();
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
@@ -515,10 +537,7 @@ describe('GET /api/events/server/:serverId — input validation', () => {
   });
 
   it('accepts a valid UUID-formatted serverId and returns 200', async () => {
-    const { statusCode } = await sseGet(
-      server,
-      `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
-    );
+    const { statusCode } = await sseGet(server, `/api/events/server/${VALID_SERVER_ID}`);
     expect(statusCode).toBe(200);
   });
 });
@@ -526,15 +545,39 @@ describe('GET /api/events/server/:serverId — input validation', () => {
 // ─── Auth ─────────────────────────────────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — auth', () => {
+  it('issues the SSE ticket as an HTTP-only cookie, not a response body token', async () => {
+    const res = await request(app)
+      .post('/api/events/ticket')
+      .set('Authorization', 'Bearer valid-access-token')
+      .send({ stream: 'server' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(res.headers['set-cookie']).toEqual([
+      expect.stringContaining('harmony_sse_ticket_server='),
+    ]);
+    expect(res.headers['set-cookie'][0]).toContain('HttpOnly');
+    expect(res.headers['set-cookie'][0]).toContain('Max-Age=60');
+    expect(res.headers['set-cookie'][0]).not.toContain('valid-access-token');
+    expect(res.body).not.toHaveProperty('ticket');
+  });
+
   it('returns 401 when ticket is missing', async () => {
     const res = await request(app).get(`/api/events/server/${VALID_SERVER_ID}`);
     expect(res.status).toBe(401);
   });
 
-  it('returns 401 when ticket is invalid or already redeemed', async () => {
+  it('returns 401 when a ticket is provided only in the query string', async () => {
     const res = await request(app).get(
       `/api/events/server/${VALID_SERVER_ID}?ticket=11111111-1111-4111-8111-111111111111`,
     );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when the ticket cookie is invalid or already redeemed', async () => {
+    const res = await request(app)
+      .get(`/api/events/server/${VALID_SERVER_ID}`)
+      .set('Cookie', 'harmony_sse_ticket_server=11111111-1111-4111-8111-111111111111');
     expect(res.status).toBe(401);
   });
 });
@@ -545,18 +588,18 @@ describe('GET /api/events/server/:serverId — authorisation', () => {
   it('returns 404 when server is not found', async () => {
     (prisma.server.findUnique as jest.Mock).mockResolvedValueOnce(null);
 
-    const res = await request(app).get(
-      `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
-    );
+    const res = await request(app)
+      .get(`/api/events/server/${VALID_SERVER_ID}`)
+      .set('Cookie', SSE_TEST_TICKET_COOKIE);
     expect(res.status).toBe(404);
   });
 
   it('returns 403 when user is not a member of the server', async () => {
     (prisma.serverMember.findFirst as jest.Mock).mockResolvedValueOnce(null);
 
-    const res = await request(app).get(
-      `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
-    );
+    const res = await request(app)
+      .get(`/api/events/server/${VALID_SERVER_ID}`)
+      .set('Cookie', SSE_TEST_TICKET_COOKIE);
     expect(res.status).toBe(403);
   });
 });
@@ -569,9 +612,9 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     mockSubscribe.mockReturnValueOnce({ unsubscribe: firstUnsub, ready: failingReady });
     mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
 
-    const res = await request(app).get(
-      `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
-    );
+    const res = await request(app)
+      .get(`/api/events/server/${VALID_SERVER_ID}`)
+      .set('Cookie', SSE_TEST_TICKET_COOKIE);
 
     expect(res.status).toBe(503);
     expect(res.body).toEqual({ error: 'Failed to establish event stream' });
@@ -592,9 +635,9 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     mockSubscribe.mockReturnValueOnce({ unsubscribe: thirdUnsub, ready: failingReady });
     mockSubscribe.mockReturnValue({ unsubscribe: jest.fn(), ready: Promise.resolve() });
 
-    const res = await request(app).get(
-      `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
-    );
+    const res = await request(app)
+      .get(`/api/events/server/${VALID_SERVER_ID}`)
+      .set('Cookie', SSE_TEST_TICKET_COOKIE);
 
     // Headers must NOT have been flushed — client receives a proper 503 JSON response.
     expect(res.status).toBe(503);

--- a/harmony-backend/tests/events.router.sse-server-updated.test.ts
+++ b/harmony-backend/tests/events.router.sse-server-updated.test.ts
@@ -12,7 +12,7 @@ import { createApp } from '../src/app';
 import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
 import { redis } from '../src/db/redis';
-import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
+import { seedSseTestTicket, SSE_TEST_CHANNEL_TICKET_COOKIE } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 
 const VALID_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440001';
@@ -82,53 +82,6 @@ jest.mock('../src/db/redis', () => {
 
 type SubscriberHandler = (payload: unknown) => void;
 
-/**
- * Collect SSE data from an open streaming connection for a window of time,
- * optionally triggering an event bus publish mid-stream, then resolve with
- * all received text chunks concatenated.
- */
-function sseGetWithEvent(
-  server: http.Server,
-  path: string,
-  onConnected: (triggerEvent: () => void) => void,
-  timeoutMs = 600,
-): Promise<{ statusCode: number; body: string }> {
-  return new Promise((resolve, reject) => {
-    const addr = server.address();
-    if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
-    const port = addr.port;
-
-    let body = '';
-
-    const req = http.get({ hostname: 'localhost', port, path }, (res) => {
-      const statusCode = res.statusCode ?? 0;
-
-      res.on('data', (chunk: Buffer) => {
-        body += chunk.toString();
-      });
-
-      // Allow caller to trigger the event once connected
-      onConnected(() => {});
-
-      const timer = setTimeout(() => {
-        res.destroy();
-        resolve({ statusCode, body });
-      }, timeoutMs);
-
-      res.on('close', () => {
-        clearTimeout(timer);
-        resolve({ statusCode, body });
-      });
-    });
-
-    req.on('error', reject);
-    req.setTimeout(timeoutMs + 500, () => {
-      req.destroy();
-      reject(new Error('Request timed out'));
-    });
-  });
-}
-
 // ─── Test setup ───────────────────────────────────────────────────────────────
 
 const mockSubscribe = eventBus.subscribe as jest.Mock;
@@ -170,7 +123,7 @@ beforeEach(() => {
 // ─── SERVER_UPDATED subscription ─────────────────────────────────────────────
 
 describe('GET /api/events/channel/:channelId — SERVER_UPDATED subscription', () => {
-  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?ticket=${SSE_TEST_TICKET}`;
+  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}`;
 
   it('subscribes to SERVER_UPDATED event channel', async () => {
     await new Promise<void>((resolve, reject) => {
@@ -178,13 +131,21 @@ describe('GET /api/events/channel/:channelId — SERVER_UPDATED subscription', (
       if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
       const port = (addr as { port: number }).port;
 
-      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
-        res.on('data', () => {});
-        setTimeout(() => {
-          res.destroy();
-          resolve();
-        }, 300);
-      });
+      const req = http.get(
+        {
+          hostname: 'localhost',
+          port,
+          path: sseUrl,
+          headers: { Cookie: SSE_TEST_CHANNEL_TICKET_COOKIE },
+        },
+        (res) => {
+          res.on('data', () => {});
+          setTimeout(() => {
+            res.destroy();
+            resolve();
+          }, 300);
+        },
+      );
       req.on('error', reject);
     });
 
@@ -208,22 +169,30 @@ describe('GET /api/events/channel/:channelId — SERVER_UPDATED subscription', (
       if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
       const port = (addr as { port: number }).port;
 
-      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
-        res.on('data', (chunk: Buffer) => {
-          receivedBody += chunk.toString();
-        });
+      const req = http.get(
+        {
+          hostname: 'localhost',
+          port,
+          path: sseUrl,
+          headers: { Cookie: SSE_TEST_CHANNEL_TICKET_COOKIE },
+        },
+        (res) => {
+          res.on('data', (chunk: Buffer) => {
+            receivedBody += chunk.toString();
+          });
 
-        // Fire the event after a brief moment to let subscriptions register
-        setTimeout(() => {
-          const handler = capturedHandlers.get('harmony:SERVER_UPDATED');
-          if (handler) handler(serverUpdatedPayload);
-        }, 100);
+          // Fire the event after a brief moment to let subscriptions register
+          setTimeout(() => {
+            const handler = capturedHandlers.get('harmony:SERVER_UPDATED');
+            if (handler) handler(serverUpdatedPayload);
+          }, 100);
 
-        setTimeout(() => {
-          res.destroy();
-          resolve();
-        }, 400);
-      });
+          setTimeout(() => {
+            res.destroy();
+            resolve();
+          }, 400);
+        },
+      );
       req.on('error', reject);
     });
 
@@ -248,21 +217,29 @@ describe('GET /api/events/channel/:channelId — SERVER_UPDATED subscription', (
       if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
       const port = (addr as { port: number }).port;
 
-      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
-        res.on('data', (chunk: Buffer) => {
-          receivedBody += chunk.toString();
-        });
+      const req = http.get(
+        {
+          hostname: 'localhost',
+          port,
+          path: sseUrl,
+          headers: { Cookie: SSE_TEST_CHANNEL_TICKET_COOKIE },
+        },
+        (res) => {
+          res.on('data', (chunk: Buffer) => {
+            receivedBody += chunk.toString();
+          });
 
-        setTimeout(() => {
-          const handler = capturedHandlers.get('harmony:SERVER_UPDATED');
-          if (handler) handler(serverUpdatedPayload);
-        }, 100);
+          setTimeout(() => {
+            const handler = capturedHandlers.get('harmony:SERVER_UPDATED');
+            if (handler) handler(serverUpdatedPayload);
+          }, 100);
 
-        setTimeout(() => {
-          res.destroy();
-          resolve();
-        }, 400);
-      });
+          setTimeout(() => {
+            res.destroy();
+            resolve();
+          }, 400);
+        },
+      );
       req.on('error', reject);
     });
 

--- a/harmony-backend/tests/events.router.status.test.ts
+++ b/harmony-backend/tests/events.router.status.test.ts
@@ -12,7 +12,7 @@ import { createApp } from '../src/app';
 import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
 import { redis } from '../src/db/redis';
-import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
+import { seedSseTestTicket, SSE_TEST_TICKET_COOKIE } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 
 const VALID_SERVER_ID = '550e8400-e29b-41d4-a716-446655440002';
@@ -97,19 +97,22 @@ function sseGet(
     if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
     const port = addr.port;
 
-    const req = http.get({ hostname: 'localhost', port, path }, (res) => {
-      const headers = res.headers as Record<string, string | string[] | undefined>;
-      const statusCode = res.statusCode ?? 0;
-      res.on('data', () => {});
-      const timer = setTimeout(() => {
-        res.destroy();
-        resolve({ statusCode, headers });
-      }, timeoutMs);
-      res.on('close', () => {
-        clearTimeout(timer);
-        resolve({ statusCode, headers });
-      });
-    });
+    const req = http.get(
+      { hostname: 'localhost', port, path, headers: { Cookie: SSE_TEST_TICKET_COOKIE } },
+      (res) => {
+        const headers = res.headers as Record<string, string | string[] | undefined>;
+        const statusCode = res.statusCode ?? 0;
+        res.on('data', () => {});
+        const timer = setTimeout(() => {
+          res.destroy();
+          resolve({ statusCode, headers });
+        }, timeoutMs);
+        res.on('close', () => {
+          clearTimeout(timer);
+          resolve({ statusCode, headers });
+        });
+      },
+    );
 
     req.on('error', reject);
     req.setTimeout(timeoutMs + 500, () => {
@@ -148,7 +151,7 @@ beforeEach(() => {
 // ─── Status event subscription ────────────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — status event subscription', () => {
-  const sseUrl = (id: string) => `/api/events/server/${id}?ticket=${SSE_TEST_TICKET}`;
+  const sseUrl = (id: string) => `/api/events/server/${id}`;
 
   it('subscribes to USER_STATUS_CHANGED event channel', async () => {
     await sseGet(httpServer, sseUrl(VALID_SERVER_ID));
@@ -187,7 +190,12 @@ describe('GET /api/events/server/:serverId — member:statusChanged event', () =
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
+        {
+          hostname: 'localhost',
+          port,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
+        },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -236,7 +244,12 @@ describe('GET /api/events/server/:serverId — member:statusChanged event', () =
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
+        {
+          hostname: 'localhost',
+          port,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
+        },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 
@@ -285,7 +298,12 @@ describe('GET /api/events/server/:serverId — member:statusChanged event', () =
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
       const req = http.get(
-        { hostname: 'localhost', port, path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}` },
+        {
+          hostname: 'localhost',
+          port,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
+        },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
 

--- a/harmony-backend/tests/events.router.test.ts
+++ b/harmony-backend/tests/events.router.test.ts
@@ -16,7 +16,7 @@ import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
 import { redis } from '../src/db/redis';
 import { createDeferred, waitFor } from './helpers/async';
-import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
+import { seedSseTestTicket, SSE_TEST_CHANNEL_TICKET_COOKIE } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 import type { MessageCreatedPayload } from '../src/events/eventTypes';
 
@@ -95,21 +95,24 @@ function sseGet(
     if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
     const port = addr.port;
 
-    const req = http.get({ hostname: 'localhost', port, path }, (res) => {
-      const headers = res.headers as Record<string, string | string[] | undefined>;
-      const statusCode = res.statusCode ?? 0;
-      // Drain data to prevent socket from stalling
-      res.on('data', () => {});
-      // Resolve after a short window — we've already captured headers
-      const timer = setTimeout(() => {
-        res.destroy();
-        resolve({ statusCode, headers });
-      }, timeoutMs);
-      res.on('close', () => {
-        clearTimeout(timer);
-        resolve({ statusCode, headers });
-      });
-    });
+    const req = http.get(
+      { hostname: 'localhost', port, path, headers: { Cookie: SSE_TEST_CHANNEL_TICKET_COOKIE } },
+      (res) => {
+        const headers = res.headers as Record<string, string | string[] | undefined>;
+        const statusCode = res.statusCode ?? 0;
+        // Drain data to prevent socket from stalling
+        res.on('data', () => {});
+        // Resolve after a short window — we've already captured headers
+        const timer = setTimeout(() => {
+          res.destroy();
+          resolve({ statusCode, headers });
+        }, timeoutMs);
+        res.on('close', () => {
+          clearTimeout(timer);
+          resolve({ statusCode, headers });
+        });
+      },
+    );
 
     req.on('error', reject);
     req.setTimeout(timeoutMs + 500, () => {
@@ -150,7 +153,7 @@ beforeEach(() => {
 
 describe('GET /api/events/channel/:channelId — SSE headers', () => {
   const VALID_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440001';
-  const sseUrl = (id: string) => `/api/events/channel/${id}?ticket=${SSE_TEST_TICKET}`;
+  const sseUrl = (id: string) => `/api/events/channel/${id}`;
 
   it('sets Content-Type: text/event-stream', async () => {
     const { headers } = await sseGet(server, sseUrl(VALID_CHANNEL_ID));
@@ -184,7 +187,7 @@ describe('GET /api/events/channel/:channelId — SSE headers', () => {
 
 describe('GET /api/events/channel/:channelId — subscription readiness', () => {
   const VALID_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440001';
-  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?ticket=${SSE_TEST_TICKET}`;
+  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}`;
 
   it('waits for all subscription handshakes before flushing SSE headers', async () => {
     const ready = createDeferred<void>();
@@ -198,10 +201,18 @@ describe('GET /api/events/channel/:channelId — subscription readiness', () => 
     const port = addr.port;
 
     let headersReceived = false;
-    const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
-      headersReceived = true;
-      res.resume();
-    });
+    const req = http.get(
+      {
+        hostname: 'localhost',
+        port,
+        path: sseUrl,
+        headers: { Cookie: SSE_TEST_CHANNEL_TICKET_COOKIE },
+      },
+      (res) => {
+        headersReceived = true;
+        res.resume();
+      },
+    );
 
     await new Promise((resolve) => setTimeout(resolve, 75));
     expect(headersReceived).toBe(false);
@@ -253,12 +264,20 @@ describe('GET /api/events/channel/:channelId — subscription readiness', () => 
     const chunks: string[] = [];
     let response: http.IncomingMessage | null = null;
     await new Promise<void>((resolve, reject) => {
-      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
-        response = res;
-        responseStarted.resolve();
-        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
-        res.on('error', reject);
-      });
+      const req = http.get(
+        {
+          hostname: 'localhost',
+          port,
+          path: sseUrl,
+          headers: { Cookie: SSE_TEST_CHANNEL_TICKET_COOKIE },
+        },
+        (res) => {
+          response = res;
+          responseStarted.resolve();
+          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+          res.on('error', reject);
+        },
+      );
 
       req.on('error', reject);
 
@@ -297,7 +316,7 @@ describe('GET /api/events/channel/:channelId — subscription readiness', () => 
 describe('GET /api/events/channel/:channelId — Last-Event-ID replay', () => {
   const VALID_CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440001';
   const lastEventId = '2026-04-19T09:59:00.000Z';
-  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?ticket=${SSE_TEST_TICKET}&lastEventId=${encodeURIComponent(lastEventId)}`;
+  const sseUrl = `/api/events/channel/${VALID_CHANNEL_ID}?lastEventId=${encodeURIComponent(lastEventId)}`;
 
   it('replays message:created events missed during the reconnect gap', async () => {
     const missedMessage = {
@@ -319,15 +338,23 @@ describe('GET /api/events/channel/:channelId — Last-Event-ID replay', () => {
 
     const chunks: string[] = [];
     await new Promise<void>((resolve, reject) => {
-      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
-        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
-        res.on('error', reject);
-        setTimeout(() => {
-          res.destroy();
-          req.destroy();
-          resolve();
-        }, 150);
-      });
+      const req = http.get(
+        {
+          hostname: 'localhost',
+          port,
+          path: sseUrl,
+          headers: { Cookie: SSE_TEST_CHANNEL_TICKET_COOKIE },
+        },
+        (res) => {
+          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+          res.on('error', reject);
+          setTimeout(() => {
+            res.destroy();
+            req.destroy();
+            resolve();
+          }, 150);
+        },
+      );
       req.on('error', reject);
     });
 
@@ -360,7 +387,7 @@ describe('GET /api/events/channel/:channelId — input validation', () => {
   it('accepts a valid UUID-formatted channelId and returns 200', async () => {
     const { statusCode } = await sseGet(
       server,
-      `/api/events/channel/550e8400-e29b-41d4-a716-446655440001?ticket=${SSE_TEST_TICKET}`,
+      `/api/events/channel/550e8400-e29b-41d4-a716-446655440001`,
     );
     expect(statusCode).toBe(200);
   });
@@ -377,10 +404,7 @@ describe('GET /api/events/channel/:channelId — subscription readiness', () => 
       ready: channel === 'harmony:MESSAGE_CREATED' ? failingReady : Promise.resolve(),
     }));
 
-    const res = await sseGet(
-      server,
-      `/api/events/channel/550e8400-e29b-41d4-a716-446655440001?ticket=${SSE_TEST_TICKET}`,
-    );
+    const res = await sseGet(server, `/api/events/channel/550e8400-e29b-41d4-a716-446655440001`);
 
     expect(res.statusCode).toBe(503);
   });

--- a/harmony-backend/tests/events.router.visibility.test.ts
+++ b/harmony-backend/tests/events.router.visibility.test.ts
@@ -12,7 +12,7 @@ import { createApp } from '../src/app';
 import { eventBus } from '../src/events/eventBus';
 import { prisma } from '../src/db/prisma';
 import { redis } from '../src/db/redis';
-import { seedSseTestTicket, SSE_TEST_TICKET } from './helpers/redisTicketJestMock';
+import { seedSseTestTicket, SSE_TEST_TICKET_COOKIE } from './helpers/redisTicketJestMock';
 import type { Express } from 'express';
 
 const VALID_SERVER_ID = '550e8400-e29b-41d4-a716-446655440003';
@@ -97,19 +97,22 @@ function sseGet(
     if (!addr || typeof addr === 'string') return reject(new Error('Bad server address'));
     const port = addr.port;
 
-    const req = http.get({ hostname: 'localhost', port, path }, (res) => {
-      const headers = res.headers as Record<string, string | string[] | undefined>;
-      const statusCode = res.statusCode ?? 0;
-      res.on('data', () => {});
-      const timer = setTimeout(() => {
-        res.destroy();
-        resolve({ statusCode, headers });
-      }, timeoutMs);
-      res.on('close', () => {
-        clearTimeout(timer);
-        resolve({ statusCode, headers });
-      });
-    });
+    const req = http.get(
+      { hostname: 'localhost', port, path, headers: { Cookie: SSE_TEST_TICKET_COOKIE } },
+      (res) => {
+        const headers = res.headers as Record<string, string | string[] | undefined>;
+        const statusCode = res.statusCode ?? 0;
+        res.on('data', () => {});
+        const timer = setTimeout(() => {
+          res.destroy();
+          resolve({ statusCode, headers });
+        }, timeoutMs);
+        res.on('close', () => {
+          clearTimeout(timer);
+          resolve({ statusCode, headers });
+        });
+      },
+    );
 
     req.on('error', reject);
     req.setTimeout(timeoutMs + 500, () => {
@@ -162,7 +165,7 @@ beforeEach(() => {
 // ─── VISIBILITY_CHANGED subscription ──────────────────────────────────────────
 
 describe('GET /api/events/server/:serverId — visibility subscription', () => {
-  const sseUrl = (id: string) => `/api/events/server/${id}?ticket=${SSE_TEST_TICKET}`;
+  const sseUrl = (id: string) => `/api/events/server/${id}`;
 
   it('subscribes to VISIBILITY_CHANGED event channel', async () => {
     await sseGet(httpServer, sseUrl(VALID_SERVER_ID));
@@ -206,7 +209,8 @@ describe('GET /api/events/server/:serverId — channel:visibility-changed event'
         {
           hostname: 'localhost',
           port,
-          path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
         },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
@@ -269,7 +273,8 @@ describe('GET /api/events/server/:serverId — channel:visibility-changed event'
         {
           hostname: 'localhost',
           port,
-          path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
         },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
@@ -327,7 +332,8 @@ describe('GET /api/events/server/:serverId — channel:visibility-changed event'
         {
           hostname: 'localhost',
           port,
-          path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
+          path: `/api/events/server/${VALID_SERVER_ID}`,
+          headers: { Cookie: SSE_TEST_TICKET_COOKIE },
         },
         (res) => {
           res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));

--- a/harmony-backend/tests/helpers/redisTicketJestMock.ts
+++ b/harmony-backend/tests/helpers/redisTicketJestMock.ts
@@ -5,6 +5,8 @@
 
 export const SSE_TEST_TICKET = '550e8400-e29b-41d4-a716-446655440099';
 export const SSE_TEST_USER_ID = 'test-user-id';
+export const SSE_TEST_TICKET_COOKIE = `harmony_sse_ticket_server=${SSE_TEST_TICKET}`;
+export const SSE_TEST_CHANNEL_TICKET_COOKIE = `harmony_sse_ticket_channel=${SSE_TEST_TICKET}`;
 
 export function redisTicketMockFactory(): { redis: Record<string, jest.Mock> } {
   const store = new Map<string, string>();

--- a/harmony-frontend/src/__tests__/useChannelEvents.test.tsx
+++ b/harmony-frontend/src/__tests__/useChannelEvents.test.tsx
@@ -9,6 +9,7 @@
 
 import { renderHook, act } from '@testing-library/react';
 import { useChannelEvents } from '../hooks/useChannelEvents';
+import { fetchSseTicket } from '../lib/api-client';
 import type { Message } from '../types/message';
 import type { Server } from '../types/server';
 
@@ -16,7 +17,7 @@ import type { Server } from '../types/server';
 
 jest.mock('../lib/api-client', () => ({
   getAccessToken: jest.fn(() => 'mock-token'),
-  fetchSseTicket: jest.fn(() => Promise.resolve('mock-ticket')),
+  fetchSseTicket: jest.fn(() => Promise.resolve()),
   refreshAccessToken: jest.fn(() => Promise.resolve()),
 }));
 
@@ -39,7 +40,7 @@ interface MockEventSourceInstance {
 
 let mockEventSourceInstance: MockEventSourceInstance | null = null;
 
-const MockEventSource = jest.fn().mockImplementation((url: string) => {
+const MockEventSource = jest.fn().mockImplementation((url: string, _init?: EventSourceInit) => {
   const handlers = new Map<string, EventSourceHandler[]>();
 
   const instance: MockEventSourceInstance = {
@@ -149,9 +150,11 @@ describe('useChannelEvents — connection', () => {
     );
     await flushPromises();
 
-    expect(MockEventSource).toHaveBeenCalledWith(
-      `${API_URL}/api/events/channel/${CHANNEL_ID}?ticket=mock-ticket`,
-    );
+    expect(MockEventSource).toHaveBeenCalledWith(`${API_URL}/api/events/channel/${CHANNEL_ID}`, {
+      withCredentials: true,
+    });
+    expect(fetchSseTicket).toHaveBeenCalledWith(API_URL, 'mock-token', 'channel');
+    expect(new URL(mockEventSourceInstance!.url).search).toBe('');
   });
 
   it('does NOT create EventSource when enabled=false', async () => {

--- a/harmony-frontend/src/__tests__/useServerEvents.test.tsx
+++ b/harmony-frontend/src/__tests__/useServerEvents.test.tsx
@@ -10,6 +10,7 @@
 
 import { renderHook, act } from '@testing-library/react';
 import { useServerEvents } from '../hooks/useServerEvents';
+import { fetchSseTicket } from '../lib/api-client';
 import { ChannelType, ChannelVisibility } from '../types/channel';
 import type { Channel } from '../types/channel';
 import type { Message } from '../types/message';
@@ -19,7 +20,7 @@ import type { User } from '../types/user';
 
 jest.mock('../lib/api-client', () => ({
   getAccessToken: jest.fn(() => 'mock-token'),
-  fetchSseTicket: jest.fn(() => Promise.resolve('mock-ticket')),
+  fetchSseTicket: jest.fn(() => Promise.resolve()),
   refreshAccessToken: jest.fn(() => Promise.resolve()),
 }));
 
@@ -41,7 +42,7 @@ interface MockEventSourceInstance {
 
 let mockEventSourceInstance: MockEventSourceInstance | null = null;
 
-const MockEventSource = jest.fn().mockImplementation((url: string) => {
+const MockEventSource = jest.fn().mockImplementation((url: string, _init?: EventSourceInit) => {
   const handlers = new Map<string, EventSourceHandler[]>();
 
   const instance: MockEventSourceInstance = {
@@ -161,9 +162,11 @@ describe('useServerEvents — connection', () => {
     );
     await flushPromises();
 
-    expect(MockEventSource).toHaveBeenCalledWith(
-      `${API_URL}/api/events/server/${SERVER_ID}?ticket=mock-ticket`,
-    );
+    expect(MockEventSource).toHaveBeenCalledWith(`${API_URL}/api/events/server/${SERVER_ID}`, {
+      withCredentials: true,
+    });
+    expect(fetchSseTicket).toHaveBeenCalledWith(API_URL, 'mock-token', 'server');
+    expect(new URL(mockEventSourceInstance!.url).search).toBe('');
   });
 
   it('does NOT create EventSource when enabled=false', async () => {

--- a/harmony-frontend/src/components/channel/NotificationBell.tsx
+++ b/harmony-frontend/src/components/channel/NotificationBell.tsx
@@ -59,7 +59,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
   const router = useRouter();
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [isOpen, setIsOpen] = useState(false);
-  const unreadCount = useMemo(() => notifications.filter((n) => !n.read).length, [notifications]);
+  const unreadCount = useMemo(() => notifications.filter(n => !n.read).length, [notifications]);
   const [isLoading, setIsLoading] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -93,16 +93,15 @@ export function NotificationBell({ userId }: NotificationBellProps) {
     let cancelled = false;
 
     (async () => {
-      let ticket: string;
       try {
-        ticket = await fetchSseTicket(apiBase, token);
+        await fetchSseTicket(apiBase, token, 'user');
       } catch {
         return; // abort silently — notification bell is non-critical
       }
       if (cancelled) return;
 
-      const url = `${apiBase}/api/events/user?ticket=${encodeURIComponent(ticket)}`;
-      const es = new EventSource(url);
+      const url = `${apiBase}/api/events/user`;
+      const es = new EventSource(url, { withCredentials: true });
       eventSourceRef.current = es;
 
       es.addEventListener('notification:mention', (e: MessageEvent) => {
@@ -137,7 +136,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
               },
             },
           };
-          setNotifications((prev) => [optimistic, ...prev].slice(0, 50));
+          setNotifications(prev => [optimistic, ...prev].slice(0, 50));
         } catch {
           // malformed payload — ignore
         }
@@ -151,7 +150,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
       eventSourceRef.current?.close();
       eventSourceRef.current = null;
     };
-  }, [userId]);
+  }, [userId, loadNotifications]);
 
   // Close panel on outside click
   useEffect(() => {
@@ -166,15 +165,13 @@ export function NotificationBell({ userId }: NotificationBellProps) {
   }, [isOpen]);
 
   const toggleOpen = () => {
-    setIsOpen((prev) => !prev);
+    setIsOpen(prev => !prev);
   };
 
   const markAsRead = async (id: string) => {
     try {
       await apiClient.trpcMutation('notification.markAsRead', { notificationId: id });
-      setNotifications((prev) =>
-        prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
-      );
+      setNotifications(prev => prev.map(n => (n.id === id ? { ...n, read: true } : n)));
     } catch {
       // ignore — non-critical, badge will self-correct on next load
     }
@@ -183,7 +180,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
   const markAllAsRead = async () => {
     try {
       await apiClient.trpcMutation('notification.markAllAsRead');
-      setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+      setNotifications(prev => prev.map(n => ({ ...n, read: true })));
     } catch {
       // ignore — non-critical, badge will self-correct on next load
     }
@@ -235,16 +232,12 @@ export function NotificationBell({ userId }: NotificationBellProps) {
 
           {/* List */}
           <ul className='max-h-80 overflow-y-auto'>
-            {isLoading && (
-              <li className='px-4 py-6 text-center text-sm text-gray-400'>Loading…</li>
-            )}
+            {isLoading && <li className='px-4 py-6 text-center text-sm text-gray-400'>Loading…</li>}
             {!isLoading && notifications.length === 0 && (
-              <li className='px-4 py-6 text-center text-sm text-gray-400'>
-                No notifications yet.
-              </li>
+              <li className='px-4 py-6 text-center text-sm text-gray-400'>No notifications yet.</li>
             )}
             {!isLoading &&
-              notifications.map((n) => {
+              notifications.map(n => {
                 const serverSlug = n.channel?.server?.slug;
                 const channelSlug = n.channel?.slug;
                 const isNavigable = !!(serverSlug && channelSlug);
@@ -260,7 +253,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
                       role='button'
                       tabIndex={0}
                       onClick={handleRowClick}
-                      onKeyDown={(e) => {
+                      onKeyDown={e => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault();
                           handleRowClick();
@@ -296,7 +289,10 @@ export function NotificationBell({ userId }: NotificationBellProps) {
                       {!n.read && (
                         <button
                           type='button'
-                          onClick={(e) => { e.stopPropagation(); markAsRead(n.id); }}
+                          onClick={e => {
+                            e.stopPropagation();
+                            markAsRead(n.id);
+                          }}
                           title='Mark as read'
                           className='mt-0.5 flex-shrink-0 text-[10px] text-indigo-400 hover:text-indigo-300 transition-colors'
                         >

--- a/harmony-frontend/src/hooks/useChannelEvents.ts
+++ b/harmony-frontend/src/hooks/useChannelEvents.ts
@@ -88,9 +88,8 @@ export function useChannelEvents({
     const activeHandlers: Array<[string, (event: MessageEvent<string>) => void]> = [];
 
     const connect = async () => {
-      let ticket: string;
       try {
-        ticket = await fetchSseTicket(apiUrl, token);
+        await fetchSseTicket(apiUrl, token, 'channel');
       } catch (err) {
         logger.warn('Failed to fetch SSE ticket; aborting channel connection', {
           feature: 'channel-events',
@@ -103,8 +102,8 @@ export function useChannelEvents({
       }
       if (cancelled) return;
 
-      const url = `${apiUrl}/api/events/channel/${channelId}?ticket=${encodeURIComponent(ticket)}`;
-      es = new EventSource(url);
+      const url = `${apiUrl}/api/events/channel/${channelId}`;
+      es = new EventSource(url, { withCredentials: true });
 
       // ── Event handlers ────────────────────────────────────────────────────
 

--- a/harmony-frontend/src/hooks/useServerEvents.ts
+++ b/harmony-frontend/src/hooks/useServerEvents.ts
@@ -87,9 +87,19 @@ export interface UseServerEventsOptions {
   /** Called when server metadata (name, icon, description) changes. Optional. */
   onServerUpdated?: (server: Server) => void;
   /** Called when a reaction is added to a message in any channel of the server. Optional. */
-  onReactionAdded?: (data: { messageId: string; channelId: string; userId: string; emoji: string }) => void;
+  onReactionAdded?: (data: {
+    messageId: string;
+    channelId: string;
+    userId: string;
+    emoji: string;
+  }) => void;
   /** Called when a reaction is removed from a message in any channel of the server. Optional. */
-  onReactionRemoved?: (data: { messageId: string; channelId: string; userId: string; emoji: string }) => void;
+  onReactionRemoved?: (data: {
+    messageId: string;
+    channelId: string;
+    userId: string;
+    emoji: string;
+  }) => void;
   /** Set to false to disable the connection (e.g. for unauthenticated guests). Defaults to true. */
   enabled?: boolean;
 }
@@ -167,9 +177,8 @@ export function useServerEvents({
     const activeHandlers: Array<[string, (event: MessageEvent<string>) => void]> = [];
 
     const connect = async () => {
-      let ticket: string;
       try {
-        ticket = await fetchSseTicket(apiUrl, token);
+        await fetchSseTicket(apiUrl, token, 'server');
       } catch (err) {
         logger.warn('Failed to fetch SSE ticket; aborting server connection', {
           feature: 'server-events',
@@ -182,255 +191,255 @@ export function useServerEvents({
       }
       if (cancelled) return;
 
-      let url = `${apiUrl}/api/events/server/${serverId}?ticket=${encodeURIComponent(ticket)}`;
+      let url = `${apiUrl}/api/events/server/${serverId}`;
       // On reconnect, pass the last seen event id so the server can replay missed messages.
       if (reconnectKey > 0 && lastEventIdRef.current) {
-        url += `&lastEventId=${encodeURIComponent(lastEventIdRef.current)}`;
+        url += `?lastEventId=${encodeURIComponent(lastEventIdRef.current)}`;
       }
-      es = new EventSource(url);
+      es = new EventSource(url, { withCredentials: true });
 
-    const handleCreated = (event: MessageEvent<string>) => {
-      try {
-        const channel = JSON.parse(event.data) as Channel;
-        onCreatedRef.current(channel);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'channel:created',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleCreated = (event: MessageEvent<string>) => {
+        try {
+          const channel = JSON.parse(event.data) as Channel;
+          onCreatedRef.current(channel);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'channel:created',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleUpdated = (event: MessageEvent<string>) => {
-      try {
-        const channel = JSON.parse(event.data) as Channel;
-        onUpdatedRef.current(channel);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'channel:updated',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleUpdated = (event: MessageEvent<string>) => {
+        try {
+          const channel = JSON.parse(event.data) as Channel;
+          onUpdatedRef.current(channel);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'channel:updated',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleDeleted = (event: MessageEvent<string>) => {
-      try {
-        const payload = JSON.parse(event.data) as { channelId: string };
-        onDeletedRef.current(payload.channelId);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'channel:deleted',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleDeleted = (event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as { channelId: string };
+          onDeletedRef.current(payload.channelId);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'channel:deleted',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleMemberJoined = (event: MessageEvent<string>) => {
-      try {
-        const user = JSON.parse(event.data) as User;
-        onMemberJoinedRef.current?.(user);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'member:joined',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleMemberJoined = (event: MessageEvent<string>) => {
+        try {
+          const user = JSON.parse(event.data) as User;
+          onMemberJoinedRef.current?.(user);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'member:joined',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleMemberLeft = (event: MessageEvent<string>) => {
-      try {
-        const payload = JSON.parse(event.data) as { userId: string };
-        onMemberLeftRef.current?.(payload.userId);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'member:left',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleMemberLeft = (event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as { userId: string };
+          onMemberLeftRef.current?.(payload.userId);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'member:left',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleMemberStatusChanged = (event: MessageEvent<string>) => {
-      try {
-        const payload = JSON.parse(event.data) as { id: string; status: UserStatus };
-        onMemberStatusChangedRef.current?.(payload);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'member:statusChanged',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleMemberStatusChanged = (event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as { id: string; status: UserStatus };
+          onMemberStatusChangedRef.current?.(payload);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'member:statusChanged',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleMemberProfileUpdated = (event: MessageEvent<string>) => {
-      try {
-        const payload = JSON.parse(event.data) as {
-          id: string;
-          username: string;
-          displayName?: string;
-          avatarUrl?: string;
-        };
-        onMemberProfileUpdatedRef.current?.(payload);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'member:profileUpdated',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleMemberProfileUpdated = (event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as {
+            id: string;
+            username: string;
+            displayName?: string;
+            avatarUrl?: string;
+          };
+          onMemberProfileUpdatedRef.current?.(payload);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'member:profileUpdated',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleVisibilityChanged = (event: MessageEvent<string>) => {
-      try {
-        // The backend sends the full updated channel object plus oldVisibility.
-        const payload = JSON.parse(event.data) as Channel & { oldVisibility: ChannelVisibility };
-        const { oldVisibility, ...channel } = payload;
-        onVisibilityChangedRef.current?.(channel, oldVisibility);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'channel:visibility-changed',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleVisibilityChanged = (event: MessageEvent<string>) => {
+        try {
+          // The backend sends the full updated channel object plus oldVisibility.
+          const payload = JSON.parse(event.data) as Channel & { oldVisibility: ChannelVisibility };
+          const { oldVisibility, ...channel } = payload;
+          onVisibilityChangedRef.current?.(channel, oldVisibility);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'channel:visibility-changed',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleMessageCreated = (event: MessageEvent<string>) => {
-      try {
-        const msg = JSON.parse(event.data) as Message;
-        // Track the last event id for Last-Event-ID replay on reconnect.
-        if (event.lastEventId) lastEventIdRef.current = event.lastEventId;
-        onMessageCreatedRef.current?.(msg);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'message:created',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleMessageCreated = (event: MessageEvent<string>) => {
+        try {
+          const msg = JSON.parse(event.data) as Message;
+          // Track the last event id for Last-Event-ID replay on reconnect.
+          if (event.lastEventId) lastEventIdRef.current = event.lastEventId;
+          onMessageCreatedRef.current?.(msg);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'message:created',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleMessageEdited = (event: MessageEvent<string>) => {
-      try {
-        const msg = JSON.parse(event.data) as Message;
-        onMessageEditedRef.current?.(msg);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'message:edited',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleMessageEdited = (event: MessageEvent<string>) => {
+        try {
+          const msg = JSON.parse(event.data) as Message;
+          onMessageEditedRef.current?.(msg);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'message:edited',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleMessageDeleted = (event: MessageEvent<string>) => {
-      try {
-        const payload = JSON.parse(event.data) as { messageId: string; channelId: string };
-        onMessageDeletedRef.current?.(payload.messageId, payload.channelId);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'message:deleted',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleMessageDeleted = (event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as { messageId: string; channelId: string };
+          onMessageDeletedRef.current?.(payload.messageId, payload.channelId);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'message:deleted',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleServerUpdated = (event: MessageEvent<string>) => {
-      try {
-        const server = JSON.parse(event.data) as Server;
-        onServerUpdatedRef.current?.(server);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'server:updated',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleServerUpdated = (event: MessageEvent<string>) => {
+        try {
+          const server = JSON.parse(event.data) as Server;
+          onServerUpdatedRef.current?.(server);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'server:updated',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleReactionAdded = (event: MessageEvent<string>) => {
-      try {
-        const payload = JSON.parse(event.data) as {
-          messageId: string;
-          channelId: string;
-          userId: string;
-          emoji: string;
-        };
-        onReactionAddedRef.current?.(payload);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'reaction:added',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleReactionAdded = (event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as {
+            messageId: string;
+            channelId: string;
+            userId: string;
+            emoji: string;
+          };
+          onReactionAddedRef.current?.(payload);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'reaction:added',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
-    const handleReactionRemoved = (event: MessageEvent<string>) => {
-      try {
-        const payload = JSON.parse(event.data) as {
-          messageId: string;
-          channelId: string;
-          userId: string;
-          emoji: string;
-        };
-        onReactionRemovedRef.current?.(payload);
-      } catch (error) {
-        logger.warn('Dropped malformed server SSE payload', {
-          feature: 'server-events',
-          event: 'payload_parse_failed',
-          source: 'sse',
-          operation: 'reaction:removed',
-          target: '/api/events/server/[serverId]',
-          error,
-        });
-      }
-    };
+      const handleReactionRemoved = (event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as {
+            messageId: string;
+            channelId: string;
+            userId: string;
+            emoji: string;
+          };
+          onReactionRemovedRef.current?.(payload);
+        } catch (error) {
+          logger.warn('Dropped malformed server SSE payload', {
+            feature: 'server-events',
+            event: 'payload_parse_failed',
+            source: 'sse',
+            operation: 'reaction:removed',
+            target: '/api/events/server/[serverId]',
+            error,
+          });
+        }
+      };
 
       es.addEventListener('channel:created', handleCreated);
       es.addEventListener('channel:updated', handleUpdated);

--- a/harmony-frontend/src/lib/api-client.ts
+++ b/harmony-frontend/src/lib/api-client.ts
@@ -242,18 +242,26 @@ class ApiClient {
 export const apiClient = new ApiClient();
 
 /**
- * Fetches a one-shot SSE ticket from the backend.
- * The ticket must be passed as ?ticket=<nonce> when opening an EventSource.
+ * Issues a one-shot SSE ticket cookie from the backend.
+ * EventSource cannot set Authorization headers, so the backend stores the
+ * nonce in a short-lived HTTP-only cookie that is redeemed by the SSE GET.
  * Throws if the request fails (caller should abort the SSE connection).
  */
-export async function fetchSseTicket(apiBaseUrl: string, accessToken: string): Promise<string> {
+export async function fetchSseTicket(
+  apiBaseUrl: string,
+  accessToken: string,
+  stream: 'channel' | 'server' | 'user',
+): Promise<void> {
   const res = await fetch(`${apiBaseUrl}/api/events/ticket`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${accessToken}` },
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ stream }),
+    credentials: 'include',
   });
   if (!res.ok) throw new Error(`Failed to fetch SSE ticket: ${res.status}`);
-  const data = await res.json() as { ticket: string };
-  return data.ticket;
 }
 
 /**

--- a/tests/integration/sse.test.ts
+++ b/tests/integration/sse.test.ts
@@ -10,18 +10,25 @@
 import { BACKEND_URL, LOCAL_SEEDS, localOnlyDescribe } from './env';
 import { login, register } from './helpers/auth';
 
-/** One-shot SSE nonce from POST /api/events/ticket (JWT cannot live in query strings). */
-async function getSseTicket(accessToken: string): Promise<string> {
+type SseStream = 'channel' | 'server' | 'user';
+
+/** One-shot SSE cookie from POST /api/events/ticket (JWT cannot live in query strings). */
+async function getSseTicketCookie(accessToken: string, stream: SseStream): Promise<string> {
   const res = await fetch(`${BACKEND_URL}/api/events/ticket`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${accessToken}` },
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ stream }),
   });
   if (!res.ok) {
     throw new Error(`SSE ticket issuance failed: HTTP ${res.status}`);
   }
-  const body = (await res.json()) as { ticket?: string };
-  if (!body.ticket) throw new Error('SSE ticket response missing ticket field');
-  return body.ticket;
+
+  const setCookie = res.headers.get('set-cookie');
+  if (!setCookie) throw new Error('SSE ticket response missing Set-Cookie header');
+  return setCookie.split(';')[0];
 }
 
 // ─── Cloud-read-only smoke ────────────────────────────────────────────────────
@@ -37,10 +44,9 @@ describe('SSE Smoke (cloud-read-only)', () => {
       // Without a known server ID and token, only verify the endpoint is mounted.
       // Send a request without ticket to check it returns 401 (not 404).
       const fakeServerId = '00000000-0000-0000-0000-000000000000';
-      const res = await fetch(
-        `${BACKEND_URL}/api/events/server/${fakeServerId}`,
-        { signal: AbortSignal.timeout(5000) },
-      ).catch(() => null);
+      const res = await fetch(`${BACKEND_URL}/api/events/server/${fakeServerId}`, {
+        signal: AbortSignal.timeout(5000),
+      }).catch(() => null);
       if (res) {
         // 401 means the endpoint exists; anything else still shows it's mounted
         expect([401, 403, 200]).toContain(res.status);
@@ -52,11 +58,11 @@ describe('SSE Smoke (cloud-read-only)', () => {
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
     try {
-      const ticket = await getSseTicket(token);
-      const res = await fetch(
-        `${BACKEND_URL}/api/events/server/${serverId}?ticket=${encodeURIComponent(ticket)}`,
-        { signal: controller.signal },
-      );
+      const cookie = await getSseTicketCookie(token, 'server');
+      const res = await fetch(`${BACKEND_URL}/api/events/server/${serverId}`, {
+        headers: { Cookie: cookie },
+        signal: controller.signal,
+      });
       clearTimeout(timeoutId);
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toMatch(/text\/event-stream/i);
@@ -101,11 +107,11 @@ localOnlyDescribe('SSE (local-only)', () => {
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
     try {
-      const ticket = await getSseTicket(accessToken);
-      const res = await fetch(
-        `${BACKEND_URL}/api/events/channel/${channelId}?ticket=${encodeURIComponent(ticket)}`,
-        { signal: controller.signal },
-      );
+      const cookie = await getSseTicketCookie(accessToken, 'channel');
+      const res = await fetch(`${BACKEND_URL}/api/events/channel/${channelId}`, {
+        headers: { Cookie: cookie },
+        signal: controller.signal,
+      });
       clearTimeout(timeoutId);
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toMatch(/text\/event-stream/i);
@@ -122,10 +128,9 @@ localOnlyDescribe('SSE (local-only)', () => {
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
     try {
-      const res = await fetch(
-        `${BACKEND_URL}/api/events/channel/${channelId}`,
-        { signal: controller.signal },
-      );
+      const res = await fetch(`${BACKEND_URL}/api/events/channel/${channelId}`, {
+        signal: controller.signal,
+      });
       clearTimeout(timeoutId);
       expect(res.status).toBe(401);
     } catch (err: unknown) {
@@ -148,7 +153,7 @@ localOnlyDescribe('SSE (local-only)', () => {
       freshUsername,
       'TestPass123!',
     );
-    const freshTicket = await getSseTicket(freshToken);
+    const freshCookie = await getSseTicketCookie(freshToken, 'channel');
 
     // Look up a channel from open-source-hub (not auto-joined on registration).
     const nonDefaultChannelRes = await fetch(
@@ -164,10 +169,10 @@ localOnlyDescribe('SSE (local-only)', () => {
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
     try {
-      const res = await fetch(
-        `${BACKEND_URL}/api/events/channel/${nonDefaultChannelId}?ticket=${encodeURIComponent(freshTicket)}`,
-        { signal: controller.signal },
-      );
+      const res = await fetch(`${BACKEND_URL}/api/events/channel/${nonDefaultChannelId}`, {
+        headers: { Cookie: freshCookie },
+        signal: controller.signal,
+      });
       clearTimeout(timeoutId);
       // Fresh user is not a member of open-source-hub → expect 403 Forbidden
       expect(res.status).toBe(403);
@@ -191,11 +196,11 @@ localOnlyDescribe('SSE (local-only)', () => {
 
     return new Promise<void>(async (resolve, reject) => {
       try {
-        const ticket = await getSseTicket(accessToken);
-        const res = await fetch(
-          `${BACKEND_URL}/api/events/channel/${channelId}?ticket=${encodeURIComponent(ticket)}`,
-          { signal: controller.signal },
-        );
+        const cookie = await getSseTicketCookie(accessToken, 'channel');
+        const res = await fetch(`${BACKEND_URL}/api/events/channel/${channelId}`, {
+          headers: { Cookie: cookie },
+          signal: controller.signal,
+        });
 
         if (res.status !== 200 || !res.body) {
           clearTimeout(timeoutId);
@@ -210,17 +215,14 @@ localOnlyDescribe('SSE (local-only)', () => {
 
         // Post a message to trigger the SSE event
         const msgInput = encodeURIComponent(JSON.stringify({ channelId }));
-        const postRes = await fetch(
-          `${BACKEND_URL}/trpc/message.sendMessage`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${accessToken}`,
-            },
-            body: JSON.stringify({ serverId, channelId, content: 'SSE integration test message' }),
+        const postRes = await fetch(`${BACKEND_URL}/trpc/message.sendMessage`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${accessToken}`,
           },
-        );
+          body: JSON.stringify({ serverId, channelId, content: 'SSE integration test message' }),
+        });
         void msgInput; // used above just for clarity
 
         if (postRes.status !== 200) {
@@ -260,11 +262,11 @@ localOnlyDescribe('SSE (local-only)', () => {
 
     return new Promise<void>(async (resolve, reject) => {
       try {
-        const ticket = await getSseTicket(accessToken);
-        const res = await fetch(
-          `${BACKEND_URL}/api/events/server/${serverId}?ticket=${encodeURIComponent(ticket)}`,
-          { signal: controller.signal },
-        );
+        const cookie = await getSseTicketCookie(accessToken, 'server');
+        const res = await fetch(`${BACKEND_URL}/api/events/server/${serverId}`, {
+          headers: { Cookie: cookie },
+          signal: controller.signal,
+        });
 
         if (res.status !== 200 || !res.body) {
           clearTimeout(timeoutId);
@@ -329,11 +331,11 @@ localOnlyDescribe('SSE (local-only)', () => {
 
     return new Promise<void>(async (resolve, reject) => {
       try {
-        const ticket = await getSseTicket(accessToken);
-        const res = await fetch(
-          `${BACKEND_URL}/api/events/channel/${channelId}?ticket=${encodeURIComponent(ticket)}`,
-          { signal: controller.signal },
-        );
+        const cookie = await getSseTicketCookie(accessToken, 'channel');
+        const res = await fetch(`${BACKEND_URL}/api/events/channel/${channelId}`, {
+          headers: { Cookie: cookie },
+          signal: controller.signal,
+        });
 
         if (res.status !== 200 || !res.body) {
           clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary
- replace SSE query-string tickets with stream-scoped HTTP-only one-shot ticket cookies
- open channel/server/user EventSource connections with credentials and no auth material in URLs
- add regression coverage for cookie ticket issuance, query-ticket rejection, and frontend SSE URLs

Closes #479

## Verification
- Backend: `npm test -- --runInBand tests/events.router.server.test.ts tests/events.router.test.ts tests/events.router.member.test.ts tests/events.router.status.test.ts tests/events.router.visibility.test.ts tests/events.router.sse-server-updated.test.ts` (passed; local port binding required escalation)
- Backend: `npm run build` (passed)
- Backend: `npm run lint` (passed with one unrelated warning in `tests/channelMember.test.ts`)
- Frontend: `npm test -- --runInBand src/__tests__/useChannelEvents.test.tsx src/__tests__/useServerEvents.test.tsx src/__tests__/NotificationBell.test.tsx` (passed)
- Frontend: `npm test -- --runInBand` (passed)
- Frontend: `npm run lint` (passed with two unrelated warnings)
- Frontend: `tsc --noEmit` (blocked by existing unrelated `src/__tests__/gifsRoute.test.ts` cast errors)
- Backend: full `npm test -- --runInBand` (blocked by missing local `DATABASE_URL` and Redis auth for DB-backed tests)