### PR TITLE
Add frontend Content Security Policy

### DIFF
--- a/harmony-frontend/next.config.ts
+++ b/harmony-frontend/next.config.ts
@@ -1,5 +1,68 @@
 import type { NextConfig } from 'next';
 
+const isDevelopment = process.env.NODE_ENV === 'development';
+const localApiUrl = 'http://localhost:4000';
+
+function getOriginFromEnv(envVarName: string): string | null {
+  const value = process.env[envVarName]?.trim();
+  if (!value) return null;
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    throw new Error(`Invalid ${envVarName} value "${value}". Expected an absolute URL.`);
+  }
+}
+
+function uniqueSources(sources: Array<string | null | undefined>): string[] {
+  return [...new Set(sources.filter((source): source is string => Boolean(source)))];
+}
+
+export function buildContentSecurityPolicy(): string {
+  const apiOrigin = getOriginFromEnv('NEXT_PUBLIC_API_URL') ?? localApiUrl;
+  const r2PublicOrigin = getOriginFromEnv('R2_PUBLIC_URL');
+
+  const directives: Record<string, string[]> = {
+    'default-src': ["'self'"],
+    'script-src': uniqueSources([
+      "'self'",
+      "'unsafe-inline'",
+      isDevelopment ? "'unsafe-eval'" : null,
+    ]),
+    'style-src': ["'self'", "'unsafe-inline'"],
+    'img-src': uniqueSources([
+      "'self'",
+      'data:',
+      'blob:',
+      apiOrigin,
+      r2PublicOrigin,
+      'https://api.dicebear.com',
+      'https://cdn.pixabay.com',
+    ]),
+    'media-src': uniqueSources(["'self'", 'blob:', apiOrigin, r2PublicOrigin]),
+    'connect-src': uniqueSources([
+      "'self'",
+      apiOrigin,
+      'https://*.twilio.com',
+      'wss://*.twilio.com',
+      'https://*.twiliocdn.com',
+      'wss://*.twiliocdn.com',
+    ]),
+    'font-src': ["'self'"],
+    'frame-src': ['https://www.youtube.com', 'https://www.youtube-nocookie.com'],
+    'object-src': ["'none'"],
+    'base-uri': ["'self'"],
+    'form-action': ["'self'"],
+    'frame-ancestors': ["'none'"],
+  };
+
+  const csp = Object.entries(directives)
+    .map(([directive, sources]) => `${directive} ${sources.join(' ')}`)
+    .join('; ');
+
+  return isDevelopment ? csp : `${csp}; upgrade-insecure-requests`;
+}
+
 // On Vercel preview deployments the canonical origin isn't known ahead of time
 // (each branch/PR gets a unique `*.vercel.app` host). Map Vercel's own
 // VERCEL_URL system variable into NEXT_PUBLIC_BASE_URL so runtime-config and
@@ -15,6 +78,19 @@ if (
 }
 
 const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: buildContentSecurityPolicy(),
+          },
+        ],
+      },
+    ];
+  },
   images: {
     // All <Image> usages currently pass `unoptimized` to support arbitrary
     // external avatar/icon URLs without host restrictions. This remotePatterns

--- a/harmony-frontend/src/__tests__/next-config-csp.test.ts
+++ b/harmony-frontend/src/__tests__/next-config-csp.test.ts
@@ -1,0 +1,63 @@
+import nextConfig, { buildContentSecurityPolicy } from '../../next.config';
+
+describe('next.config Content Security Policy', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.NEXT_PUBLIC_API_URL;
+    delete process.env.R2_PUBLIC_URL;
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('adds the Content-Security-Policy header to every route', async () => {
+    const headers = await nextConfig.headers?.();
+
+    expect(headers).toEqual([
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: buildContentSecurityPolicy(),
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('allows only configured API and attachment origins for app connections and media', () => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.harmony.example/v1/';
+    process.env.R2_PUBLIC_URL = 'https://attachments.harmony.example/public/';
+
+    const csp = buildContentSecurityPolicy();
+
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).not.toContain("'unsafe-eval'");
+    expect(csp).toContain(
+      "img-src 'self' data: blob: https://api.harmony.example https://attachments.harmony.example https://api.dicebear.com https://cdn.pixabay.com",
+    );
+    expect(csp).toContain(
+      "media-src 'self' blob: https://api.harmony.example https://attachments.harmony.example",
+    );
+    expect(csp).toContain(
+      "connect-src 'self' https://api.harmony.example https://*.twilio.com wss://*.twilio.com https://*.twiliocdn.com wss://*.twiliocdn.com",
+    );
+    expect(csp).toContain('frame-ancestors');
+  });
+
+  it('uses the local backend fallback when the API origin is not configured', () => {
+    expect(buildContentSecurityPolicy()).toContain("connect-src 'self' http://localhost:4000");
+  });
+
+  it('throws for malformed origin environment variables', () => {
+    process.env.R2_PUBLIC_URL = 'attachments.harmony.example';
+
+    expect(() => buildContentSecurityPolicy()).toThrow('Invalid R2_PUBLIC_URL value');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Content Security Policy header through the Next.js headers() config for all frontend routes
- Include configured API and R2 attachment origins in CSP media/image/connect directives
- Add Jest coverage for CSP header generation and malformed origin handling

Closes #434

## Verification
- PASS: harmony-frontend npm test -- next-config-csp.test.ts
- PASS: harmony-frontend npm test
- PASS: harmony-frontend npm run lint (existing warnings only)
- PASS: harmony-frontend npm run build (rerun outside sandbox after sandbox-only Turbopack port-binding failure)
- PASS: harmony-backend npm run lint (existing warnings only)
- PASS: harmony-backend npm run build
- NOTE: harmony-frontend npm run format:check still fails on 59 pre-existing files outside this PR diff; changed files were formatted directly with prettier
- NOTE: harmony-backend npm test was attempted; sandboxed runs could not reach localhost Postgres/Redis, and the escalated run reached services but failed on existing local DB/schema/test-state issues unrelated to this frontend CSP change