### PR TITLE
fix: rate limit login challenge endpoint

### DIFF
--- a/harmony-backend/src/app.ts
+++ b/harmony-backend/src/app.ts
@@ -197,7 +197,7 @@ export function createApp(options: CreateAppOptions = {}) {
   app.use(seoRouter);
 
   // Auth endpoints
-  app.use('/api/auth/login', loginLimiter);
+  app.use(['/api/auth/login', '/api/auth/login/challenge'], loginLimiter);
   app.use('/api/auth/register', registerLimiter);
   app.use('/api/auth/refresh', refreshLimiter);
   app.use('/api/auth', authRouter);

--- a/harmony-backend/tests/app.rate-limit.test.ts
+++ b/harmony-backend/tests/app.rate-limit.test.ts
@@ -50,6 +50,15 @@ describe('auth rate limiters — store delegation (Issue #318)', () => {
     expect(incrementCalls.length).toBeGreaterThan(0);
   });
 
+  it('calls increment() on the injected store for POST /api/auth/login/challenge', async () => {
+    const { factory, incrementCalls } = createStoreFactory();
+    const app = createApp({ rateLimitStore: factory });
+
+    await request(app).post('/api/auth/login/challenge').send({ email: 'alice@example.com' });
+
+    expect(incrementCalls.length).toBeGreaterThan(0);
+  });
+
   it('calls increment() on the injected store for POST /api/auth/register', async () => {
     const { factory, incrementCalls } = createStoreFactory();
     const app = createApp({ rateLimitStore: factory });
@@ -68,17 +77,17 @@ describe('auth rate limiters — store delegation (Issue #318)', () => {
     expect(incrementCalls.length).toBeGreaterThan(0);
   });
 
-  it('uses the injected store for all three auth limiters (shared counting via factory)', async () => {
+  it('uses the injected store for all four auth limiters (shared counting via factory)', async () => {
     const { factory, incrementCalls } = createStoreFactory();
     const app = createApp({ rateLimitStore: factory });
 
     await request(app).post('/api/auth/login').send({});
+    await request(app).post('/api/auth/login/challenge').send({ email: 'alice@example.com' });
     await request(app).post('/api/auth/register').send({});
     await request(app).post('/api/auth/refresh').send({});
 
-    // All three routes delegated to stores created by the same factory →
-    // 3 increment calls recorded in the shared array
-    expect(incrementCalls.length).toBe(3);
+    // All four routes delegated to stores created by the same factory.
+    expect(incrementCalls.length).toBe(4);
   });
 
   it('does not lock out local development after 10 login attempts', async () => {


### PR DESCRIPTION
## Summary
- Explicitly applies the login rate limiter mount to `/api/auth/login/challenge`.
- Adds backend regression coverage proving the login challenge endpoint delegates to the injected rate-limit store.

Closes #432

## Verification
- `npm run lint` (passes; unrelated existing warnings in `tests/channelMember.test.ts` and `tests/events.router.sse-server-updated.test.ts`)
- `npx tsc --noEmit`
- `npm test -- --runTestsByPath tests/app.rate-limit.test.ts`
- Attempted `npm test -- --runInBand`; local environment lacks `DATABASE_URL` and Redis rejects cache tests with `NOAUTH`, so DB/cache-backed suites could not complete here.