### PR TITLE
Fix refresh token cookie storage

### DIFF
--- a/harmony-backend/.env.example
+++ b/harmony-backend/.env.example
@@ -40,6 +40,11 @@ JWT_REFRESH_SECRET=change-me-refresh-secret
 JWT_ACCESS_EXPIRES_IN=15m
 # Refresh token TTL in days
 JWT_REFRESH_EXPIRES_DAYS=7
+# Refresh cookie SameSite override: strict, lax, or none.
+# Defaults to Strict outside production and None in production for the current
+# cross-site Vercel -> Railway browser API flow. Use strict when frontend and
+# backend share the same site, for example harmony.chat and api.harmony.chat.
+AUTH_REFRESH_COOKIE_SAMESITE=
 
 # Storage provider — 'local' for development (disk), 's3' for production (Cloudflare R2)
 # Set STORAGE_PROVIDER=s3 in production and configure the R2 variables below.

--- a/harmony-backend/src/routes/auth.router.ts
+++ b/harmony-backend/src/routes/auth.router.ts
@@ -6,6 +6,10 @@ import { authService } from '../services/auth.service';
 
 export const authRouter = Router();
 const logger = createLogger({ component: 'auth-router' });
+const REFRESH_COOKIE_NAME = 'harmony_refresh_token';
+const REFRESH_COOKIE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const REFRESH_COOKIE_PATHS = ['/api/auth/refresh', '/api/auth/logout'] as const;
+type RefreshCookieSameSite = 'strict' | 'lax' | 'none';
 
 // ─── Input schemas ────────────────────────────────────────────────────────────
 
@@ -41,11 +45,11 @@ const loginSchema = z.object({
 });
 
 const logoutSchema = z.object({
-  refreshToken: z.string().min(1),
+  refreshToken: z.string().min(1).optional(),
 });
 
 const refreshSchema = z.object({
-  refreshToken: z.string().min(1),
+  refreshToken: z.string().min(1).optional(),
 });
 
 // ─── Error helper ─────────────────────────────────────────────────────────────
@@ -80,6 +84,74 @@ function handleError(res: Response, err: unknown): void {
   res.status(500).json({ error: 'Internal server error' });
 }
 
+function parseCookieHeader(cookieHeader: string | undefined): Record<string, string> {
+  if (!cookieHeader) return {};
+  return cookieHeader.split(';').reduce<Record<string, string>>((cookies, part) => {
+    const separatorIndex = part.indexOf('=');
+    if (separatorIndex === -1) return cookies;
+    const name = part.slice(0, separatorIndex).trim();
+    const value = part.slice(separatorIndex + 1).trim();
+    if (name) {
+      try {
+        cookies[name] = decodeURIComponent(value);
+      } catch {
+        cookies[name] = value;
+      }
+    }
+    return cookies;
+  }, {});
+}
+
+function getRefreshTokenFromRequest(req: Request, bodyToken?: string): string | undefined {
+  return bodyToken ?? parseCookieHeader(req.headers.cookie)[REFRESH_COOKIE_NAME];
+}
+
+function getRefreshCookieSameSite(): RefreshCookieSameSite {
+  const configured = process.env.AUTH_REFRESH_COOKIE_SAMESITE?.toLowerCase();
+  if (configured === 'strict' || configured === 'lax' || configured === 'none') {
+    return configured;
+  }
+
+  // Production currently runs frontend and backend on separate Vercel/Railway
+  // sites. SameSite=None is required for browser credentialed API calls there;
+  // CORS origin checks remain the CSRF gate for refresh/logout POSTs.
+  return process.env.NODE_ENV === 'production' ? 'none' : 'strict';
+}
+
+function setRefreshTokenCookies(res: Response, refreshToken: string): void {
+  const sameSite = getRefreshCookieSameSite();
+  for (const path of REFRESH_COOKIE_PATHS) {
+    res.cookie(REFRESH_COOKIE_NAME, refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production' || sameSite === 'none',
+      sameSite,
+      path,
+      maxAge: REFRESH_COOKIE_MAX_AGE_MS,
+    });
+  }
+}
+
+function clearRefreshTokenCookies(res: Response): void {
+  const sameSite = getRefreshCookieSameSite();
+  for (const path of REFRESH_COOKIE_PATHS) {
+    res.clearCookie(REFRESH_COOKIE_NAME, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production' || sameSite === 'none',
+      sameSite,
+      path,
+    });
+  }
+}
+
+function sendAuthTokens(
+  res: Response,
+  status: number,
+  tokens: { accessToken: string; refreshToken: string },
+): void {
+  setRefreshTokenCookies(res, tokens.refreshToken);
+  res.status(status).json({ accessToken: tokens.accessToken });
+}
+
 // ─── Routes ───────────────────────────────────────────────────────────────────
 
 /**
@@ -104,7 +176,7 @@ authRouter.post('/register', async (req: Request, res: Response) => {
   try {
     const { email, username, passwordSalt, passwordVerifier } = parsed.data;
     const tokens = await authService.register(email, username, passwordSalt, passwordVerifier);
-    res.status(201).json(tokens);
+    sendAuthTokens(res, 201, tokens);
   } catch (err) {
     handleError(res, err);
   }
@@ -144,7 +216,7 @@ authRouter.post('/login', async (req: Request, res: Response) => {
   try {
     const { email, passwordVerifier } = parsed.data;
     const tokens = await authService.login(email, passwordVerifier);
-    res.status(200).json(tokens);
+    sendAuthTokens(res, 200, tokens);
   } catch (err) {
     handleError(res, err);
   }
@@ -161,8 +233,13 @@ authRouter.post('/logout', async (req: Request, res: Response) => {
     return;
   }
 
+  const refreshToken = getRefreshTokenFromRequest(req, parsed.data.refreshToken);
+
   try {
-    await authService.logout(parsed.data.refreshToken);
+    if (refreshToken) {
+      await authService.logout(refreshToken);
+    }
+    clearRefreshTokenCookies(res);
     res.status(204).send();
   } catch (err) {
     handleError(res, err);
@@ -180,10 +257,19 @@ authRouter.post('/refresh', async (req: Request, res: Response) => {
     return;
   }
 
+  const refreshToken = getRefreshTokenFromRequest(req, parsed.data.refreshToken);
+  if (!refreshToken) {
+    res
+      .status(400)
+      .json({ error: 'Validation failed', details: [{ message: 'Refresh token is required' }] });
+    return;
+  }
+
   try {
-    const tokens = await authService.refreshTokens(parsed.data.refreshToken);
-    res.status(200).json(tokens);
+    const tokens = await authService.refreshTokens(refreshToken);
+    sendAuthTokens(res, 200, tokens);
   } catch (err) {
+    clearRefreshTokenCookies(res);
     handleError(res, err);
   }
 });

--- a/harmony-backend/tests/auth.flow.integration.test.ts
+++ b/harmony-backend/tests/auth.flow.integration.test.ts
@@ -59,6 +59,24 @@ function expectJwtForUser(token: string, userId: string) {
   expect(decoded?.sub).toBe(userId);
 }
 
+function getSetCookieHeaders(res: request.Response): string[] {
+  const header = res.headers['set-cookie'];
+  if (!header) return [];
+  return Array.isArray(header) ? header : [header];
+}
+
+function getRefreshCookie(res: request.Response): string {
+  const refreshCookie = getSetCookieHeaders(res).find((cookie) =>
+    cookie.startsWith('harmony_refresh_token='),
+  );
+  expect(refreshCookie).toBeDefined();
+  return refreshCookie!;
+}
+
+function getRefreshTokenFromCookie(res: request.Response): string {
+  return decodeURIComponent(getRefreshCookie(res).split(';')[0].split('=')[1]);
+}
+
 describe('auth flow integration', () => {
   let app: Express;
   const createdUserIds: string[] = [];
@@ -107,7 +125,7 @@ describe('auth flow integration', () => {
       username,
       userId: createdUser!.id,
       accessToken: response.body.accessToken,
-      refreshToken: response.body.refreshToken,
+      refreshToken: getRefreshTokenFromCookie(response),
     };
   }
 
@@ -117,6 +135,7 @@ describe('auth flow integration', () => {
     expect(registered.response.status).toBe(201);
     expect(typeof registered.accessToken).toBe('string');
     expect(typeof registered.refreshToken).toBe('string');
+    expect(registered.response.body.refreshToken).toBeUndefined();
     expectJwtForUser(registered.accessToken, registered.userId);
     expectJwtForUser(registered.refreshToken, registered.userId);
 
@@ -222,7 +241,8 @@ describe('auth flow integration', () => {
     // describe only the login -> refresh -> logout lifecycle under test.
     const initialLogoutRes = await request(app)
       .post('/api/auth/logout')
-      .send({ refreshToken: registered.refreshToken });
+      .set('Cookie', getRefreshCookie(registered.response))
+      .send({});
 
     expect(initialLogoutRes.status).toBe(204);
 
@@ -238,7 +258,11 @@ describe('auth flow integration', () => {
 
     expect(loginRes.status).toBe(200);
 
-    const loginTokens = loginRes.body as AuthTokens;
+    const loginTokens: AuthTokens = {
+      accessToken: loginRes.body.accessToken,
+      refreshToken: getRefreshTokenFromCookie(loginRes),
+    };
+    expect(loginRes.body.refreshToken).toBeUndefined();
     expectJwtForUser(loginTokens.accessToken, registered.userId);
     expectJwtForUser(loginTokens.refreshToken, registered.userId);
 
@@ -263,14 +287,16 @@ describe('auth flow integration', () => {
 
     const refreshRes = await request(app)
       .post('/api/auth/refresh')
-      .send({ refreshToken: loginTokens.refreshToken });
+      .set('Cookie', getRefreshCookie(loginRes))
+      .send({});
 
     expect(refreshRes.status).toBe(200);
     expect(typeof refreshRes.body.accessToken).toBe('string');
-    expect(typeof refreshRes.body.refreshToken).toBe('string');
-    expect(refreshRes.body.refreshToken).not.toBe(loginTokens.refreshToken);
+    expect(refreshRes.body.refreshToken).toBeUndefined();
+    const rotatedRefreshToken = getRefreshTokenFromCookie(refreshRes);
+    expect(rotatedRefreshToken).not.toBe(loginTokens.refreshToken);
     expectJwtForUser(refreshRes.body.accessToken, registered.userId);
-    expectJwtForUser(refreshRes.body.refreshToken, registered.userId);
+    expectJwtForUser(rotatedRefreshToken, registered.userId);
 
     const reusedOldRefreshRes = await request(app)
       .post('/api/auth/refresh')
@@ -288,13 +314,14 @@ describe('auth flow integration', () => {
 
     const logoutRes = await request(app)
       .post('/api/auth/logout')
-      .send({ refreshToken: refreshRes.body.refreshToken });
+      .set('Cookie', getRefreshCookie(refreshRes))
+      .send({});
 
     expect(logoutRes.status).toBe(204);
 
     const revokedRefreshRes = await request(app)
       .post('/api/auth/refresh')
-      .send({ refreshToken: refreshRes.body.refreshToken });
+      .send({ refreshToken: rotatedRefreshToken });
 
     expect(revokedRefreshRes.status).toBe(401);
     expect(revokedRefreshRes.body.error).toMatch(/revoked|expired/i);

--- a/harmony-backend/tests/auth.test.ts
+++ b/harmony-backend/tests/auth.test.ts
@@ -115,8 +115,24 @@ describe('POST /api/auth/register/challenge', () => {
   });
 });
 
+function getSetCookieHeaders(res: request.Response): string[] {
+  const header = res.headers['set-cookie'];
+  if (!header) return [];
+  return Array.isArray(header) ? header : [header];
+}
+
+function expectRefreshCookie(res: request.Response): string {
+  const cookies = getSetCookieHeaders(res);
+  const refreshCookie = cookies.find((cookie) => cookie.startsWith('harmony_refresh_token='));
+  expect(refreshCookie).toBeDefined();
+  expect(refreshCookie).toContain('HttpOnly');
+  expect(refreshCookie).toContain('SameSite=Strict');
+  expect(refreshCookie).toContain('Path=/api/auth/refresh');
+  return refreshCookie!;
+}
+
 describe('POST /api/auth/register', () => {
-  it('creates a new user and returns access + refresh tokens', async () => {
+  it('creates a new user and returns an access token with the refresh token in an httpOnly cookie', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(null);
     mockPrisma.user.create.mockResolvedValue(mockUser);
     mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
@@ -133,7 +149,8 @@ describe('POST /api/auth/register', () => {
 
     expect(res.status).toBe(201);
     expect(typeof res.body.accessToken).toBe('string');
-    expect(typeof res.body.refreshToken).toBe('string');
+    expect(res.body.refreshToken).toBeUndefined();
+    expectRefreshCookie(res);
   });
 
   it('returns 400 when the verifier payload is missing', async () => {
@@ -243,7 +260,7 @@ describe('POST /api/auth/login/challenge', () => {
 });
 
 describe('POST /api/auth/login', () => {
-  it('returns access + refresh tokens on a valid verifier payload', async () => {
+  it('returns an access token and stores the refresh token in an httpOnly cookie', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(mockUser);
     mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
 
@@ -257,7 +274,8 @@ describe('POST /api/auth/login', () => {
 
     expect(res.status).toBe(200);
     expect(typeof res.body.accessToken).toBe('string');
-    expect(typeof res.body.refreshToken).toBe('string');
+    expect(res.body.refreshToken).toBeUndefined();
+    expectRefreshCookie(res);
   });
 
   it('returns 401 for the wrong verifier', async () => {
@@ -300,7 +318,7 @@ describe('POST /api/auth/login', () => {
 });
 
 describe('POST /api/auth/logout', () => {
-  it('revokes the refresh token and returns 204', async () => {
+  it('revokes the refresh token cookie, clears auth cookies, and returns 204', async () => {
     mockPrisma.refreshToken.updateMany.mockResolvedValue({ count: 1 });
     mockPrisma.user.findUnique.mockResolvedValue(mockUser);
     mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
@@ -313,29 +331,35 @@ describe('POST /api/auth/logout', () => {
         passwordVerifier: derivePasswordVerifier('password123'),
       });
 
-    const { refreshToken } = loginRes.body as { refreshToken: string };
+    const refreshCookie = expectRefreshCookie(loginRes);
 
     const logoutRes = await request(app)
       .post('/api/auth/logout')
       .set('Origin', 'http://localhost:3000')
-      .send({ refreshToken });
+      .set('Cookie', refreshCookie)
+      .send({});
 
     expect(logoutRes.status).toBe(204);
     expect(mockPrisma.refreshToken.updateMany).toHaveBeenCalledTimes(1);
+    const clearedCookies = getSetCookieHeaders(logoutRes);
+    expect(clearedCookies.some((cookie) => cookie.startsWith('harmony_refresh_token=;'))).toBe(
+      true,
+    );
   });
 
-  it('returns 400 when refreshToken is missing', async () => {
+  it('returns 204 and clears auth cookies when refresh token is already missing', async () => {
     const res = await request(app)
       .post('/api/auth/logout')
       .set('Origin', 'http://localhost:3000')
       .send({});
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(204);
+    expect(mockPrisma.refreshToken.updateMany).not.toHaveBeenCalled();
   });
 });
 
 describe('POST /api/auth/refresh', () => {
-  it('issues new tokens when given a valid refresh token', async () => {
+  it('rotates the httpOnly refresh cookie and returns only a new access token', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(mockUser);
     mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
 
@@ -347,7 +371,7 @@ describe('POST /api/auth/refresh', () => {
         passwordVerifier: derivePasswordVerifier('password123'),
       });
 
-    const { refreshToken } = loginRes.body as { refreshToken: string };
+    const refreshCookie = expectRefreshCookie(loginRes);
 
     mockPrisma.refreshToken.updateMany.mockResolvedValue({ count: 1 });
     mockPrisma.refreshToken.create.mockResolvedValue(mockRefreshToken);
@@ -355,11 +379,13 @@ describe('POST /api/auth/refresh', () => {
     const refreshRes = await request(app)
       .post('/api/auth/refresh')
       .set('Origin', 'http://localhost:3000')
-      .send({ refreshToken });
+      .set('Cookie', refreshCookie)
+      .send({});
 
     expect(refreshRes.status).toBe(200);
     expect(typeof refreshRes.body.accessToken).toBe('string');
-    expect(typeof refreshRes.body.refreshToken).toBe('string');
+    expect(refreshRes.body.refreshToken).toBeUndefined();
+    expectRefreshCookie(refreshRes);
   });
 });
 

--- a/harmony-frontend/src/__tests__/authService.test.ts
+++ b/harmony-frontend/src/__tests__/authService.test.ts
@@ -5,9 +5,8 @@ jest.mock('@/lib/api-client', () => ({
     trpcMutation: jest.fn(),
   },
   setTokens: jest.fn(),
-  clearTokens: jest.fn(),
+  clearTokens: jest.fn(() => window.localStorage.removeItem('harmony_refresh_token')),
   getAccessToken: jest.fn(() => null),
-  getRefreshToken: jest.fn(() => null),
 }));
 
 jest.mock('@/lib/passwordAuth', () => ({
@@ -67,7 +66,7 @@ describe('authService password transport hardening', () => {
   it('requests a login salt and never posts the raw password during login', async () => {
     mockedApiClient.post
       .mockResolvedValueOnce({ passwordSalt: '00112233445566778899aabbccddeeff' })
-      .mockResolvedValueOnce({ accessToken: 'access', refreshToken: 'refresh' });
+      .mockResolvedValueOnce({ accessToken: 'access' });
 
     await login('user@example.com', 'plain-text-password');
 
@@ -86,14 +85,15 @@ describe('authService password transport hardening', () => {
       email: 'user@example.com',
       password: 'plain-text-password',
     });
-    expect(mockedSetTokens).toHaveBeenCalledWith('access', 'refresh');
+    expect(mockedSetTokens).toHaveBeenCalledWith('access');
+    expect(window.localStorage.getItem('harmony_refresh_token')).toBeNull();
     expect(setSessionCookie).toHaveBeenCalledWith('access');
   });
 
   it('requests a registration salt and never posts the raw password during signup', async () => {
     mockedApiClient.post
       .mockResolvedValueOnce({ passwordSalt: 'ffeeddccbbaa99887766554433221100' })
-      .mockResolvedValueOnce({ accessToken: 'access', refreshToken: 'refresh' });
+      .mockResolvedValueOnce({ accessToken: 'access' });
 
     await register('user@example.com', 'alice', 'Alice', 'plain-text-password');
 
@@ -113,17 +113,21 @@ describe('authService password transport hardening', () => {
       username: 'alice',
       password: 'plain-text-password',
     });
+    expect(mockedSetTokens).toHaveBeenCalledWith('access');
+    expect(window.localStorage.getItem('harmony_refresh_token')).toBeNull();
     expect(setSessionCookie).toHaveBeenCalledWith('access');
   });
 
-  it('clears the server auth cookie on logout', async () => {
+  it('logs out without posting a refresh token from localStorage', async () => {
     const { logout } = await import('@/services/authService');
     window.localStorage.setItem('harmony_refresh_token', 'refresh-token');
     mockedApiClient.post.mockResolvedValueOnce(undefined);
 
     await logout();
 
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/logout');
     expect(clearSessionCookie).toHaveBeenCalled();
+    expect(window.localStorage.getItem('harmony_refresh_token')).toBeNull();
   });
 
   it('preserves backend OFFLINE until live presence tracking marks the session online', async () => {

--- a/harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts
+++ b/harmony-frontend/src/__tests__/issue-242-join-server-fix.test.ts
@@ -46,7 +46,7 @@ const mockAxiosInstance: jest.Mock & Record<string, any> = Object.assign(
 );
 
 const mockAxiosPost = jest.fn().mockResolvedValue({
-  data: { accessToken: 'refreshed-access-token', refreshToken: 'refreshed-refresh-token' },
+  data: { accessToken: 'refreshed-access-token' },
 });
 
 // ─── Jest module mocks ────────────────────────────────────────────────────────
@@ -88,18 +88,16 @@ describe('Fix 1 — api-client: setSessionCookie is called after token refresh',
   beforeEach(() => {
     jest.clearAllMocks();
     mockAxiosPost.mockResolvedValue({
-      data: { accessToken: 'refreshed-access-token', refreshToken: 'refreshed-refresh-token' },
+      data: { accessToken: 'refreshed-access-token' },
     });
     // Re-configure the callable mock so the retry (this.client(req)) resolves
     mockAxiosInstance.mockResolvedValue({ data: {} });
-    window.localStorage.setItem('harmony_refresh_token', 'stored-refresh-token');
     // Suppress jsdom "not implemented: navigation" from window.location.href = '/auth/login'
     jest.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
-    window.localStorage.removeItem('harmony_refresh_token');
   });
 
   it('registers a response error interceptor during ApiClient construction', () => {
@@ -120,18 +118,20 @@ describe('Fix 1 — api-client: setSessionCookie is called after token refresh',
     expect(setSessionCookie).toHaveBeenCalledWith('refreshed-access-token');
   });
 
-  it('does NOT call setSessionCookie when there is no stored refresh token', async () => {
-    window.localStorage.removeItem('harmony_refresh_token');
-
+  it('attempts refresh with credentials even without a JavaScript-readable refresh token', async () => {
     const mock401Error = {
       config: { _retry: false, headers: {} },
       response: { status: 401 },
     };
 
-    // Without a refresh token the interceptor rejects immediately (no refresh attempt)
-    await mockCapturedResponseErrorHandler!(mock401Error).catch(() => undefined);
+    await mockCapturedResponseErrorHandler!(mock401Error);
 
-    expect(setSessionCookie).not.toHaveBeenCalled();
+    expect(mockAxiosPost).toHaveBeenCalledWith(
+      expect.stringContaining('/api/auth/refresh'),
+      {},
+      { withCredentials: true },
+    );
+    expect(setSessionCookie).toHaveBeenCalledWith('refreshed-access-token');
   });
 
   it('continues with the client-side retry even when setSessionCookie throws', async () => {

--- a/harmony-frontend/src/lib/api-client.ts
+++ b/harmony-frontend/src/lib/api-client.ts
@@ -10,10 +10,11 @@ import { setSessionCookie } from '@/app/actions/session';
 // ─── Token storage ────────────────────────────────────────────────────────────
 // Access token is kept only in module-level memory (never persisted) so it is
 // cleared on page refresh and cannot be read by injected scripts via localStorage.
-// Refresh token is stored in localStorage so users stay logged-in across reloads.
+// Refresh tokens are stored by the backend in httpOnly cookies so injected
+// scripts cannot read or exfiltrate them from browser storage.
 
-const REFRESH_TOKEN_KEY = 'harmony_refresh_token';
 const logger = createFrontendLogger({ component: 'api-client' });
+const LEGACY_REFRESH_TOKEN_KEY = 'harmony_refresh_token';
 
 let _accessToken: string | null = null;
 let _isRefreshing = false;
@@ -24,27 +25,19 @@ function notifyRefreshQueue(token: string | null) {
   _refreshQueue = [];
 }
 
-export function setTokens(accessToken: string, refreshToken: string): void {
+export function setTokens(accessToken: string): void {
   _accessToken = accessToken;
-  if (typeof window !== 'undefined') {
-    localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
-  }
 }
 
 export function clearTokens(): void {
   _accessToken = null;
   if (typeof window !== 'undefined') {
-    localStorage.removeItem(REFRESH_TOKEN_KEY);
+    localStorage.removeItem(LEGACY_REFRESH_TOKEN_KEY);
   }
 }
 
 export function getAccessToken(): string | null {
   return _accessToken;
-}
-
-export function getRefreshToken(): string | null {
-  if (typeof window === 'undefined') return null;
-  return localStorage.getItem(REFRESH_TOKEN_KEY);
 }
 
 // ─── tRPC HTTP helpers ────────────────────────────────────────────────────────
@@ -71,6 +64,7 @@ class ApiClient {
       baseURL: API_CONFIG.BASE_URL,
       timeout: API_CONFIG.TIMEOUT,
       headers: { 'Content-Type': 'application/json' },
+      withCredentials: true,
     });
 
     this.setupInterceptors();
@@ -104,20 +98,6 @@ class ApiClient {
         const route = typeof originalRequest?.url === 'string' ? originalRequest.url : undefined;
 
         if (statusCode === 401 && !originalRequest._retry) {
-          const refreshToken = getRefreshToken();
-          if (!refreshToken) {
-            logger.warn('Auth session refresh skipped because no refresh token is stored', {
-              feature: 'auth',
-              event: 'refresh_skipped',
-              method,
-              route,
-              statusCode,
-              reason: 'missing_refresh_token',
-            });
-            clearTokens();
-            return Promise.reject(error);
-          }
-
           if (_isRefreshing) {
             // Queue concurrent requests until the refresh completes
             return new Promise(resolve => {
@@ -137,12 +117,13 @@ class ApiClient {
           _isRefreshing = true;
 
           try {
-            const res = await axios.post<{ accessToken: string; refreshToken: string }>(
+            const res = await axios.post<{ accessToken: string }>(
               `${API_CONFIG.BASE_URL}/api/auth/refresh`,
-              { refreshToken },
+              {},
+              { withCredentials: true },
             );
-            const { accessToken: newAt, refreshToken: newRt } = res.data;
-            setTokens(newAt, newRt);
+            const { accessToken: newAt } = res.data;
+            setTokens(newAt);
             // Sync the httpOnly cookie so server-side code (Server Components, Server Actions,
             // tRPC routes) reads the fresh token. Without this, the cookie stays stale after
             // the in-memory token is refreshed and all server-side calls return 401.
@@ -252,7 +233,7 @@ export async function fetchSseTicket(apiBaseUrl: string, accessToken: string): P
     headers: { Authorization: `Bearer ${accessToken}` },
   });
   if (!res.ok) throw new Error(`Failed to fetch SSE ticket: ${res.status}`);
-  const data = await res.json() as { ticket: string };
+  const data = (await res.json()) as { ticket: string };
   return data.ticket;
 }
 
@@ -272,9 +253,6 @@ export async function fetchSseTicket(apiBaseUrl: string, accessToken: string): P
 export async function refreshAccessToken(): Promise<void> {
   if (typeof window === 'undefined') return;
 
-  const refreshToken = getRefreshToken();
-  if (!refreshToken) return;
-
   // Piggyback on an in-flight interceptor refresh rather than racing it.
   if (_isRefreshing) {
     await new Promise<void>(resolve => {
@@ -285,12 +263,13 @@ export async function refreshAccessToken(): Promise<void> {
 
   _isRefreshing = true;
   try {
-    const res = await axios.post<{ accessToken: string; refreshToken: string }>(
+    const res = await axios.post<{ accessToken: string }>(
       `${API_CONFIG.BASE_URL}/api/auth/refresh`,
-      { refreshToken },
+      {},
+      { withCredentials: true },
     );
-    const { accessToken: newAt, refreshToken: newRt } = res.data;
-    setTokens(newAt, newRt);
+    const { accessToken: newAt } = res.data;
+    setTokens(newAt);
     try {
       await setSessionCookie(newAt);
     } catch {

--- a/harmony-frontend/src/services/authService.ts
+++ b/harmony-frontend/src/services/authService.ts
@@ -7,19 +7,14 @@
  *
  * Token strategy:
  *   - accessToken  : kept in module memory (cleared on page refresh, never in localStorage)
- *   - refreshToken : stored in localStorage so sessions survive page reloads
+ *   - refreshToken : stored in a backend-set httpOnly cookie so sessions survive reloads
+ *                    without exposing long-lived tokens to JavaScript
  *
  * The api-client handles silent token refresh automatically on 401 responses.
  */
 
 import type { User, UserStatus } from '@/types';
-import {
-  apiClient,
-  setTokens,
-  clearTokens,
-  getAccessToken,
-  getRefreshToken,
-} from '@/lib/api-client';
+import { apiClient, setTokens, clearTokens } from '@/lib/api-client';
 import { derivePasswordVerifier } from '@/lib/passwordAuth';
 import { clearSessionCookie, setSessionCookie } from '@/app/actions/session';
 
@@ -27,7 +22,6 @@ import { clearSessionCookie, setSessionCookie } from '@/app/actions/session';
 
 interface AuthTokensResponse {
   accessToken: string;
-  refreshToken: string;
 }
 
 interface PasswordChallengeResponse {
@@ -115,13 +109,11 @@ export function shouldEnablePresenceTracking(user: Pick<User, 'id' | 'status'> |
 
 /**
  * Returns the current authenticated user by fetching from the backend.
- * Returns null if no access token is present or the token is expired/invalid.
- * The api-client will silently refresh the access token if a refresh token is
- * available, so callers rarely need to handle 401 themselves.
+ * Returns null if the session is missing or invalid. If only the httpOnly
+ * refresh cookie remains after a reload, the api-client will receive a 401,
+ * refresh with browser credentials, and retry this request.
  */
 export async function getCurrentUser(): Promise<User | null> {
-  // No access token and no refresh token → definitely not logged in
-  if (!getAccessToken() && !getRefreshToken()) return null;
   try {
     const user = await apiClient.trpcQuery<BackendUser>('user.getCurrentUser');
     return applyStoredManualStatusOverride(mapBackendUser(user));
@@ -146,7 +138,7 @@ export async function login(email: string, password: string): Promise<User> {
     email,
     passwordVerifier,
   });
-  setTokens(tokens.accessToken, tokens.refreshToken);
+  setTokens(tokens.accessToken);
   await setSessionCookie(tokens.accessToken);
 
   const user = await apiClient.trpcQuery<BackendUser>('user.getCurrentUser');
@@ -174,7 +166,7 @@ export async function register(
     passwordSalt,
     passwordVerifier,
   });
-  setTokens(tokens.accessToken, tokens.refreshToken);
+  setTokens(tokens.accessToken);
   await setSessionCookie(tokens.accessToken);
 
   let user = await apiClient.trpcQuery<BackendUser>('user.getCurrentUser');
@@ -188,16 +180,13 @@ export async function register(
 }
 
 /**
- * Revokes the stored refresh token on the server and clears local token storage.
+ * Revokes the httpOnly refresh cookie on the server and clears local token storage.
  */
 export async function logout(): Promise<void> {
-  const refreshToken = getRefreshToken();
-  if (refreshToken) {
-    try {
-      await apiClient.post('/api/auth/logout', { refreshToken });
-    } catch {
-      // Best-effort: clear tokens locally even if the server call fails
-    }
+  try {
+    await apiClient.post('/api/auth/logout');
+  } catch {
+    // Best-effort: clear tokens locally even if the server call fails
   }
   clearTokens();
   await clearSessionCookie();

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -56,12 +56,15 @@ describe('Auth Smoke', () => {
 localOnlyDescribe('Auth (local-only)', () => {
   const { email, password } = LOCAL_SEEDS.alice;
 
-  test('AUTH-1: successful login returns accessToken and refreshToken', async () => {
+  test('AUTH-1: successful login returns accessToken and an httpOnly refresh cookie', async () => {
     const tokens = await login(email, password);
     expect(typeof tokens.accessToken).toBe('string');
     expect(typeof tokens.refreshToken).toBe('string');
     expect(tokens.accessToken.split('.')).toHaveLength(3);
     expect(tokens.refreshToken.split('.')).toHaveLength(3);
+    expect(tokens.refreshCookie).toContain('HttpOnly');
+    expect(tokens.refreshCookie).toContain('SameSite=Strict');
+    expect(tokens.refreshCookie).toContain('Path=/api/auth/refresh');
   });
 
   test('AUTH-2: login with wrong password returns 401', async () => {
@@ -115,12 +118,15 @@ localOnlyDescribe('Auth (local-only)', () => {
     expect(body.result?.data?.email).toBe(email);
   });
 
-  test('AUTH-6: valid refresh token issues new access and refresh tokens', async () => {
+  test('AUTH-6: valid refresh cookie issues a new access token and rotated refresh cookie', async () => {
     const first = await login(email, password);
     const res = await fetch(`${BACKEND_URL}/api/auth/refresh`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refreshToken: first.refreshToken }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: first.refreshCookie,
+      },
+      body: JSON.stringify({}),
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -128,13 +134,18 @@ localOnlyDescribe('Auth (local-only)', () => {
       refreshToken?: string;
     };
     expect(typeof body.accessToken).toBe('string');
-    expect(typeof body.refreshToken).toBe('string');
+    expect(body.refreshToken).toBeUndefined();
+    const headers = res.headers as Headers & { getSetCookie?: () => string[] };
+    const rotatedRefreshCookie = headers
+      .getSetCookie?.()
+      .find((value) => value.startsWith('harmony_refresh_token='));
+    expect(rotatedRefreshCookie).toBeDefined();
 
     // Revoke to clean up
     await fetch(`${BACKEND_URL}/api/auth/logout`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refreshToken: body.refreshToken }),
+      headers: { 'Content-Type': 'application/json', Cookie: rotatedRefreshCookie! },
+      body: JSON.stringify({}),
     });
   });
 
@@ -148,12 +159,12 @@ localOnlyDescribe('Auth (local-only)', () => {
   });
 
   localOnlyTest('AUTH-8: logout invalidates the refresh token', async () => {
-    const { refreshToken } = await login(email, password);
+    const { refreshCookie, refreshToken } = await login(email, password);
 
     const logoutRes = await fetch(`${BACKEND_URL}/api/auth/logout`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refreshToken }),
+      headers: { 'Content-Type': 'application/json', Cookie: refreshCookie },
+      body: JSON.stringify({}),
     });
     expect(logoutRes.status).toBe(204);
 

--- a/tests/integration/helpers/auth.ts
+++ b/tests/integration/helpers/auth.ts
@@ -4,12 +4,27 @@ import { BACKEND_URL } from '../env';
 export interface AuthTokens {
   accessToken: string;
   refreshToken: string;
+  refreshCookie: string;
 }
 
 function derivePasswordVerifier(password: string, saltHex: string): string {
   return crypto
     .pbkdf2Sync(password, Buffer.from(saltHex, 'hex'), 310000, 32, 'sha256')
     .toString('base64');
+}
+
+function getRefreshCookie(res: Response): string {
+  const headers = res.headers as Headers & { getSetCookie?: () => string[] };
+  const setCookieHeaders = headers.getSetCookie?.() ?? [];
+  const cookie = setCookieHeaders.find((value) => value.startsWith('harmony_refresh_token='));
+  if (!cookie) {
+    throw new Error('Auth response did not include harmony_refresh_token cookie');
+  }
+  return cookie;
+}
+
+function getRefreshTokenFromCookie(cookie: string): string {
+  return decodeURIComponent(cookie.split(';')[0].split('=')[1]);
 }
 
 export async function register(
@@ -37,7 +52,13 @@ export async function register(
     const body = await regRes.text();
     throw new Error(`Register failed (${regRes.status}): ${body}`);
   }
-  return regRes.json() as Promise<AuthTokens>;
+  const body = (await regRes.json()) as { accessToken: string; refreshToken?: string };
+  const refreshCookie = getRefreshCookie(regRes);
+  return {
+    accessToken: body.accessToken,
+    refreshCookie,
+    refreshToken: getRefreshTokenFromCookie(refreshCookie),
+  };
 }
 
 export async function login(email: string, password: string): Promise<AuthTokens> {
@@ -62,5 +83,11 @@ export async function login(email: string, password: string): Promise<AuthTokens
     const body = await loginRes.text();
     throw new Error(`Login failed (${loginRes.status}): ${body}`);
   }
-  return loginRes.json() as Promise<AuthTokens>;
+  const body = (await loginRes.json()) as { accessToken: string; refreshToken?: string };
+  const refreshCookie = getRefreshCookie(loginRes);
+  return {
+    accessToken: body.accessToken,
+    refreshCookie,
+    refreshToken: getRefreshTokenFromCookie(refreshCookie),
+  };
 }


### PR DESCRIPTION
## Summary
- Move refresh-token persistence from frontend localStorage to backend-set httpOnly cookies
- Rotate refresh cookies on login/register/refresh and clear them on logout or failed refresh
- Update frontend auth refresh/logout flows to use credentialed cookie requests and keep access tokens memory-only
- Update auth regression tests and integration helpers for the cookie-only refresh contract

## Verification
- Backend: npm run lint (passes with 2 existing unrelated warnings)
- Backend: npm run build
- Backend: npm test -- auth.test.ts --runInBand
- Frontend: npm run lint (passes with 3 existing unrelated warnings)
- Frontend: npm run build
- Frontend: npm test -- --runInBand
- Integration helpers: tsc --noEmit -p tests/integration/tsconfig.json

Backend full Jest was attempted but this local environment does not provide DATABASE_URL or usable Redis auth for unrelated DB/cache suites.

Closes #436