### PR TITLE
test: require indexable cloud fixture channel

### DIFF
--- a/tests/integration/env.test.ts
+++ b/tests/integration/env.test.ts
@@ -24,6 +24,9 @@ describe('getCloudFixture cache behavior', () => {
       )
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ channels: [{ slug: 'general' }] }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_INDEXABLE' }), { status: 200 }),
       );
     global.fetch = fetchMock;
 
@@ -43,7 +46,7 @@ describe('getCloudFixture cache behavior', () => {
       publicChannelTargets: [{ serverSlug: 'harmony-hq', channelSlug: 'general' }],
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   test('reuses an in-flight discovery promise for concurrent callers', async () => {
@@ -58,6 +61,9 @@ describe('getCloudFixture cache behavior', () => {
       )
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ channels: [{ slug: 'general' }] }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_INDEXABLE' }), { status: 200 }),
       );
     global.fetch = fetchMock;
 
@@ -91,7 +97,7 @@ describe('getCloudFixture cache behavior', () => {
       },
     ]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   test('discovers up to 3 channels and populates publicChannels', async () => {
@@ -112,6 +118,15 @@ describe('getCloudFixture cache behavior', () => {
           }),
           { status: 200 },
         ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_INDEXABLE' }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_INDEXABLE' }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_INDEXABLE' }), { status: 200 }),
       );
     global.fetch = fetchMock;
 
@@ -131,7 +146,54 @@ describe('getCloudFixture cache behavior', () => {
       ],
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  test('confirms candidate channels are PUBLIC_INDEXABLE before selecting the cloud fixture', async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: 'server-1', slug: 'harmony-hq' }]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            channels: [
+              { slug: 'introductions' },
+              { slug: 'general' },
+              { slug: 'private-detail-fails' },
+              { slug: 'announcements' },
+            ],
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_NO_INDEX' }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_INDEXABLE' }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_INDEXABLE' }), { status: 200 }),
+      );
+    global.fetch = fetchMock;
+
+    const { getCloudFixture } = await loadCloudEnvModule();
+
+    const fixture = await getCloudFixture();
+
+    expect(fixture).toEqual({
+      serverId: 'server-1',
+      serverSlug: 'harmony-hq',
+      publicChannel: 'general',
+      publicChannels: ['general', 'announcements'],
+      publicChannelTargets: [
+        { serverSlug: 'harmony-hq', channelSlug: 'general' },
+        { serverSlug: 'harmony-hq', channelSlug: 'announcements' },
+      ],
+    });
   });
 
   test('collects crawler targets across multiple servers while keeping the primary fixture on the richest server', async () => {
@@ -155,12 +217,21 @@ describe('getCloudFixture cache behavior', () => {
         ),
       )
       .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_INDEXABLE' }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
             channels: [{ slug: 'two' }, { slug: 'three' }],
           }),
           { status: 200 },
         ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_INDEXABLE' }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ visibility: 'PUBLIC_INDEXABLE' }), { status: 200 }),
       );
     global.fetch = fetchMock;
 

--- a/tests/integration/env.ts
+++ b/tests/integration/env.ts
@@ -116,6 +116,31 @@ type DiscoveredServerFixture = {
 
 let cloudFixturePromise: Promise<CloudFixture> | null = null;
 
+async function resolveIndexableChannelSlugs(
+  serverSlug: string,
+  channels: Array<{ slug?: string }>,
+): Promise<string[]> {
+  const channelSlugs = channels
+    .filter((ch): ch is { slug: string } => typeof ch.slug === 'string' && ch.slug.length > 0)
+    .map((ch) => ch.slug);
+  const indexableChannelSlugs: string[] = [];
+
+  for (const channelSlug of channelSlugs) {
+    const channelRes = await fetch(
+      `${BACKEND_URL}/api/public/servers/${serverSlug}/channels/${channelSlug}`,
+    );
+    if (!channelRes.ok) continue;
+
+    const channel = (await channelRes.json()) as { visibility?: string };
+    if (channel.visibility !== 'PUBLIC_INDEXABLE') continue;
+
+    indexableChannelSlugs.push(channelSlug);
+    if (indexableChannelSlugs.length >= 3) break;
+  }
+
+  return indexableChannelSlugs;
+}
+
 async function resolveCloudFixtureFromPublicApi(): Promise<CloudFixture> {
   const serversRes = await fetch(`${BACKEND_URL}/api/public/servers`);
   if (!serversRes.ok) {
@@ -139,10 +164,12 @@ async function resolveCloudFixtureFromPublicApi(): Promise<CloudFixture> {
     const channelsBody = (await channelsRes.json()) as {
       channels?: Array<{ slug?: string }>;
     };
-    const publicChannels = (channelsBody.channels ?? [])
-      .filter((ch): ch is { slug: string } => typeof ch.slug === 'string' && ch.slug.length > 0)
-      .slice(0, 3)
-      .map((ch) => ch.slug);
+    // The channel list intentionally omits visibility, so treat it as candidates
+    // and confirm the indexable SEO fixture through the channel detail endpoint.
+    const publicChannels = await resolveIndexableChannelSlugs(
+      server.slug,
+      channelsBody.channels ?? [],
+    );
     if (!publicChannels.length) continue;
 
     discoveredFixtures.push({


### PR DESCRIPTION
## Summary
- Confirm cloud fixture channel candidates through the public channel detail endpoint before selecting them
- Keep only PUBLIC_INDEXABLE channels for cloud fixture targets
- Add regression coverage for mixed public candidate lists

Closes #421

## Verification
- npm --prefix tests/integration test -- env.test.ts
- tests/integration/node_modules/.bin/tsc --noEmit --project tests/integration/tsconfig.json
- npx prisma generate
- npm --prefix harmony-backend test -- public.router.test.ts

Note: npm --prefix tests/integration test was attempted, but the full suite requires running local frontend/backend services and failed with fetch failed against the default local URLs.