### PR TITLE
Fix production CORS localhost default

### DIFF
--- a/harmony-backend/src/middleware/cors.ts
+++ b/harmony-backend/src/middleware/cors.ts
@@ -8,7 +8,9 @@ export class CorsError extends Error {
   }
 }
 
-const defaultAllowedOrigins = ['http://localhost:3000'];
+function getDefaultAllowedOrigins(): string[] {
+  return process.env.NODE_ENV !== 'production' ? ['http://localhost:3000'] : [];
+}
 
 // FRONTEND_URL may be a comma-separated list of allowed origins so that
 // preview and production frontend URLs can both be permitted without a
@@ -25,7 +27,7 @@ export const corsOptions: CorsOptions = {
   origin: (origin, callback) => {
     // Build allowed origins at request time so env-based URLs reflect current configuration
     const allowedOrigins = [
-      ...defaultAllowedOrigins,
+      ...getDefaultAllowedOrigins(),
       ...parseFrontendOrigins(process.env.FRONTEND_URL),
     ];
     // Allow server-to-server requests (no Origin header) so internal callers

--- a/harmony-backend/tests/app.test.ts
+++ b/harmony-backend/tests/app.test.ts
@@ -43,15 +43,35 @@ describe('404 handler', () => {
 });
 
 describe('CORS', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
   it('returns 403 for disallowed origins', async () => {
     const res = await request(app).get('/health').set('Origin', 'https://evil.example.com');
     expect(res.status).toBe(403);
     expect(res.body).toMatchObject({ error: 'CORS: origin not allowed' });
   });
 
-  it('allows requests from localhost:3000', async () => {
+  it('allows requests from localhost:3000 outside production', async () => {
+    process.env.NODE_ENV = 'development';
+
     const res = await request(app).get('/health').set('Origin', 'http://localhost:3000');
     expect(res.status).toBe(200);
+  });
+
+  it('rejects requests from localhost:3000 in production', async () => {
+    process.env.NODE_ENV = 'production';
+
+    const res = await request(app).get('/health').set('Origin', 'http://localhost:3000');
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: 'CORS: origin not allowed' });
   });
 
   describe('FRONTEND_URL comma-separated origins', () => {


### PR DESCRIPTION
## Summary
- Remove `http://localhost:3000` from the default CORS allowlist when `NODE_ENV=production`.
- Preserve localhost CORS behavior outside production for local development.
- Add regression coverage for production rejection and development allowance.

Closes #433.

## Verification
- `npm --prefix harmony-backend test -- app.test.ts` passed.
- `npm --prefix harmony-backend run lint` passed with existing warnings only.
- `npm --prefix harmony-backend run build` passed.
- `npm --prefix harmony-frontend run lint` passed with existing warnings only.
- `npm --prefix harmony-frontend test -- --runInBand` passed.
- `npm --prefix harmony-backend test -- --runInBand --forceExit` completed but failed in environment-backed suites because this isolated worktree has no `DATABASE_URL` and the local Redis endpoint requires auth; the CORS regression suite passed.