### PR TITLE
Fix dummy login salt enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Point both backend services at the `harmony-backend` directory. The checked-in `
 Minimum backend env/config to mirror the documented deployment shape:
 
 - Shared on `backend-api` and `backend-worker`: `DATABASE_URL`, `REDIS_URL`
-- Required on `backend-api`: `FRONTEND_URL`, `TRUST_PROXY_HOPS=1`, `JWT_ACCESS_SECRET`, `JWT_REFRESH_SECRET`, `JWT_ACCESS_EXPIRES_IN`, `JWT_REFRESH_EXPIRES_DAYS`, `BASE_URL`
+- Required on `backend-api`: `FRONTEND_URL`, `TRUST_PROXY_HOPS=1`, `JWT_ACCESS_SECRET`, `JWT_REFRESH_SECRET`, `DUMMY_SALT_HMAC_KEY`, `JWT_ACCESS_EXPIRES_IN`, `JWT_REFRESH_EXPIRES_DAYS`, `BASE_URL`
 - Required for production uploads: `STORAGE_PROVIDER=s3` plus `R2_ACCOUNT_ID`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `S3_BUCKET`, `R2_PUBLIC_URL`
 
 SEO-specific deploy notes:

--- a/docs/deployment/deployment-architecture.md
+++ b/docs/deployment/deployment-architecture.md
@@ -276,6 +276,7 @@ Not part of the deployment contract:
 | `TRUST_PROXY_HOPS`         | Required                                    | `1`                                         | Required behind Railway proxy/load balancer                                              |
 | `JWT_ACCESS_SECRET`        | Required                                    | secret                                      | Shared with worker only if worker verifies tokens; do not rotate independently           |
 | `JWT_REFRESH_SECRET`       | Required                                    | secret                                      | Shared auth secret                                                                       |
+| `DUMMY_SALT_HMAC_KEY`      | Required                                    | secret                                      | HMAC key for unknown-user login challenge salts; do not expose to clients                |
 | `JWT_ACCESS_EXPIRES_IN`    | Required                                    | `15m`                                       | Keep explicit                                                                            |
 | `JWT_REFRESH_EXPIRES_DAYS` | Required                                    | `7`                                         | Keep explicit                                                                            |
 | `BASE_URL`                 | Required                                    | `https://harmony.chat`                      | Canonical public base URL for generated public links/sitemaps                            |
@@ -308,6 +309,7 @@ Must not be enabled in production:
 | `TRUST_PROXY_HOPS`         | Optional                                                       | `1`                                         | Only needed if worker exposes HTTP health traffic behind proxy |
 | `JWT_ACCESS_SECRET`        | Optional/currently likely unnecessary                          | shared secret                               | Only if worker code verifies or issues tokens                  |
 | `JWT_REFRESH_SECRET`       | Optional/currently likely unnecessary                          | shared secret                               | Same note                                                      |
+| `DUMMY_SALT_HMAC_KEY`      | Optional/currently likely unnecessary                          | shared secret                               | Required only if worker imports auth challenge code            |
 | `JWT_ACCESS_EXPIRES_IN`    | Optional/currently likely unnecessary                          | `15m`                                       | Keep aligned if auth code is reused                            |
 | `JWT_REFRESH_EXPIRES_DAYS` | Optional/currently likely unnecessary                          | `7`                                         | Keep aligned if auth code is reused                            |
 | `BASE_URL`                 | Future/Required if worker generates canonical public artifacts | `https://harmony.chat`                      | For sitemap/meta generation jobs                               |
@@ -316,12 +318,12 @@ Must not be enabled in production:
 
 ## 6.4 Shared service env ownership
 
-| Variable family      | Owner                         | Shared across                                |
-| -------------------- | ----------------------------- | -------------------------------------------- |
-| `DATABASE_URL`       | Railway project config        | `backend-api`, `backend-worker`              |
-| `REDIS_URL`          | Railway project config        | `backend-api`, `backend-worker`              |
-| JWT secrets and TTLs | Railway project config        | `backend-api`, `backend-worker` when needed  |
-| `BASE_URL`           | Deployment architecture owner | Any service generating canonical public URLs |
+| Variable family                 | Owner                         | Shared across                                |
+| ------------------------------- | ----------------------------- | -------------------------------------------- |
+| `DATABASE_URL`                  | Railway project config        | `backend-api`, `backend-worker`              |
+| `REDIS_URL`                     | Railway project config        | `backend-api`, `backend-worker`              |
+| JWT/dummy-salt secrets and TTLs | Railway project config        | `backend-api`, `backend-worker` when needed  |
+| `BASE_URL`                      | Deployment architecture owner | Any service generating canonical public URLs |
 
 ## 7. Preview vs Production Model
 

--- a/harmony-backend/.env.example
+++ b/harmony-backend/.env.example
@@ -36,6 +36,8 @@ HARMONY_DEMO_MODE=false
 # The server will start with placeholders, but anyone can forge authentication tokens.
 JWT_ACCESS_SECRET=change-me-access-secret
 JWT_REFRESH_SECRET=change-me-refresh-secret
+# HMAC key for unknown-user login challenge salts. Required in production.
+DUMMY_SALT_HMAC_KEY=change-me-dummy-salt-hmac-key
 # Access token TTL (jsonwebtoken format: 15m, 1h, etc.)
 JWT_ACCESS_EXPIRES_IN=15m
 # Refresh token TTL in days

--- a/harmony-backend/README.md
+++ b/harmony-backend/README.md
@@ -126,6 +126,7 @@ Copy `.env.example` to `.env` before running locally. All variables with no defa
 | `BASE_URL`                 | `http://localhost:3000` | Canonical public frontend origin used for generated public links and sitemap XML                       |
 | `JWT_ACCESS_SECRET`        | —                       | **Required.** Sign/verify access tokens. Must be 32+ random chars in production.                       |
 | `JWT_REFRESH_SECRET`       | —                       | **Required.** Sign/verify refresh tokens. Must be 32+ random chars in production.                      |
+| `DUMMY_SALT_HMAC_KEY`      | —                       | **Required in production.** HMAC key for unknown-user login challenge salts. Must be 32+ random chars. |
 | `JWT_ACCESS_EXPIRES_IN`    | `15m`                   | Access token TTL (`jsonwebtoken` duration string)                                                      |
 | `JWT_REFRESH_EXPIRES_DAYS` | `7`                     | Refresh token TTL in days                                                                              |
 | `TWILIO_ACCOUNT_SID`       | —                       | Optional. Twilio Account SID for voice channels.                                                       |
@@ -169,8 +170,8 @@ AWS_SECRET_ACCESS_KEY=<r2-api-token-secret>
 S3_BUCKET=<your-bucket-name>
 R2_PUBLIC_URL=https://pub-<token>.r2.dev   # or your custom domain
 ```
-
 To obtain the R2 credentials:
+
 1. Open the [Cloudflare dashboard](https://dash.cloudflare.com/) → **R2** → your bucket.
 2. Go to **Manage API tokens** and create a token with **Object Read & Write** on the target bucket.
 3. Copy the **Access Key ID** and **Secret Access Key** — the secret is shown only once.
@@ -203,7 +204,8 @@ docker compose up -d
 
 # 2. Create your local env file
 cp .env.example .env
-# Open .env and set strong secrets for JWT_ACCESS_SECRET and JWT_REFRESH_SECRET
+# Open .env and set strong secrets for JWT_ACCESS_SECRET, JWT_REFRESH_SECRET,
+# and DUMMY_SALT_HMAC_KEY
 # before running the server in any environment beyond your own laptop.
 
 # 3. Apply database migrations

--- a/harmony-backend/src/services/auth.service.ts
+++ b/harmony-backend/src/services/auth.service.ts
@@ -31,6 +31,17 @@ const REFRESH_SECRET = (() => {
 
 const ACCESS_EXPIRES_IN = process.env.JWT_ACCESS_EXPIRES_IN ?? '15m';
 
+const DUMMY_SALT_HMAC_KEY = (() => {
+  const value = process.env.DUMMY_SALT_HMAC_KEY;
+  if (value) return value;
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('DUMMY_SALT_HMAC_KEY environment variable is not set');
+  }
+
+  return ACCESS_SECRET;
+})();
+
 const REFRESH_EXPIRES_IN_DAYS: number = (() => {
   const raw = process.env.JWT_REFRESH_EXPIRES_DAYS;
   if (raw === undefined) return 7;
@@ -79,7 +90,7 @@ function decodePasswordVerifierRecord(
 
 function createDummyPasswordSalt(email: string): string {
   return crypto
-    .createHash('sha256')
+    .createHmac('sha256', DUMMY_SALT_HMAC_KEY)
     .update(`missing-user:${email.toLowerCase()}`)
     .digest('hex')
     .slice(0, PASSWORD_SALT_BYTES * 2);
@@ -166,7 +177,11 @@ export const authService = {
   },
 
   async getLoginPasswordSalt(email: string): Promise<string> {
-    if (process.env.NODE_ENV === 'development' && process.env.ENABLE_DEV_ADMIN === 'true' && email === ADMIN_EMAIL) {
+    if (
+      process.env.NODE_ENV === 'development' &&
+      process.env.ENABLE_DEV_ADMIN === 'true' &&
+      email === ADMIN_EMAIL
+    ) {
       return DEV_ADMIN_PASSWORD_SALT;
     }
 

--- a/harmony-backend/tests/auth.service.test.ts
+++ b/harmony-backend/tests/auth.service.test.ts
@@ -149,6 +149,19 @@ describe('authService password-verifier helpers', () => {
     expect(first).toBe(second);
     expect(first).toMatch(/^[0-9a-f]{32}$/i);
   });
+
+  it('does not expose the public SHA-256 missing-user salt for unknown users', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    const salt = await authService.getLoginPasswordSalt('missing@example.com');
+    const publicFormulaSalt = crypto
+      .createHash('sha256')
+      .update('missing-user:missing@example.com')
+      .digest('hex')
+      .slice(0, 32);
+
+    expect(salt).not.toBe(publicFormulaSalt);
+  });
 });
 
 describe('authService.register', () => {

--- a/harmony-backend/tests/auth.test.ts
+++ b/harmony-backend/tests/auth.test.ts
@@ -235,10 +235,16 @@ describe('POST /api/auth/login/challenge', () => {
       .post('/api/auth/login/challenge')
       .set('Origin', 'http://localhost:3000')
       .send({ email: 'nobody@example.com' });
+    const publicFormulaSalt = crypto
+      .createHash('sha256')
+      .update('missing-user:nobody@example.com')
+      .digest('hex')
+      .slice(0, 32);
 
     expect(first.status).toBe(200);
     expect(first.body.passwordSalt).toMatch(/^[0-9a-f]{32}$/i);
     expect(second.body.passwordSalt).toBe(first.body.passwordSalt);
+    expect(first.body.passwordSalt).not.toBe(publicFormulaSalt);
   });
 });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,17 @@
+# Issue #431 - Dummy salt email enumeration
+
+- [x] Read `AGENTS.md` and `WORKFLOW.md`
+- [x] Inspect issue #431 body/comments
+- [x] Create isolated branch `codex/issue-431-dummy-salt-enumeration` from `origin/main`
+- [x] Assign `acabrera04` and post starting issue comment
+- [x] Add regression coverage for public-formula dummy salt enumeration
+- [x] Replace public SHA-256 dummy salt with server-secret keyed HMAC
+- [x] Run backend and frontend verification
+- [ ] Commit, push, and open ready-for-review PR closing #431
+
+## Review
+
+- `authService.getLoginPasswordSalt()` now returns HMAC-derived dummy salts using `DUMMY_SALT_HMAC_KEY` in production.
+- Unknown-user dummy salts stay stable per email, but no longer match the public SHA-256 formula from issue #431.
+- Added service and route regression tests for the offline-precomputable salt value.
+- Verification completed with targeted backend auth suites, backend lint/build, frontend lint/tests/build. Full backend Jest was attempted but hung without output and was stopped.


### PR DESCRIPTION
## Summary
- replace public SHA-256 dummy login salts with server-secret HMAC-derived salts
- document the production `DUMMY_SALT_HMAC_KEY` requirement
- add service and route regressions proving unknown-user salts no longer match the public formula

Closes #431

## Verification
- `npm test -- auth.service.test.ts --runInBand` (backend)
- `npm test -- auth.test.ts --runInBand` (backend, rerun outside sandbox for Supertest bind)
- `npm run lint` (backend; existing warnings only)
- `npm run build` (backend)
- `npm run lint` (frontend; existing warnings only)
- `npm test -- --runInBand` (frontend)
- `npm run build` (frontend, rerun outside sandbox for Turbopack bind)

Note: full backend `npm test -- --runInBand` was attempted but hung without output in this worktree and was stopped; targeted auth suites passed.