### PR TITLE
Fix server SSE message hydration fanout

### DIFF
--- a/harmony-backend/src/events/eventTypes.ts
+++ b/harmony-backend/src/events/eventTypes.ts
@@ -47,12 +47,14 @@ export interface MessageCreatedPayload {
   /** Present only when the message is a thread reply; absent for top-level channel messages. */
   parentMessageId?: string;
   timestamp: string;
+  message?: SseMessagePayload;
 }
 
 export interface MessageEditedPayload {
   messageId: string;
   channelId: string;
   timestamp: string;
+  message?: SseMessagePayload;
 }
 
 export interface MessageDeletedPayload {
@@ -167,6 +169,40 @@ export interface UserMentionedPayload {
   authorId: string;
   authorUsername: string;
   timestamp: string;
+}
+
+export interface SseMessageAuthorPayload {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+export interface SseMessageAttachmentPayload {
+  id: string;
+  filename: string;
+  url: string;
+  contentType: string;
+}
+
+export interface SseParentMessagePayload {
+  id: string;
+  content: string;
+  isDeleted: boolean;
+  author: SseMessageAuthorPayload;
+}
+
+export interface SseMessagePayload {
+  id: string;
+  channelId: string;
+  authorId: string;
+  author: SseMessageAuthorPayload;
+  content: string;
+  timestamp: string;
+  attachments: SseMessageAttachmentPayload[];
+  editedAt: string | null;
+  parentMessageId: string | null;
+  parentMessage: SseParentMessagePayload | null;
 }
 
 // Map each channel to its payload type for type-safe subscribe/publish

--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -40,6 +40,7 @@ import type {
   UserMentionedPayload,
   ReactionAddedPayload,
   ReactionRemovedPayload,
+  SseMessagePayload,
 } from '../events/eventTypes';
 
 export const eventsRouter = Router();
@@ -188,6 +189,34 @@ function createBufferedEventWriter(
       return;
     }
     res.write(frame);
+  };
+}
+
+function messageCreatedEventData(message: SseMessagePayload) {
+  return {
+    id: message.id,
+    channelId: message.channelId,
+    authorId: message.authorId,
+    author: message.author,
+    content: message.content,
+    timestamp: message.timestamp,
+    attachments: message.attachments,
+    editedAt: message.editedAt,
+    parentMessageId: message.parentMessageId,
+    parentMessage: message.parentMessage,
+  };
+}
+
+function messageEditedEventData(message: SseMessagePayload) {
+  return {
+    id: message.id,
+    channelId: message.channelId,
+    authorId: message.authorId,
+    author: message.author,
+    content: message.content,
+    timestamp: message.timestamp,
+    attachments: message.attachments,
+    editedAt: message.editedAt,
   };
 }
 
@@ -636,43 +665,13 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     EventChannels.MESSAGE_CREATED,
     async (payload: MessageCreatedPayload) => {
       if (!serverChannelIds.has(payload.channelId)) return;
+      if (!payload.message) return;
 
-      try {
-        const message = await prisma.message.findUnique({
-          where: { id: payload.messageId },
-          include: MESSAGE_SSE_INCLUDE,
-        });
-        if (!message || message.isDeleted) return;
-
-        writeEvent(
-          'message:created',
-          {
-            id: message.id,
-            channelId: message.channelId,
-            authorId: message.authorId,
-            author: message.author,
-            content: message.content,
-            timestamp: message.createdAt.toISOString(),
-            attachments: message.attachments,
-            editedAt: message.editedAt ? message.editedAt.toISOString() : null,
-            parentMessageId: message.parentMessageId,
-            parentMessage: message.parent
-              ? {
-                  id: message.parent.id,
-                  content: message.parent.isDeleted ? '' : message.parent.content,
-                  isDeleted: message.parent.isDeleted,
-                  author: message.parent.author,
-                }
-              : null,
-          },
-          message.createdAt.toISOString(),
-        );
-      } catch (err) {
-        logger.warn(
-          { err, serverId, messageId: payload.messageId },
-          'Failed to hydrate SSE message:created payload on server endpoint',
-        );
-      }
+      writeEvent(
+        'message:created',
+        messageCreatedEventData(payload.message),
+        payload.message.timestamp,
+      );
     },
   );
   subscriptions.push(messageCreatedSubscription);
@@ -681,30 +680,9 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     EventChannels.MESSAGE_EDITED,
     async (payload: MessageEditedPayload) => {
       if (!serverChannelIds.has(payload.channelId)) return;
+      if (!payload.message) return;
 
-      try {
-        const message = await prisma.message.findUnique({
-          where: { id: payload.messageId },
-          include: MESSAGE_SSE_INCLUDE,
-        });
-        if (!message || message.isDeleted) return;
-
-        writeEvent('message:edited', {
-          id: message.id,
-          channelId: message.channelId,
-          authorId: message.authorId,
-          author: message.author,
-          content: message.content,
-          timestamp: message.createdAt.toISOString(),
-          attachments: message.attachments,
-          editedAt: message.editedAt ? message.editedAt.toISOString() : null,
-        });
-      } catch (err) {
-        logger.warn(
-          { err, serverId, messageId: payload.messageId },
-          'Failed to hydrate SSE message:edited payload on server endpoint',
-        );
-      }
+      writeEvent('message:edited', messageEditedEventData(payload.message));
     },
   );
   subscriptions.push(messageEditedSubscription);
@@ -954,7 +932,14 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
       }
     : undefined;
 
-  await finalizeSseSetup(req, res, sseState, subscriptions, { route: 'server-events', serverId }, serverReplayFrames);
+  await finalizeSseSetup(
+    req,
+    res,
+    sseState,
+    subscriptions,
+    { route: 'server-events', serverId },
+    serverReplayFrames,
+  );
 });
 
 // ─── User-scoped notification SSE route ──────────────────────────────────────
@@ -998,5 +983,8 @@ eventsRouter.get('/user', async (req: Request, res: Response) => {
     },
   );
 
-  await finalizeSseSetup(req, res, sseState, [mentionSubscription], { route: 'user-events', userId });
+  await finalizeSseSetup(req, res, sseState, [mentionSubscription], {
+    route: 'user-events',
+    userId,
+  });
 });

--- a/harmony-backend/src/services/message.service.ts
+++ b/harmony-backend/src/services/message.service.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from '@trpc/server';
+import { Prisma } from '@prisma/client';
 import { prisma } from '../db/prisma';
 import { createLogger } from '../lib/logger';
 import { cacheService, CacheTTL, sanitizeKeySegment } from './cache.service';
@@ -10,6 +11,7 @@ import { channelMemberRepository } from '../repositories/channelMember.repositor
 import { messageRepository } from '../repositories/message.repository';
 import { processMentions, processBroadcastMentions } from './mention.service';
 import { pushNotificationService } from './pushNotification.service';
+import type { SseMessagePayload } from '../events/eventTypes';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -101,6 +103,55 @@ function msgCacheKey(
   );
 }
 
+type HydratedMessageForSse = {
+  id: string;
+  channelId: string;
+  authorId: string;
+  author: SseMessagePayload['author'];
+  content: string;
+  createdAt: Date | string;
+  editedAt: Date | string | null;
+  attachments: SseMessagePayload['attachments'];
+  parentMessageId: string | null;
+  parent?: {
+    id: string;
+    content: string;
+    isDeleted: boolean;
+    author: SseMessagePayload['author'];
+  } | null;
+};
+
+function toIsoString(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function toNullableIsoString(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  return toIsoString(value);
+}
+
+function toSseMessagePayload(message: HydratedMessageForSse): SseMessagePayload {
+  return {
+    id: message.id,
+    channelId: message.channelId,
+    authorId: message.authorId,
+    author: message.author,
+    content: message.content,
+    timestamp: toIsoString(message.createdAt),
+    attachments: message.attachments,
+    editedAt: toNullableIsoString(message.editedAt),
+    parentMessageId: message.parentMessageId,
+    parentMessage: message.parent
+      ? {
+          id: message.parent.id,
+          content: message.parent.isDeleted ? '' : message.parent.content,
+          isDeleted: message.parent.isDeleted,
+          author: message.parent.author,
+        }
+      : null,
+  };
+}
+
 /**
  * Resolve a channel and assert it belongs to the given server.
  * Throws NOT_FOUND (collapsed from both "no channel" and "wrong server") to
@@ -129,7 +180,10 @@ async function requirePrivateChannelAccess(
 
   const isMember = await channelMemberRepository.isMember(userId, channel.id);
   if (!isMember) {
-    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this private channel' });
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'You do not have access to this private channel',
+    });
   }
 }
 
@@ -175,7 +229,7 @@ export const messageService = {
         const page = hasMore ? messages.slice(0, clampedLimit) : messages;
         const nextCursor = hasMore ? page[page.length - 1].id : null;
 
-        const messagesWithReactions = page.map(msg => ({
+        const messagesWithReactions = page.map((msg: (typeof page)[number]) => ({
           ...msg,
           reactions: groupReactions(msg.reactions),
         }));
@@ -213,7 +267,10 @@ export const messageService = {
         `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)}:*`,
       );
     } catch (err) {
-      logger.warn({ err, channelId, serverId }, 'Failed to invalidate channel message cache after send');
+      logger.warn(
+        { err, channelId, serverId },
+        'Failed to invalidate channel message cache after send',
+      );
     }
 
     eventBus
@@ -222,6 +279,7 @@ export const messageService = {
         channelId,
         authorId,
         timestamp: message.createdAt.toISOString(),
+        message: toSseMessagePayload(message),
       })
       .catch((err) =>
         logger.warn(
@@ -256,7 +314,10 @@ export const messageService = {
     // Dispatch push notifications fire-and-forget
     (async () => {
       try {
-        const server = await prisma.server.findUnique({ where: { id: serverId }, select: { slug: true } });
+        const server = await prisma.server.findUnique({
+          where: { id: serverId },
+          select: { slug: true },
+        });
         if (!server) return;
 
         const ctx = {
@@ -312,6 +373,7 @@ export const messageService = {
         messageId,
         channelId: message.channelId,
         timestamp: updated.editedAt!.toISOString(),
+        message: toSseMessagePayload(updated),
       })
       .catch((err) =>
         logger.warn(
@@ -329,9 +391,7 @@ export const messageService = {
       authorId,
       authorUsername: updated.author.username,
       content,
-    }).catch((err) =>
-      logger.warn({ err, messageId }, 'processMentions failed on editMessage'),
-    );
+    }).catch((err) => logger.warn({ err, messageId }, 'processMentions failed on editMessage'));
     processBroadcastMentions({
       messageId,
       channelId: message.channelId,
@@ -370,7 +430,7 @@ export const messageService = {
       }
     }
 
-    await prisma.$transaction(async (tx) => {
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       // Soft-delete the message itself
       await messageRepository.updateRaw(messageId, { isDeleted: true }, tx);
 
@@ -438,7 +498,7 @@ export const messageService = {
     const channel = await requireChannelInServer(preCheck.channelId, serverId);
     await requirePrivateChannelAccess(channel, userId, serverId);
 
-    const updated = await prisma.$transaction(async (tx) => {
+    const updated = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const msg = await messageRepository.findByIdWithChannel(messageId, tx);
 
       if (!msg || msg.isDeleted || msg.channel.serverId !== serverId) {
@@ -477,7 +537,7 @@ export const messageService = {
     const channel = await requireChannelInServer(preCheck.channelId, serverId);
     await requirePrivateChannelAccess(channel, userId, serverId);
 
-    const updated = await prisma.$transaction(async (tx) => {
+    const updated = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const msg = await messageRepository.findByIdWithChannel(messageId, tx);
 
       if (!msg || msg.isDeleted || msg.channel.serverId !== serverId) {
@@ -524,7 +584,7 @@ export const messageService = {
     const channel = await requireChannelInServer(channelId, serverId);
     await requirePrivateChannelAccess(channel, authorId, serverId);
 
-    const reply = await prisma.$transaction(async (tx) => {
+    const reply = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const parent = await messageRepository.findByIdWithChannelFull(parentMessageId, tx);
 
       if (
@@ -557,11 +617,7 @@ export const messageService = {
         tx,
       );
 
-      await messageRepository.updateRaw(
-        parentMessageId,
-        { replyCount: { increment: 1 } },
-        tx,
-      );
+      await messageRepository.updateRaw(parentMessageId, { replyCount: { increment: 1 } }, tx);
 
       return created;
     });
@@ -572,7 +628,10 @@ export const messageService = {
         `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)}:*`,
       );
     } catch (err) {
-      logger.warn({ err, channelId, serverId }, 'Failed to invalidate channel message cache after reply');
+      logger.warn(
+        { err, channelId, serverId },
+        'Failed to invalidate channel message cache after reply',
+      );
     }
     try {
       await cacheService.invalidatePattern(`thread:msgs:${sanitizeKeySegment(parentMessageId)}:*`);
@@ -587,6 +646,7 @@ export const messageService = {
         authorId,
         parentMessageId,
         timestamp: reply.createdAt.toISOString(),
+        message: toSseMessagePayload(reply),
       })
       .catch((err) =>
         logger.warn(

--- a/harmony-backend/tests/events.router.server.test.ts
+++ b/harmony-backend/tests/events.router.server.test.ts
@@ -305,17 +305,18 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
       },
     );
 
-    (prisma.message.findUnique as jest.Mock).mockResolvedValue({
+    const hydratedMessage = {
       id: MESSAGE_ID,
       channelId: CHANNEL_ID,
       authorId: 'author-1',
       author: { id: 'author-1', username: 'bob', displayName: 'Bob', avatarUrl: null },
       content: 'live message during setup window',
-      createdAt: new Date('2026-04-19T11:00:00.000Z'),
+      timestamp: '2026-04-19T11:00:00.000Z',
       editedAt: null,
       attachments: [],
-      isDeleted: false,
-    });
+      parentMessageId: null,
+      parentMessage: null,
+    };
 
     const addr = server.address();
     if (!addr || typeof addr === 'string') throw new Error('Bad server address');
@@ -324,15 +325,12 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     const chunks: string[] = [];
     let response: http.IncomingMessage | null = null;
     await new Promise<void>((resolve, reject) => {
-      const req = http.get(
-        { hostname: 'localhost', port, path: sseUrl },
-        (res) => {
-          response = res;
-          responseStarted.resolve();
-          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
-          res.on('error', reject);
-        },
-      );
+      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
+        response = res;
+        responseStarted.resolve();
+        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+        res.on('error', reject);
+      });
 
       req.on('error', reject);
 
@@ -347,6 +345,7 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
           channelId: CHANNEL_ID,
           authorId: 'author-1',
           timestamp: new Date('2026-04-19T11:00:00.000Z').toISOString(),
+          message: hydratedMessage,
         });
 
         ready.resolve();
@@ -363,6 +362,84 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     const body = chunks.join('');
     expect(body).toContain('event: message:created');
     expect(body).toContain('live message during setup window');
+    expect(prisma.message.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('does not hydrate message:created once per connected server SSE client', async () => {
+    const CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440012';
+    const MESSAGE_ID = '550e8400-e29b-41d4-a716-446655440013';
+    const hydratedMessage = {
+      id: MESSAGE_ID,
+      channelId: CHANNEL_ID,
+      authorId: 'author-1',
+      author: { id: 'author-1', username: 'bob', displayName: 'Bob', avatarUrl: null },
+      content: 'one hydrated payload',
+      timestamp: '2026-04-19T11:05:00.000Z',
+      attachments: [],
+      editedAt: null,
+      parentMessageId: null,
+      parentMessage: null,
+    };
+    const messageCreatedHandlers: Array<(payload: MessageCreatedPayload) => Promise<void>> = [];
+
+    (prisma.channel.findMany as jest.Mock).mockResolvedValue([{ id: CHANNEL_ID }]);
+    mockSubscribe.mockImplementation(
+      (channel: string, handler: (payload: MessageCreatedPayload) => Promise<void>) => {
+        if (channel === 'harmony:MESSAGE_CREATED') messageCreatedHandlers.push(handler);
+        return { unsubscribe: jest.fn(), ready: Promise.resolve() };
+      },
+    );
+
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad server address');
+    const port = addr.port;
+
+    const openSse = () =>
+      new Promise<{ req: http.ClientRequest; chunks: string[] }>((resolve, reject) => {
+        const chunks: string[] = [];
+        const req = http.get(
+          {
+            hostname: 'localhost',
+            port,
+            path: `/api/events/server/${VALID_SERVER_ID}?ticket=${SSE_TEST_TICKET}`,
+          },
+          (res) => {
+            res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+            res.on('error', reject);
+            resolve({ req, chunks });
+          },
+        );
+        req.on('error', reject);
+      });
+
+    const first = await openSse();
+    seedSseTestTicket(redis as unknown as { set: jest.Mock });
+    const second = await openSse();
+
+    expect(messageCreatedHandlers).toHaveLength(2);
+
+    await Promise.all(
+      messageCreatedHandlers.map((handler) =>
+        handler({
+          messageId: MESSAGE_ID,
+          channelId: CHANNEL_ID,
+          authorId: 'author-1',
+          timestamp: hydratedMessage.timestamp,
+          message: hydratedMessage,
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      return (
+        first.chunks.join('').includes('one hydrated payload') &&
+        second.chunks.join('').includes('one hydrated payload')
+      );
+    });
+
+    first.req.destroy();
+    second.req.destroy();
+    expect(prisma.message.findUnique).not.toHaveBeenCalled();
   });
 });
 
@@ -462,14 +539,11 @@ describe('GET /api/events/server/:serverId — Last-Event-ID replay', () => {
     const chunks: string[] = [];
     const responseStarted = createDeferred<void>();
     await new Promise<void>((resolve, reject) => {
-      const req = http.get(
-        { hostname: 'localhost', port, path: sseUrlWithReplay },
-        (res) => {
-          responseStarted.resolve();
-          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
-          res.on('error', reject);
-        },
-      );
+      const req = http.get({ hostname: 'localhost', port, path: sseUrlWithReplay }, (res) => {
+        responseStarted.resolve();
+        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+        res.on('error', reject);
+      });
       req.on('error', reject);
 
       setTimeout(async () => {
@@ -483,6 +557,18 @@ describe('GET /api/events/server/:serverId — Last-Event-ID replay', () => {
           channelId: LIVE_CHANNEL_ID,
           authorId: 'author-3',
           timestamp: new Date('2026-04-19T10:01:00.000Z').toISOString(),
+          message: {
+            id: liveMsg.id,
+            channelId: liveMsg.channelId,
+            authorId: liveMsg.authorId,
+            author: liveMsg.author,
+            content: liveMsg.content,
+            timestamp: liveMsg.createdAt.toISOString(),
+            attachments: liveMsg.attachments,
+            editedAt: null,
+            parentMessageId: null,
+            parentMessage: null,
+          },
         });
         ready.resolve();
         await responseStarted.promise;

--- a/harmony-backend/tests/message.service.events.test.ts
+++ b/harmony-backend/tests/message.service.events.test.ts
@@ -181,6 +181,33 @@ describe('messageService.sendMessage — event publishing', () => {
     );
   });
 
+  it('publishes the hydrated message so SSE consumers do not re-query per client', async () => {
+    await messageService.sendMessage({
+      serverId: SERVER_ID,
+      channelId: CHANNEL_ID,
+      authorId: AUTHOR_ID,
+      content: 'hello',
+    });
+
+    expect(mockPublish).toHaveBeenCalledWith(
+      'harmony:MESSAGE_CREATED',
+      expect.objectContaining({
+        message: expect.objectContaining({
+          id: MESSAGE_ID,
+          channelId: CHANNEL_ID,
+          authorId: AUTHOR_ID,
+          author: MOCK_MESSAGE.author,
+          content: 'hello',
+          timestamp: MOCK_MESSAGE.createdAt.toISOString(),
+          attachments: [],
+          editedAt: null,
+          parentMessageId: null,
+          parentMessage: null,
+        }),
+      }),
+    );
+  });
+
   it('timestamp in MESSAGE_CREATED is a valid ISO 8601 string', async () => {
     await messageService.sendMessage({
       serverId: SERVER_ID,
@@ -227,6 +254,33 @@ describe('messageService.editMessage — event publishing', () => {
         messageId: MESSAGE_ID,
         channelId: CHANNEL_ID,
         timestamp: expect.any(String),
+      }),
+    );
+  });
+
+  it('publishes the edited hydrated message so SSE consumers do not re-query per client', async () => {
+    await messageService.editMessage({
+      serverId: SERVER_ID,
+      messageId: MESSAGE_ID,
+      authorId: AUTHOR_ID,
+      content: 'edited',
+    });
+
+    expect(mockPublish).toHaveBeenCalledWith(
+      'harmony:MESSAGE_EDITED',
+      expect.objectContaining({
+        message: expect.objectContaining({
+          id: MESSAGE_ID,
+          channelId: CHANNEL_ID,
+          authorId: AUTHOR_ID,
+          author: MOCK_UPDATED_MESSAGE.author,
+          content: 'edited',
+          timestamp: MOCK_UPDATED_MESSAGE.createdAt.toISOString(),
+          attachments: [],
+          editedAt: MOCK_UPDATED_MESSAGE.editedAt!.toISOString(),
+          parentMessageId: null,
+          parentMessage: null,
+        }),
       }),
     );
   });
@@ -341,6 +395,34 @@ describe('messageService.createReply — event publishing', () => {
         authorId: AUTHOR_ID,
         parentMessageId: MESSAGE_ID,
         timestamp: expect.any(String),
+      }),
+    );
+  });
+
+  it('publishes the hydrated reply message so SSE consumers do not re-query per client', async () => {
+    await messageService.createReply({
+      parentMessageId: MESSAGE_ID,
+      channelId: CHANNEL_ID,
+      serverId: SERVER_ID,
+      authorId: AUTHOR_ID,
+      content: 'reply',
+    });
+
+    expect(mockPublish).toHaveBeenCalledWith(
+      'harmony:MESSAGE_CREATED',
+      expect.objectContaining({
+        message: expect.objectContaining({
+          id: REPLY_ID,
+          channelId: CHANNEL_ID,
+          authorId: AUTHOR_ID,
+          author: MOCK_REPLY.author,
+          content: 'reply',
+          timestamp: MOCK_REPLY.createdAt.toISOString(),
+          attachments: [],
+          editedAt: null,
+          parentMessageId: MESSAGE_ID,
+          parentMessage: null,
+        }),
       }),
     );
   });


### PR DESCRIPTION
## Summary

Closes #416.

- Publish hydrated, JSON-safe message payloads from `messageService.sendMessage`, `editMessage`, and `createReply`.
- Update the server-scoped SSE route to emit `message:created` and `message:edited` from the producer payload instead of calling `prisma.message.findUnique` for every connected client.
- Add regression coverage proving hydrated payload publication and no per-client server SSE message hydration query across multiple connected clients.

## Verification

- `npm test -- --runTestsByPath tests/message.service.events.test.ts tests/events.router.server.test.ts`
- `npm run lint` in `harmony-backend` (passes with existing unrelated warnings in `tests/channelMember.test.ts` and `tests/events.router.sse-server-updated.test.ts`)
- `npm run build` in `harmony-backend`
- `npm run lint` in `harmony-frontend` (passes with existing unrelated warnings in issue #516 test, `NotificationBell.tsx`, and `VoiceContext.tsx`)
- `npm test -- --runInBand` in `harmony-frontend`
- `npm run build` in `harmony-frontend` (rerun with elevated local permissions because Turbopack needs worker/local port binding)

Note: full backend Jest was attempted, but local DB/Redis-backed suites require `DATABASE_URL` and authenticated Redis in this worktree environment, so the relevant mocked SSE/service suites plus backend lint/build were used for this change.