### PR TITLE
fix: hydrate SSE message events at producer

### DIFF
--- a/harmony-backend/src/events/eventTypes.ts
+++ b/harmony-backend/src/events/eventTypes.ts
@@ -47,12 +47,50 @@ export interface MessageCreatedPayload {
   /** Present only when the message is a thread reply; absent for top-level channel messages. */
   parentMessageId?: string;
   timestamp: string;
+  /** Hydrated once by the producer so SSE fan-out does not query per connected client. */
+  message?: EventMessagePayload;
 }
 
 export interface MessageEditedPayload {
   messageId: string;
   channelId: string;
   timestamp: string;
+  /** Hydrated once by the producer so SSE fan-out does not query per connected client. */
+  message?: EventMessagePayload;
+}
+
+export interface EventMessageAuthor {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+export interface EventMessageAttachment {
+  id: string;
+  filename: string;
+  url: string;
+  contentType: string;
+}
+
+export interface EventMessageParent {
+  id: string;
+  content: string;
+  isDeleted: boolean;
+  author: EventMessageAuthor;
+}
+
+export interface EventMessagePayload {
+  id: string;
+  channelId: string;
+  authorId: string;
+  author: EventMessageAuthor;
+  content: string;
+  timestamp: string;
+  attachments: EventMessageAttachment[];
+  editedAt: string | null;
+  parentMessageId: string | null;
+  parentMessage: EventMessageParent | null;
 }
 
 export interface MessageDeletedPayload {

--- a/harmony-backend/src/routes/events.router.ts
+++ b/harmony-backend/src/routes/events.router.ts
@@ -191,6 +191,38 @@ function createBufferedEventWriter(
   };
 }
 
+function writeCreatedMessageEvent(
+  writeEvent: (eventType: string, data: unknown, id?: string) => void,
+  payload: MessageCreatedPayload,
+  logContext: Record<string, string>,
+): void {
+  if (!payload.message) {
+    logger.warn(
+      { ...logContext, messageId: payload.messageId },
+      'Missing hydrated SSE message:created payload',
+    );
+    return;
+  }
+
+  writeEvent('message:created', payload.message, payload.message.timestamp);
+}
+
+function writeEditedMessageEvent(
+  writeEvent: (eventType: string, data: unknown, id?: string) => void,
+  payload: MessageEditedPayload,
+  logContext: Record<string, string>,
+): void {
+  if (!payload.message) {
+    logger.warn(
+      { ...logContext, messageId: payload.messageId },
+      'Missing hydrated SSE message:edited payload',
+    );
+    return;
+  }
+
+  writeEvent('message:edited', payload.message);
+}
+
 async function finalizeSseSetup(
   req: Request,
   res: Response,
@@ -307,43 +339,7 @@ eventsRouter.get('/channel/:channelId', async (req: Request, res: Response) => {
     EventChannels.MESSAGE_CREATED,
     async (payload: MessageCreatedPayload) => {
       if (payload.channelId !== channelId) return;
-
-      try {
-        const message = await prisma.message.findUnique({
-          where: { id: payload.messageId },
-          include: MESSAGE_SSE_INCLUDE,
-        });
-        if (!message || message.isDeleted) return;
-
-        writeEvent(
-          'message:created',
-          {
-            id: message.id,
-            channelId: message.channelId,
-            authorId: message.authorId,
-            author: message.author,
-            content: message.content,
-            timestamp: message.createdAt.toISOString(),
-            attachments: message.attachments,
-            editedAt: message.editedAt ? message.editedAt.toISOString() : null,
-            parentMessageId: message.parentMessageId,
-            parentMessage: message.parent
-              ? {
-                  id: message.parent.id,
-                  content: message.parent.isDeleted ? '' : message.parent.content,
-                  isDeleted: message.parent.isDeleted,
-                  author: message.parent.author,
-                }
-              : null,
-          },
-          message.createdAt.toISOString(),
-        );
-      } catch (err) {
-        logger.warn(
-          { err, channelId, messageId: payload.messageId },
-          'Failed to hydrate SSE message:created payload',
-        );
-      }
+      writeCreatedMessageEvent(writeEvent, payload, { channelId });
     },
   );
 
@@ -351,30 +347,7 @@ eventsRouter.get('/channel/:channelId', async (req: Request, res: Response) => {
     EventChannels.MESSAGE_EDITED,
     async (payload: MessageEditedPayload) => {
       if (payload.channelId !== channelId) return;
-
-      try {
-        const message = await prisma.message.findUnique({
-          where: { id: payload.messageId },
-          include: MESSAGE_SSE_INCLUDE,
-        });
-        if (!message || message.isDeleted) return;
-
-        writeEvent('message:edited', {
-          id: message.id,
-          channelId: message.channelId,
-          authorId: message.authorId,
-          author: message.author,
-          content: message.content,
-          timestamp: message.createdAt.toISOString(),
-          attachments: message.attachments,
-          editedAt: message.editedAt ? message.editedAt.toISOString() : null,
-        });
-      } catch (err) {
-        logger.warn(
-          { err, channelId, messageId: payload.messageId },
-          'Failed to hydrate SSE message:edited payload',
-        );
-      }
+      writeEditedMessageEvent(writeEvent, payload, { channelId });
     },
   );
 
@@ -636,43 +609,7 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     EventChannels.MESSAGE_CREATED,
     async (payload: MessageCreatedPayload) => {
       if (!serverChannelIds.has(payload.channelId)) return;
-
-      try {
-        const message = await prisma.message.findUnique({
-          where: { id: payload.messageId },
-          include: MESSAGE_SSE_INCLUDE,
-        });
-        if (!message || message.isDeleted) return;
-
-        writeEvent(
-          'message:created',
-          {
-            id: message.id,
-            channelId: message.channelId,
-            authorId: message.authorId,
-            author: message.author,
-            content: message.content,
-            timestamp: message.createdAt.toISOString(),
-            attachments: message.attachments,
-            editedAt: message.editedAt ? message.editedAt.toISOString() : null,
-            parentMessageId: message.parentMessageId,
-            parentMessage: message.parent
-              ? {
-                  id: message.parent.id,
-                  content: message.parent.isDeleted ? '' : message.parent.content,
-                  isDeleted: message.parent.isDeleted,
-                  author: message.parent.author,
-                }
-              : null,
-          },
-          message.createdAt.toISOString(),
-        );
-      } catch (err) {
-        logger.warn(
-          { err, serverId, messageId: payload.messageId },
-          'Failed to hydrate SSE message:created payload on server endpoint',
-        );
-      }
+      writeCreatedMessageEvent(writeEvent, payload, { serverId });
     },
   );
   subscriptions.push(messageCreatedSubscription);
@@ -681,30 +618,7 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
     EventChannels.MESSAGE_EDITED,
     async (payload: MessageEditedPayload) => {
       if (!serverChannelIds.has(payload.channelId)) return;
-
-      try {
-        const message = await prisma.message.findUnique({
-          where: { id: payload.messageId },
-          include: MESSAGE_SSE_INCLUDE,
-        });
-        if (!message || message.isDeleted) return;
-
-        writeEvent('message:edited', {
-          id: message.id,
-          channelId: message.channelId,
-          authorId: message.authorId,
-          author: message.author,
-          content: message.content,
-          timestamp: message.createdAt.toISOString(),
-          attachments: message.attachments,
-          editedAt: message.editedAt ? message.editedAt.toISOString() : null,
-        });
-      } catch (err) {
-        logger.warn(
-          { err, serverId, messageId: payload.messageId },
-          'Failed to hydrate SSE message:edited payload on server endpoint',
-        );
-      }
+      writeEditedMessageEvent(writeEvent, payload, { serverId });
     },
   );
   subscriptions.push(messageEditedSubscription);
@@ -954,7 +868,14 @@ eventsRouter.get('/server/:serverId', async (req: Request, res: Response) => {
       }
     : undefined;
 
-  await finalizeSseSetup(req, res, sseState, subscriptions, { route: 'server-events', serverId }, serverReplayFrames);
+  await finalizeSseSetup(
+    req,
+    res,
+    sseState,
+    subscriptions,
+    { route: 'server-events', serverId },
+    serverReplayFrames,
+  );
 });
 
 // ─── User-scoped notification SSE route ──────────────────────────────────────
@@ -998,5 +919,8 @@ eventsRouter.get('/user', async (req: Request, res: Response) => {
     },
   );
 
-  await finalizeSseSetup(req, res, sseState, [mentionSubscription], { route: 'user-events', userId });
+  await finalizeSseSetup(req, res, sseState, [mentionSubscription], {
+    route: 'user-events',
+    userId,
+  });
 });

--- a/harmony-backend/src/services/message.service.ts
+++ b/harmony-backend/src/services/message.service.ts
@@ -5,6 +5,7 @@ import { cacheService, CacheTTL, sanitizeKeySegment } from './cache.service';
 import { permissionService } from './permission.service';
 import { isSystemAdmin } from '../lib/admin.utils';
 import { eventBus, EventChannels } from '../events/eventBus';
+import type { EventMessagePayload } from '../events/eventTypes';
 import { channelRepository } from '../repositories/channel.repository';
 import { channelMemberRepository } from '../repositories/channelMember.repository';
 import { messageRepository } from '../repositories/message.repository';
@@ -84,6 +85,39 @@ function groupReactions(raw: { emoji: string; userId: string }[]) {
   }));
 }
 
+function serializeMessageForEvent(message: {
+  id: string;
+  channelId: string;
+  authorId: string;
+  author: EventMessagePayload['author'];
+  content: string;
+  createdAt: Date;
+  editedAt: Date | null;
+  attachments: EventMessagePayload['attachments'];
+  parentMessageId: string | null;
+  parent?: EventMessagePayload['parentMessage'];
+}): EventMessagePayload {
+  return {
+    id: message.id,
+    channelId: message.channelId,
+    authorId: message.authorId,
+    author: message.author,
+    content: message.content,
+    timestamp: message.createdAt.toISOString(),
+    attachments: message.attachments,
+    editedAt: message.editedAt ? message.editedAt.toISOString() : null,
+    parentMessageId: message.parentMessageId,
+    parentMessage: message.parent
+      ? {
+          id: message.parent.id,
+          content: message.parent.isDeleted ? '' : message.parent.content,
+          isDeleted: message.parent.isDeleted,
+          author: message.parent.author,
+        }
+      : null,
+  };
+}
+
 /**
  * Cache key scoped to both server and channel so that private-channel entries
  * cannot be hit by users authorized on a different server.
@@ -129,7 +163,10 @@ async function requirePrivateChannelAccess(
 
   const isMember = await channelMemberRepository.isMember(userId, channel.id);
   if (!isMember) {
-    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this private channel' });
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'You do not have access to this private channel',
+    });
   }
 }
 
@@ -175,7 +212,7 @@ export const messageService = {
         const page = hasMore ? messages.slice(0, clampedLimit) : messages;
         const nextCursor = hasMore ? page[page.length - 1].id : null;
 
-        const messagesWithReactions = page.map(msg => ({
+        const messagesWithReactions = page.map((msg) => ({
           ...msg,
           reactions: groupReactions(msg.reactions),
         }));
@@ -213,7 +250,10 @@ export const messageService = {
         `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)}:*`,
       );
     } catch (err) {
-      logger.warn({ err, channelId, serverId }, 'Failed to invalidate channel message cache after send');
+      logger.warn(
+        { err, channelId, serverId },
+        'Failed to invalidate channel message cache after send',
+      );
     }
 
     eventBus
@@ -222,6 +262,7 @@ export const messageService = {
         channelId,
         authorId,
         timestamp: message.createdAt.toISOString(),
+        message: serializeMessageForEvent(message),
       })
       .catch((err) =>
         logger.warn(
@@ -256,7 +297,10 @@ export const messageService = {
     // Dispatch push notifications fire-and-forget
     (async () => {
       try {
-        const server = await prisma.server.findUnique({ where: { id: serverId }, select: { slug: true } });
+        const server = await prisma.server.findUnique({
+          where: { id: serverId },
+          select: { slug: true },
+        });
         if (!server) return;
 
         const ctx = {
@@ -312,6 +356,7 @@ export const messageService = {
         messageId,
         channelId: message.channelId,
         timestamp: updated.editedAt!.toISOString(),
+        message: serializeMessageForEvent(updated),
       })
       .catch((err) =>
         logger.warn(
@@ -329,9 +374,7 @@ export const messageService = {
       authorId,
       authorUsername: updated.author.username,
       content,
-    }).catch((err) =>
-      logger.warn({ err, messageId }, 'processMentions failed on editMessage'),
-    );
+    }).catch((err) => logger.warn({ err, messageId }, 'processMentions failed on editMessage'));
     processBroadcastMentions({
       messageId,
       channelId: message.channelId,
@@ -557,11 +600,7 @@ export const messageService = {
         tx,
       );
 
-      await messageRepository.updateRaw(
-        parentMessageId,
-        { replyCount: { increment: 1 } },
-        tx,
-      );
+      await messageRepository.updateRaw(parentMessageId, { replyCount: { increment: 1 } }, tx);
 
       return created;
     });
@@ -572,7 +611,10 @@ export const messageService = {
         `channel:msgs:${sanitizeKeySegment(serverId)}:${sanitizeKeySegment(channelId)}:*`,
       );
     } catch (err) {
-      logger.warn({ err, channelId, serverId }, 'Failed to invalidate channel message cache after reply');
+      logger.warn(
+        { err, channelId, serverId },
+        'Failed to invalidate channel message cache after reply',
+      );
     }
     try {
       await cacheService.invalidatePattern(`thread:msgs:${sanitizeKeySegment(parentMessageId)}:*`);
@@ -587,6 +629,7 @@ export const messageService = {
         authorId,
         parentMessageId,
         timestamp: reply.createdAt.toISOString(),
+        message: serializeMessageForEvent(reply),
       })
       .catch((err) =>
         logger.warn(

--- a/harmony-backend/tests/events.router.server.test.ts
+++ b/harmony-backend/tests/events.router.server.test.ts
@@ -305,18 +305,6 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
       },
     );
 
-    (prisma.message.findUnique as jest.Mock).mockResolvedValue({
-      id: MESSAGE_ID,
-      channelId: CHANNEL_ID,
-      authorId: 'author-1',
-      author: { id: 'author-1', username: 'bob', displayName: 'Bob', avatarUrl: null },
-      content: 'live message during setup window',
-      createdAt: new Date('2026-04-19T11:00:00.000Z'),
-      editedAt: null,
-      attachments: [],
-      isDeleted: false,
-    });
-
     const addr = server.address();
     if (!addr || typeof addr === 'string') throw new Error('Bad server address');
     const port = addr.port;
@@ -324,15 +312,12 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     const chunks: string[] = [];
     let response: http.IncomingMessage | null = null;
     await new Promise<void>((resolve, reject) => {
-      const req = http.get(
-        { hostname: 'localhost', port, path: sseUrl },
-        (res) => {
-          response = res;
-          responseStarted.resolve();
-          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
-          res.on('error', reject);
-        },
-      );
+      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
+        response = res;
+        responseStarted.resolve();
+        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+        res.on('error', reject);
+      });
 
       req.on('error', reject);
 
@@ -347,6 +332,18 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
           channelId: CHANNEL_ID,
           authorId: 'author-1',
           timestamp: new Date('2026-04-19T11:00:00.000Z').toISOString(),
+          message: {
+            id: MESSAGE_ID,
+            channelId: CHANNEL_ID,
+            authorId: 'author-1',
+            author: { id: 'author-1', username: 'bob', displayName: 'Bob', avatarUrl: null },
+            content: 'live message during setup window',
+            timestamp: new Date('2026-04-19T11:00:00.000Z').toISOString(),
+            attachments: [],
+            editedAt: null,
+            parentMessageId: null,
+            parentMessage: null,
+          },
         });
 
         ready.resolve();
@@ -363,6 +360,84 @@ describe('GET /api/events/server/:serverId — subscription readiness', () => {
     const body = chunks.join('');
     expect(body).toContain('event: message:created');
     expect(body).toContain('live message during setup window');
+  });
+
+  it('uses hydrated message payloads without per-client Prisma message lookup', async () => {
+    const CHANNEL_ID = '550e8400-e29b-41d4-a716-446655440012';
+    const MESSAGE_ID = '550e8400-e29b-41d4-a716-446655440013';
+    const createdAt = '2026-04-19T11:30:00.000Z';
+    const ready = createDeferred<void>();
+    const responseStarted = createDeferred<void>();
+    const messageHandlers: Array<(payload: MessageCreatedPayload) => Promise<void>> = [];
+
+    (prisma.channel.findMany as jest.Mock).mockResolvedValue([{ id: CHANNEL_ID }]);
+    (prisma.message.findUnique as jest.Mock).mockResolvedValue(null);
+
+    mockSubscribe.mockImplementation(
+      (channel: string, handler: (payload: MessageCreatedPayload) => Promise<void>) => {
+        if (channel === 'harmony:MESSAGE_CREATED') {
+          messageHandlers.push(handler);
+        }
+        return { unsubscribe: jest.fn(), ready: ready.promise };
+      },
+    );
+
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('Bad server address');
+    const port = addr.port;
+
+    const chunks: string[] = [];
+    let response: http.IncomingMessage | null = null;
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get({ hostname: 'localhost', port, path: sseUrl }, (res) => {
+        response = res;
+        responseStarted.resolve();
+        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+        res.on('error', reject);
+      });
+
+      req.on('error', reject);
+
+      setTimeout(async () => {
+        if (messageHandlers.length !== 1) {
+          reject(new Error(`Expected one MESSAGE_CREATED handler, got ${messageHandlers.length}`));
+          return;
+        }
+
+        await messageHandlers[0]({
+          messageId: MESSAGE_ID,
+          channelId: CHANNEL_ID,
+          authorId: 'author-1',
+          timestamp: createdAt,
+          message: {
+            id: MESSAGE_ID,
+            channelId: CHANNEL_ID,
+            authorId: 'author-1',
+            author: { id: 'author-1', username: 'bob', displayName: 'Bob', avatarUrl: null },
+            content: 'already hydrated once by producer',
+            timestamp: createdAt,
+            attachments: [],
+            editedAt: null,
+            parentMessageId: null,
+            parentMessage: null,
+          },
+        });
+
+        ready.resolve();
+        await responseStarted.promise;
+
+        setTimeout(() => {
+          response?.destroy();
+          req.destroy();
+          resolve();
+        }, 75);
+      }, 50);
+    });
+
+    const body = chunks.join('');
+    expect(body).toContain('event: message:created');
+    expect(body).toContain('already hydrated once by producer');
+    expect(prisma.message.findUnique).not.toHaveBeenCalled();
   });
 });
 
@@ -433,20 +508,7 @@ describe('GET /api/events/server/:serverId — Last-Event-ID replay', () => {
       attachments: [],
       isDeleted: false,
     };
-    const liveMsg = {
-      id: LIVE_MESSAGE_ID,
-      channelId: LIVE_CHANNEL_ID,
-      authorId: 'author-3',
-      author: { id: 'author-3', username: 'dave', displayName: 'Dave', avatarUrl: null },
-      content: 'live message',
-      createdAt: new Date('2026-04-19T10:01:00.000Z'),
-      editedAt: null,
-      attachments: [],
-      isDeleted: false,
-    };
-
     (prisma.message.findMany as jest.Mock).mockResolvedValue([replayMsg]);
-    (prisma.message.findUnique as jest.Mock).mockResolvedValue(liveMsg);
 
     mockSubscribe.mockImplementation(
       (channel: string, handler: (payload: MessageCreatedPayload) => Promise<void>) => {
@@ -462,14 +524,11 @@ describe('GET /api/events/server/:serverId — Last-Event-ID replay', () => {
     const chunks: string[] = [];
     const responseStarted = createDeferred<void>();
     await new Promise<void>((resolve, reject) => {
-      const req = http.get(
-        { hostname: 'localhost', port, path: sseUrlWithReplay },
-        (res) => {
-          responseStarted.resolve();
-          res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
-          res.on('error', reject);
-        },
-      );
+      const req = http.get({ hostname: 'localhost', port, path: sseUrlWithReplay }, (res) => {
+        responseStarted.resolve();
+        res.on('data', (chunk: Buffer) => chunks.push(chunk.toString()));
+        res.on('error', reject);
+      });
       req.on('error', reject);
 
       setTimeout(async () => {
@@ -483,6 +542,18 @@ describe('GET /api/events/server/:serverId — Last-Event-ID replay', () => {
           channelId: LIVE_CHANNEL_ID,
           authorId: 'author-3',
           timestamp: new Date('2026-04-19T10:01:00.000Z').toISOString(),
+          message: {
+            id: LIVE_MESSAGE_ID,
+            channelId: LIVE_CHANNEL_ID,
+            authorId: 'author-3',
+            author: { id: 'author-3', username: 'dave', displayName: 'Dave', avatarUrl: null },
+            content: 'live message',
+            timestamp: new Date('2026-04-19T10:01:00.000Z').toISOString(),
+            attachments: [],
+            editedAt: null,
+            parentMessageId: null,
+            parentMessage: null,
+          },
         });
         ready.resolve();
         await responseStarted.promise;

--- a/harmony-backend/tests/events.router.test.ts
+++ b/harmony-backend/tests/events.router.test.ts
@@ -229,23 +229,6 @@ describe('GET /api/events/channel/:channelId — subscription readiness', () => 
       },
     );
 
-    (prisma.message.findUnique as jest.Mock).mockResolvedValue({
-      id: 'message-1',
-      channelId: VALID_CHANNEL_ID,
-      authorId: 'author-1',
-      author: {
-        id: 'author-1',
-        username: 'alice',
-        displayName: 'Alice',
-        avatarUrl: null,
-      },
-      content: 'hello from the setup window',
-      createdAt: new Date('2026-04-19T10:00:00.000Z'),
-      editedAt: null,
-      attachments: [],
-      isDeleted: false,
-    });
-
     const addr = server.address();
     if (!addr || typeof addr === 'string') throw new Error('Bad server address');
     const port = addr.port;
@@ -273,6 +256,23 @@ describe('GET /api/events/channel/:channelId — subscription readiness', () => 
           channelId: VALID_CHANNEL_ID,
           authorId: 'author-1',
           timestamp: new Date('2026-04-19T10:00:00.000Z').toISOString(),
+          message: {
+            id: 'message-1',
+            channelId: VALID_CHANNEL_ID,
+            authorId: 'author-1',
+            author: {
+              id: 'author-1',
+              username: 'alice',
+              displayName: 'Alice',
+              avatarUrl: null,
+            },
+            content: 'hello from the setup window',
+            timestamp: new Date('2026-04-19T10:00:00.000Z').toISOString(),
+            attachments: [],
+            editedAt: null,
+            parentMessageId: null,
+            parentMessage: null,
+          },
         });
 
         ready.resolve();

--- a/harmony-backend/tests/message.service.events.test.ts
+++ b/harmony-backend/tests/message.service.events.test.ts
@@ -177,6 +177,16 @@ describe('messageService.sendMessage — event publishing', () => {
         channelId: CHANNEL_ID,
         authorId: AUTHOR_ID,
         timestamp: expect.any(String),
+        message: expect.objectContaining({
+          id: MESSAGE_ID,
+          channelId: CHANNEL_ID,
+          authorId: AUTHOR_ID,
+          content: 'hello',
+          timestamp: MOCK_MESSAGE.createdAt.toISOString(),
+          editedAt: null,
+          parentMessageId: null,
+          parentMessage: null,
+        }),
       }),
     );
   });
@@ -227,6 +237,14 @@ describe('messageService.editMessage — event publishing', () => {
         messageId: MESSAGE_ID,
         channelId: CHANNEL_ID,
         timestamp: expect.any(String),
+        message: expect.objectContaining({
+          id: MESSAGE_ID,
+          channelId: CHANNEL_ID,
+          authorId: AUTHOR_ID,
+          content: 'edited',
+          timestamp: MOCK_UPDATED_MESSAGE.createdAt.toISOString(),
+          editedAt: MOCK_UPDATED_MESSAGE.editedAt!.toISOString(),
+        }),
       }),
     );
   });
@@ -341,6 +359,14 @@ describe('messageService.createReply — event publishing', () => {
         authorId: AUTHOR_ID,
         parentMessageId: MESSAGE_ID,
         timestamp: expect.any(String),
+        message: expect.objectContaining({
+          id: REPLY_ID,
+          channelId: CHANNEL_ID,
+          authorId: AUTHOR_ID,
+          content: 'reply',
+          timestamp: MOCK_REPLY.createdAt.toISOString(),
+          parentMessageId: MESSAGE_ID,
+        }),
       }),
     );
   });


### PR DESCRIPTION
## Summary

- Hydrate `MESSAGE_CREATED` and `MESSAGE_EDITED` payloads once in `message.service`.
- Send hydrated message payloads directly from channel/server SSE handlers instead of calling `prisma.message.findUnique` inside each connected client handler.
- Add regression coverage proving server SSE live message fan-out emits from the producer payload without a per-client Prisma message lookup.

Closes #408

## Verification

- `npm test -- --runTestsByPath tests/events.router.server.test.ts tests/events.router.test.ts tests/events.router.member.test.ts tests/events.router.status.test.ts tests/events.router.visibility.test.ts tests/events.router.sse-server-updated.test.ts tests/message.service.events.test.ts --runInBand`
- `npm run lint` (backend; passes with existing unrelated warnings in `tests/channelMember.test.ts` and `tests/events.router.sse-server-updated.test.ts`)
- `npx tsc --noEmit` (backend)
- `npm run build` (backend)
- `npm run lint` (frontend; passes with existing unrelated warnings)
- `npm test -- --runInBand` (frontend)
- `npm run build:sandbox` (frontend; passes with existing Next deprecation/module-type warnings and a non-fatal build-time public API request log)

## Notes

- Issue #416 appears duplicative, but no open PR currently covers it; this PR closes #408.
