### PR TITLE
fix: repair profile card layout and status display

### DIFF
--- a/harmony-frontend/src/components/shared/UserProfilePopover.tsx
+++ b/harmony-frontend/src/components/shared/UserProfilePopover.tsx
@@ -121,34 +121,33 @@ export function UserProfilePopover({
       className='fixed z-50 rounded-lg bg-[#18191c] shadow-2xl ring-1 ring-black/40'
       style={style}
     >
-      {/* Banner + avatar */}
-      <div className='h-16 rounded-t-lg bg-[#5865f2]' />
-      <div className='relative px-4 pb-4'>
-        <div className='absolute -top-8 left-4'>
-          <div className='relative'>
-            {avatarUrl && !avatarError ? (
-              <Image
-                src={avatarUrl}
-                alt={displayName}
-                width={56}
-                height={56}
-                unoptimized
-                className='h-14 w-14 rounded-full ring-4 ring-[#18191c]'
-                onError={() => setAvatarError(true)}
-              />
-            ) : (
-              <div className='flex h-14 w-14 items-center justify-center rounded-full bg-[#5865f2] text-xl font-bold text-white ring-4 ring-[#18191c]'>
-                {initial}
-              </div>
-            )}
-            <span
-              className={`absolute bottom-0.5 right-0.5 h-3.5 w-3.5 rounded-full ring-2 ring-[#18191c] ${STATUS_COLOR[status] ?? STATUS_COLOR.offline}`}
-              aria-label={STATUS_LABEL[status] ?? 'Offline'}
+      {/* Banner */}
+      <div className='h-10 rounded-t-lg bg-[#5865f2]' />
+      {/* Avatar + name side-by-side */}
+      <div className='flex items-center gap-3 px-4 py-3'>
+        <div className='relative flex-shrink-0'>
+          {avatarUrl && !avatarError ? (
+            <Image
+              src={avatarUrl}
+              alt={displayName}
+              width={56}
+              height={56}
+              unoptimized
+              className='h-14 w-14 rounded-full ring-4 ring-[#18191c]'
+              onError={() => setAvatarError(true)}
             />
-          </div>
+          ) : (
+            <div className='flex h-14 w-14 items-center justify-center rounded-full bg-[#5865f2] text-xl font-bold text-white ring-4 ring-[#18191c]'>
+              {initial}
+            </div>
+          )}
+          <span
+            className={`absolute bottom-0.5 right-0.5 h-3.5 w-3.5 rounded-full ring-2 ring-[#18191c] ${STATUS_COLOR[status] ?? STATUS_COLOR.offline}`}
+            aria-label={STATUS_LABEL[status] ?? 'Offline'}
+          />
         </div>
 
-        <div className='mt-10'>
+        <div>
           <p className='text-base font-bold leading-tight text-white'>
             {displayName}
           </p>

--- a/harmony-frontend/src/components/shared/UserProfilePopover.tsx
+++ b/harmony-frontend/src/components/shared/UserProfilePopover.tsx
@@ -110,7 +110,7 @@ export function UserProfilePopover({
   const displayName = displayed?.displayName || displayed?.username || '…';
   const username = displayed?.username || '';
   const avatarUrl = displayed?.avatarUrl;
-  const status = (user?.status ?? 'offline') as UserStatus;
+  const status = (user?.status?.toLowerCase() ?? 'offline') as UserStatus;
   const initial = displayName.charAt(0).toUpperCase();
 
   return (


### PR DESCRIPTION
## Summary

- Replaces the broken absolute-positioned avatar layout in `UserProfilePopover` with a flex row so the avatar and display name sit side-by-side beneath the banner, rather than the avatar floating disconnected above the name
- Fixes status badge always showing \"Offline\" by lowercasing the Prisma enum value (`ONLINE` → `online`) before looking it up in `STATUS_COLOR`/`STATUS_LABEL` — the maps and `UserStatus` type use lowercase keys but the backend serializes uppercase

## Test plan

- [ ] Open a profile card by clicking a username in a message or in the members sidebar — avatar and display name should appear side-by-side
- [ ] Verify a user who is online shows a green \"Online\" badge (not gray \"Offline\")
- [ ] Verify idle, DND, and offline statuses render with the correct colour and label
- [ ] All 7 existing `issue-516-username-click` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)