### PR TITLE
fix(notifications): enlarge dismiss button and fix markAllAsRead body

### DIFF
--- a/harmony-frontend/src/__tests__/NotificationBell.test.tsx
+++ b/harmony-frontend/src/__tests__/NotificationBell.test.tsx
@@ -179,7 +179,7 @@ describe('NotificationBell — mark-as-read flows (Issue #574)', () => {
     });
 
     await waitFor(() =>
-      expect(mockTrpcMutation).toHaveBeenCalledWith('notification.markAllAsRead'),
+      expect(mockTrpcMutation).toHaveBeenCalledWith('notification.markAllAsRead', {}),
     );
   });
 

--- a/harmony-frontend/src/components/channel/NotificationBell.tsx
+++ b/harmony-frontend/src/components/channel/NotificationBell.tsx
@@ -182,7 +182,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
 
   const markAllAsRead = async () => {
     try {
-      await apiClient.trpcMutation('notification.markAllAsRead');
+      await apiClient.trpcMutation('notification.markAllAsRead', {});
       setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
     } catch {
       // ignore — non-critical, badge will self-correct on next load
@@ -298,9 +298,20 @@ export function NotificationBell({ userId }: NotificationBellProps) {
                           type='button'
                           onClick={(e) => { e.stopPropagation(); markAsRead(n.id); }}
                           title='Mark as read'
-                          className='mt-0.5 flex-shrink-0 text-[10px] text-indigo-400 hover:text-indigo-300 transition-colors'
+                          aria-label='Mark as read'
+                          className='mt-0.5 flex-shrink-0 rounded p-1.5 text-indigo-400 transition-colors hover:bg-indigo-500/20 hover:text-indigo-300'
                         >
-                          ✓
+                          <svg
+                            className='h-3.5 w-3.5'
+                            viewBox='0 0 24 24'
+                            fill='none'
+                            stroke='currentColor'
+                            strokeWidth={2.5}
+                            strokeLinecap='round'
+                            strokeLinejoin='round'
+                          >
+                            <polyline points='20 6 9 17 4 12' />
+                          </svg>
                         </button>
                       )}
                     </div>


### PR DESCRIPTION
## Summary

- **Dismiss button too small to click**: The per-notification mark-as-read button was rendered as a bare `✓` character with `text-[10px]` and no padding, making it nearly impossible to hit. Replaced with a properly-sized SVG checkmark icon (`h-3.5 w-3.5`) inside a `p-1.5` padded button that also shows a hover background, giving a comfortable tap target.

- **"Mark all as read" not clearing notifications**: The previous fix (#602) changed `input ?? null` → `input` (sending `undefined`) to avoid serializing JSON `null`. However, passing `undefined` to Axios with a globally-set `Content-Type: application/json` header can produce an ambiguous empty body that some body-parser configurations reject. Now `markAllAsRead` explicitly passes `{}` so Axios always sends a valid JSON object body and the tRPC adapter can parse it reliably.

## Changes

- `harmony-frontend/src/components/channel/NotificationBell.tsx`: enlarged dismiss button; pass `{}` to `markAllAsRead`
- `harmony-frontend/src/__tests__/NotificationBell.test.tsx`: updated assertion to match `{}` argument

## Test plan

- [ ] Verify unread notifications show a clearly-clickable checkmark button that dismisses the individual notification and removes it from the unread count
- [ ] Verify "Mark all as read" clears the unread badge and removes the indigo highlight from all notifications
- [ ] All 13 `NotificationBell` unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)